### PR TITLE
test(server): clear waitFor timers so test files exit when they finish

### DIFF
--- a/server/test/credentials.test.mjs
+++ b/server/test/credentials.test.mjs
@@ -41,12 +41,19 @@ test("an unconfigured server reports no usable model, then onboards without a re
 
     client.send({ type: "set_credential", provider: "anthropic", apiKey: "sk-ant-not-a-real-key" });
 
-    // The pi SDK may make network calls when registering the key (cache refresh,
-    // provider metadata), so allow longer than the default 60 s waitFor timeout.
-    // CI runners can take 90+ s for the SDK's network calls to time out, so we
-    // grant 180 s — the node --test-timeout (300 s) still has headroom for the
-    // rest of the test after this wait.
-    const replaced = await client.waitFor((m) => m.type === "credentials_changed", 180_000);
+    // Registering the key stays local: the SDK's anthropic provider declares no
+    // api-key `check`, so the availability pass behind set_credential resolves the
+    // credential from disk without a request. The default 60 s wait is generous —
+    // the whole exchange is a few hundred milliseconds. Earlier this wait was raised
+    // to 180 s to absorb "SDK network calls" that never happen; what it really
+    // absorbed was the harness leaking its own timer (see waitFor).
+    const replaced = await client
+      .waitFor((m) => m.type === "credentials_changed")
+      // Nothing else tells us why the server stayed silent, and this test only ever
+      // fails on CI — carry the server's own output into the failure.
+      .catch((error) => {
+        throw new Error(`${error.message}\n--- server log ---\n${server.log()}`);
+      });
     assert.equal(replaced.credentials.usableModel, true, "the agent can answer now");
     const anthropic = replaced.credentials.providers.find((provider) => provider.id === "anthropic");
     assert.equal(anthropic.configured, true);

--- a/server/test/harness.mjs
+++ b/server/test/harness.mjs
@@ -139,13 +139,17 @@ export function connect(url) {
     for (const waiter of [...waiters]) {
       if (waiter.matches(message)) {
         waiters.splice(waiters.indexOf(waiter), 1);
+        clearTimeout(waiter.timer);
         waiter.resolve(message);
       }
     }
   });
   ws.on("close", (code) => {
     closeInfo = { code };
-    for (const waiter of waiters.splice(0)) waiter.reject(new Error(`socket closed (${code})`));
+    for (const waiter of waiters.splice(0)) {
+      clearTimeout(waiter.timer);
+      waiter.reject(new Error(`socket closed (${code})`));
+    }
   });
 
   return {
@@ -153,29 +157,39 @@ export function connect(url) {
     received,
     closed: () => closeInfo,
     send: (message) => ws.send(JSON.stringify(message)),
-    /** First message matching `match` (a type string or predicate), or reject on timeout. */
+    /**
+     * First message matching `match` (a type string or predicate), or reject on timeout.
+     *
+     * The timer is cleared the moment the wait settles. Left running, it holds the event
+     * loop open for its full duration *after the test has passed*: a file whose longest
+     * wait is 180 s exits 180 s late, and node --test counts that idle process against
+     * its concurrency limit — starving the remaining files on a CI runner.
+     */
     waitFor(match, timeoutMs = 60_000) {
       const predicate = typeof match === "string" ? (m) => m.type === match : match;
       const existing = received.find(predicate);
       if (existing) return Promise.resolve(existing);
       return new Promise((resolve, reject) => {
         const waiter = { matches: predicate, resolve, reject };
-        waiters.push(waiter);
-        setTimeout(() => {
+        waiter.timer = setTimeout(() => {
           const i = waiters.indexOf(waiter);
           if (i >= 0) {
             waiters.splice(i, 1);
             reject(new Error(`timed out waiting for ${typeof match === "string" ? match : "predicate"}`));
           }
         }, timeoutMs);
+        waiters.push(waiter);
       });
     },
     /** Resolves with the close code (never rejects) — for auth rejection tests. */
     waitForClose(timeoutMs = 10_000) {
       if (closeInfo) return Promise.resolve(closeInfo.code);
       return new Promise((resolve, reject) => {
-        ws.on("close", (code) => resolve(code));
-        setTimeout(() => reject(new Error("socket did not close")), timeoutMs);
+        const timer = setTimeout(() => reject(new Error("socket did not close")), timeoutMs);
+        ws.on("close", (code) => {
+          clearTimeout(timer);
+          resolve(code);
+        });
       });
     },
     open() {


### PR DESCRIPTION
Fixes #27.

`connect().waitFor()` in `server/test/harness.mjs` created its rejection timer and never cleared it on success. The timer then held the event loop open for its full duration **after the test had already passed**.

| | test body | file wall time |
|---|---|---|
| `credentials.test.mjs` before | 3.3 s | **183 s** |
| after | 3.3 s | **12.7 s** |
| full server suite before | — | **188 s** |
| after | — | **87 s** |

183 s is exactly the 180 s cap that one test passes explicitly.

That idle time is what made CI flaky rather than merely slow: `node --test` counts a live-but-idle file process against its concurrency limit, so finished files keep occupying slots and the remaining ones start under contention on a 4-core runner — long enough for a real server spawn plus WebSocket handshake to miss even a generous deadline.

## Changes

- Clear the timer wherever a wait settles: on match, on socket close, and in `waitForClose` (which leaked a 10 s timer the same way).
- Drop the 180 s override back to the 60 s default. Its stated reason — "the SDK may make network calls when registering the key" — does not hold: `set_credential` ends in `ModelRuntime.refreshProviderAvailability`, and the SDK's anthropic provider declares only an api-key `resolve` (reads the credential off disk), no `check`. `ModelRuntime.create` also defaults `allowModelNetwork: false`.
- On failure, attach the captured server log to the error. `timed out waiting for predicate` alone told us nothing, which is why this took a CI archaeology dig to pin down.

## Verification

`npm test --workspace server` — 245 passed, 87 s (was 188 s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)