### PR TITLE
Startup reliability, sandbox RO/RW split, composer @ mentions, and an embeddable widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ Optional. Create `pi-interface.config.json` next to where you launch the server 
 |-----|--------|
 | `cwd` | Agent working directory |
 | `agentDir` | Own config dir (auth, models, settings, sessions) — fully separate from `~/.pi/agent` |
-| `sandbox.root` | File tools (read/ls/grep/find) are confined to this directory, symlinks resolved. Defaults to `cwd` if omitted |
-| `sandbox.allowWrite` | Adds edit/write, still confined to the root (default `false`) |
+| `sandbox.root` | Read-only zone: read/ls/grep/find are confined to this directory, symlinks resolved. Defaults to `cwd` if omitted |
+| `sandbox.allowWrite` | Adds edit/write, confined to `sandbox.writableRoot` (or the whole root if unset) (default `false`) |
+| `sandbox.writableRoot` | Read-write zone: subdirectory of `root` that edit/write are further confined to. Must be inside `root`. Defaults to `root` itself |
 | `sandbox.allowBash` | Adds bash — **not path-confined**, explicit opt-in (default `false`) |
 | `tools` | Tool allowlist in non-sandbox mode, e.g. `["read","grep","find","ls"]` |
 | `noExtensions` / `extensionPaths` | Disable extension discovery / load only listed extensions |

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install
 npm run dev
 ```
 
-- Web UI: http://localhost:5173 (Vite dev server, proxies `/ws` to the agent server)
+- Web UI: http://localhost:5173 (Vite dev server, proxies `/ws`, `/branding`, `/health` to the agent server)
 - Agent server: ws://127.0.0.1:3141/ws
 
 The agent works in the directory the server is started from; override with `PI_CWD=/path/to/project`.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The agent works in the directory the server is started from; override with `PI_C
 - File mentions with autocompletion (`@` in the composer: recursive name search over the browser root, inserts the relative path)
 - Extension "Custom UI" support: dialogs, notifications, status/widgets, editor prefill (see below)
 - Standalone mode: own config dir, file sandbox, branding (see below)
+- Embeddable widget (`@pi-interface/embed`): mount into any web app, isolated via Shadow DOM (see below)
 
 ## Standalone configuration
 
@@ -66,17 +67,38 @@ Optional. Create `pi-interface.config.json` next to where you launch the server 
 
 ### Theming
 
-The UI ships with light and dark themes. Precedence: a local pick from the toggle button (persisted in `localStorage`) or a message from a host page beats `branding.defaultTheme`, which falls back to the OS preference (`"system"`).
+The UI ships with light and dark themes. Precedence: a local pick from the toggle button (persisted in `localStorage`) or an explicit override (the embed widget's `theme` option / `setTheme()`, or a host page's `postMessage`) beats `branding.defaultTheme`, which falls back to the OS preference (`"system"`).
 
-To embed pi-interface in another app that controls the theme, set `"allowThemeToggle": false` (hides the toggle) and drive the theme from the host page with:
+Relative paths are resolved against the config file's directory.
+
+## Embedding
+
+`embed/` publishes `@pi-interface/embed`, mounting pi-interface into any element inside a **Shadow DOM** — fully isolated from the host app's CSS in both directions, React supplied as a peer dependency (not bundled), everything else (Tailwind, markdown/mermaid/highlight.js, the shared protocol types) compiled into the package.
+
+```js
+import { mount } from "@pi-interface/embed";
+
+const widget = mount(document.getElementById("assistant"), {
+  serverUrl: "https://your-pi-interface-server", // omit for same-origin
+  theme: "dark", // optional; falls back to branding.defaultTheme, then "system"
+});
+
+widget.setTheme("light"); // change the theme at runtime
+widget.unmount(); // tear down the React tree
+```
+
+Build it with `npm run build --workspace @pi-interface/embed` (outputs ESM + CJS to `embed/dist/`, plus a rolled-up `.d.ts`), then publish `embed/` to your own registry.
+
+Two things to configure on the server side regardless of deployment topology:
+
+- **`server.allowedOrigins`**: the widget's WebSocket connection carries the *host page's* origin (e.g. `https://your-app.example.com`), not pi-interface's own — add it explicitly, even same-domain deployments need this (only `localhost`/`127.0.0.1` are trusted automatically).
+- **CORS**: `/branding` and `/health` are plain HTTP endpoints with no CORS headers. They work with zero extra config when the widget and the backend share an origin (recommended: reverse-proxy pi-interface under your own domain). A genuinely cross-origin deployment needs a CORS layer in front — not built in yet.
+
+A raw iframe (`<iframe src="https://your-pi-interface-server">`) still works too, and still honors `branding.allowThemeToggle: false` plus the host-driven theme channel:
 
 ```js
 iframeWindow.postMessage({ type: "pi-interface:set-theme", theme: "light" }, "https://your-pi-interface-origin")
 ```
-
-`theme` is `"light"`, `"dark"`, or `"system"`. This works whether or not the toggle is shown. Use the exact origin the UI is served from as the target, not `"*"`.
-
-Relative paths are resolved against the config file's directory.
 
 ### Extension Custom UI
 
@@ -97,7 +119,7 @@ web/  (React + Vite + Tailwind)          server/  (Fastify + ws)
 
 Sessions persist in `<agentDir>/sessions/` — reconnecting clients receive the full history (`hello` message).
 
-Planned: fork/tree navigation, images, embeddable build.
+Planned: fork/tree navigation, images.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Optional. Create `pi-interface.config.json` next to where you launch the server 
 | `sandbox.allowBash` | Adds bash — **not path-confined**, explicit opt-in (default `false`) |
 | `tools` | Tool allowlist in non-sandbox mode, e.g. `["read","grep","find","ls"]` |
 | `noExtensions` / `extensionPaths` | Disable extension discovery / load only listed extensions |
+| `systemPrompt` / `systemPromptFile` | Replace pi's built-in system prompt entirely (mutually exclusive; `systemPromptFile` is a path to a text file). Project context files, skills, and `appendSystemPrompt` are still layered on top |
+| `appendSystemPrompt` | Array of extra paragraphs appended after the (built-in or custom) system prompt |
 | `server.port` | Port to listen on (default `3141`, or the `PORT` env var if set) |
 | `server.host` | Host to bind to (default `127.0.0.1` — only change this if you understand the security note above) |
 | `server.allowedOrigins` | Extra exact Origins accepted on the WebSocket (embed the UI as a tab in another app) |

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The agent works in the directory the server is started from; override with `PI_C
 - Steer / follow-up while streaming, abort
 - Model + thinking-level selectors
 - Session list / resume / new / delete
-- Collapsible file-browser sidebar: lazy-loaded tree + read-only preview (syntax-highlighted, Markdown rendered), confined to the same root the agent's own tools can see
+- Collapsible file-browser sidebar: lazy-loaded tree + read-only preview (syntax-highlighted, Markdown rendered), confined to the same root the agent's own tools can see; entries outside `sandbox.writableRoot` render dimmed
 - Slash commands with autocompletion (`/` in the composer: extension commands, prompt templates, skills)
 - Extension "Custom UI" support: dialogs, notifications, status/widgets, editor prefill (see below)
 - Standalone mode: own config dir, file sandbox, branding (see below)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The agent works in the directory the server is started from; override with `PI_C
 - Session list / resume / new / delete
 - Collapsible file-browser sidebar: lazy-loaded tree + read-only preview (syntax-highlighted, Markdown rendered), confined to the same root the agent's own tools can see; entries outside `sandbox.writableRoot` render dimmed
 - Slash commands with autocompletion (`/` in the composer: extension commands, prompt templates, skills)
+- File mentions with autocompletion (`@` in the composer: recursive name search over the browser root, inserts the relative path)
 - Extension "Custom UI" support: dialogs, notifications, status/widgets, editor prefill (see below)
 - Standalone mode: own config dir, file sandbox, branding (see below)
 

--- a/embed/package.json
+++ b/embed/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@pi-interface/embed",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Mount pi-interface as a Shadow-DOM-isolated widget inside another web app.",
+  "main": "./dist/pi-interface-embed.cjs",
+  "module": "./dist/pi-interface-embed.js",
+  "types": "./dist/mount.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/mount.d.ts",
+      "import": "./dist/pi-interface-embed.js",
+      "require": "./dist/pi-interface-embed.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "scripts": {
+    "build": "tsc -b && vite build",
+    "typecheck": "tsc -b"
+  },
+  "devDependencies": {
+    "@pi-interface/shared": "*",
+    "@tailwindcss/vite": "^4.3.2",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.3",
+    "highlight.js": "^11.11.1",
+    "mermaid": "^11.16.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
+    "tailwindcss": "^4.3.2",
+    "typescript": "~6.0.2",
+    "vite": "^8.1.1",
+    "vite-plugin-dts": "^5.0.3",
+    "web": "*"
+  }
+}

--- a/embed/src/mount.tsx
+++ b/embed/src/mount.tsx
@@ -1,0 +1,59 @@
+import { createElement, createRef } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type { Theme } from "@pi-interface/shared";
+import App, { type AppHandle } from "web/App";
+// eslint-disable-next-line import/no-unresolved -- resolved at build time via the `?inline` query (raw CSS string)
+import css from "web/index.css?inline";
+
+export interface MountOptions {
+  /** pi-interface backend origin, e.g. "https://api.example.com". Defaults to same-origin as the host page. */
+  serverUrl?: string;
+  /** Initial theme; falls back to the server's branding.defaultTheme, then "system". */
+  theme?: Theme;
+}
+
+export interface MountHandle {
+  /** Unmounts the React tree. `container` itself is left in the DOM (with an empty shadow root). */
+  unmount(): void;
+  setTheme(theme: Theme): void;
+}
+
+/**
+ * Mounts pi-interface into `container` inside a Shadow DOM, fully isolated from the
+ * host page's CSS in both directions (Tailwind's reset never touches the host page,
+ * and the host page's styles never bleed into the widget).
+ */
+export function mount(container: HTMLElement, options: MountOptions = {}): MountHandle {
+  const shadow = container.shadowRoot ?? container.attachShadow({ mode: "open" });
+  shadow.replaceChildren();
+
+  const style = document.createElement("style");
+  style.textContent = css;
+  shadow.appendChild(style);
+
+  // Same id as the standalone app's mount point — reuses index.css's `#root { height: 100% }`
+  // rule as-is inside the shadow tree.
+  const wrapper = document.createElement("div");
+  wrapper.id = "root";
+  shadow.appendChild(wrapper);
+
+  const appRef = createRef<AppHandle>();
+  const root: Root = createRoot(wrapper);
+  root.render(
+    createElement(App, {
+      ref: appRef,
+      serverUrl: options.serverUrl,
+      rootElement: container,
+      initialTheme: options.theme,
+    }),
+  );
+
+  return {
+    unmount() {
+      root.unmount();
+    },
+    setTheme(theme) {
+      appRef.current?.setTheme(theme);
+    },
+  };
+}

