### PR TITLE
fix(ui): strip trailing punctuation linearly, not with a ReDoS regex

### DIFF
--- a/ui/src/attachments.test.ts
+++ b/ui/src/attachments.test.ts
@@ -195,6 +195,13 @@ describe("mentionedPaths", () => {
     expect(mentionedPaths("just @")).toEqual([]);
   });
 
+  it("strips a long run of trailing punctuation without stalling", () => {
+    // The regex this replaced was O(n^2) on exactly this shape (CodeQL #9): 100k
+    // repetitions took seconds. Linear stripping returns immediately, so the test's
+    // own timeout is the assertion that it stayed linear.
+    expect(mentionedPaths(`see @a.ts${"!".repeat(100_000)}`)).toEqual(["a.ts"]);
+  });
+
   it("does not read an email address as a path", () => {
     expect(mentionedPaths("mail@example.com is not a path")).toEqual([]);
   });

--- a/ui/src/attachments.ts
+++ b/ui/src/attachments.ts
@@ -76,6 +76,23 @@ function mentions(text: string, path: string): boolean {
   return new RegExp(`(^|\\s)@${escaped}[,.;:!?)\\]]*(\\s|$)`).test(text);
 }
 
+const TRAILING_PUNCTUATION = new Set([",", ".", ";", ":", "!", "?", ")", "]"]);
+
+/**
+ * Drop sentence punctuation from the end of a path, by hand.
+ *
+ * The regex this replaces — `/[,.;:!?)\]]+$/` — is a polynomial ReDoS (CodeQL #9):
+ * anchoring `+` to the end makes the engine retry the run from every position, so a
+ * draft holding a long stretch of `!` costs O(n²). The text comes from the composer,
+ * which means a user can only hang their own tab, but the loop below is linear and
+ * every bit as clear.
+ */
+function withoutTrailingPunctuation(path: string): string {
+  let end = path.length;
+  while (end > 0 && TRAILING_PUNCTUATION.has(path[end - 1])) end--;
+  return path.slice(0, end);
+}
+
 /**
  * Paths the user named with `@` in their draft. They reference a file just as an
  * attachment does, so the tree marks them too — the file tree cannot see the composer's
@@ -83,7 +100,7 @@ function mentions(text: string, path: string): boolean {
  */
 export function mentionedPaths(text: string): string[] {
   const found = text.matchAll(/(?:^|\s)@([^\s@]+)/g);
-  return [...found].map(([, path]) => path.replace(/[,.;:!?)\]]+$/, "")).filter((path) => path.length > 0);
+  return [...found].map(([, path]) => withoutTrailingPunctuation(path)).filter((path) => path.length > 0);
 }
 
 /**


### PR DESCRIPTION
Closes the open CodeQL alert [#9](https://github.com/laurentftech/pi-outpost/security/code-scanning/9) (high, `js/polynomial-redos`) — the only one currently open.

`mentionedPaths` cleaned trailing sentence punctuation with `/[,.;:!?)\]]+$/`. Anchoring a `+` run to the end makes the engine retry from every start position, so the cost is O(n²) in the length of the punctuation run: `@a.ts` followed by 100k `!` took seconds.

Replaced with a linear loop over a `Set` of the same characters. Same behaviour, no backtracking.

## Severity, honestly

The input is the composer's own draft text, so the only session a user can stall is their own — no remote path to anyone else's tab. That makes this lower-impact than "high" suggests. Worth fixing anyway: the loop is no less readable than the regex, and it clears the alert.

## Verification

- `npm test --workspace ui` — 178 passed (177 + the new regression test)
- `npm run typecheck` — clean, all workspaces

The regression test feeds 100k repetitions and relies on its own timeout as the assertion: linear returns instantly, the old regex would not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)