### PR TITLE
chore(npm): widen the published keywords, say "web interface"

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -2,7 +2,7 @@
   "name": "pi-outpost",
   "version": "0.6.5",
   "type": "module",
-  "description": "A web chat UI for the pi coding agent — run it with npx, no clone, no build.",
+  "description": "A web interface for the pi coding agent: a browser chat UI you run with npx — no clone, no build.",
   "license": "MIT",
   "author": "Laurent Francoise",
   "homepage": "https://github.com/laurentftech/pi-outpost#readme",
@@ -16,10 +16,19 @@
   },
   "keywords": [
     "pi",
+    "pi-coding-agent",
+    "pi-agent",
     "coding-agent",
+    "agent",
     "ai",
+    "ai-agent",
+    "llm",
     "chat",
     "web-ui",
+    "webui",
+    "web-interface",
+    "frontend",
+    "self-hosted",
     "cli"
   ],
   "bin": {

--- a/embed/package.json
+++ b/embed/package.json
@@ -16,9 +16,17 @@
   },
   "keywords": [
     "pi",
+    "pi-coding-agent",
     "coding-agent",
+    "agent",
+    "ai",
+    "ai-agent",
+    "llm",
     "chat",
+    "web-ui",
+    "web-interface",
     "widget",
+    "embeddable",
     "shadow-dom",
     "react",
     "embed"


### PR DESCRIPTION
From a Reddit comment: *"Can you add keywords to your package.json? It helps a lot when searching. I was looking for pi web interfaces the other day and missed this one."*

Both published packages did already carry keywords — the problem is which ones. `pi-outpost` had `web-ui`, and its description said *"A web chat UI"*. Neither matches **interface**, the word the commenter actually searched. npm ranks name, description and keyword matches, so the phrase needs to appear literally.

## `pi-outpost` (cli)

- description → `A web interface for the pi coding agent: a browser chat UI you run with npx — no clone, no build.`
- keywords + `pi-coding-agent` (the SDK's own package name), `pi-agent`, `agent`, `ai-agent`, `llm`, `webui`, `web-interface`, `frontend`, `self-hosted`

## `@pi-outpost/embed`

- keywords + `pi-coding-agent`, `agent`, `ai`, `ai-agent`, `llm`, `web-ui`, `web-interface`, `embeddable`

No code changes. Note that npm only reindexes on publish, so this takes effect with the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)