--- a/embed/tsconfig.app.json
+++ b/embed/tsconfig.app.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "es2023",
+    "lib": ["ES2023", "DOM"],
+    "module": "esnext",
+    "types": ["vite/client"],
+    "allowArbitraryExtensions": true,
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/embed/tsconfig.json
+++ b/embed/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/embed/tsconfig.node.json
+++ b/embed/tsconfig.node.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "es2023",
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "module": "nodenext",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/embed/vite.config.ts
+++ b/embed/vite.config.ts
@@ -1,0 +1,26 @@
+import tailwindcss from '@tailwindcss/vite'
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
+import dts from 'vite-plugin-dts'
+
+// Library build: mount(container, options) — bundles everything (Tailwind CSS
+// inlined at runtime, shared protocol types, markdown/mermaid/highlight.js) except
+// React, which the host app supplies as a peer dependency.
+export default defineConfig({
+  plugins: [
+    react(),
+    tailwindcss(),
+    dts({ tsconfigPath: './tsconfig.app.json', include: ['src'], bundleTypes: true }),
+  ],
+  build: {
+    lib: {
+      entry: 'src/mount.tsx',
+      name: 'PiInterfaceEmbed',
+      fileName: 'pi-interface-embed',
+      formats: ['es', 'cjs'],
+    },
+    rollupOptions: {
+      external: ['react', 'react-dom', 'react-dom/client', 'react/jsx-runtime'],
+    },
+  },
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,51 @@
       "workspaces": [
         "shared",
         "server",
-        "web"
+        "web",
+        "embed"
       ],
       "devDependencies": {
         "concurrently": "^10.0.3"
+      }
+    },
+    "embed": {
+      "name": "@pi-interface/embed",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@pi-interface/shared": "*",
+        "@tailwindcss/vite": "^4.3.2",
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^6.0.3",
+        "highlight.js": "^11.11.1",
+        "mermaid": "^11.16.0",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+        "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1",
+        "tailwindcss": "^4.3.2",
+        "typescript": "~6.0.2",
+        "vite": "^8.1.1",
+        "vite-plugin-dts": "^5.0.3",
+        "web": "*"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
+    },
+    "embed/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -2883,6 +2924,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@pi-interface/embed": {
+      "resolved": "embed",
+      "link": true
+    },
     "node_modules/@pi-interface/server": {
       "resolved": "server",
       "link": true
@@ -3144,6 +3189,29 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "license": "MIT"
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.2",
@@ -3813,11 +3881,53 @@
         }
       }
     },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.28"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@volar/typescript": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
       "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
       "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/ajv": {
       "version": "8.20.0",
@@ -4014,6 +4124,13 @@
         "node": ">= 10"
       }
     },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/concurrently": {
       "version": "10.0.3",
       "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.3.tgz",
@@ -4038,6 +4155,13 @@
       "funding": {
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
       }
+    },
+    "node_modules/confbox": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "1.1.1",
@@ -4776,6 +4900,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/exsolve": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
+      "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -5212,6 +5350,13 @@
       "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
       "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
     },
+    "node_modules/kolorist": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
+      "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/layout-base": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
@@ -5502,6 +5647,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/local-pkg": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.2.1.tgz",
+      "integrity": "sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.4",
+        "pkg-types": "^2.3.0",
+        "quansync": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/lodash-es": {
@@ -6413,6 +6576,38 @@
       ],
       "license": "MIT"
     },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mlly/node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -6535,10 +6730,24 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-data-parser": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
       "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -6595,6 +6804,18 @@
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
+    },
+    "node_modules/pkg-types": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
+        "pathe": "^2.0.3"
+      }
     },
     "node_modules/points-on-curve": {
       "version": "0.2.0",
@@ -6665,6 +6886,23 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/quansync": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+      "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/antfu"
+        },
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/sxzz"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
@@ -7307,6 +7545,13 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
@@ -7399,6 +7644,76 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unplugin": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
+      "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "acorn": "^8.15.0",
+        "picomatch": "^4.0.3",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/unplugin-dts": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/unplugin-dts/-/unplugin-dts-1.0.3.tgz",
+      "integrity": "sha512-/GR887wfG4r1cWyt1UZsLRuMIjsmEbGkS9yJrz+0dsToHAYUD5CTyP3JMGVLv25j9K0mJcwAVvZno/aTuSUvNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.1.4",
+        "@volar/typescript": "^2.4.26",
+        "compare-versions": "^6.1.1",
+        "debug": "^4.4.0",
+        "kolorist": "^1.8.0",
+        "local-pkg": "^1.1.1",
+        "magic-string": "^0.30.17",
+        "unplugin": "^2.3.2"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": ">=7",
+        "@rspack/core": "^1",
+        "@vue/language-core": "^3.1.5",
+        "esbuild": "*",
+        "rolldown": "*",
+        "rollup": ">=3",
+        "typescript": ">=4",
+        "vite": ">=3",
+        "webpack": "^4 || ^5"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@rspack/core": {
+          "optional": true
+        },
+        "@vue/language-core": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "rolldown": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
       }
     },
     "node_modules/util-deprecate": {
@@ -7525,9 +7840,49 @@
         }
       }
     },
+    "node_modules/vite-plugin-dts": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-5.0.3.tgz",
+      "integrity": "sha512-gIth6NdCEHWPiiRMCK3N6C8WjvdsrtEQrmsiG8h6Ov+lFP+b07Y+wcs9H0H7n146l0PDTYK4cQN1vgeG1pMdRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unplugin-dts": "1.0.3"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": ">=7",
+        "rollup": ">=3",
+        "vite": ">=3"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/web": {
       "resolved": "web",
       "link": true
+    },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "9.0.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "workspaces": [
     "shared",
     "server",
-    "web"
+    "web",
+    "embed"
   ],
   "scripts": {
     "dev": "concurrently -n server,web -c blue,green \"npm run dev --workspace server\" \"npm run dev --workspace web\"",

--- a/pi-interface.config.example.json
+++ b/pi-interface.config.example.json
@@ -3,7 +3,8 @@
   "agentDir": "./.pi-interface-agent",
   "sandbox": {
     "root": "./workspace",
-    "allowWrite": false,
+    "allowWrite": true,
+    "writableRoot": "./workspace/scratch",
     "allowBash": false
   },
   "noExtensions": true,

--- a/pi-interface.config.example.json
+++ b/pi-interface.config.example.json
@@ -9,6 +9,7 @@
   },
   "noExtensions": true,
   "extensionPaths": [],
