### PR TITLE
feat(ui): add sandbox config settings menu with lock enforcement

### DIFF
--- a/interactive-test/pi-outpost.config.json
+++ b/interactive-test/pi-outpost.config.json
@@ -7,6 +7,9 @@
     "writableRoot": "./workspace",
     "allowBash": false
   },
+  "sandboxLocks": {
+    "allowBash": true
+  },
   "noExtensions": true,
   "extensionPaths": ["./mon-ext/index.ts"],
   "noSkills": true,

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -53,6 +53,17 @@ export interface SandboxConfig {
   allowBash: boolean;
 }
 
+export interface SandboxLocks {
+  /** Whether sandbox.root is locked (not editable from UI). Default: false. */
+  root?: boolean;
+  /** Whether sandbox.allowWrite is locked. Default: false. */
+  allowWrite?: boolean;
+  /** Whether sandbox.allowBash is locked. Default: false. */
+  allowBash?: boolean;
+  /** Whether sandbox.writableRoot is locked. Default: false. */
+  writableRoot?: boolean;
+}
+
 export interface AppConfig {
   /** The file this configuration was read from — the one of four locations that won. */
   configFile: string;
@@ -62,6 +73,8 @@ export interface AppConfig {
   agentDir?: string;
   /** File-scoped sandbox. When set, built-in tools are replaced by scoped ones. */
   sandbox?: SandboxConfig;
+  /** Which sandbox fields the user's settings menu may not change. */
+  sandboxLocks?: SandboxLocks;
   /** Tool name allowlist (non-sandbox mode), e.g. ["read","grep","find","ls"]. */
   tools?: string[];
   /** Skip loading extensions entirely. */
@@ -344,6 +357,16 @@ export function loadConfig(
     if (config.sandbox.writableRoot && !fs.existsSync(config.sandbox.writableRoot)) {
       fail(`sandbox.writableRoot does not exist: ${config.sandbox.writableRoot}`);
     }
+  }
+
+  if (raw.sandboxLocks !== undefined) {
+    const locks = asObject(raw.sandboxLocks, "sandboxLocks");
+    config.sandboxLocks = {
+      root: optionalBoolean(locks, "root", false),
+      allowWrite: optionalBoolean(locks, "allowWrite", false),
+      allowBash: optionalBoolean(locks, "allowBash", false),
+      writableRoot: optionalBoolean(locks, "writableRoot", false),
+    };
   }
 
   config.tools = optionalStringArray(raw, "tools");

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -170,10 +170,10 @@ if (cli.command === "login") {
   }
 }
 
-const sandboxedTools = config.sandbox ? await createSandboxedTools(config.sandbox) : undefined;
-const BROWSER_ROOT = await resolveBrowserRoot(config);
-const WRITABLE_ROOT = await resolveWritableRoot(config, BROWSER_ROOT);
-const GIT = await probeGit(BROWSER_ROOT);
+let sandboxedTools = config.sandbox ? await createSandboxedTools(config.sandbox) : undefined;
+let BROWSER_ROOT = await resolveBrowserRoot(config);
+let WRITABLE_ROOT = await resolveWritableRoot(config, BROWSER_ROOT);
+let GIT = await probeGit(BROWSER_ROOT);
 
 // --- HTTP server ---------------------------------------------------------------
 //
@@ -560,6 +560,9 @@ function branchUserEntries(): { entryId: string; text: string }[] {
     .map((e) => ({ entryId: e.id, text: contentText(e.message!.content as never) }));
 }
 
+/** Sandbox paths to announce after updating. */
+let lastAnnouncedSandbox: { root: string; allowWrite: boolean; allowBash: boolean; writableRoot?: string } | undefined;
+
 function snapshot(): SessionSnapshot {
   const session = runtime.session;
   return {
@@ -579,6 +582,16 @@ function snapshot(): SessionSnapshot {
     writableRoot: WRITABLE_ROOT,
     gitAvailable: GIT !== null,
     credentials: credentialStatus(),
+    extensionPaths: session.extensionRunner.getExtensionPaths(),
+    sandbox: config.sandbox
+      ? {
+          root: config.sandbox.root,
+          allowWrite: config.sandbox.allowWrite ?? false,
+          allowBash: config.sandbox.allowBash ?? false,
+          writableRoot: config.sandbox.writableRoot,
+          locks: config.sandboxLocks,
+        }
+      : undefined,
   };
 }
 
@@ -1037,6 +1050,58 @@ async function handleSetCredential(socket: WebSocket, provider: string, apiKey: 
   }
   runtime.services.modelRegistry.refresh();
   await adoptUsableModel(socket);
+}
+
+/**
+ * Update sandbox config at runtime. Re-resolves the file browser paths and
+ * creates a fresh session so new tool restrictions take effect for subsequent
+ * turns. The running turn (if any) continues under the old sandbox.
+ */
+async function handleUpdateConfig(
+  socket: WebSocket,
+  newSandbox: { root: string; allowWrite: boolean; allowBash: boolean; writableRoot?: string },
+): Promise<void> {
+  if (replacingSession) {
+    send(socket, { type: "error", message: "Session change already in progress" });
+    return;
+  }
+
+  // Enforce locks from config: locked fields keep their current value
+  const locks = config.sandboxLocks ?? {};
+  const mergedSandbox = {
+    root: locks.root ? config.sandbox!.root : newSandbox.root,
+    allowWrite: locks.allowWrite ? config.sandbox!.allowWrite : newSandbox.allowWrite,
+    allowBash: locks.allowBash ? config.sandbox!.allowBash : newSandbox.allowBash,
+    writableRoot: locks.writableRoot ? config.sandbox!.writableRoot : newSandbox.writableRoot,
+  };
+
+  replacingSession = true;
+  try {
+    // Persist to the live config object so the next server start remembers
+    config.sandbox = {
+      root: mergedSandbox.root,
+      allowWrite: mergedSandbox.allowWrite,
+      allowBash: mergedSandbox.allowBash,
+      writableRoot: mergedSandbox.writableRoot,
+    };
+    BROWSER_ROOT = await resolveBrowserRoot(config);
+    WRITABLE_ROOT = await resolveWritableRoot(config, BROWSER_ROOT);
+    GIT = await probeGit(BROWSER_ROOT);
+    sandboxedTools = config.sandbox ? await createSandboxedTools(config.sandbox) : undefined;
+    // Replace the current session so the new runtime picks up the updated tools
+    const { cancelled } = await runtime.newSession();
+    if (!cancelled) await rebindAndAnnounce();
+  } catch (error) {
+    reportError(error);
+    try {
+      const { cancelled } = await runtime.newSession();
+      if (!cancelled) await rebindAndAnnounce();
+    } catch (recoveryError) {
+      reportError(recoveryError);
+    }
+  } finally {
+    replacingSession = false;
+  }
 }
 
 /** Declare an OpenAI-compatible endpoint: live for this session, and persisted for the next. */
@@ -1765,6 +1830,23 @@ function handleClientMessage(socket: WebSocket, raw: string): void {
         ...(message.compat ? { compat: message.compat } : {}),
       }).catch(reportError);
       break;
