### PR TITLE
Workflow actions v5, and publish through the trusted publisher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,10 @@ on:
 
 permissions:
   contents: read
-  # Signed provenance ("built from this commit, by this workflow") — npm mints it
-  # from GitHub's OIDC token, so publishing needs it even with an NPM_TOKEN.
+  # The OIDC token GitHub mints for this workflow. npm's trusted publisher for both
+  # packages names this repo and this file, so the token *is* the credential: no
+  # NPM_TOKEN, nothing to steal from the repo's secrets, and provenance is attested
+  # from it automatically.
   id-token: write
 
 jobs:
@@ -23,6 +25,10 @@ jobs:
           node-version: 22
           cache: npm
           registry-url: https://registry.npmjs.org
+
+      # Trusted publishing (OIDC) needs npm >= 11.5.1; Node 22 ships npm 10.
+      # Without this npm never even attempts OIDC, and asks for a token instead.
+      - run: npm install -g npm@latest
 
       - run: npm ci
 
@@ -60,10 +66,12 @@ jobs:
 
       # prepack rebuilds each package from this clean checkout, so what ships is what
       # was just tested — never a stale dist/ from someone's machine.
+      #
+      # No credential here on purpose: npm authenticates with the OIDC token above,
+      # against the trusted publisher registered for each package. `--provenance` is
+      # not passed either — trusted publishing attests it on its own.
       - name: Publish
         run: |
           for pkg in ${{ steps.plan.outputs.publish }}; do
-            npm publish --workspace "$pkg" --provenance
+            npm publish --workspace "$pkg"
           done
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Two changes to the workflows, both prompted by warnings/settings rather than by code.

**Actions v5.** GitHub already forces `actions/checkout@v4` and `actions/setup-node@v4` onto the Node 24 runner and warns about it on every run ([deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). v5 targets it natively.

**Trusted publishing (OIDC), no token.** Both `pi-outpost` and `@pi-outpost/embed` now register a trusted publisher on npm naming this repository and `release.yml`, so the OIDC token GitHub mints for the job *is* the credential. `NPM_TOKEN` is removed from the workflow — nothing left in the repo's secrets for an attacker to steal and publish `pi-outpost` with, which matters for a package people run with `npx`.

Two things that are easy to get wrong and are handled here:
- npm only attempts OIDC from **11.5.1** onward, and Node 22 ships npm 10 — so the job upgrades npm first. Without it, npm silently falls back to asking for a token.
- `--provenance` is dropped: trusted publishing attests provenance on its own.

**After this merges**, the npm package setting can safely move to *"Require two-factor authentication and disallow tokens (recommended)"* — the trusted publisher is not a token, so it keeps working, and the release path stops depending on a long-lived credential.

Next release (a `v*` tag) is what actually exercises the new publish path; the gates before it (typecheck, lint, 41 tests, build) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)