### PR TITLE
fix(server): keep tests offline, and notice an aborted model refresh

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1103,15 +1103,17 @@ async function replaceSession(socket: WebSocket, action: () => Promise<{ cancell
 const CREDENTIAL_SYNC_TIMEOUT_MS = 20_000;
 
 async function handleSetCredential(socket: WebSocket, provider: string, apiKey: string): Promise<void> {
-  // Neither of the two SDK calls below carries a deadline of its own, and both are
-  // serialised behind whatever credential work is already in flight for this provider.
-  // Onboarding is a user pressing Save and watching a spinner, so give the pair a
-  // ceiling: past it, announce what we have rather than leaving the UI waiting forever.
-  const deadline = AbortSignal.timeout(CREDENTIAL_SYNC_TIMEOUT_MS);
-  const stalled = (step: string, error: unknown) =>
+  // Neither of the two SDK calls below carries a deadline of its own. Onboarding is a
+  // user pressing Save and watching a spinner, so give each one a ceiling: past it,
+  // announce what we have rather than leaving the UI waiting forever.
+  //
+  // A ceiling *each*, not one shared between them: with a single signal, a first step
+  // that burns the whole budget leaves the second none, and the second would abort
+  // instantly for a reason that has nothing to do with it.
+  const stalled = (step: string, detail: unknown) =>
     console.warn(
       `[pi] ${provider} key stored, but ${step} did not finish within ${CREDENTIAL_SYNC_TIMEOUT_MS / 1000}s: ${
-        error instanceof Error ? error.message : String(error)
+        detail instanceof Error ? detail.message : String(detail)
       }`,
     );
 
@@ -1119,7 +1121,9 @@ async function handleSetCredential(socket: WebSocket, provider: string, apiKey: 
     // Through the session's own ModelRuntime: the live registry reads its auth
     // through that instance, so a key written with any other one would sit on
     // disk while the agent still claims to have none.
-    await storeApiKey(AGENT_DIR, provider, apiKey, runtime.services.modelRuntime, { signal: deadline });
+    await storeApiKey(AGENT_DIR, provider, apiKey, runtime.services.modelRuntime, {
+      signal: AbortSignal.timeout(CREDENTIAL_SYNC_TIMEOUT_MS),
+    });
   } catch (error) {
     // A key that never reached disk is a failed login. One that reached disk but not
     // the live runtime is not: it works on the next start, and the snapshot below
@@ -1132,7 +1136,16 @@ async function handleSetCredential(socket: WebSocket, provider: string, apiKey: 
   }
 
   try {
-    await runtime.services.modelRuntime.refresh({ signal: deadline });
+    // refresh() reaches the network unless PI_OFFLINE is set: it re-fetches remote
+    // model catalogs, and that request is what hangs on a constrained host.
+    //
+    // It also *swallows* an abort — it resolves with `{ aborted: true }` instead of
+    // throwing — so the catch below never sees one. Read the flag, or a refresh cut
+    // short at the ceiling passes for a clean one and the warning never fires.
+    const result = await runtime.services.modelRuntime.refresh({
+      signal: AbortSignal.timeout(CREDENTIAL_SYNC_TIMEOUT_MS),
+    });
+    if (result?.aborted) stalled("the model refresh", "aborted at the ceiling");
   } catch (error) {
     stalled("the model refresh", error);
   }

--- a/server/test/credentials.test.mjs
+++ b/server/test/credentials.test.mjs
@@ -41,12 +41,12 @@ test("an unconfigured server reports no usable model, then onboards without a re
 
     client.send({ type: "set_credential", provider: "anthropic", apiKey: "sk-ant-not-a-real-key" });
 
-    // Registering the key stays local: the SDK's anthropic provider declares no
-    // api-key `check`, so the availability pass behind set_credential resolves the
-    // credential from disk without a request. The default 60 s wait is generous —
-    // the whole exchange is a few hundred milliseconds. Earlier this wait was raised
-    // to 180 s to absorb "SDK network calls" that never happen; what it really
-    // absorbed was the harness leaking its own timer (see waitFor).
+    // Registering the key is local — the SDK's anthropic provider declares no api-key
+    // `check`, so it resolves the credential from disk. The model refresh that follows
+    // is *not*: it fetches remote catalogs, and on a CI runner that request hangs until
+    // the server's ceiling cuts it, which is what made this test flaky (#27). The
+    // harness runs the server with PI_OFFLINE, so the exchange stays in the hundreds of
+    // milliseconds and the default 60 s wait is generous.
     const replaced = await client
       .waitFor((m) => m.type === "credentials_changed")
       // Nothing else tells us why the server stayed silent, and this test only ever

--- a/server/test/harness.mjs
+++ b/server/test/harness.mjs
@@ -68,7 +68,12 @@ export async function startServer(root, config = {}, options = {}) {
   // `options.env` patches the child's environment; a key set to undefined is *removed*.
   // Credential tests need that: the developer's own ANTHROPIC_API_KEY (or CI's) would
   // otherwise configure the very server the test needs to find unconfigured.
-  const env = { ...process.env, PI_OUTPOST_CONFIG: configPath };
+  // PI_OFFLINE keeps the SDK's model runtime off the network. Without it,
+  // ModelRuntime.refresh() fetches remote model catalogs — on a CI runner that
+  // request hangs, and set_credential went from ~200 ms to 20 s (its ceiling) in
+  // roughly a quarter of runs, which is the whole of #27. These tests assert local
+  // onboarding behaviour; a remote catalog has nothing to do with what they check.
+  const env = { ...process.env, PI_OUTPOST_CONFIG: configPath, PI_OFFLINE: "1" };
   for (const [key, value] of Object.entries(options.env ?? {})) {
     if (value === undefined) delete env[key];
     else env[key] = value;


### PR DESCRIPTION
Fixes #27.

## The answer

Probing each await inside `handleSetCredential` ended three rounds of guessing:

```
[probe] set_credential frame received
[probe] enter at 0ms
[probe] storeApiKey resolved at 4ms      ← not the suspect after all
[probe] refresh resolved at 20006ms      ← and it RESOLVES, it does not throw
```

Three stalls, three identical profiles. It was never `setRuntimeApiKey` and its per-provider credential queue, which is where I looked first and longest. That returns in 4 ms.

It is **`ModelRuntime.refresh()`, which reaches the network**:

```js
new ModelRuntime(..., process.env.PI_OFFLINE === undefined)   // modelNetworkEnabled
...
allowNetwork: options.allowNetwork ?? this.modelNetworkEnabled
```

So `refresh()` re-fetches remote model catalogs. On a CI runner that request hangs, and `set_credential` burned its full 20 s ceiling in ~25% of runs — **on ubuntu as much as on windows**, and with Defender excluded. Neither the OS nor the antivirus was ever involved; windows only surfaced it first because its ~2× slower boot pushed totals past the deadline sooner.

## Why it stayed invisible

`refresh()` swallows an abort — it resolves with `{ aborted: true }` instead of throwing:

```js
const result = (await this.models.refresh(refreshOptions)) ?? { aborted: …, errors: new Map() };
```

So the ceiling added in #29 *was* firing, silently, and its `catch` never ran. That is why the server log showed a clean run for three rounds while the clock said 20 s.

## Changes

- **`PI_OFFLINE=1` in the test harness.** Removes the cause rather than the symptom: these tests assert local onboarding behaviour, and a remote catalog has nothing to do with what they check.
- **Read `result.aborted`** so a refresh cut short at the ceiling reports itself instead of passing for a clean one.
- **A ceiling per call** instead of one shared signal, which left the second step with no budget when the first spent it.

## Verification

- `npm run typecheck --workspace server` — clean
- `credentials.test.mjs` — 3 passed
- `npm test --workspace server` — 245 passed

The investigation rig (phase timings, Defender arm, repetition matrix) stays on `investigate/windows-credentials-timing`; it is not merged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)