+    case "update_config": {
+      if (config.sandbox === undefined) {
+        send(socket, { type: "error", message: "No sandbox configured — cannot update" });
+        return;
+      }
+      if (
+        typeof message.sandbox?.root !== "string" ||
+        typeof message.sandbox.allowWrite !== "boolean" ||
+        typeof message.sandbox.allowBash !== "boolean" ||
+        (message.sandbox.writableRoot !== undefined && typeof message.sandbox.writableRoot !== "string")
+      ) {
+        send(socket, { type: "error", message: "Invalid sandbox config" });
+        return;
+      }
+      handleUpdateConfig(socket, message.sandbox).catch(reportError);
+      break;
+    }
   }
 }
 

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -227,6 +227,17 @@ export interface SessionSnapshot {
   gitAvailable?: boolean;
   /** Which providers are usable, and whether the agent can answer at all. Never carries a key. */
   credentials?: CredentialStatus;
+  /** Absolute paths of loaded extension files. */
+  extensionPaths?: string[];
+  /** Sandbox configuration — absent when no sandbox is configured. */
+  sandbox?: {
+    root: string;
+    allowWrite: boolean;
+    allowBash: boolean;
+    writableRoot?: string;
+    /** Which fields the settings menu must not allow editing — set from config.sandboxLocks. */
+    locks?: { root?: boolean; allowWrite?: boolean; allowBash?: boolean; writableRoot?: boolean };
+  };
 }
 
 /**
@@ -322,6 +333,8 @@ export type ServerMessage =
   | { type: "git_log"; requestId: string; entries: GitLogEntry[] }
   | { type: "git_show"; requestId: string; sha: string; patch: string; truncated: boolean }
   | { type: "git_error"; requestId: string; message: string }
+  /** Sandbox config was updated — carries the full new snapshot after session replacement. */
+  | ({ type: "update_config_ack" } & SessionSnapshot)
   | ExtensionUIRequest;
 
 /** Client -> server */
