### PR TITLE
Rename project from pi-interface to pi-outpost

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,44 @@
-# Pi Interface
+# Pi Outpost
 
-Web UI for the [pi coding agent](https://github.com/earendil-works/pi), built on its [SDK](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/sdk.md).
+[![CI](https://github.com/laurentftech/pi-outpost/actions/workflows/ci.yml/badge.svg)](https://github.com/laurentftech/pi-outpost/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Node](https://img.shields.io/badge/node-%E2%89%A520-brightgreen)](https://nodejs.org)
+
+**A web chat UI for the [pi coding agent](https://github.com/earendil-works/pi)** — run it as a standalone app, or embed it as a Shadow-DOM-isolated widget inside any web app. Built directly on pi's [SDK](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/sdk.md).
 
 A Node server embeds a pi `AgentSession` and bridges it to a React chat UI over WebSocket: streaming responses, collapsible thinking blocks, live tool-execution cards (bash, edit, …), steering while the agent runs, and abort.
 
 <p align="center">
-  <img src="docs/screenshots/chat-light.png" alt="pi-interface, light theme" width="49%">
-  <img src="docs/screenshots/chat-dark.png" alt="pi-interface, dark theme" width="49%">
+  <img src="docs/screenshots/chat-light.png" alt="pi-outpost, light theme" width="49%">
+  <img src="docs/screenshots/chat-dark.png" alt="pi-outpost, dark theme" width="49%">
 </p>
 
-## Requirements
+## Contents
 
-- Node ≥ 20
-- [pi](https://github.com/earendil-works/pi) configured (`~/.pi/agent/auth.json` or provider env vars like `ANTHROPIC_API_KEY`)
+- [Features](#features)
+- [Quick start](#quick-start)
+- [Production (single process)](#production-single-process)
+- [Standalone configuration](#standalone-configuration)
+- [Embedding](#embedding)
+- [Architecture](#architecture)
 
-## Run
+## Features
+
+- Streaming chat (markdown, thinking blocks, mermaid diagrams)
+- Tool execution cards with live output
+- Steer / follow-up while streaming, abort
+- Model + thinking-level selectors
+- Session list / resume / new / delete
+- Collapsible file-browser sidebar: lazy-loaded tree + read-only preview (syntax-highlighted, Markdown rendered), confined to the same root the agent's own tools can see; entries outside `sandbox.writableRoot` render dimmed
+- Slash commands with autocompletion (`/` in the composer: extension commands, prompt templates, skills)
+- File mentions with autocompletion (`@` in the composer: recursive name search over the browser root, inserts the relative path)
+- Extension "Custom UI" support: dialogs, notifications, status/widgets, editor prefill (see below)
+- Standalone mode: own config dir, file sandbox, branding (see below)
+- Embeddable widget (`@pi-outpost/embed`): mount into any web app, isolated via Shadow DOM (see below)
+
+## Quick start
+
+Requirements: Node ≥ 20, and [pi](https://github.com/earendil-works/pi) configured (`~/.pi/agent/auth.json` or provider env vars like `ANTHROPIC_API_KEY`).
 
 ```bash
 npm install
@@ -40,23 +64,9 @@ Rebuild (`npm run build --workspace web`) and restart after any UI change — th
 
 Need to distribute a version that doesn't require Node.js installed at all (e.g. a Windows `.exe` for non-technical users)? See [`docs/sea-packaging.md`](docs/sea-packaging.md).
 
-## Features
-
-- Streaming chat (markdown, thinking blocks, mermaid diagrams)
-- Tool execution cards with live output
-- Steer / follow-up while streaming, abort
-- Model + thinking-level selectors
-- Session list / resume / new / delete
-- Collapsible file-browser sidebar: lazy-loaded tree + read-only preview (syntax-highlighted, Markdown rendered), confined to the same root the agent's own tools can see; entries outside `sandbox.writableRoot` render dimmed
-- Slash commands with autocompletion (`/` in the composer: extension commands, prompt templates, skills)
-- File mentions with autocompletion (`@` in the composer: recursive name search over the browser root, inserts the relative path)
-- Extension "Custom UI" support: dialogs, notifications, status/widgets, editor prefill (see below)
-- Standalone mode: own config dir, file sandbox, branding (see below)
-- Embeddable widget (`@pi-interface/embed`): mount into any web app, isolated via Shadow DOM (see below)
-
 ## Standalone configuration
 
-Optional. Create `pi-interface.config.json` next to where you launch the server (or point `PI_INTERFACE_CONFIG` at a file). See [`pi-interface.config.example.json`](pi-interface.config.example.json). Without it, the server behaves like a plain local pi (user's `~/.pi/agent`, full toolset).
+Optional. Create `pi-outpost.config.json` next to where you launch the server (or point `PI_OUTPOST_CONFIG` at a file). See [`pi-outpost.config.example.json`](pi-outpost.config.example.json). Without it, the server behaves like a plain local pi (user's `~/.pi/agent`, full toolset).
 
 | Key | Effect |
 |-----|--------|
@@ -88,13 +98,13 @@ Relative paths are resolved against the config file's directory.
 
 ## Embedding
 
-`embed/` publishes `@pi-interface/embed`, mounting pi-interface into any element inside a **Shadow DOM** — fully isolated from the host app's CSS in both directions, React supplied as a peer dependency (not bundled), everything else (Tailwind, markdown/mermaid/highlight.js, the shared protocol types) compiled into the package.
+`embed/` publishes `@pi-outpost/embed`, mounting pi-outpost into any element inside a **Shadow DOM** — fully isolated from the host app's CSS in both directions, React supplied as a peer dependency (not bundled), everything else (Tailwind, markdown/mermaid/highlight.js, the shared protocol types) compiled into the package.
 
 ```js
-import { mount } from "@pi-interface/embed";
+import { mount } from "@pi-outpost/embed";
 
 const widget = mount(document.getElementById("assistant"), {
-  serverUrl: "https://your-pi-interface-server", // omit for same-origin
+  serverUrl: "https://your-pi-outpost-server", // omit for same-origin
   theme: "dark", // optional; falls back to branding.defaultTheme, then "system"
 });
 
@@ -102,17 +112,17 @@ widget.setTheme("light"); // change the theme at runtime
 widget.unmount(); // tear down the React tree
 ```
 
-Build it with `npm run build --workspace @pi-interface/embed` (outputs ESM + CJS to `embed/dist/`, plus a rolled-up `.d.ts`), then publish `embed/` to your own registry.
+Build it with `npm run build --workspace @pi-outpost/embed` (outputs ESM + CJS to `embed/dist/`, plus a rolled-up `.d.ts`), then publish `embed/` to your own registry.
 
 Two things to configure on the server side regardless of deployment topology:
 
-- **`server.allowedOrigins`**: the widget's WebSocket connection carries the *host page's* origin (e.g. `https://your-app.example.com`), not pi-interface's own — add it explicitly, even same-domain deployments need this (only `localhost`/`127.0.0.1` are trusted automatically).
-- **CORS**: `/branding` and `/health` are plain HTTP endpoints with no CORS headers. They work with zero extra config when the widget and the backend share an origin (recommended: reverse-proxy pi-interface under your own domain). A genuinely cross-origin deployment needs a CORS layer in front — not built in yet.
+- **`server.allowedOrigins`**: the widget's WebSocket connection carries the *host page's* origin (e.g. `https://your-app.example.com`), not pi-outpost's own — add it explicitly, even same-domain deployments need this (only `localhost`/`127.0.0.1` are trusted automatically).
+- **CORS**: `/branding` and `/health` are plain HTTP endpoints with no CORS headers. They work with zero extra config when the widget and the backend share an origin (recommended: reverse-proxy pi-outpost under your own domain). A genuinely cross-origin deployment needs a CORS layer in front — not built in yet.
 
-A raw iframe (`<iframe src="https://your-pi-interface-server">`) still works too, and still honors `branding.allowThemeToggle: false` plus the host-driven theme channel:
+A raw iframe (`<iframe src="https://your-pi-outpost-server">`) still works too, and still honors `branding.allowThemeToggle: false` plus the host-driven theme channel:
 
 ```js
-iframeWindow.postMessage({ type: "pi-interface:set-theme", theme: "light" }, "https://your-pi-interface-origin")
+iframeWindow.postMessage({ type: "pi-outpost:set-theme", theme: "light" }, "https://your-pi-outpost-origin")
 ```
 
 ### Extension Custom UI

--- a/docs/sea-packaging.md
+++ b/docs/sea-packaging.md
@@ -1,4 +1,4 @@
-# Packaging pi-interface as a Windows executable (Node SEA)
+# Packaging pi-outpost as a Windows executable (Node SEA)
 
 Node's [Single Executable Applications](https://nodejs.org/api/single-executable-applications.html)
 (SEA) feature bundles the server into one `.exe` with the Node runtime baked
@@ -10,7 +10,7 @@ loading), but the final Windows-only steps (injecting into a real `node.exe`,
 code-signing) haven't been — verify on a real Windows machine before
 distributing.
 
-## Known limitation: `pi-interface.config.json`'s `extensionPaths` doesn't work
+## Known limitation: `pi-outpost.config.json`'s `extensionPaths` doesn't work
 
 Extensions loaded via `extensionPaths` are loaded dynamically at runtime by
 the SDK's `jiti`-based loader. That does not survive being bundled into a
@@ -64,30 +64,30 @@ Produces, in `server/dist/`:
 
 ```powershell
 # 1. Start from a real Windows node.exe (same major version used to build the blob)
-copy "C:\path\to\node.exe" pi-interface.exe
+copy "C:\path\to\node.exe" pi-outpost.exe
 
 # 2. Inject the blob (requires the `postject` npm package)
-npx postject pi-interface.exe NODE_SEA_BLOB server\dist\sea-prep.blob ^
+npx postject pi-outpost.exe NODE_SEA_BLOB server\dist\sea-prep.blob ^
   --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2 ^
   --overwrite
 
 # 3. Re-sign (requires signtool + a code-signing cert) — postject invalidates
 #    node.exe's original signature; an unsigned .exe reliably triggers
 #    Windows SmartScreen for a downloaded file
-signtool sign /fd SHA256 pi-interface.exe
+signtool sign /fd SHA256 pi-outpost.exe
 ```
 
 Then lay out the final folder so the server's existing static-file resolution
 (`../../web/dist` relative to where the bundle lives) keeps working:
 
 ```
-pi-interface\
-  pi-interface.exe
+pi-outpost\
+  pi-outpost.exe
   web\
     dist\            <- from `npm run build --workspace web`
-  pi-interface.config.json
+  pi-outpost.config.json
 ```
 
-`pi-interface.exe` run from that folder serves the UI, `/ws`, `/branding`,
+`pi-outpost.exe` run from that folder serves the UI, `/ws`, `/branding`,
 `/health` — same behavior as `npm run start`, just no Node.js install
 required on the machine running it.

--- a/embed/package.json
+++ b/embed/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "@pi-interface/embed",
+  "name": "@pi-outpost/embed",
   "version": "0.1.0",
   "type": "module",
-  "description": "Mount pi-interface as a Shadow-DOM-isolated widget inside another web app.",
-  "main": "./dist/pi-interface-embed.cjs",
-  "module": "./dist/pi-interface-embed.js",
+  "description": "Mount pi-outpost as a Shadow-DOM-isolated widget inside another web app.",
+  "main": "./dist/pi-outpost-embed.cjs",
+  "module": "./dist/pi-outpost-embed.js",
   "types": "./dist/mount.d.ts",
   "exports": {
     ".": {
       "types": "./dist/mount.d.ts",
-      "import": "./dist/pi-interface-embed.js",
-      "require": "./dist/pi-interface-embed.cjs"
+      "import": "./dist/pi-outpost-embed.js",
+      "require": "./dist/pi-outpost-embed.cjs"
     }
   },
   "files": [
@@ -25,7 +25,7 @@
     "typecheck": "tsc -b"
   },
   "devDependencies": {
-    "@pi-interface/shared": "*",
+    "@pi-outpost/shared": "*",
     "@tailwindcss/vite": "^4.3.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/embed/src/mount.tsx
+++ b/embed/src/mount.tsx
@@ -1,12 +1,12 @@
 import { createElement, createRef } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import type { Theme } from "@pi-interface/shared";
+import type { Theme } from "@pi-outpost/shared";
 import App, { type AppHandle } from "web/App";
 // eslint-disable-next-line import/no-unresolved -- resolved at build time via the `?inline` query (raw CSS string)
 import css from "web/index.css?inline";
 
 export interface MountOptions {
-  /** pi-interface backend origin, e.g. "https://api.example.com". Defaults to same-origin as the host page. */
+  /** pi-outpost backend origin, e.g. "https://api.example.com". Defaults to same-origin as the host page. */
   serverUrl?: string;
   /** Initial theme; falls back to the server's branding.defaultTheme, then "system". */
   theme?: Theme;
@@ -19,7 +19,7 @@ export interface MountHandle {
 }
 
 /**
- * Mounts pi-interface into `container` inside a Shadow DOM, fully isolated from the
+ * Mounts pi-outpost into `container` inside a Shadow DOM, fully isolated from the
  * host page's CSS in both directions (Tailwind's reset never touches the host page,
  * and the host page's styles never bleed into the widget).
  */

--- a/embed/vite.config.ts
+++ b/embed/vite.config.ts
@@ -15,8 +15,8 @@ export default defineConfig({
   build: {
     lib: {
       entry: 'src/mount.tsx',
-      name: 'PiInterfaceEmbed',
-      fileName: 'pi-interface-embed',
+      name: 'PiOutpostEmbed',
+      fileName: 'pi-outpost-embed',
       formats: ['es', 'cjs'],
     },
     rollupOptions: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "pi-interface",
+  "name": "pi-outpost",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pi-interface",
+      "name": "pi-outpost",
       "workspaces": [
         "shared",
         "server",
@@ -16,10 +16,10 @@
       }
     },
     "embed": {
-      "name": "@pi-interface/embed",
+      "name": "@pi-outpost/embed",
       "version": "0.1.0",
       "devDependencies": {
-        "@pi-interface/shared": "*",
+        "@pi-outpost/shared": "*",
         "@tailwindcss/vite": "^4.3.2",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
@@ -3012,15 +3012,15 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@pi-interface/embed": {
+    "node_modules/@pi-outpost/embed": {
       "resolved": "embed",
       "link": true
     },
-    "node_modules/@pi-interface/server": {
+    "node_modules/@pi-outpost/server": {
       "resolved": "server",
       "link": true
     },
-    "node_modules/@pi-interface/shared": {
+    "node_modules/@pi-outpost/shared": {
       "resolved": "shared",
       "link": true
     },
@@ -8520,12 +8520,12 @@
       }
     },
     "server": {
-      "name": "@pi-interface/server",
+      "name": "@pi-outpost/server",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "^0.80.3",
         "@fastify/static": "^9.3.0",
         "@fastify/websocket": "^11.0.2",
-        "@pi-interface/shared": "*",
+        "@pi-outpost/shared": "*",
         "fastify": "^5.3.0"
       },
       "devDependencies": {
@@ -8537,12 +8537,12 @@
       }
     },
     "shared": {
-      "name": "@pi-interface/shared"
+      "name": "@pi-outpost/shared"
     },
     "web": {
       "version": "0.0.0",
       "dependencies": {
-        "@pi-interface/shared": "*",
+        "@pi-outpost/shared": "*",
         "@tailwindcss/vite": "^4.3.2",
         "highlight.js": "^11.11.1",
         "katex": "^0.16.47",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pi-interface",
+  "name": "pi-outpost",
   "private": true,
   "workspaces": [
     "shared",

--- a/pi-outpost.config.example.json
+++ b/pi-outpost.config.example.json
@@ -1,6 +1,6 @@
 {
   "cwd": "./workspace",
-  "agentDir": "./.pi-interface-agent",
+  "agentDir": "./.pi-outpost-agent",
   "sandbox": {
     "root": "./workspace",
     "allowWrite": true,

--- a/server/package.json
+++ b/server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pi-interface/server",
+  "name": "@pi-outpost/server",
   "private": true,
   "type": "module",
   "scripts": {
@@ -13,7 +13,7 @@
     "@earendil-works/pi-coding-agent": "^0.80.3",
     "@fastify/static": "^9.3.0",
     "@fastify/websocket": "^11.0.2",
-    "@pi-interface/shared": "*",
+    "@pi-outpost/shared": "*",
     "fastify": "^5.3.0"
   },
   "devDependencies": {

--- a/server/scripts/build-sea.mjs
+++ b/server/scripts/build-sea.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 /**
- * Builds a Node SEA (Single Executable Application) blob for pi-interface's
+ * Builds a Node SEA (Single Executable Application) blob for pi-outpost's
  * server, for distribution as a standalone Windows .exe. See
  * docs/sea-packaging.md for the full walkthrough, including why extensions
- * must go through sea-extensions.ts instead of pi-interface.config.json's
+ * must go through sea-extensions.ts instead of pi-outpost.config.json's
  * extensionPaths, and the Windows-only steps this script can't do for you.
  *
  * Output layout (server/dist/), mirroring server/src/'s depth so the server's
@@ -72,17 +72,17 @@ console.log(`
   ${BLOB_PATH}
 
 Known limitation (see docs/sea-packaging.md): extensions loaded via
-pi-interface.config.json's "extensionPaths" do NOT work once bundled — add
+pi-outpost.config.json's "extensionPaths" do NOT work once bundled — add
 them as static imports in server/src/sea-extensions.ts instead, then re-run
 this script.
 
 Remaining steps happen on Windows (this script can only prepare the blob):
-  1. Copy a Windows node.exe (same major version as this build) to pi-interface.exe
-  2. npx postject pi-interface.exe NODE_SEA_BLOB "${BLOB_PATH}" ^
+  1. Copy a Windows node.exe (same major version as this build) to pi-outpost.exe
+  2. npx postject pi-outpost.exe NODE_SEA_BLOB "${BLOB_PATH}" ^
        --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2 ^
        --overwrite
-  3. (Windows only, requires signtool) re-sign pi-interface.exe — postject invalidates
+  3. (Windows only, requires signtool) re-sign pi-outpost.exe — postject invalidates
      the original Node signature, and an unsigned .exe will trigger SmartScreen
-  4. Place pi-interface.exe next to a "web" folder containing dist/ (i.e. web/dist/,
-     a sibling of where this script's bundle.js would sit) and a pi-interface.config.json
+  4. Place pi-outpost.exe next to a "web" folder containing dist/ (i.e. web/dist/,
+     a sibling of where this script's bundle.js would sit) and a pi-outpost.config.json
 `);

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,8 +1,8 @@
 /**
- * Standalone configuration for pi-interface.
+ * Standalone configuration for pi-outpost.
  *
- * Loaded from PI_INTERFACE_CONFIG (path to a JSON file) or
- * `pi-interface.config.json` in the launch directory. Everything is optional:
+ * Loaded from PI_OUTPOST_CONFIG (path to a JSON file) or
+ * `pi-outpost.config.json` in the launch directory. Everything is optional:
  * without a config file the server behaves like a plain local pi (user's
  * ~/.pi/agent config, full toolset, no branding).
  *
@@ -10,7 +10,7 @@
  */
 import fs from "node:fs";
 import path from "node:path";
-import { THEMES, type Theme } from "@pi-interface/shared";
+import { THEMES, type Theme } from "@pi-outpost/shared";
 
 export interface BrandingConfig {
   /** Header title. Default: "π". */
@@ -23,8 +23,8 @@ export interface BrandingConfig {
   defaultTheme?: Theme;
   /**
    * Whether the UI shows a theme toggle button. Default: true.
-   * Disable when embedding pi-interface in a host app that drives the theme
-   * itself (e.g. by posting `{ type: "pi-interface:set-theme", theme }`).
+   * Disable when embedding pi-outpost in a host app that drives the theme
+   * itself (e.g. by posting `{ type: "pi-outpost:set-theme", theme }`).
    */
   allowThemeToggle?: boolean;
 }
@@ -156,8 +156,8 @@ export function loadConfig(baseCwd: string): AppConfig {
     branding: {},
   };
 
-  const explicitPath = process.env.PI_INTERFACE_CONFIG;
-  const filePath = explicitPath ?? path.join(baseCwd, "pi-interface.config.json");
+  const explicitPath = process.env.PI_OUTPOST_CONFIG;
+  const filePath = explicitPath ?? path.join(baseCwd, "pi-outpost.config.json");
   if (!fs.existsSync(filePath)) {
     if (explicitPath) fail(`config file not found: ${explicitPath}`);
     return config;

--- a/server/src/convert.ts
+++ b/server/src/convert.ts
@@ -1,7 +1,7 @@
 /**
  * Conversion from SDK AgentMessage history to wire ChatItems.
  */
-import type { AssistantBlock, ChatItem } from "@pi-interface/shared";
+import type { AssistantBlock, ChatItem } from "@pi-outpost/shared";
 
 const MAX_TOOL_OUTPUT = 20_000;
 

--- a/server/src/fileBrowser.ts
+++ b/server/src/fileBrowser.ts
@@ -7,7 +7,7 @@
 import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { DirEntry, FileSearchEntry } from "@pi-interface/shared";
+import type { DirEntry, FileSearchEntry } from "@pi-outpost/shared";
 import type { AppConfig } from "./config.ts";
 import { isWithin, realResolve } from "./sandbox.ts";
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Pi-interface server: bridges a pi AgentSession to WebSocket clients.
+ * Pi-outpost server: bridges a pi AgentSession to WebSocket clients.
  *
  * SECURITY: binds to 127.0.0.1 only (protects against the network) and
  * validates the Origin header on WebSocket upgrades (protects against
@@ -30,7 +30,7 @@ import {
   type ServerMessage,
   type SessionSnapshot,
   THINKING_LEVELS,
-} from "@pi-interface/shared";
+} from "@pi-outpost/shared";
 import path from "node:path";
 import { loadConfig } from "./config.ts";
 import { assistantToItem, contentText, customMessageToItem, historyToItems, truncate } from "./convert.ts";
@@ -419,7 +419,7 @@ function createExtensionUIContext() {
       return undefined;
     },
     setTheme() {
-      return { success: false, error: "Theme switching not supported in pi-interface" };
+      return { success: false, error: "Theme switching not supported in pi-outpost" };
     },
     getToolsExpanded() {
       return false;
@@ -463,7 +463,7 @@ async function bindExtensionsForSession(): Promise<void> {
       shutdownHandler: () => {
         // Unlike pi's one-shot RPC subprocess, this server is long-lived and shared
         // across tabs/sessions — an extension asking to "shut down" shouldn't kill it.
-        console.warn("[pi] extension requested shutdown — ignored (pi-interface is a persistent server)");
+        console.warn("[pi] extension requested shutdown — ignored (pi-outpost is a persistent server)");
       },
       onError: (err) => {
         reportError(new Error(`[extension ${err.extensionPath}] ${err.error}`));

--- a/server/src/sea-extensions.ts
+++ b/server/src/sea-extensions.ts
@@ -4,7 +4,7 @@ import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
  * Extensions to bake into a SEA (Single Executable Application) build — see
  * server/scripts/build-sea.mjs and docs/sea-packaging.md.
  *
- * config.extensionPaths (pi-interface.config.json) loads extensions dynamically
+ * config.extensionPaths (pi-outpost.config.json) loads extensions dynamically
  * at runtime via the SDK's jiti-based loader, which does not survive being bundled
  * into a single file (confirmed: silently registers zero commands, no error).
  * extensionFactories sidesteps that entirely — the SDK just calls the function

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pi-interface/shared",
+  "name": "@pi-outpost/shared",
   "private": true,
   "type": "module",
   "exports": {

--- a/web/package.json
+++ b/web/package.json
@@ -15,7 +15,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@pi-interface/shared": "*",
+    "@pi-outpost/shared": "*",
     "@tailwindcss/vite": "^4.3.2",
     "highlight.js": "^11.11.1",
     "katex": "^0.16.47",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
-import type { Theme } from "@pi-interface/shared";
+import type { Theme } from "@pi-outpost/shared";
 import { AssistantMessage } from "./components/AssistantMessage";
 import { Composer } from "./components/Composer";
 import { CustomMessageCard } from "./components/CustomMessageCard";
@@ -19,7 +19,7 @@ export interface AppHandle {
 }
 
 interface AppProps {
-  /** pi-interface backend origin (e.g. "https://api.example.com"); "" (default) = same origin as this page. */
+  /** pi-outpost backend origin (e.g. "https://api.example.com"); "" (default) = same origin as this page. */
   serverUrl?: string;
   /**
    * Element `data-theme`/`--accent` are applied to. Defaults to

--- a/web/src/components/AssistantMessage.tsx
+++ b/web/src/components/AssistantMessage.tsx
@@ -3,7 +3,7 @@ import ReactMarkdown from "react-markdown";
 import rehypeKatex from "rehype-katex";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
-import type { ChatItem } from "@pi-interface/shared";
+import type { ChatItem } from "@pi-outpost/shared";
 import { CopyButton } from "./CopyButton";
 import { Mermaid } from "./Mermaid";
 

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { CommandInfo, FileSearchEntry } from "@pi-interface/shared";
+import type { CommandInfo, FileSearchEntry } from "@pi-outpost/shared";
 import type { FileSearch } from "../useAgent";
 
 interface ComposerProps {

--- a/web/src/components/CustomMessageCard.tsx
+++ b/web/src/components/CustomMessageCard.tsx
@@ -3,7 +3,7 @@ import ReactMarkdown from "react-markdown";
 import rehypeKatex from "rehype-katex";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
-import type { ChatItem } from "@pi-interface/shared";
+import type { ChatItem } from "@pi-outpost/shared";
 
 type CustomItem = Extract<ChatItem, { kind: "custom" }>;
 

--- a/web/src/components/FileTree.tsx
+++ b/web/src/components/FileTree.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { DirEntry } from "@pi-interface/shared";
+import type { DirEntry } from "@pi-outpost/shared";
 import type { DirState } from "../useAgent";
 
 interface TreeProps {

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import type { SessionSummary } from "@pi-interface/shared";
+import type { SessionSummary } from "@pi-outpost/shared";
 
 interface HeaderProps {
   title?: string;

--- a/web/src/components/ModelBar.tsx
+++ b/web/src/components/ModelBar.tsx
@@ -1,5 +1,5 @@
-import type { ContextUsage, ModelChoice, ThinkingLevel } from "@pi-interface/shared";
-import { THINKING_LEVELS } from "@pi-interface/shared";
+import type { ContextUsage, ModelChoice, ThinkingLevel } from "@pi-outpost/shared";
+import { THINKING_LEVELS } from "@pi-outpost/shared";
 
 interface ModelBarProps {
   model: string;

--- a/web/src/components/ToolCard.tsx
+++ b/web/src/components/ToolCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { ChatItem } from "@pi-interface/shared";
+import type { ChatItem } from "@pi-outpost/shared";
 
 type ToolItem = Extract<ChatItem, { kind: "tool" }>;
 

--- a/web/src/theme.ts
+++ b/web/src/theme.ts
@@ -1,6 +1,6 @@
-import type { Theme } from "@pi-interface/shared";
+import type { Theme } from "@pi-outpost/shared";
 
-const STORAGE_KEY = "pi-interface:theme";
+const STORAGE_KEY = "pi-outpost:theme";
 
 export function resolveSystemTheme(): "light" | "dark" {
   return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";

--- a/web/src/useAgent.ts
+++ b/web/src/useAgent.ts
@@ -12,7 +12,7 @@ import type {
   ServerMessage,
   SessionSummary,
   ThinkingLevel,
-} from "@pi-interface/shared";
+} from "@pi-outpost/shared";
 
 type AssistantItem = Extract<ChatItem, { kind: "assistant" }>;
 type ToolItem = Extract<ChatItem, { kind: "tool" }>;
@@ -335,7 +335,7 @@ function wsUrlFor(serverUrl: string): string {
 }
 
 /**
- * `serverUrl` is the pi-interface backend's origin (e.g. "https://api.example.com"),
+ * `serverUrl` is the pi-outpost backend's origin (e.g. "https://api.example.com"),
  * used by the embeddable widget (`embed/src/mount.tsx`) whose page isn't served by
  * that backend. Defaults to "" — same-origin, the standalone app's behavior.
  */

--- a/web/src/useTheme.ts
+++ b/web/src/useTheme.ts
@@ -1,12 +1,12 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
-import type { Theme } from "@pi-interface/shared";
+import type { Theme } from "@pi-outpost/shared";
 import { loadStoredTheme, resolveSystemTheme, storeTheme } from "./theme";
 
 /**
  * Resolves and applies the effective light/dark theme.
  *
  * Precedence: an explicit local pick (toggle button, persisted) or a message
- * from a host page (`{ type: "pi-interface:set-theme", theme }` — for
+ * from a host page (`{ type: "pi-outpost:set-theme", theme }` — for
  * embedding, independent of whether the toggle is enabled) wins over
  * `defaultTheme` from server config, which itself falls back to "system".
  *
@@ -28,7 +28,7 @@ export function useTheme(defaultTheme: Theme, allowToggle: boolean, rootElement:
   useEffect(() => {
     function onMessage(event: MessageEvent) {
       const data = event.data as { type?: string; theme?: string } | undefined;
-      if (data?.type !== "pi-interface:set-theme") return;
+      if (data?.type !== "pi-outpost:set-theme") return;
       if (data.theme !== "light" && data.theme !== "dark" && data.theme !== "system") return;
       hasOverride.current = true;
       setPreference(data.theme);


### PR DESCRIPTION
Code-level rename only: npm package scope (@pi-interface/* ->
@pi-outpost/*), the standalone config file name and its env var (pi-interface.config.json -> pi-outpost.config.json, PI_INTERFACE_CONFIG -> PI_OUTPOST_CONFIG), the localStorage/postMessage theme channel key, the embed library's global/file names, and all prose references in README.md and docs/sea-packaging.md. The GitHub repository itself is renamed separately (out of scope for this diff).

Verified: npm install regenerates a consistent lockfile, typecheck and build pass across all workspaces, and a smoke-tested server boots and serves /health and /branding correctly under the new names.


Claude-Session: https://claude.ai/code/session_01HsnzX9rsdyPdy1Z63DxFhu