### PR TITLE
fix(server): bound the SDK calls behind set_credential

### DIFF
--- a/server/src/credentials.ts
+++ b/server/src/credentials.ts
@@ -14,6 +14,13 @@ import type { ProviderCompat } from "@pi-outpost/shared";
 
 export class CredentialError extends Error {}
 
+/**
+ * The key reached disk, but the live model runtime did not take it — a distinct
+ * outcome from "could not store it": the credential survives a restart, so the
+ * caller should say so and carry on rather than report a failed login.
+ */
+export class CredentialSyncError extends Error {}
+
 /** OpenAI-compatible endpoint as the UI and the CLI describe it. */
 export interface ProviderDeclaration {
   provider: string;
@@ -66,7 +73,10 @@ export async function storeApiKey(
   agentDir: string,
   provider: string,
   apiKey: string,
-  modelRuntime?: { setRuntimeApiKey(provider: string, apiKey: string): Promise<void> },
+  modelRuntime?: {
+    setRuntimeApiKey(provider: string, apiKey: string, options?: { signal?: AbortSignal }): Promise<void>;
+  },
+  options?: { signal?: AbortSignal },
 ): Promise<string> {
   if (!validProviderId(provider)) throw new CredentialError(`Invalid provider name: ${provider}`);
   if (typeof apiKey !== "string" || apiKey.trim().length === 0) throw new CredentialError("An API key is required");
@@ -87,9 +97,17 @@ export async function storeApiKey(
     throw new CredentialError(`Could not write ${authPath}: ${(error as Error).message}`);
   }
 
-  // Also register with the live model runtime so the current session sees it.
+  // Also register with the live model runtime so the current session sees it. The
+  // SDK imposes no deadline of its own here (its operationSignal() is documented as
+  // normalising a signal "without imposing a deadline"), and the registration is
+  // serialised behind any credential operation already in flight for this provider —
+  // so without a caller-supplied signal this await can hang indefinitely.
   if (modelRuntime) {
-    await modelRuntime.setRuntimeApiKey(provider, apiKey.trim());
+    try {
+      await modelRuntime.setRuntimeApiKey(provider, apiKey.trim(), { signal: options?.signal });
+    } catch (error) {
+      throw new CredentialSyncError((error as Error).message, { cause: error });
+    }
   }
 
   return authPath;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -42,6 +42,7 @@ import { CliError, helpText, parseCli, readSecret, runInit } from "./cli.ts";
 import { loadConfig, NoConfigError } from "./config.ts";
 import {
   CredentialError,
+  CredentialSyncError,
   knownProviders,
   type ProviderDeclaration,
   providerConfig,
@@ -1098,17 +1099,43 @@ async function replaceSession(socket: WebSocket, action: () => Promise<{ cancell
  * Rebuilding through replaceSession is what turns the onboarding screen into a
  * working chat without a restart or even a reload.
  */
+/** How long onboarding waits on the SDK before it reports what it has. */
+const CREDENTIAL_SYNC_TIMEOUT_MS = 20_000;
+
 async function handleSetCredential(socket: WebSocket, provider: string, apiKey: string): Promise<void> {
+  // Neither of the two SDK calls below carries a deadline of its own, and both are
+  // serialised behind whatever credential work is already in flight for this provider.
+  // Onboarding is a user pressing Save and watching a spinner, so give the pair a
+  // ceiling: past it, announce what we have rather than leaving the UI waiting forever.
+  const deadline = AbortSignal.timeout(CREDENTIAL_SYNC_TIMEOUT_MS);
+  const stalled = (step: string, error: unknown) =>
+    console.warn(
+      `[pi] ${provider} key stored, but ${step} did not finish within ${CREDENTIAL_SYNC_TIMEOUT_MS / 1000}s: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+
   try {
     // Through the session's own ModelRuntime: the live registry reads its auth
     // through that instance, so a key written with any other one would sit on
     // disk while the agent still claims to have none.
-    await storeApiKey(AGENT_DIR, provider, apiKey, runtime.services.modelRuntime);
+    await storeApiKey(AGENT_DIR, provider, apiKey, runtime.services.modelRuntime, { signal: deadline });
   } catch (error) {
-    send(socket, { type: "error", message: error instanceof CredentialError ? error.message : String(error) });
-    return;
+    // A key that never reached disk is a failed login. One that reached disk but not
+    // the live runtime is not: it works on the next start, and the snapshot below
+    // still tells the client where things stand.
+    if (!(error instanceof CredentialSyncError)) {
+      send(socket, { type: "error", message: error instanceof CredentialError ? error.message : String(error) });
+      return;
+    }
+    stalled("the live model runtime", error);
   }
-  await runtime.services.modelRuntime.refresh();
+
+  try {
+    await runtime.services.modelRuntime.refresh({ signal: deadline });
+  } catch (error) {
+    stalled("the model refresh", error);
+  }
   await adoptUsableModel(socket);
 }
 


### PR DESCRIPTION
Refs #27. **This bounds and diagnoses the stall; it is not yet proven to be the whole cure.**

## What the last failure told us

CI on main (`748e41d`, [run 31526593036](https://github.com/laurentftech/pi-outpost/actions/runs/31526593036)) still failed the onboarding test — but this time it carried the server log, which is the diagnostic #28 added:

```
[server] http://127.0.0.1:3508/
[pi] session 019ff23d-…
[pi] no credentials in /tmp/pi-outpost-test-UkQ6tj/.pi-agent — …
[snapshot] sandbox = {…}
```

…and nothing else. The server started cleanly, answered `hello`, then went silent for the full 60 s after `set_credential`: no `credentials_changed`, no `error` frame. So the stall is on the server side of that handler, not in the harness and not in the test.

## Why it can hang forever

`handleSetCredential` awaits two SDK calls, neither of which carries a deadline:

- `ModelRuntime.setRuntimeApiKey` → `enqueueCredentialOperation`, which waits on `previous` — any credential operation already in flight for that provider — before it starts.
- `ModelRuntime.refresh()`.

The SDK's own `operationSignal()` is commented *"Normalize an optional public signal **without imposing a deadline**"*. Pass nothing and there is no ceiling anywhere on that path.

This is a real UX hazard independent of CI: onboarding is a user pressing Save and watching a spinner.

## Change

- 20 s ceiling (`AbortSignal.timeout`) across both calls.
- Past it, log which step stalled and fall through to `adoptUsableModel` so the client always gets an answer.
- `CredentialSyncError` separates "the key never reached disk" (still a hard error — a failed login) from "the key is stored but the live runtime did not take it" (works on the next start; say so and carry on).

## Verification

- `npm run typecheck --workspace server` — clean
- `credentials.test.mjs` — 3 passed, 12.5 s

If CI still fails after this, the warning line will name the stalled step, which is the thing we have been missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)