@@ -373,6 +386,8 @@ export type ClientMessage =
   | { type: "set_credential"; provider: string; apiKey: string }
   /** Declare an OpenAI-compatible endpoint (a corporate gateway, vLLM, Ollama…). */
   | { type: "declare_provider"; provider: string; baseUrl: string; apiKey: string; models: string[]; compat?: ProviderCompat }
+  /** Update the sandbox config at runtime — server will replace the session with the new settings. */
+  | { type: "update_config"; sandbox: { root: string; allowWrite: boolean; allowBash: boolean; writableRoot?: string } }
   | ExtensionUIResponse;
 
 /**

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -87,6 +87,7 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
     clearGitShow,
     setCredential,
     declareProvider,
+    updateConfig,
   } = useAgent(serverUrl, token, embedded);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [attachments, setAttachments] = useState<Attachment[]>([]);
@@ -345,6 +346,9 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
             gitAvailable={state.gitAvailable}
             gitStatus={state.gitStatus}
             gitLog={state.gitLog}
+            extensionPaths={state.extensionPaths}
+            sandbox={state.sandbox}
+            onUpdateConfig={updateConfig}
             onFetchGitLog={fetchGitLog}
             onShowCommit={fetchGitShow}
           />

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { MIN_SESSION_QUERY_LENGTH, type GitLogEntry, type SessionSummary, type TreeNode } from "@pi-outpost/shared";
 import type { GitStatusState, SessionSearch } from "../useAgent";
 import { GitMenu } from "./GitMenu";
+import { SettingsMenu } from "./SettingsMenu";
 import { TreeMenu } from "./TreeMenu";
 
 interface HeaderProps {
@@ -23,6 +24,9 @@ interface HeaderProps {
   gitAvailable: boolean;
   gitStatus: GitStatusState | null;
   gitLog: GitLogEntry[] | null;
+  extensionPaths: string[];
+  sandbox: { root: string; allowWrite: boolean; allowBash: boolean; writableRoot?: string } | null;
+  onUpdateConfig: (sandbox: { root: string; allowWrite: boolean; allowBash: boolean; writableRoot?: string }) => void;
   onToggleSidebar: () => void;
   onToggleHideTools: () => void;
   onToggleTheme: () => void;
@@ -372,6 +376,11 @@ export function Header(props: HeaderProps) {
           onRenameSession={props.onRenameSession}
           onSearchSessions={props.onSearchSessions}
           onClearSessionSearch={props.onClearSessionSearch}
+        />
+        <SettingsMenu
+          extensionPaths={props.extensionPaths}
+          sandbox={props.sandbox}
+          onUpdateConfig={props.onUpdateConfig}
         />
         <span
           className={`h-2 w-2 rounded-full ${connected ? "bg-emerald-500" : "bg-red-500"}`}

--- a/web/src/components/SettingsMenu.tsx
+++ b/web/src/components/SettingsMenu.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useRef, useState } from "react";
+
+interface SandboxConfig {
+  root: string;
+  allowWrite: boolean;
+  allowBash: boolean;
+  writableRoot?: string;
+  locks?: { root?: boolean; allowWrite?: boolean; allowBash?: boolean; writableRoot?: boolean };
+}
+
+interface SettingsMenuProps {
+  extensionPaths: string[];
+  sandbox: SandboxConfig | null;
+  onUpdateConfig: (sandbox: SandboxConfig) => void;
+}
+
+function useClickOutside(onClose: () => void) {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    function handler(event: MouseEvent) {
+      if (ref.current && !ref.current.contains(event.target as Node)) onClose();
+    }
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [onClose]);
+  return ref;
+}
+
+export function SettingsMenu({ extensionPaths, sandbox, onUpdateConfig }: SettingsMenuProps) {
+  const [open, setOpen] = useState(false);
+  const [sandboxRoot, setSandboxRoot] = useState("");
+  const [sandboxWritableRoot, setSandboxWritableRoot] = useState("");
+  const [sandboxAllowWrite, setSandboxAllowWrite] = useState(false);
+  const [sandboxAllowBash, setSandboxAllowBash] = useState(false);
+  const [applying, setApplying] = useState(false);
+  const ref = useClickOutside(() => setOpen(false));
+
+  // Sync local state when sandbox config changes (e.g. after apply ack)
+  useEffect(() => {
+    if (sandbox) {
+      setSandboxRoot(sandbox.root);
+      setSandboxWritableRoot(sandbox.writableRoot ?? "");
+      setSandboxAllowWrite(sandbox.allowWrite);
+      setSandboxAllowBash(sandbox.allowBash);
+    }
+  }, [sandbox]);
+
+  function close() {
+    setOpen(false);
+    setApplying(false);
+  }
+
+  function handleApply() {
+    if (!sandbox) return;
+    setApplying(true);
+    // Always send all fields; the server enforces locks, so skipping locked
+    // fields here would fail server-side validation (typeof check on missing bools).
+    const payload: SandboxConfig = {
+      root: sandboxRoot,
+      allowWrite: sandboxAllowWrite,
+      allowBash: sandboxAllowBash,
+      writableRoot: sandboxWritableRoot.trim() || undefined,
+    };
+    onUpdateConfig(payload);
+    close();
+  }
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        title="Settings"
+        aria-label="Settings"
+        className="rounded-md border border-zinc-300 px-2 py-1 text-xs text-zinc-500 hover:border-zinc-400 hover:text-zinc-700 dark:border-zinc-800 dark:text-zinc-400 dark:hover:border-zinc-600 dark:hover:text-zinc-200"
+      >
+        ⚙
+      </button>
+      {open && (
+        <div className="absolute right-0 top-full z-20 mt-1 flex max-h-[80vh] w-[380px] flex-col rounded-lg border border-zinc-200 bg-white shadow-xl dark:border-zinc-700 dark:bg-zinc-900">
+          <div className="border-b border-zinc-200 px-4 py-3 dark:border-zinc-800">
+            <h2 className="text-sm font-semibold text-zinc-800 dark:text-zinc-200">Settings</h2>
+          </div>
+
+          <div className="min-h-0 overflow-y-auto p-4">
+            {/* Extensions section */}
+            <section className="mb-4">
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+                Extensions
+              </h3>
+              {extensionPaths.length === 0 ? (
+                <p className="text-xs text-zinc-400 dark:text-zinc-500">No extensions loaded</p>
+              ) : (
+                <ul className="space-y-1">
+                  {extensionPaths.map((p, i) => (
+                    <li key={i} className="truncate rounded bg-zinc-50 px-2 py-1 text-xs text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400" title={p}>
+                      {p}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+
+            {/* Sandbox section */}
+            {sandbox && (
+              <section>
+                <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+                  Sandbox
+                </h3>
+                  <div className="space-y-3">
+                    <label className="block">
+                      <span className="text-xs text-zinc-600 dark:text-zinc-400">
+                        Root {sandbox.locks?.root ? <span className="text-zinc-400">(locked)</span> : null}
+                      </span>
+                      <input
+                        type="text"
+                        value={sandboxRoot}
+                        onChange={(e) => setSandboxRoot(e.target.value)}
+                        disabled={sandbox.locks?.root}
+                        className="mt-1 w-full rounded-md border border-zinc-300 bg-transparent px-2 py-1 text-sm outline-none focus:border-zinc-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:focus:border-zinc-500"
+                      />
+                    </label>
+                    <label className="block">
+                      <span className="text-xs text-zinc-600 dark:text-zinc-400">
+                        Writable root (optional) {sandbox.locks?.writableRoot ? <span className="text-zinc-400">(locked)</span> : null}
+                      </span>
+                      <input
+                        type="text"
+                        value={sandboxWritableRoot}
+                        onChange={(e) => setSandboxWritableRoot(e.target.value)}
+                        disabled={sandbox.locks?.writableRoot}
+                        placeholder="Same as root"
+                        className="mt-1 w-full rounded-md border border-zinc-300 bg-transparent px-2 py-1 text-sm outline-none placeholder:text-zinc-400 focus:border-zinc-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:placeholder:text-zinc-600 dark:focus:border-zinc-500"
+                      />
+                    </label>
+                    <label className="flex items-center gap-2">
+                      <input
+                        type="checkbox"
+                        checked={sandboxAllowWrite}
+                        onChange={(e) => setSandboxAllowWrite(e.target.checked)}
+                        disabled={sandbox.locks?.allowWrite}
+                        className="rounded border-zinc-300 text-zinc-700 focus:ring-zinc-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
+                      />
+                      <span className="text-xs text-zinc-600 dark:text-zinc-400">
+                        Allow write {sandbox.locks?.allowWrite ? <span className="text-zinc-400">(locked)</span> : null}
+                      </span>
+                    </label>
+                    <label className="flex items-center gap-2">
+                      <input
+                        type="checkbox"
+                        checked={sandboxAllowBash}
+                        onChange={(e) => setSandboxAllowBash(e.target.checked)}
+                        disabled={sandbox.locks?.allowBash}
+                        className="rounded border-zinc-300 text-zinc-700 focus:ring-zinc-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
+                      />
+                      <span className="text-xs text-zinc-600 dark:text-zinc-400">
+                        Allow bash {sandbox.locks?.allowBash ? <span className="text-zinc-400">(locked)</span> : null}
+                      </span>
+                    </label>
+                  <button
+                    type="button"
+                    disabled={applying || !sandboxRoot.trim()}
+                    onClick={handleApply}
+                    className="w-full rounded-md bg-zinc-800 px-3 py-1.5 text-xs font-medium text-white hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-zinc-200 dark:text-zinc-900 dark:hover:bg-zinc-300"
+                  >
+                    {applying ? "Applying…" : "Apply & restart session"}
+                  </button>
+                  <p className="text-[11px] text-zinc-400 dark:text-zinc-500">
+                    File browser paths update immediately. Agent tools (read/write/bash) use the new sandbox after a server restart.
+                  </p>
+                </div>
+              </section>
+            )}
+            {!sandbox && (
+              <p className="text-xs text-zinc-400 dark:text-zinc-500">No sandbox configured</p>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/useAgent.ts
+++ b/web/src/useAgent.ts
@@ -118,6 +118,8 @@ export interface AgentState {
   /** Which providers can answer; drives the onboarding screen. Never carries a key. */
   credentials: CredentialStatus | null;
   fileSearch: FileSearch | null;
+  extensionPaths: string[];
+  sandbox: { root: string; allowWrite: boolean; allowBash: boolean; writableRoot?: string } | null;
   gitAvailable: boolean;
   gitStatus: GitStatusState | null;
   /** Worktree-vs-HEAD contents for the viewer's diff toggle. */
@@ -153,6 +155,8 @@ const initialState: AgentState = {
   fileTree: {},
   openFile: null,
   fileSearch: null,
+  extensionPaths: [],
+  sandbox: null,
   gitAvailable: false,
   credentials: null,
   gitStatus: null,
@@ -211,7 +215,7 @@ function upsertTool(items: ChatItem[], toolCallId: string, toolName: string, pat
 }
 
 function applySnapshot(state: AgentState, message: ServerMessage & { sessionId: string }): AgentState {
-  if (message.type !== "hello" && message.type !== "session_replaced") return state;
+  if (message.type !== "hello" && message.type !== "session_replaced" && message.type !== "update_config_ack") return state;
   const current = message.models.find((m) => `${m.provider}/${m.id}` === message.model);
   return {
     ...state,
@@ -242,6 +246,8 @@ function applySnapshot(state: AgentState, message: ServerMessage & { sessionId: 
     writableRoot: message.writableRoot,
     gitAvailable: message.gitAvailable === true,
     credentials: message.credentials ?? null,
+    extensionPaths: message.extensionPaths ?? [],
+    sandbox: message.sandbox ?? null,
   };
 }
 
@@ -301,6 +307,7 @@ function reduce(state: AgentState, action: Action): AgentState {
   switch (message.type) {
     case "hello":
     case "session_replaced":
+    case "update_config_ack":
       return applySnapshot(state, message);
     case "sessions":
       return { ...state, sessions: message.sessions };
@@ -795,5 +802,8 @@ export function useAgent(serverUrl = "", explicitToken?: string, embedded = fals
     /** Onboarding: declare an OpenAI-compatible endpoint (corporate gateway, vLLM, Ollama…). */
     declareProvider: (declaration: { provider: string; baseUrl: string; apiKey: string; models: string[]; compat?: ProviderCompat }) =>
       sendMessage({ type: "declare_provider", ...declaration }),
+    /** Update sandbox config at runtime. */
+    updateConfig: (sandbox: { root: string; allowWrite: boolean; allowBash: boolean; writableRoot?: string }) =>
+      sendMessage({ type: "update_config", sandbox }),
   };
 }


### PR DESCRIPTION
- shared/src/protocol.ts: Add sandbox (+locks) and extensionPaths to SessionSnapshot; add update_config / update_config_ack message types
- server/src/config.ts: Add SandboxLocks interface and sandboxLocks field to AppConfig with config parsing
- server/src/index.ts: Add handleUpdateConfig() that reinitialises the session with new sandbox values while enforcing locks; update snapshot() to expose sandbox config; convert runtime globals from const to let
- web/src/useAgent.ts: Handle sandbox (+locks) and extensionPaths in AgentState; add updateConfig() API; handle update_config_ack in reducer
- web/src/components/SettingsMenu.tsx: New SettingsMenu component with gear button, extensions list, and editable sandbox fields with disabled/locked field UX
- web/src/App.tsx, web/src/components/Header.tsx: Wire SettingsMenu
- interactive-test/pi-outpost.config.json: sandboxLocks.allowBash: true for testing lock behaviour