### PR TITLE
Isolate skill loading and restrict the model switcher via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Optional. Create `pi-interface.config.json` next to where you launch the server 
 | `tools` | Tool allowlist in non-sandbox mode, e.g. `["read","grep","find","ls"]` |
 | `noExtensions` / `extensionPaths` | Disable extension discovery / load only listed extensions |
 | `noSkills` | Disable skill discovery entirely. Needed for real isolation: even with a custom `agentDir`, skills also auto-load from `~/.agents/skills` (hardcoded to the real home directory) and from `.agents/skills` walked up from `cwd` to the git root — neither is scoped by `agentDir` |
+| `noPromptTemplates` | Disable prompt template auto-discovery entirely (both `agentDir` and the project's `cwd/.pi/prompts`). Relevant when `cwd` points at a real project: it doubles as a resource-discovery root, so that project's own prompt templates load too unless disabled |
 | `allowedModels` | Restrict the model switcher to these `{ "provider", "id" }` pairs. Without it, every built-in model whose provider has configured auth is listed — often more variants than a given deployment (e.g. an air-gapped internal endpoint) actually serves |
 | `systemPrompt` / `systemPromptFile` | Replace pi's built-in system prompt entirely (mutually exclusive; `systemPromptFile` is a path to a text file). Project context files, skills, and `appendSystemPrompt` are still layered on top |
 | `appendSystemPrompt` | Array of extra paragraphs appended after the (built-in or custom) system prompt |

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Optional. Create `pi-interface.config.json` next to where you launch the server 
 | `tools` | Tool allowlist in non-sandbox mode, e.g. `["read","grep","find","ls"]` |
 | `noExtensions` / `extensionPaths` | Disable extension discovery / load only listed extensions |
 | `noSkills` | Disable skill discovery entirely. Needed for real isolation: even with a custom `agentDir`, skills also auto-load from `~/.agents/skills` (hardcoded to the real home directory) and from `.agents/skills` walked up from `cwd` to the git root — neither is scoped by `agentDir` |
+| `allowedModels` | Restrict the model switcher to these `{ "provider", "id" }` pairs. Without it, every built-in model whose provider has configured auth is listed — often more variants than a given deployment (e.g. an air-gapped internal endpoint) actually serves |
 | `systemPrompt` / `systemPromptFile` | Replace pi's built-in system prompt entirely (mutually exclusive; `systemPromptFile` is a path to a text file). Project context files, skills, and `appendSystemPrompt` are still layered on top |
 | `appendSystemPrompt` | Array of extra paragraphs appended after the (built-in or custom) system prompt |
 | `server.port` | Port to listen on (default `3141`, or the `PORT` env var if set) |

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Optional. Create `pi-interface.config.json` next to where you launch the server 
 | `sandbox.allowBash` | Adds bash — **not path-confined**, explicit opt-in (default `false`) |
 | `tools` | Tool allowlist in non-sandbox mode, e.g. `["read","grep","find","ls"]` |
 | `noExtensions` / `extensionPaths` | Disable extension discovery / load only listed extensions |
+| `noSkills` | Disable skill discovery entirely. Needed for real isolation: even with a custom `agentDir`, skills also auto-load from `~/.agents/skills` (hardcoded to the real home directory) and from `.agents/skills` walked up from `cwd` to the git root — neither is scoped by `agentDir` |
 | `systemPrompt` / `systemPromptFile` | Replace pi's built-in system prompt entirely (mutually exclusive; `systemPromptFile` is a path to a text file). Project context files, skills, and `appendSystemPrompt` are still layered on top |
 | `appendSystemPrompt` | Array of extra paragraphs appended after the (built-in or custom) system prompt |
 | `server.port` | Port to listen on (default `3141`, or the `PORT` env var if set) |

--- a/pi-interface.config.example.json
+++ b/pi-interface.config.example.json
@@ -10,6 +10,7 @@
   "noExtensions": true,
   "extensionPaths": [],
   "noSkills": true,
+  "noPromptTemplates": true,
   "allowedModels": [{ "provider": "anthropic", "id": "claude-sonnet-5" }],
   "appendSystemPrompt": ["Only discuss topics related to this project."],
   "server": {

--- a/pi-interface.config.example.json
+++ b/pi-interface.config.example.json
@@ -9,6 +9,7 @@
   },
   "noExtensions": true,
   "extensionPaths": [],
+  "noSkills": true,
   "appendSystemPrompt": ["Only discuss topics related to this project."],
   "server": {
     "port": 3141,

--- a/pi-interface.config.example.json
+++ b/pi-interface.config.example.json
@@ -10,6 +10,7 @@
   "noExtensions": true,
   "extensionPaths": [],
   "noSkills": true,
+  "allowedModels": [{ "provider": "anthropic", "id": "claude-sonnet-5" }],
   "appendSystemPrompt": ["Only discuss topics related to this project."],
   "server": {
     "port": 3141,

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -68,6 +68,13 @@ export interface AppConfig {
    */
   noSkills: boolean;
   /**
+   * Skip auto-discovering prompt templates entirely (both agentDir and the
+   * project's cwd/.pi/prompts). Like noSkills, cwd doubles as both the
+   * agent's working directory and a resource-discovery root, so pointing
+   * cwd at a real project pulls in that project's .pi/prompts too.
+   */
+  noPromptTemplates: boolean;
+  /**
    * Restrict the model switcher to exactly these provider/id pairs. Without
    * this, it lists every built-in model whose provider has configured auth —
    * often dozens of variants the deployment doesn't actually serve (e.g. an
@@ -141,6 +148,7 @@ export function loadConfig(baseCwd: string): AppConfig {
     noExtensions: false,
     extensionPaths: [],
     noSkills: false,
+    noPromptTemplates: false,
     appendSystemPrompt: [],
     port: Number(process.env.PORT ?? 3141),
     host: "127.0.0.1",
@@ -201,6 +209,7 @@ export function loadConfig(baseCwd: string): AppConfig {
   config.noExtensions = optionalBoolean(raw, "noExtensions", false);
   config.extensionPaths = (optionalStringArray(raw, "extensionPaths") ?? []).map(resolve);
   config.noSkills = optionalBoolean(raw, "noSkills", false);
+  config.noPromptTemplates = optionalBoolean(raw, "noPromptTemplates", false);
   config.allowedModels = optionalModelList(raw, "allowedModels");
 
   const systemPrompt = optionalString(raw, "systemPrompt");

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -60,6 +60,13 @@ export interface AppConfig {
   noExtensions: boolean;
   /** Explicit extension paths to load (in addition to defaults). */
   extensionPaths: string[];
+  /**
+   * Skip loading skills entirely. Needed for real isolation even with a custom
+   * agentDir: skills also auto-load from ~/.agents/skills (hardcoded to the real
+   * home directory, not agentDir) and from .agents/skills walked up from cwd to
+   * the git root — neither is scoped by agentDir.
+   */
+  noSkills: boolean;
   /** Replace pi's built-in system prompt entirely (tool guidelines are lost — write your own). */
   systemPrompt?: string;
   /** Extra text appended after the (built-in or custom) system prompt, one entry per paragraph. */
@@ -110,6 +117,7 @@ export function loadConfig(baseCwd: string): AppConfig {
     cwd: baseCwd,
     noExtensions: false,
     extensionPaths: [],
+    noSkills: false,
     appendSystemPrompt: [],
     port: Number(process.env.PORT ?? 3141),
     host: "127.0.0.1",
@@ -169,6 +177,7 @@ export function loadConfig(baseCwd: string): AppConfig {
   config.tools = optionalStringArray(raw, "tools");
   config.noExtensions = optionalBoolean(raw, "noExtensions", false);
   config.extensionPaths = (optionalStringArray(raw, "extensionPaths") ?? []).map(resolve);
+  config.noSkills = optionalBoolean(raw, "noSkills", false);
 
   const systemPrompt = optionalString(raw, "systemPrompt");
   const systemPromptFile = optionalString(raw, "systemPromptFile");

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -67,6 +67,13 @@ export interface AppConfig {
    * the git root — neither is scoped by agentDir.
    */
   noSkills: boolean;
+  /**
+   * Restrict the model switcher to exactly these provider/id pairs. Without
+   * this, it lists every built-in model whose provider has configured auth —
+   * often dozens of variants the deployment doesn't actually serve (e.g. an
+   * air-gapped internal endpoint). Omit to keep the unrestricted list.
+   */
+  allowedModels?: { provider: string; id: string }[];
   /** Replace pi's built-in system prompt entirely (tool guidelines are lost — write your own). */
   systemPrompt?: string;
   /** Extra text appended after the (built-in or custom) system prompt, one entry per paragraph. */
@@ -103,6 +110,22 @@ function optionalStringArray(raw: Record<string, unknown>, key: string): string[
     fail(`"${key}" must be an array of strings`);
   }
   return value as string[];
+}
+
+function optionalModelList(
+  raw: Record<string, unknown>,
+  key: string,
+): { provider: string; id: string }[] | undefined {
+  const value = raw[key];
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) fail(`"${key}" must be an array`);
+  return value.map((entry, i) => {
+    const obj = asObject(entry, `${key}[${i}]`);
+    const provider = optionalString(obj, "provider");
+    const id = optionalString(obj, "id");
+    if (!provider || !id) fail(`"${key}[${i}]" must have "provider" and "id" strings`);
+    return { provider, id };
+  });
 }
 
 function asObject(value: unknown, key: string): Record<string, unknown> {
@@ -178,6 +201,7 @@ export function loadConfig(baseCwd: string): AppConfig {
   config.noExtensions = optionalBoolean(raw, "noExtensions", false);
   config.extensionPaths = (optionalStringArray(raw, "extensionPaths") ?? []).map(resolve);
   config.noSkills = optionalBoolean(raw, "noSkills", false);
+  config.allowedModels = optionalModelList(raw, "allowedModels");
 
   const systemPrompt = optionalString(raw, "systemPrompt");
   const systemPromptFile = optionalString(raw, "systemPromptFile");

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -128,6 +128,7 @@ const createRuntime: CreateAgentSessionRuntimeFactory = async ({
         ? { additionalExtensionPaths: config.extensionPaths }
         : {}),
       ...(config.noSkills ? { noSkills: true } : {}),
+      ...(config.noPromptTemplates ? { noPromptTemplates: true } : {}),
       ...(config.systemPrompt !== undefined ? { systemPrompt: config.systemPrompt } : {}),
       ...(config.appendSystemPrompt.length > 0 ? { appendSystemPrompt: config.appendSystemPrompt } : {}),
       ...(seaExtensionFactories.length > 0 ? { extensionFactories: seaExtensionFactories } : {}),

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -165,7 +165,12 @@ function contextUsage(): ContextUsage | undefined {
 }
 
 function availableModels(): ModelChoice[] {
-  return runtime.services.modelRegistry.getAvailable().map((model) => ({
+  let models = runtime.services.modelRegistry.getAvailable();
+  if (config.allowedModels) {
+    const allowed = config.allowedModels;
+    models = models.filter((m) => allowed.some((a) => a.provider === m.provider && a.id === m.id));
+  }
+  return models.map((model) => ({
     provider: model.provider,
     id: model.id,
     name: model.name,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -127,6 +127,7 @@ const createRuntime: CreateAgentSessionRuntimeFactory = async ({
       ...(config.extensionPaths.length > 0
         ? { additionalExtensionPaths: config.extensionPaths }
         : {}),
+      ...(config.noSkills ? { noSkills: true } : {}),
       ...(config.systemPrompt !== undefined ? { systemPrompt: config.systemPrompt } : {}),
       ...(config.appendSystemPrompt.length > 0 ? { appendSystemPrompt: config.appendSystemPrompt } : {}),
       ...(seaExtensionFactories.length > 0 ? { extensionFactories: seaExtensionFactories } : {}),


### PR DESCRIPTION
## Summary

- **`noSkills` config** — a custom `agentDir` isolates auth/models/settings, but skills still auto-load from `~/.agents/skills` (hardcoded to the real home directory) and from `.agents/skills` walked up from `cwd` to the git root, neither of which is scoped by `agentDir`. `noSkills: true` (mirrors the existing `noExtensions`) disables skill discovery entirely for real isolation.
- **`allowedModels` config** — the model switcher lists every built-in model whose provider has configured auth, which can be far more variants than a deployment actually serves (e.g. an air-gapped internal endpoint fronting only one or two model IDs). `allowedModels` restricts it to an explicit `{ "provider", "id" }` allowlist while keeping the switcher itself for choosing among the configured models. Omit it to keep the unrestricted list (default, backward compatible).

Both are documented in the README config table and `pi-interface.config.example.json`.

## Test plan

- [x] `npm run typecheck` passes across all workspaces
- [x] `noSkills`: reproduced the leak (planted a test skill under `~/.agents/skills`, connected to an isolated instance via WS, confirmed it appeared in the command list), then confirmed `noSkills: true` removes it
- [x] `allowedModels`: verified `loadConfig()` parses a valid allowlist correctly and rejects malformed entries (missing `provider`/`id`)
- [ ] Reviewer: full `allowedModels` filtering wasn't exercised against real provider auth (no API keys in this dev environment) — worth a quick manual check that the switcher only shows the allowlisted models with real credentials configured

---
_Generated by [Claude Code](https://claude.ai/code/session_01HsnzX9rsdyPdy1Z63DxFhu)_