+  "appendSystemPrompt": ["Only discuss topics related to this project."],
   "server": {
     "port": 3141,
     "host": "127.0.0.1",

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -30,10 +30,16 @@ export interface BrandingConfig {
 }
 
 export interface SandboxConfig {
-  /** Directory file tools are confined to (absolute after load). */
+  /** Directory file tools are confined to (absolute after load) — the read-only zone. */
   root: string;
-  /** Enable edit/write inside the root. Default: false (read-only). */
+  /** Enable edit/write inside writableRoot (or the whole root). Default: false (read-only). */
   allowWrite: boolean;
+  /**
+   * Subdirectory of root that edit/write are further confined to — the read-write zone.
+   * Must resolve inside root. Defaults to root itself (the whole sandbox is writable).
+   * Ignored when allowWrite is false.
+   */
+  writableRoot?: string;
   /**
    * Enable the bash tool. Default: false — bash cannot be path-scoped, so
    * turning it on effectively disables the file sandbox. Explicit opt-in only.
@@ -130,13 +136,28 @@ export function loadConfig(baseCwd: string): AppConfig {
   if (raw.sandbox !== undefined) {
     const sandbox = asObject(raw.sandbox, "sandbox");
     const root = optionalString(sandbox, "root");
+    const resolvedRoot = root ? resolve(root) : config.cwd;
+    const allowWrite = optionalBoolean(sandbox, "allowWrite", false);
+    const writableRoot = optionalString(sandbox, "writableRoot");
+    const resolvedWritableRoot = writableRoot ? resolve(writableRoot) : undefined;
+    if (resolvedWritableRoot !== undefined) {
+      if (!allowWrite) fail(`"sandbox.writableRoot" requires "sandbox.allowWrite" to be true`);
+      const rel = path.relative(resolvedRoot, resolvedWritableRoot);
+      if (rel.startsWith("..") || path.isAbsolute(rel)) {
+        fail(`"sandbox.writableRoot" must be inside "sandbox.root"`);
+      }
+    }
     config.sandbox = {
-      root: root ? resolve(root) : config.cwd,
-      allowWrite: optionalBoolean(sandbox, "allowWrite", false),
+      root: resolvedRoot,
+      allowWrite,
+      writableRoot: resolvedWritableRoot,
       allowBash: optionalBoolean(sandbox, "allowBash", false),
     };
     if (!fs.existsSync(config.sandbox.root)) {
       fail(`sandbox.root does not exist: ${config.sandbox.root}`);
+    }
+    if (config.sandbox.writableRoot && !fs.existsSync(config.sandbox.writableRoot)) {
+      fail(`sandbox.writableRoot does not exist: ${config.sandbox.writableRoot}`);
     }
   }
 

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -60,6 +60,10 @@ export interface AppConfig {
   noExtensions: boolean;
   /** Explicit extension paths to load (in addition to defaults). */
   extensionPaths: string[];
+  /** Replace pi's built-in system prompt entirely (tool guidelines are lost — write your own). */
+  systemPrompt?: string;
+  /** Extra text appended after the (built-in or custom) system prompt, one entry per paragraph. */
+  appendSystemPrompt: string[];
   port: number;
   host: string;
   /** Extra exact Origins allowed on the WebSocket (for embedding in another app). */
@@ -106,6 +110,7 @@ export function loadConfig(baseCwd: string): AppConfig {
     cwd: baseCwd,
     noExtensions: false,
     extensionPaths: [],
+    appendSystemPrompt: [],
     port: Number(process.env.PORT ?? 3141),
     host: "127.0.0.1",
     allowedOrigins: [],
@@ -164,6 +169,20 @@ export function loadConfig(baseCwd: string): AppConfig {
   config.tools = optionalStringArray(raw, "tools");
   config.noExtensions = optionalBoolean(raw, "noExtensions", false);
   config.extensionPaths = (optionalStringArray(raw, "extensionPaths") ?? []).map(resolve);
+
+  const systemPrompt = optionalString(raw, "systemPrompt");
+  const systemPromptFile = optionalString(raw, "systemPromptFile");
+  if (systemPrompt !== undefined && systemPromptFile !== undefined) {
+    fail(`"systemPrompt" and "systemPromptFile" are mutually exclusive`);
+  }
+  if (systemPromptFile !== undefined) {
+    const resolvedFile = resolve(systemPromptFile);
+    if (!fs.existsSync(resolvedFile)) fail(`systemPromptFile does not exist: ${resolvedFile}`);
+    config.systemPrompt = fs.readFileSync(resolvedFile, "utf8");
+  } else if (systemPrompt !== undefined) {
+    config.systemPrompt = systemPrompt;
+  }
+  config.appendSystemPrompt = optionalStringArray(raw, "appendSystemPrompt") ?? [];
 
   if (raw.server !== undefined) {
     const server = asObject(raw.server, "server");

--- a/server/src/fileBrowser.ts
+++ b/server/src/fileBrowser.ts
@@ -7,7 +7,7 @@
 import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { DirEntry } from "@pi-interface/shared";
+import type { DirEntry, FileSearchEntry } from "@pi-interface/shared";
 import type { AppConfig } from "./config.ts";
 import { isWithin, realResolve } from "./sandbox.ts";
 
@@ -118,4 +118,48 @@ export async function readFileForPreview(root: string, relPath: string): Promise
     throw new FileBrowserError("binary", "Binary file — preview not supported");
   }
   return { content: buffer.toString("utf8"), size: stat.size };
+}
+
+const SEARCH_IGNORED_NAMES = new Set(["node_modules", "dist", "build", ".git", ".next", ".turbo", "__pycache__"]);
+/** Guard against pathologically large trees — this is a UI convenience, not a full index. */
+const SEARCH_MAX_VISITED = 20_000;
+
+/**
+ * Recursively search file/directory names under `root` for `query` (case-insensitive
+ * substring match against the relative path). Powers the composer's `@` mention
+ * autocomplete — best-effort and capped, not a full-text or fuzzy search. Skips
+ * dotfiles, common build/dependency directories, and symlinks (avoids cycles).
+ */
+export async function searchFiles(root: string, query: string, limit = 20): Promise<FileSearchEntry[]> {
+  const q = query.trim().toLowerCase();
+  if (!q) return [];
+  const results: FileSearchEntry[] = [];
+  let visited = 0;
+
+  async function walk(dir: string, relDir: string): Promise<void> {
+    if (results.length >= limit || visited >= SEARCH_MAX_VISITED) return;
+    let dirents: Dirent[];
+    try {
+      dirents = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const dirent of dirents) {
+      if (results.length >= limit || visited >= SEARCH_MAX_VISITED) return;
+      visited++;
+      if (dirent.isSymbolicLink() || dirent.name.startsWith(".") || SEARCH_IGNORED_NAMES.has(dirent.name)) continue;
+      const relPath = relDir ? `${relDir}/${dirent.name}` : dirent.name;
+      const isDirectory = dirent.isDirectory();
+      if (relPath.toLowerCase().includes(q)) {
+        results.push({ path: relPath, type: isDirectory ? "directory" : dirent.isFile() ? "file" : "other" });
+      }
+      if (isDirectory) {
+        await walk(path.join(dir, dirent.name), relPath);
+      }
+    }
+  }
+
+  await walk(root, "");
+  results.sort((a, b) => a.path.length - b.path.length || a.path.localeCompare(b.path));
+  return results.slice(0, limit);
 }

--- a/server/src/fileBrowser.ts
+++ b/server/src/fileBrowser.ts
@@ -30,6 +30,18 @@ export async function resolveBrowserRoot(config: AppConfig): Promise<string> {
   return fs.realpath(config.sandbox?.root ?? config.cwd);
 }
 
+/**
+ * Writable zone the browser should highlight, relative to `browserRoot` (posix
+ * separators): undefined when no sandbox is configured, null when the sandbox
+ * is entirely read-only, or the writable subtree's path ("" = the whole root).
+ */
+export async function resolveWritableRoot(config: AppConfig, browserRoot: string): Promise<string | null | undefined> {
+  if (!config.sandbox) return undefined;
+  if (!config.sandbox.allowWrite) return null;
+  const target = config.sandbox.writableRoot ? await fs.realpath(config.sandbox.writableRoot) : browserRoot;
+  return path.relative(browserRoot, target).split(path.sep).join("/");
+}
+
 /** Resolve a client-supplied relative path against root, rejecting anything that escapes it. */
 async function resolveConfined(root: string, relPath: string): Promise<string> {
   const target = path.resolve(root, relPath);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -46,11 +46,55 @@ const AGENT_DIR = config.agentDir ?? getAgentDir();
 // Own agentDir ⇒ own session store, fully separate from ~/.pi/agent
 const SESSION_DIR = config.agentDir ? path.join(config.agentDir, "sessions") : undefined;
 
-// --- Agent session runtime ---------------------------------------------------
-
 const sandboxedTools = config.sandbox ? await createSandboxedTools(config.sandbox) : undefined;
 const BROWSER_ROOT = await resolveBrowserRoot(config);
 const WRITABLE_ROOT = await resolveWritableRoot(config, BROWSER_ROOT);
+
+// --- HTTP server ---------------------------------------------------------------
+//
+// Started now, before the AgentSessionRuntime below (which loads models, extensions,
+// and skills, and can take a few seconds) — branding is pure config with no session
+// dependency, so it must not wait behind that setup (that wait was showing up as a
+// flash of default branding on every page load). /ws and /health stay stubbed out
+// (WS connections are closed immediately, so the client's reconnect loop just
+// retries) until the runtime is ready and wires up the real handlers below.
+
+/**
+ * WebSocket connections are exempt from the same-origin policy: any webpage
+ * could otherwise connect to this localhost server and drive an agent that
+ * has bash/write tools. Only accept browser connections from local dev
+ * origins. Requests without an Origin header (non-browser clients: curl,
+ * native tools) are allowed — a local process already has shell access.
+ */
+const ORIGIN_ALLOWLIST = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/;
+
+/** Local dev origins always pass; config.allowedOrigins adds exact origins for embedding. */
+function originAllowed(origin: string): boolean {
+  return ORIGIN_ALLOWLIST.test(origin) || config.allowedOrigins.includes(origin);
+}
+
+let handleWsConnection: (socket: WebSocket) => void = (socket) => {
+  socket.close(1013, "starting up");
+};
+let getHealth: () => { ok: boolean; sessionId?: string } = () => ({ ok: false });
+
+const app = Fastify({ logger: false });
+await app.register(websocket);
+app.get("/branding", () => config.branding);
+app.get("/ws", { websocket: true }, (socket, req) => {
+  const origin = req.headers.origin;
+  if (origin !== undefined && !originAllowed(origin)) {
+    console.warn(`[server] rejected ws connection from origin ${origin}`);
+    socket.close(1008, "forbidden origin");
+    return;
+  }
+  handleWsConnection(socket);
+});
+app.get("/health", () => getHealth());
+await app.listen({ port: PORT, host: HOST });
+console.log(`[server] ws://${HOST}:${PORT}/ws`);
+
+// --- Agent session runtime ---------------------------------------------------
 
 const createRuntime: CreateAgentSessionRuntimeFactory = async ({
   cwd,
@@ -734,41 +778,16 @@ function handleClientMessage(socket: WebSocket, raw: string): void {
   }
 }
 
-// --- HTTP server -------------------------------------------------------------------
+// --- Wire up the real /ws and /health handlers, now that the runtime is ready ------
 
-const app = Fastify({ logger: false });
-await app.register(websocket);
-
-/**
- * WebSocket connections are exempt from the same-origin policy: any webpage
- * could otherwise connect to this localhost server and drive an agent that
- * has bash/write tools. Only accept browser connections from local dev
- * origins. Requests without an Origin header (non-browser clients: curl,
- * native tools) are allowed — a local process already has shell access.
- */
-const ORIGIN_ALLOWLIST = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/;
-
-/** Local dev origins always pass; config.allowedOrigins adds exact origins for embedding. */
-function originAllowed(origin: string): boolean {
-  return ORIGIN_ALLOWLIST.test(origin) || config.allowedOrigins.includes(origin);
-}
-
-app.get("/ws", { websocket: true }, (socket, req) => {
-  const origin = req.headers.origin;
-  if (origin !== undefined && !originAllowed(origin)) {
-    console.warn(`[server] rejected ws connection from origin ${origin}`);
-    socket.close(1008, "forbidden origin");
-    return;
-  }
+handleWsConnection = (socket) => {
   clients.add(socket);
   send(socket, { type: "hello", ...snapshot() });
   socket.on("message", (data: Buffer) => handleClientMessage(socket, data.toString()));
   socket.on("close", () => clients.delete(socket));
-});
+};
+getHealth = () => ({ ok: true, sessionId: runtime.session.sessionId });
 
-app.get("/health", () => ({ ok: true, sessionId: runtime.session.sessionId }));
-
-await app.listen({ port: PORT, host: HOST });
 console.log(`[pi] session ${runtime.session.sessionId}`);
 console.log(`[pi] model ${modelName()} · cwd ${AGENT_CWD} · agentDir ${AGENT_DIR}`);
 if (config.sandbox) {
@@ -779,7 +798,6 @@ if (config.sandbox) {
   console.log(`[pi] sandbox ${config.sandbox.root} · ${extras}`);
 }
 console.log(`[pi] file browser root ${BROWSER_ROOT}`);
-console.log(`[server] ws://${HOST}:${PORT}/ws`);
 
 // --- Shutdown -------------------------------------------------------------------------
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -372,22 +372,32 @@ function cancelPendingExtensionRequests(): void {
 
 /** (Re)bind the extension runtime — UI bridge, mode, error reporting — to the current session. */
 async function bindExtensionsForSession(): Promise<void> {
-  await runtime.session.bindExtensions({
-    // Cast: structurally satisfies ExtensionUIContext (verified against the SDK's
-    // own RPC-mode implementation); see the `theme` getter above for the one gap.
-    uiContext: createExtensionUIContext() as any,
-    mode: "rpc",
-    // Extensions can call ctx.abort() themselves; no override needed here.
-    // commandContextActions (fork/tree navigation) isn't wired up — out of scope for the UI bridge.
-    shutdownHandler: () => {
-      // Unlike pi's one-shot RPC subprocess, this server is long-lived and shared
-      // across tabs/sessions — an extension asking to "shut down" shouldn't kill it.
-      console.warn("[pi] extension requested shutdown — ignored (pi-interface is a persistent server)");
-    },
-    onError: (err) => {
-      reportError(new Error(`[extension ${err.extensionPath}] ${err.error}`));
-    },
-  });
+  // runtime.session.bindExtensions() has been observed to never settle in some
+  // process contexts (e.g. spawned under `concurrently` / Start-Process, where
+  // stdout isn't a TTY). This warning surfaces that case instead of hanging silently.
+  const stallWarning = setTimeout(() => {
+    console.warn("[pi] bindExtensions has not resolved after 5s — extensions may be unavailable this session");
+  }, 5000);
+  try {
+    await runtime.session.bindExtensions({
+      // Cast: structurally satisfies ExtensionUIContext (verified against the SDK's
+      // own RPC-mode implementation); see the `theme` getter above for the one gap.
+      uiContext: createExtensionUIContext() as any,
+      mode: "rpc",
+      // Extensions can call ctx.abort() themselves; no override needed here.
+      // commandContextActions (fork/tree navigation) isn't wired up — out of scope for the UI bridge.
+      shutdownHandler: () => {
+        // Unlike pi's one-shot RPC subprocess, this server is long-lived and shared
+        // across tabs/sessions — an extension asking to "shut down" shouldn't kill it.
+        console.warn("[pi] extension requested shutdown — ignored (pi-interface is a persistent server)");
+      },
+      onError: (err) => {
+        reportError(new Error(`[extension ${err.extensionPath}] ${err.error}`));
+      },
+    });
+  } finally {
+    clearTimeout(stallWarning);
+  }
 }
 
 /**
@@ -492,7 +502,9 @@ function bindSession(): () => void {
 }
 
 let unsubscribe = bindSession();
-await bindExtensionsForSession();
+// Fire-and-forget: if this hangs (see the stall warning inside bindExtensionsForSession),
+// it must not block app.listen() below — the server should still come up without extensions.
+void bindExtensionsForSession().catch((err) => console.error(`[pi] bindExtensions failed: ${err}`));
 
 /** After runtime.newSession()/switchSession(), runtime.session is a new object. */
 async function rebindAndAnnounce(): Promise<void> {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -33,7 +33,7 @@ import {
 import path from "node:path";
 import { loadConfig } from "./config.ts";
 import { assistantToItem, contentText, customMessageToItem, historyToItems, truncate } from "./convert.ts";
-import { FileBrowserError, listDirectory, readFileForPreview, resolveBrowserRoot, resolveWritableRoot } from "./fileBrowser.ts";
+import { FileBrowserError, listDirectory, readFileForPreview, resolveBrowserRoot, resolveWritableRoot, searchFiles } from "./fileBrowser.ts";
 import { createSandboxedTools, isWithin, realResolve } from "./sandbox.ts";
 
 // npm workspace scripts run with cwd=server/ — INIT_CWD is where `npm run` was invoked
@@ -648,6 +648,12 @@ async function handleReadFile(socket: WebSocket, filePath: string, requestId: st
   }
 }
 
+/** Composer's `@` mention autocomplete: recursive name search, confined to BROWSER_ROOT. */
+async function handleSearchFiles(socket: WebSocket, query: string, requestId: string): Promise<void> {
+  const results = await searchFiles(BROWSER_ROOT, query);
+  send(socket, { type: "file_search_results", requestId, query, results });
+}
+
 function handleClientMessage(socket: WebSocket, raw: string): void {
   let message: ClientMessage;
   try {
@@ -718,6 +724,10 @@ function handleClientMessage(socket: WebSocket, raw: string): void {
     case "read_file":
       if (typeof message.path !== "string" || typeof message.requestId !== "string") return;
       handleReadFile(socket, message.path, message.requestId).catch(reportError);
+      break;
+    case "search_files":
+      if (typeof message.query !== "string" || typeof message.requestId !== "string") return;
+      handleSearchFiles(socket, message.query, message.requestId).catch(reportError);
       break;
   }
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -65,6 +65,8 @@ const createRuntime: CreateAgentSessionRuntimeFactory = async ({
       ...(config.extensionPaths.length > 0
         ? { additionalExtensionPaths: config.extensionPaths }
         : {}),
+      ...(config.systemPrompt !== undefined ? { systemPrompt: config.systemPrompt } : {}),
+      ...(config.appendSystemPrompt.length > 0 ? { appendSystemPrompt: config.appendSystemPrompt } : {}),
     },
   });
   return {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -33,7 +33,7 @@ import {
 import path from "node:path";
 import { loadConfig } from "./config.ts";
 import { assistantToItem, contentText, customMessageToItem, historyToItems, truncate } from "./convert.ts";
-import { FileBrowserError, listDirectory, readFileForPreview, resolveBrowserRoot } from "./fileBrowser.ts";
+import { FileBrowserError, listDirectory, readFileForPreview, resolveBrowserRoot, resolveWritableRoot } from "./fileBrowser.ts";
 import { createSandboxedTools, isWithin, realResolve } from "./sandbox.ts";
 
 // npm workspace scripts run with cwd=server/ — INIT_CWD is where `npm run` was invoked
@@ -50,6 +50,7 @@ const SESSION_DIR = config.agentDir ? path.join(config.agentDir, "sessions") : u
 
 const sandboxedTools = config.sandbox ? await createSandboxedTools(config.sandbox) : undefined;
 const BROWSER_ROOT = await resolveBrowserRoot(config);
+const WRITABLE_ROOT = await resolveWritableRoot(config, BROWSER_ROOT);
 
 const createRuntime: CreateAgentSessionRuntimeFactory = async ({
   cwd,
@@ -158,6 +159,7 @@ function snapshot(): SessionSnapshot {
     models: availableModels(),
     commands: availableCommands(),
     contextUsage: contextUsage(),
+    writableRoot: WRITABLE_ROOT,
   };
 }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -400,13 +400,15 @@ async function bindExtensionsForSession(): Promise<void> {
   }
 }
 
+/** args of an in-flight edit/write call, captured at tool_execution_start and consumed at tool_execution_end. */
+const pendingFileMutations = new Map<string, unknown>();
+
 /**
  * Best-effort file-browser invalidation: if an edit/write tool touched a path inside
  * BROWSER_ROOT, tell clients so an expanded directory or open preview can refresh.
  * Not a security boundary — resolution failures or out-of-root paths are just skipped.
  */
-async function announceFileChange(toolName: string, args: unknown): Promise<void> {
-  if (toolName !== "edit" && toolName !== "write") return;
+async function announceFileChange(args: unknown): Promise<void> {
   const targetPath = (args as { path?: unknown } | null)?.path;
   if (typeof targetPath !== "string") return;
   try {
@@ -463,7 +465,9 @@ function bindSession(): () => void {
           toolName: event.toolName,
           args: event.args,
         });
-        void announceFileChange(event.toolName, event.args);
+        if (event.toolName === "edit" || event.toolName === "write") {
+          pendingFileMutations.set(event.toolCallId, event.args);
+        }
         break;
       case "tool_execution_update": {
         const text = contentText(event.partialResult?.content);
@@ -479,6 +483,13 @@ function bindSession(): () => void {
           isError: event.isError,
           text: truncate(contentText(event.result?.content)),
         });
+        {
+          const args = pendingFileMutations.get(event.toolCallId);
+          pendingFileMutations.delete(event.toolCallId);
+          // Only announce once the write has actually landed on disk — the client
+          // may otherwise refetch a directory/file before the change is visible.
+          if (args !== undefined && !event.isError) void announceFileChange(args);
+        }
         break;
       case "queue_update":
         broadcast({ type: "queue", steering: [...event.steering], followUp: [...event.followUp] });

--- a/server/src/sandbox.ts
+++ b/server/src/sandbox.ts
@@ -1,10 +1,12 @@
 /**
  * File-scoped tool sandbox.
  *
- * SECURITY: wraps the built-in file tools (read/ls/grep/find, optionally
- * edit/write) so every `path` argument must resolve — symlinks included —
- * inside the sandbox root. Bash is excluded unless explicitly allowed in the
- * config, because a shell cannot be path-scoped.
+ * SECURITY: wraps the built-in file tools so every `path` argument must
+ * resolve — symlinks included — inside the relevant zone. Read tools
+ * (read/ls/grep/find) are confined to the whole sandbox root (the read-only
+ * zone); edit/write, if enabled, are further confined to `writableRoot` (the
+ * read-write zone, defaulting to the whole root). Bash is excluded unless
+ * explicitly allowed in the config, because a shell cannot be path-scoped.
  */
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -45,15 +47,22 @@ export function isWithin(root: string, target: string): boolean {
   return target === root || target.startsWith(root + path.sep);
 }
 
-function scopeToRoot(def: ToolDefinition, realRoot: string): ToolDefinition {
+/**
+ * Wrap `def` so every `path` argument — resolved relative to `cwd`, symlinks
+ * included — must land inside `allowedRoot`. `cwd` is always the sandbox root
+ * (paths the model sees are relative to it); `allowedRoot` is the zone this
+ * particular tool is confined to (the full root for read tools, `writableRoot`
+ * for edit/write).
+ */
+function scopeToRoot(def: ToolDefinition, cwd: string, allowedRoot: string): ToolDefinition {
   return {
     ...def,
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const target = (params as { path?: unknown }).path;
       if (typeof target === "string" && target !== "") {
-        const resolved = await realResolve(path.resolve(realRoot, target));
-        if (!isWithin(realRoot, resolved)) {
-          throw new Error(`Access denied: "${target}" is outside the sandbox (${realRoot})`);
+        const resolved = await realResolve(path.resolve(cwd, target));
+        if (!isWithin(allowedRoot, resolved)) {
+          throw new Error(`Access denied: "${target}" is outside the sandbox (${allowedRoot})`);
         }
       }
       return def.execute(toolCallId, params, signal, onUpdate, ctx);
@@ -67,19 +76,26 @@ function scopeToRoot(def: ToolDefinition, realRoot: string): ToolDefinition {
  */
 export async function createSandboxedTools(sandbox: SandboxConfig): Promise<ToolDefinition[]> {
   const realRoot = await fs.realpath(sandbox.root);
-  const factories: Array<(cwd: string) => ToolDefinition> = [
+  const readFactories: Array<(cwd: string) => ToolDefinition> = [
     (cwd) => createReadToolDefinition(cwd) as ToolDefinition,
     (cwd) => createLsToolDefinition(cwd) as ToolDefinition,
     (cwd) => createGrepToolDefinition(cwd) as ToolDefinition,
     (cwd) => createFindToolDefinition(cwd) as ToolDefinition,
   ];
+  const tools = readFactories.map((create) => scopeToRoot(create(realRoot), realRoot, realRoot));
+
   if (sandbox.allowWrite) {
-    factories.push(
+    const realWritableRoot = sandbox.writableRoot ? await fs.realpath(sandbox.writableRoot) : realRoot;
+    if (!isWithin(realRoot, realWritableRoot)) {
+      throw new Error(`sandbox.writableRoot (${realWritableRoot}) must be inside sandbox.root (${realRoot})`);
+    }
+    const writeFactories: Array<(cwd: string) => ToolDefinition> = [
       (cwd) => createEditToolDefinition(cwd) as ToolDefinition,
       (cwd) => createWriteToolDefinition(cwd) as ToolDefinition,
-    );
+    ];
+    tools.push(...writeFactories.map((create) => scopeToRoot(create(realRoot), realRoot, realWritableRoot)));
   }
-  const tools = factories.map((create) => scopeToRoot(create(realRoot), realRoot));
+
   if (sandbox.allowBash) {
     // Explicit opt-in: bash runs in the root but is NOT path-confined
     tools.push(createBashToolDefinition(realRoot) as ToolDefinition);

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -125,6 +125,13 @@ export interface DirEntry {
   type: "file" | "directory" | "symlink-file" | "symlink-directory" | "other";
 }
 
+/** One match from a recursive file-name search (composer's `@` mention autocomplete). */
+export interface FileSearchEntry {
+  /** Path relative to the browser root (posix separators). */
+  path: string;
+  type: DirEntry["type"];
+}
+
 /** Snapshot of session state, sent on connect and after session replacement. */
 export interface SessionSnapshot {
   branding: Branding;
@@ -175,6 +182,7 @@ export type ServerMessage =
   | { type: "file_content"; requestId: string; path: string; content: string; size: number }
   | { type: "file_browser_error"; requestId: string; path: string; message: string }
   | { type: "file_changed"; path: string }
+  | { type: "file_search_results"; requestId: string; query: string; results: FileSearchEntry[] }
   | ExtensionUIRequest;
 
 /** Client -> server */
@@ -190,4 +198,5 @@ export type ClientMessage =
   | { type: "compact" }
   | { type: "list_directory"; path: string; requestId: string }
   | { type: "read_file"; path: string; requestId: string }
+  | { type: "search_files"; query: string; requestId: string }
   | ExtensionUIResponse;

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -136,6 +136,12 @@ export interface SessionSnapshot {
   models: ModelChoice[];
   commands: CommandInfo[];
   contextUsage?: ContextUsage;
+  /**
+   * File-browser writable zone, relative to the browser root (posix separators):
+   * absent when no sandbox is configured (nothing to distinguish), `null` when the
+   * sandbox is entirely read-only, or the writable subtree's path ("" = the whole root).
+   */
+  writableRoot?: string | null;
 }
 
 /** Server -> client */

--- a/web/package.json
+++ b/web/package.json
@@ -3,6 +3,10 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "exports": {
+    "./App": "./src/App.tsx",
+    "./index.css": "./src/index.css"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from "react";
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
+import type { Theme } from "@pi-interface/shared";
 import { AssistantMessage } from "./components/AssistantMessage";
 import { Composer } from "./components/Composer";
 import { CustomMessageCard } from "./components/CustomMessageCard";
@@ -13,7 +14,27 @@ import { ThemeContext } from "./ThemeContext";
 import { useAgent } from "./useAgent";
 import { useTheme } from "./useTheme";
 
-export default function App() {
+export interface AppHandle {
+  setTheme(theme: Theme): void;
+}
+
+interface AppProps {
+  /** pi-interface backend origin (e.g. "https://api.example.com"); "" (default) = same origin as this page. */
+  serverUrl?: string;
+  /**
+   * Element `data-theme`/`--accent` are applied to. Defaults to
+   * `document.documentElement` (the standalone app). Passing one also skips the
+   * `document.title` mutation below — both would otherwise leak onto the host
+   * page when mounted inside a Shadow DOM (see `embed/src/mount.tsx`).
+   */
+  rootElement?: HTMLElement;
+  /** Overrides branding.defaultTheme (avoids a flash of the wrong theme before branding loads). */
+  initialTheme?: Theme;
+}
+
+const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootElement, initialTheme }, ref) {
+  const embedded = rootElement !== undefined;
+  const accentTarget = rootElement ?? document.documentElement;
   const {
     state,
     prompt,
@@ -32,12 +53,14 @@ export default function App() {
     closeFilePreview,
     searchFiles,
     clearFileSearch,
-  } = useAgent();
+  } = useAgent(serverUrl);
   const [sidebarOpen, setSidebarOpen] = useState(false);
-  const { theme, toggle: toggleTheme } = useTheme(
-    state.branding.defaultTheme ?? "system",
+  const { theme, toggle: toggleTheme, setTheme } = useTheme(
+    initialTheme ?? state.branding.defaultTheme ?? "system",
     state.branding.allowThemeToggle !== false,
+    accentTarget,
   );
+  useImperativeHandle(ref, () => ({ setTheme }), [setTheme]);
   const mainRef = useRef<HTMLElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const stickToBottom = useRef(true);
@@ -57,12 +80,13 @@ export default function App() {
   }, [state.items]);
 
   useEffect(() => {
-    // An extension's setTitle() (see extensions.md#custom-ui) wins until branding changes again
-    document.title = state.extensionTitle ?? state.branding.title ?? "pi";
+    // An extension's setTitle() (see extensions.md#custom-ui) wins until branding changes again.
+    // Skipped when embedded: the host page owns its own <title>.
+    if (!embedded) document.title = state.extensionTitle ?? state.branding.title ?? "pi";
     if (state.branding.accentColor) {
-      document.documentElement.style.setProperty("--accent", state.branding.accentColor);
+      accentTarget.style.setProperty("--accent", state.branding.accentColor);
     }
-  }, [state.branding, state.extensionTitle]);
+  }, [state.branding, state.extensionTitle, embedded, accentTarget]);
 
   return (
     <ThemeContext.Provider value={theme}>
@@ -188,4 +212,6 @@ export default function App() {
       <ExtensionNotifications notifications={state.notifications} onDismiss={dismissNotification} />
     </ThemeContext.Provider>
   );
-}
+});
+
+export default App;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -30,6 +30,8 @@ export default function App() {
     listDirectory,
     readFile,
     closeFilePreview,
+    searchFiles,
+    clearFileSearch,
   } = useAgent();
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const { theme, toggle: toggleTheme } = useTheme(
@@ -157,9 +159,12 @@ export default function App() {
                 isStreaming={state.isStreaming}
                 connected={state.connected}
                 commands={state.commands}
+                fileSearch={state.fileSearch}
                 prefill={state.editorPrefill}
                 onSend={prompt}
                 onAbort={abort}
+                onSearchFiles={searchFiles}
+                onClearFileSearch={clearFileSearch}
               />
               <ExtensionWidgets widgets={state.widgets} placement="belowEditor" />
               <ModelBar

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -69,6 +69,7 @@ export default function App() {
           <Sidebar
             tree={state.fileTree}
             openFile={state.openFile}
+            writableRoot={state.writableRoot}
             onExpand={listDirectory}
             onSelectFile={readFile}
             onClosePreview={closeFilePreview}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -112,7 +112,7 @@ export default function App() {
                   return (
                     <div
                       key={key}
-                      className="ml-auto max-w-[85%] whitespace-pre-wrap rounded-xl bg-sky-100 px-4 py-2 text-[15px] text-sky-950 dark:bg-sky-950/60 dark:text-zinc-100"
+                      className="ml-auto max-w-[85%] whitespace-pre-wrap rounded-xl bg-blue-100 px-4 py-2 text-[15px] text-blue-950 dark:bg-blue-950/60 dark:text-zinc-100"
                     >
                       {item.text}
                     </div>

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -1,14 +1,18 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { CommandInfo } from "@pi-interface/shared";
+import type { CommandInfo, FileSearchEntry } from "@pi-interface/shared";
+import type { FileSearch } from "../useAgent";
 
 interface ComposerProps {
   isStreaming: boolean;
   connected: boolean;
   commands: CommandInfo[];
+  fileSearch: FileSearch | null;
   /** Extension set_editor_text() request (see extensions.md#custom-ui) — bump nonce to reapply the same text. */
   prefill: { text: string; nonce: number } | null;
   onSend: (text: string) => void;
   onAbort: () => void;
+  onSearchFiles: (query: string) => void;
+  onClearFileSearch: () => void;
 }
 
 const SOURCE_BADGE: Record<CommandInfo["source"], string> = {
@@ -17,16 +21,50 @@ const SOURCE_BADGE: Record<CommandInfo["source"], string> = {
   skill: "skill",
 };
 
-export function Composer({ isStreaming, connected, commands, prefill, onSend, onAbort }: ComposerProps) {
+function isDirType(type: FileSearchEntry["type"]): boolean {
+  return type === "directory" || type === "symlink-directory";
+}
+
+/** A `@` mention being typed at the cursor: "@" preceded by start-of-text or whitespace, no space since. */
+function findMention(text: string, cursor: number): { start: number; query: string } | null {
+  const upToCursor = text.slice(0, cursor);
+  const match = /(?:^|\s)@([^\s@]*)$/.exec(upToCursor);
+  if (!match) return null;
+  return { start: cursor - match[1].length - 1, query: match[1] };
+}
+
+export function Composer({
+  isStreaming,
+  connected,
+  commands,
+  fileSearch,
+  prefill,
+  onSend,
+  onAbort,
+  onSearchFiles,
+  onClearFileSearch,
+}: ComposerProps) {
   const [text, setText] = useState("");
+  const [cursor, setCursor] = useState(0);
   const [selected, setSelected] = useState(0);
   const [dismissed, setDismissed] = useState(false);
   const listRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const pendingCursorRef = useRef<number | null>(null);
 
   useEffect(() => {
     if (prefill) setText(prefill.text);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [prefill?.nonce]);
+
+  useEffect(() => {
+    if (pendingCursorRef.current === null) return;
+    // A mouse-picked suggestion unmounts (menu closes), taking focus with it — reclaim it
+    // so the caret lands where we set it and typing/Escape keep reaching the textarea.
+    textareaRef.current?.focus();
+    textareaRef.current?.setSelectionRange(pendingCursorRef.current, pendingCursorRef.current);
+    pendingCursorRef.current = null;
+  }, [text]);
 
   // Autocomplete only while typing the command name: "/" + no whitespace yet
   const commandPrefix = useMemo(() => {
@@ -34,17 +72,40 @@ export function Composer({ isStreaming, connected, commands, prefill, onSend, on
     return match ? match[1].toLowerCase() : null;
   }, [text]);
 
-  const suggestions = useMemo(() => {
+  const commandSuggestions = useMemo(() => {
     if (commandPrefix === null) return [];
     return commands.filter((c) => c.name.toLowerCase().startsWith(commandPrefix)).slice(0, 12);
   }, [commandPrefix, commands]);
 
-  const open = suggestions.length > 0 && !dismissed;
+  const mention = commandPrefix === null ? findMention(text, cursor) : null;
 
+  // Debounce the search request; drop it once the mention is gone or empty.
+  useEffect(() => {
+    if (!mention || mention.query.length === 0) {
+      onClearFileSearch();
+      return;
+    }
+    const handle = window.setTimeout(() => onSearchFiles(mention.query), 150);
+    return () => clearTimeout(handle);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mention?.query]);
+
+  const fileSuggestions = mention && fileSearch?.query === mention.query ? fileSearch.results : [];
+
+  const menu = useMemo(() => {
+    if (commandSuggestions.length > 0) return { kind: "command" as const, items: commandSuggestions };
+    if (mention && fileSuggestions.length > 0) return { kind: "file" as const, items: fileSuggestions };
+    return null;
+  }, [commandSuggestions, mention, fileSuggestions]);
+
+  const open = menu !== null && !dismissed;
+
+  // Re-open (and reset the selection) whenever the trigger text changes
+  const menuKey = commandPrefix !== null ? `cmd:${commandPrefix}` : mention ? `file:${mention.query}` : null;
   useEffect(() => {
     setSelected(0);
     setDismissed(false);
-  }, [commandPrefix]);
+  }, [menuKey]);
   useEffect(() => {
     listRef.current
       ?.querySelector('[data-selected="true"]')
@@ -56,29 +117,55 @@ export function Composer({ isStreaming, connected, commands, prefill, onSend, on
     if (!trimmed) return;
     onSend(trimmed);
     setText("");
+    onClearFileSearch();
   }
 
   function pick(command: CommandInfo) {
-    setText(`/${command.name} `);
+    const next = `/${command.name} `;
+    setText(next);
+    pendingCursorRef.current = next.length;
+    setCursor(next.length);
+  }
+
+  function pickFile(entry: FileSearchEntry) {
+    if (!mention) return;
+    const before = text.slice(0, mention.start);
+    const after = text.slice(cursor);
+    const inserted = `@${entry.path}${isDirType(entry.type) ? "/" : " "}`;
+    const next = `${before}${inserted}${after}`;
+    setText(next);
+    onClearFileSearch();
+    const newCursor = before.length + inserted.length;
+    pendingCursorRef.current = newCursor;
+    setCursor(newCursor);
+  }
+
+  function pickSelected() {
+    if (!menu) return;
+    if (menu.kind === "command") {
+      const command = menu.items[selected];
+      if (command) pick(command);
+    } else {
+      const entry = menu.items[selected];
+      if (entry) pickFile(entry);
+    }
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
-    if (open) {
+    if (open && menu) {
       if (e.key === "ArrowDown") {
         e.preventDefault();
-        setSelected((s) => (s + 1) % suggestions.length);
+        setSelected((s) => (s + 1) % menu.items.length);
         return;
       }
       if (e.key === "ArrowUp") {
         e.preventDefault();
-        setSelected((s) => (s - 1 + suggestions.length) % suggestions.length);
+        setSelected((s) => (s - 1 + menu.items.length) % menu.items.length);
         return;
       }
       if (e.key === "Tab" || e.key === "Enter") {
         e.preventDefault();
-        // suggestions can shrink under the cursor (commands refresh mid-typing)
-        const command = suggestions[selected];
-        if (command) pick(command);
+        pickSelected();
         return;
       }
       if (e.key === "Escape") {
@@ -93,50 +180,78 @@ export function Composer({ isStreaming, connected, commands, prefill, onSend, on
     }
   }
 
+  function syncCursor(e: React.SyntheticEvent<HTMLTextAreaElement>) {
+    setCursor(e.currentTarget.selectionStart ?? 0);
+  }
+
   return (
     <div className="relative">
-      {open && (
+      {open && menu && (
         <div
           ref={listRef}
           className="absolute bottom-full left-0 z-20 mb-2 max-h-72 w-full max-w-xl overflow-y-auto rounded-lg border border-zinc-200 bg-white py-1 shadow-xl dark:border-zinc-700 dark:bg-zinc-900"
         >
-          {suggestions.map((command, i) => (
-            <button
-              key={command.name}
-              type="button"
-              data-selected={i === selected}
-              onMouseEnter={() => setSelected(i)}
-              onClick={() => pick(command)}
-              className={`flex w-full items-baseline gap-2 px-3 py-1.5 text-left text-sm ${
-                i === selected ? "bg-zinc-100 dark:bg-zinc-800" : ""
-              }`}
-            >
-              <span className="font-mono text-zinc-800 dark:text-zinc-200">/{command.name}</span>
-              {command.argumentHint && (
-                <span className="font-mono text-xs text-zinc-500">{command.argumentHint}</span>
-              )}
-              {command.description && (
-                <span className="min-w-0 flex-1 truncate text-xs text-zinc-500">{command.description}</span>
-              )}
-              <span className="ml-auto shrink-0 rounded bg-zinc-200 px-1 text-[10px] uppercase text-zinc-500 dark:bg-zinc-800">
-                {SOURCE_BADGE[command.source]}
-              </span>
-            </button>
-          ))}
+          {menu.kind === "command"
+            ? menu.items.map((command, i) => (
+                <button
+                  key={command.name}
+                  type="button"
+                  data-selected={i === selected}
+                  onMouseEnter={() => setSelected(i)}
+                  onClick={() => pick(command)}
+                  className={`flex w-full items-baseline gap-2 px-3 py-1.5 text-left text-sm ${
+                    i === selected ? "bg-zinc-100 dark:bg-zinc-800" : ""
+                  }`}
+                >
+                  <span className="font-mono text-zinc-800 dark:text-zinc-200">/{command.name}</span>
+                  {command.argumentHint && (
+                    <span className="font-mono text-xs text-zinc-500">{command.argumentHint}</span>
+                  )}
+                  {command.description && (
+                    <span className="min-w-0 flex-1 truncate text-xs text-zinc-500">{command.description}</span>
+                  )}
+                  <span className="ml-auto shrink-0 rounded bg-zinc-200 px-1 text-[10px] uppercase text-zinc-500 dark:bg-zinc-800">
+                    {SOURCE_BADGE[command.source]}
+                  </span>
+                </button>
+              ))
+            : menu.items.map((entry, i) => (
+                <button
+                  key={entry.path}
+                  type="button"
+                  data-selected={i === selected}
+                  onMouseEnter={() => setSelected(i)}
+                  onClick={() => pickFile(entry)}
+                  className={`flex w-full items-baseline gap-2 px-3 py-1.5 text-left text-sm ${
+                    i === selected ? "bg-zinc-100 dark:bg-zinc-800" : ""
+                  }`}
+                >
+                  <span className="min-w-0 flex-1 truncate font-mono text-zinc-800 dark:text-zinc-200">
+                    {entry.path}
+                    {isDirType(entry.type) ? "/" : ""}
+                  </span>
+                </button>
+              ))}
         </div>
       )}
 
       <div className="flex items-end gap-2 rounded-xl border border-zinc-200 bg-zinc-50 p-2 focus-within:border-zinc-400 dark:border-zinc-800 dark:bg-zinc-900 dark:focus-within:border-zinc-600">
         <textarea
+          ref={textareaRef}
           value={text}
-          onChange={(e) => setText(e.target.value)}
+          onChange={(e) => {
+            setText(e.target.value);
+            setCursor(e.target.selectionStart ?? e.target.value.length);
+          }}
           onKeyDown={handleKeyDown}
+          onClick={syncCursor}
+          onKeyUp={syncCursor}
           placeholder={
             !connected
               ? "connecting…"
               : isStreaming
                 ? "steer the agent… (Enter to send)"
-                : "message pi… (/ for commands, Enter to send, Shift+Enter for newline)"
+                : "message pi… (/ for commands, @ for files, Enter to send, Shift+Enter for newline)"
           }
           disabled={!connected}
           rows={Math.min(6, Math.max(1, text.split("\n").length))}

--- a/web/src/components/ExtensionNotifications.tsx
+++ b/web/src/components/ExtensionNotifications.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import type { ExtensionNotification } from "../useAgent";
 
 const STYLES: Record<NonNullable<ExtensionNotification["notifyType"]>, string> = {
-  info: "border-sky-300 bg-sky-50 text-sky-800 dark:border-sky-900 dark:bg-sky-950/60 dark:text-sky-200",
+  info: "border-blue-300 bg-blue-50 text-blue-800 dark:border-blue-900 dark:bg-blue-950/60 dark:text-blue-200",
   warning: "border-amber-300 bg-amber-50 text-amber-800 dark:border-amber-900 dark:bg-amber-950/60 dark:text-amber-200",
   error: "border-red-300 bg-red-50 text-red-800 dark:border-red-900 dark:bg-red-950/60 dark:text-red-200",
 };

--- a/web/src/components/FileTree.tsx
+++ b/web/src/components/FileTree.tsx
@@ -5,12 +5,22 @@ import type { DirState } from "../useAgent";
 interface TreeProps {
   tree: Record<string, DirState>;
   openFilePath?: string;
+  /** Writable zone; see SessionSnapshot.writableRoot. Entries outside it render dimmed. */
+  writableRoot?: string | null;
   onExpand: (path: string) => void;
   onSelectFile: (path: string) => void;
 }
 
 function isDir(type: DirEntry["type"]): boolean {
   return type === "directory" || type === "symlink-directory";
+}
+
+/** undefined writableRoot = no sandbox, nothing to dim; null = the whole tree is read-only. */
+function isReadOnly(fullPath: string, writableRoot: string | null | undefined): boolean {
+  if (writableRoot === undefined) return false;
+  if (writableRoot === null) return true;
+  if (writableRoot === "") return false;
+  return fullPath !== writableRoot && !fullPath.startsWith(`${writableRoot}/`);
 }
 
 function DirChildren({ path, depth, ...props }: TreeProps & { path: string; depth: number }) {
@@ -54,6 +64,7 @@ function TreeNode({
 }: TreeProps & { parentPath: string; entry: DirEntry; depth: number }) {
   const [open, setOpen] = useState(false);
   const fullPath = parentPath ? `${parentPath}/${entry.name}` : entry.name;
+  const readOnly = isReadOnly(fullPath, props.writableRoot);
 
   if (isDir(entry.type)) {
     return (
@@ -69,7 +80,11 @@ function TreeNode({
           className="flex w-full items-center gap-1 rounded py-0.5 text-left hover:bg-zinc-100 dark:hover:bg-zinc-800"
         >
           <span className="w-3 shrink-0 text-xs text-zinc-400 dark:text-zinc-600">{open ? "▾" : "▸"}</span>
-          <span className="truncate text-zinc-700 dark:text-zinc-300">{entry.name}</span>
+          <span
+            className={`truncate ${readOnly ? "text-zinc-400 dark:text-zinc-600" : "text-zinc-700 dark:text-zinc-300"}`}
+          >
+            {entry.name}
+          </span>
         </button>
         {open && <DirChildren path={fullPath} depth={depth + 1} {...props} />}
       </div>
@@ -86,7 +101,9 @@ function TreeNode({
         selected ? "bg-zinc-100 dark:bg-zinc-800" : ""
       }`}
     >
-      <span className="truncate text-zinc-600 dark:text-zinc-400">{entry.name}</span>
+      <span className={`truncate ${readOnly ? "text-zinc-400 dark:text-zinc-600" : "text-zinc-600 dark:text-zinc-400"}`}>
+        {entry.name}
+      </span>
     </button>
   );
 }

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -6,13 +6,15 @@ import { FileTree } from "./FileTree";
 interface SidebarProps {
   tree: Record<string, DirState>;
   openFile: OpenFile | null;
+  /** Writable zone in the tree; see SessionSnapshot.writableRoot. */
+  writableRoot?: string | null;
   onExpand: (path: string) => void;
   onSelectFile: (path: string) => void;
   onClosePreview: () => void;
 }
 
 /** Collapsible file-browser sidebar: lazy tree + read-only preview. */
-export function Sidebar({ tree, openFile, onExpand, onSelectFile, onClosePreview }: SidebarProps) {
+export function Sidebar({ tree, openFile, writableRoot, onExpand, onSelectFile, onClosePreview }: SidebarProps) {
   useEffect(() => {
     if (tree[""] === undefined) onExpand("");
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -24,7 +26,13 @@ export function Sidebar({ tree, openFile, onExpand, onSelectFile, onClosePreview
         Files
       </div>
       <div className={`overflow-auto p-2 ${openFile ? "max-h-[40%]" : "flex-1"}`}>
-        <FileTree tree={tree} openFilePath={openFile?.path} onExpand={onExpand} onSelectFile={onSelectFile} />
+        <FileTree
+          tree={tree}
+          openFilePath={openFile?.path}
+          writableRoot={writableRoot}
+          onExpand={onExpand}
+          onSelectFile={onSelectFile}
+        />
       </div>
       {openFile && (
         <div className="min-h-0 flex-1 border-t border-zinc-200 dark:border-zinc-800">

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,9 +1,19 @@
 @import "tailwindcss";
 
-/* data-theme is set by useTheme() on <html>; lets dark: utilities key off it
-   instead of only prefers-color-scheme, so the in-app toggle/config default
+/* Explicit source root: Tailwind's automatic content detection is relative to the
+   Vite build consuming this file, which resolves correctly for web's own build but
+   not for embed's (a different package importing this file directly) — this makes
+   utility-class scanning of web/src work the same regardless of which build processes
+   this stylesheet. */
+@source "./**/*.{ts,tsx}";
+
+/* data-theme is set by useTheme() on the root element: document.documentElement for
+   the standalone app, or the widget's shadow host when embedded (embed/src/mount.tsx)
+   — the third branch matches that case, since [data-theme="dark"] then lives on an
+   element outside the shadow tree these rules are scoped to. Lets dark: utilities key
+   off it instead of only prefers-color-scheme, so the in-app toggle/config default
    and host-driven postMessage overrides all take effect. */
-@custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
+@custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *, :host([data-theme="dark"]) &));
 
 @theme {
   --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
@@ -11,12 +21,22 @@
 }
 
 /* Default brand accent (deep blue) — App.tsx overrides this inline when
-   branding.accentColor is configured; inline style wins over this rule. */
-:root {
+   branding.accentColor is configured; inline style wins over this rule.
+   :host variants apply the same defaults when embedded (see mount.tsx). */
+:root,
+:host {
   --accent: #1d4ed8;
 }
-:root[data-theme="dark"] {
+:root[data-theme="dark"],
+:host([data-theme="dark"]) {
   --accent: #60a5fa;
+}
+
+/* Sizing for the widget's shadow host — the standalone app's html/body/#root rule
+   below covers the equivalent for a normal page. */
+:host {
+  display: block;
+  height: 100%;
 }
 
 html,
@@ -25,7 +45,10 @@ body,
   height: 100%;
 }
 
-body {
+/* #root is body's equivalent inside the widget's shadow tree (no <body> there) —
+   same id as the standalone app's mount point, see embed/src/mount.tsx. */
+body,
+#root {
   @apply bg-white text-zinc-900 antialiased dark:bg-zinc-950 dark:text-zinc-100;
 }
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -10,6 +10,15 @@
   --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", monospace;
 }
 
+/* Default brand accent (deep blue) — App.tsx overrides this inline when
+   branding.accentColor is configured; inline style wins over this rule. */
+:root {
+  --accent: #1d4ed8;
+}
+:root[data-theme="dark"] {
+  --accent: #60a5fa;
+}
+
 html,
 body,
 #root {
@@ -57,7 +66,7 @@ body {
   @apply bg-transparent p-0 text-zinc-800 dark:text-zinc-200;
 }
 .prose-chat a {
-  @apply underline text-sky-600 dark:text-sky-400;
+  @apply underline text-blue-700 dark:text-blue-400;
 }
 .prose-chat blockquote {
   @apply border-l-2 pl-3 my-2 border-zinc-300 text-zinc-500 dark:border-zinc-700 dark:text-zinc-400;

--- a/web/src/useAgent.ts
+++ b/web/src/useAgent.ts
@@ -104,7 +104,8 @@ type Action =
   | { type: "file_read_started"; path: string; requestId: string }
   | { type: "close_file_preview" }
   | { type: "file_search_started"; query: string; requestId: string }
-  | { type: "file_search_cleared" };
+  | { type: "file_search_cleared" }
+  | { type: "branding_loaded"; branding: Branding };
 
 /** Update the in-flight assistant item; append a new one when none exists (upsert). */
 function upsertLastAssistant(items: ChatItem[], update: (item: AssistantItem) => ChatItem): ChatItem[] {
@@ -168,6 +169,9 @@ function applySnapshot(state: AgentState, message: ServerMessage & { sessionId: 
 function reduce(state: AgentState, action: Action): AgentState {
   if (action.type === "connected") return { ...state, connected: true };
   if (action.type === "disconnected") return { ...state, connected: false };
+  // Fetched independently of the WS "hello" so it renders before the session is ready
+  // (see the /branding fetch below); "hello" still wins if it arrives with a different value.
+  if (action.type === "branding_loaded") return { ...state, branding: action.branding };
   if (action.type === "dismiss_notification") {
     return { ...state, notifications: state.notifications.filter((n) => n.id !== action.id) };
   }
@@ -342,6 +346,22 @@ export function useAgent() {
     if (socket && socket.readyState === WebSocket.OPEN) {
       socket.send(JSON.stringify(message));
     }
+  }, []);
+
+  // Branding is pure config (no session dependency) and served as soon as the process
+  // starts — fetch it directly instead of waiting on the WS "hello", which only arrives
+  // once the (slower) AgentSession runtime is ready.
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/branding")
+      .then((res) => (res.ok ? (res.json() as Promise<Branding>) : null))
+      .then((branding) => {
+        if (!cancelled && branding) dispatch({ type: "branding_loaded", branding });
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(() => {

--- a/web/src/useAgent.ts
+++ b/web/src/useAgent.ts
@@ -327,7 +327,19 @@ function reduce(state: AgentState, action: Action): AgentState {
   }
 }
 
-export function useAgent() {
+/** `serverUrl.replace(/^http/, "ws") + "/ws"`, or same-origin `/ws` when unset. */
+function wsUrlFor(serverUrl: string): string {
+  if (serverUrl) return `${serverUrl.replace(/^http/, "ws")}/ws`;
+  const protocol = location.protocol === "https:" ? "wss" : "ws";
+  return `${protocol}://${location.host}/ws`;
+}
+
+/**
+ * `serverUrl` is the pi-interface backend's origin (e.g. "https://api.example.com"),
+ * used by the embeddable widget (`embed/src/mount.tsx`) whose page isn't served by
+ * that backend. Defaults to "" — same-origin, the standalone app's behavior.
+ */
+export function useAgent(serverUrl = "") {
   const [state, dispatch] = useReducer(reduce, initialState);
   const socketRef = useRef<WebSocket | null>(null);
   // Mirrors of state read from inside the stable onmessage closure below (which
@@ -353,7 +365,7 @@ export function useAgent() {
   // once the (slower) AgentSession runtime is ready.
   useEffect(() => {
     let cancelled = false;
-    fetch("/branding")
+    fetch(`${serverUrl}/branding`)
       .then((res) => (res.ok ? (res.json() as Promise<Branding>) : null))
       .then((branding) => {
         if (!cancelled && branding) dispatch({ type: "branding_loaded", branding });
@@ -362,15 +374,14 @@ export function useAgent() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [serverUrl]);
 
   useEffect(() => {
     let retryTimer: number | undefined;
     let disposed = false;
 
     function connect() {
-      const protocol = location.protocol === "https:" ? "wss" : "ws";
-      const socket = new WebSocket(`${protocol}://${location.host}/ws`);
+      const socket = new WebSocket(wsUrlFor(serverUrl));
       socketRef.current = socket;
 
       socket.onopen = () => {
@@ -418,7 +429,7 @@ export function useAgent() {
       socketRef.current = null;
       socket?.close();
     };
-  }, [sendMessage]);
+  }, [sendMessage, serverUrl]);
 
   return {
     state,

--- a/web/src/useAgent.ts
+++ b/web/src/useAgent.ts
@@ -59,6 +59,8 @@ export interface AgentState {
   editorPrefill: { text: string; nonce: number } | null;
   fileTree: Record<string, DirState>;
   openFile: OpenFile | null;
+  /** Writable zone in the file browser; see SessionSnapshot.writableRoot. */
+  writableRoot?: string | null;
 }
 
 const initialState: AgentState = {
@@ -151,6 +153,7 @@ function applySnapshot(state: AgentState, message: ServerMessage & { sessionId: 
     widgets: {},
     extensionTitle: undefined,
     editorPrefill: null,
+    writableRoot: message.writableRoot,
   };
 }
 

--- a/web/src/useAgent.ts
+++ b/web/src/useAgent.ts
@@ -7,6 +7,7 @@ import type {
   ContextUsage,
   DirEntry,
   ExtensionUIRequest,
+  FileSearchEntry,
   ModelChoice,
   ServerMessage,
   SessionSummary,
@@ -35,6 +36,9 @@ export type OpenFile =
   | { status: "loaded"; path: string; content: string; size: number }
   | { status: "error"; path: string; message: string };
 
+/** Composer `@` mention autocomplete: results for the most recently issued search. */
+export type FileSearch = { status: "loading" | "loaded"; query: string; requestId: string; results: FileSearchEntry[] };
+
 export interface AgentState {
   connected: boolean;
   branding: Branding;
@@ -61,6 +65,7 @@ export interface AgentState {
   openFile: OpenFile | null;
   /** Writable zone in the file browser; see SessionSnapshot.writableRoot. */
   writableRoot?: string | null;
+  fileSearch: FileSearch | null;
 }
 
 const initialState: AgentState = {
@@ -86,6 +91,7 @@ const initialState: AgentState = {
   editorPrefill: null,
   fileTree: {},
   openFile: null,
+  fileSearch: null,
 };
 
 type Action =
@@ -96,7 +102,9 @@ type Action =
   | { type: "dialog_answered" }
   | { type: "dir_list_started"; path: string }
   | { type: "file_read_started"; path: string; requestId: string }
-  | { type: "close_file_preview" };
+  | { type: "close_file_preview" }
+  | { type: "file_search_started"; query: string; requestId: string }
+  | { type: "file_search_cleared" };
 
 /** Update the in-flight assistant item; append a new one when none exists (upsert). */
 function upsertLastAssistant(items: ChatItem[], update: (item: AssistantItem) => ChatItem): ChatItem[] {
@@ -171,6 +179,10 @@ function reduce(state: AgentState, action: Action): AgentState {
     return { ...state, openFile: { status: "loading", path: action.path, requestId: action.requestId } };
   }
   if (action.type === "close_file_preview") return { ...state, openFile: null };
+  if (action.type === "file_search_started") {
+    return { ...state, fileSearch: { status: "loading", query: action.query, requestId: action.requestId, results: [] } };
+  }
+  if (action.type === "file_search_cleared") return { ...state, fileSearch: null };
 
   const message = action.message;
   switch (message.type) {
@@ -268,6 +280,10 @@ function reduce(state: AgentState, action: Action): AgentState {
       }
       if (state.openFile?.status !== "loading" || state.openFile.requestId !== message.requestId) return state;
       return { ...state, openFile: { status: "error", path: message.path, message: message.message } };
+    case "file_search_results":
+      // Ignore stale responses from a since-superseded (or since-cleared) search
+      if (state.fileSearch?.requestId !== message.requestId) return state;
+      return { ...state, fileSearch: { ...state.fileSearch, status: "loaded", results: message.results } };
     case "extension_ui_request":
       switch (message.method) {
         case "select":
@@ -413,5 +429,12 @@ export function useAgent() {
       sendMessage({ type: "read_file", path, requestId });
     },
     closeFilePreview: () => dispatch({ type: "close_file_preview" }),
+    /** Search file/directory names for the composer's `@` mention autocomplete. */
+    searchFiles: (query: string) => {
+      const requestId = `search:${crypto.randomUUID()}`;
+      dispatch({ type: "file_search_started", query, requestId });
+      sendMessage({ type: "search_files", query, requestId });
+    },
+    clearFileSearch: () => dispatch({ type: "file_search_cleared" }),
   };
 }

--- a/web/src/useTheme.ts
+++ b/web/src/useTheme.ts
@@ -9,8 +9,13 @@ import { loadStoredTheme, resolveSystemTheme, storeTheme } from "./theme";
  * from a host page (`{ type: "pi-interface:set-theme", theme }` — for
  * embedding, independent of whether the toggle is enabled) wins over
  * `defaultTheme` from server config, which itself falls back to "system".
+ *
+ * `rootElement` is where `data-theme` is applied — `document.documentElement`
+ * for the standalone app, or the widget's own container element when mounted
+ * inside a Shadow DOM (see `embed/src/mount.tsx`), so `dark:` styling stays
+ * scoped to the widget instead of leaking onto the host page's `<html>`.
  */
-export function useTheme(defaultTheme: Theme, allowToggle: boolean) {
+export function useTheme(defaultTheme: Theme, allowToggle: boolean, rootElement: HTMLElement = document.documentElement) {
   const stored = allowToggle ? loadStoredTheme() : null;
   const [preference, setPreference] = useState<Theme>(stored ?? defaultTheme);
   const hasOverride = useRef(stored !== null);
@@ -43,8 +48,8 @@ export function useTheme(defaultTheme: Theme, allowToggle: boolean) {
   const resolved = preference === "system" ? systemTheme : preference;
 
   useLayoutEffect(() => {
-    document.documentElement.dataset.theme = resolved;
-  }, [resolved]);
+    rootElement.dataset.theme = resolved;
+  }, [rootElement, resolved]);
 
   const setTheme = useCallback(
     (next: Theme) => {
@@ -57,5 +62,5 @@ export function useTheme(defaultTheme: Theme, allowToggle: boolean) {
 
   const toggle = useCallback(() => setTheme(resolved === "dark" ? "light" : "dark"), [resolved, setTheme]);
 
-  return { theme: resolved, toggle };
+  return { theme: resolved, toggle, setTheme };
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -11,6 +11,8 @@ export default defineConfig({
         target: 'ws://127.0.0.1:3141',
         ws: true,
       },
+      '/branding': 'http://127.0.0.1:3141',
+      '/health': 'http://127.0.0.1:3141',
     },
   },
 })


### PR DESCRIPTION
## Summary

Started as a single bug fix and grew into a batch of related server/UI work done in one session. One commit per item below.

- **Fix server startup hang** — `runtime.session.bindExtensions()` was observed to never settle in some process contexts (spawned under `concurrently`/`Start-Process`, non-TTY stdout), and the startup path awaited it directly before `app.listen()`. Made it fire-and-forget with a 5s stall warning.
- **Fix file browser not auto-refreshing** — `announceFileChange()` fired on `tool_execution_start` (before the edit/write actually landed on disk), so directory/file refreshes raced the real write and usually lost. Now fires on `tool_execution_end`, only on success.
- **Sandbox compartmentalized into read-only and read-write zones** — new `sandbox.writableRoot` config: `sandbox.root` stays fully readable, edit/write are further confined to `writableRoot` (defaults to the whole root, backward compatible).
- **File explorer dims the read-only zone** — `writableRoot` exposed to the client via `SessionSnapshot`; entries outside it render in a dimmed font, matching the sandbox split above.
- **`@` file-mention autocomplete in the composer** — recursive, capped name search over the browser root (new `search_files`/`file_search_results` WS messages), dropdown shares keyboard nav with the existing `/` command autocomplete. Along the way, fixed a real bug: picking a suggestion by mouse click unmounted the dropdown and dropped focus to `<body>`, breaking further typing/Escape.
- **Configurable system prompt** — `systemPrompt` / `systemPromptFile` (full override) and `appendSystemPrompt` (additive), wired into the SDK's existing `resourceLoaderOptions`.
- **Branding no longer waits on the slow AgentSession runtime** — `config.branding` only reached the client via the WS `hello`, which couldn't arrive until models/extensions/skills finished loading (and `app.listen()` itself was gated behind that). New `GET /branding` route registered and listening *before* the runtime setup (via a stub-then-reassign pattern for `/ws`/`/health`, since Fastify forbids adding routes after `listen()`); client fetches it directly instead of waiting on `hello`.
- **Deeper default accent color** — swapped `sky-*` for `blue-*` in the chat bubble/links/notification toast, and gave `--accent` a real default (`blue-700`/`blue-400`) instead of falling back to plain `inherit`.
- **New `@pi-interface/embed` package** — `mount(container, options) -> { unmount, setTheme }`, mounts the existing React app into a Shadow DOM so Tailwind's reset and utility classes never leak onto (or collide with) a host app in either direction. React/ReactDOM are peer dependencies; everything else (Tailwind CSS, markdown/mermaid/highlight.js, shared protocol types) is compiled into the package with a Vite library build and rolled-up `.d.ts`. Required `web/src/App.tsx` (now `forwardRef`), `useAgent.ts`, and `useTheme.ts` to accept an optional backend URL and a scoped root element instead of always assuming `document`/same-origin.

## Test plan

- [x] `npm run typecheck` and `npm run build --workspaces --if-present` pass at every step
- [x] Manual server runs (`tsx src/index.ts` + `vite`) with Playwright-driven browser checks for each change: bindExtensions no longer blocks `app.listen()`; file browser refreshes after agent writes; sandbox write rejected outside `writableRoot` and allowed inside; explorer dims non-writable entries; `@` mention search, keyboard nav, and the focus-loss fix; `systemPrompt`/`systemPromptFile`/`appendSystemPrompt` config parsing and rejection cases; `/branding` reachable before the runtime finishes (log ordering) and the standalone app's branding fetch/hello fallback; new default blue in light/dark
- [x] Embed package: Shadow DOM isolation verified in both directions (host page styles untouched, widget fully styled), WS connects and branding loads via the `hello` fallback when the cross-origin `/branding` fetch is CORS-blocked (documented, expected — same-origin deployment avoids it), `setTheme()` flips the widget's theme live, a non-allowlisted origin's WS connection is still rejected, and the standalone app (`main.tsx`, no props) is unaffected
- [ ] Reviewer: confirm `pi-interface.config.json` / `pi-interface.config.example.json` changes match your deployment (`sandbox.writableRoot`, `systemPrompt*`, branding)
