### PR TITLE
fix(ui): repair math delimiters the model mixed up

### DIFF
--- a/ui/src/util/markdownMath.test.ts
+++ b/ui/src/util/markdownMath.test.ts
@@ -37,4 +37,46 @@ describe("normalizeMathDelimiters", () => {
     expect(result).toContain("$x$");
     expect(result).toContain("$$\\sum x$$");
   });
+
+  // A formula opened one way and closed the other. Left alone, the opening $$ never
+  // closes: remark-math swallows the equation and every later $…$ in the message
+  // pairs up wrongly, so one malformed formula takes the whole answer down.
+  describe("delimiters the model mixed up", () => {
+    it("closes $$ opened math that ends with \\]", () => {
+      expect(normalizeMathDelimiters("$$e^{i\\pi} + 1 = 0\\]")).toBe("$$e^{i\\pi} + 1 = 0$$");
+    });
+
+    it("closes \\[ opened math that ends with $$", () => {
+      expect(normalizeMathDelimiters("\\[e^{i\\pi} + 1 = 0$$")).toBe("$$e^{i\\pi} + 1 = 0$$");
+    });
+
+    it("closes $ opened math that ends with \\)", () => {
+      expect(normalizeMathDelimiters("valeur $x\\) ici")).toBe("valeur $x$ ici");
+    });
+
+    it("closes \\( opened math that ends with $", () => {
+      expect(normalizeMathDelimiters("valeur \\(x$ ici")).toBe("valeur $x$ ici");
+    });
+
+    it("rescues the rest of the message, not just the broken formula", () => {
+      const result = normalizeMathDelimiters("$$e^{i\\pi} + 1 = 0\\]\n\nElle relie $e$ et $\\pi$.");
+      expect(result).toContain("$$e^{i\\pi} + 1 = 0$$");
+      expect(result).toContain("$e$ et $\\pi$");
+    });
+
+    it("leaves a lone dollar alone rather than swallowing the line", () => {
+      // A price, and an unrelated \) further along: the $ must not claim it.
+      expect(normalizeMathDelimiters("Ça coûte $5 et \\(x\\) suit")).toBe("Ça coûte $5 et $x$ suit");
+    });
+
+    it("does not pair across a paragraph break", () => {
+      const text = "$$x\n\nplus loin \\] ailleurs";
+      expect(normalizeMathDelimiters(text)).toBe(text);
+    });
+
+    it("still leaves mixed delimiters inside a fenced block alone", () => {
+      const text = "```latex\n$$e^{i\\pi} + 1 = 0\\]\n```";
+      expect(normalizeMathDelimiters(text)).toBe(text);
+    });
+  });
 });

--- a/ui/src/util/markdownMath.ts
+++ b/ui/src/util/markdownMath.ts
@@ -4,11 +4,33 @@
  * text. Rewrite those to dollar delimiters — outside code spans and fences only,
  * so LaTeX examples inside code blocks stay untouched.
  *
+ * Models also *mix* the two styles within one formula — `$$e^{i\pi} + 1 = 0\]`
+ * is a real observed answer. That is worse than an unconverted delimiter: the
+ * opening `$$` never closes, so remark-math swallows the equation (it vanishes
+ * from the page) and every later `$…$` in the message pairs up wrongly and
+ * renders as literal text. One malformed formula breaks the whole answer, which
+ * is why mismatched pairs are repaired here rather than left to the parser.
+ *
  * Written without regular expressions to avoid CodeQL polynomial-ReDoS flags
  * on library (model) input that may contain adversarial delimiter repetition.
  */
+/**
+ * Position of `closer` after `from`, but only if it really closes what we opened:
+ * a matching `opener` in between means that one owns it, and a blank line means we
+ * left the formula behind — no math span crosses a paragraph break.
+ */
+function matchingCloser(text: string, from: number, closer: string, opener: string): number {
+  const close = text.indexOf(closer, from);
+  if (close === -1) return -1;
+  const between = text.slice(from, close);
+  if (between.includes(opener) || between.includes("\n\n")) return -1;
+  return close;
+}
+
 export function normalizeMathDelimiters(text: string): string {
-  if (!text.includes("\\(") && !text.includes("\\[")) return text;
+  if (!text.includes("\\(") && !text.includes("\\[") && !text.includes("\\)") && !text.includes("\\]")) {
+    return text;
+  }
 
   const out: string[] = [];
   let i = 0;
@@ -41,6 +63,13 @@ export function normalizeMathDelimiters(text: string): string {
         i = close + 2;
         continue;
       }
+      // Opened with a bracket, closed with dollars.
+      const dollar = matchingCloser(text, i + 2, "$$", "\\[");
+      if (dollar !== -1) {
+        out.push("$$", text.slice(i + 2, dollar), "$$");
+        i = dollar + 2;
+        continue;
+      }
     }
 
     if (text.startsWith("\\(", i)) {
@@ -48,6 +77,35 @@ export function normalizeMathDelimiters(text: string): string {
       if (close !== -1) {
         out.push("$", text.slice(i + 2, close), "$");
         i = close + 2;
+        continue;
+      }
+      const dollar = matchingCloser(text, i + 2, "$", "\\(");
+      if (dollar !== -1) {
+        out.push("$", text.slice(i + 2, dollar), "$");
+        i = dollar + 1;
+        continue;
+      }
+    }
+
+    // The mixed pairs: `$$…\]` and `$…\)`. Only rewritten when the bracket closer
+    // arrives before any dollar closer would, so well-formed text is never touched
+    // and a lone `$` (a price, a shell prompt) cannot swallow the line.
+    if (text.startsWith("$$", i)) {
+      const bracket = matchingCloser(text, i + 2, "\\]", "\\[");
+      const dollar = text.indexOf("$$", i + 2);
+      if (bracket !== -1 && (dollar === -1 || bracket < dollar)) {
+        out.push("$$", text.slice(i + 2, bracket), "$$");
+        i = bracket + 2;
+        continue;
+      }
+    }
+
+    if (text[i] === "$") {
+      const paren = matchingCloser(text, i + 1, "\\)", "\\(");
+      const dollar = text.indexOf("$", i + 1);
+      if (paren !== -1 && (dollar === -1 || paren < dollar)) {
+        out.push("$", text.slice(i + 1, paren), "$");
+        i = paren + 2;
         continue;
       }
     }


### PR DESCRIPTION
Reported as "le LaTeX ne s'affiche pas toujours correctement". It is not intermittent — it is one specific malformed formula taking down every formula after it.

## What the model actually emitted

```
$$e^{i\pi} + 1 = 0\]
```

Opened with dollars, closed with a bracket. `normalizeMathDelimiters` only looked for `\[` and `\(` **openers**, so this passed through untouched. remark-math then saw a `$$` that never closes:

- the equation **vanished from the page** — not rendered as raw text, gone;
- every later `$…$` in the message paired against the wrong delimiter and rendered literally.

That is the whole reported symptom, including why the *second*, perfectly well-formed `$$x = \frac{-b \pm \sqrt{b^2-4ac}}{2a}$$` in the same answer did not render either.

Measured by rendering the reported message through the real pipeline (`react-markdown` + `remark-math` + `rehype-katex`):

| | KaTeX nodes |
|---|---|
| before | **0** |
| after | **8** |

## The fix

Repair all four mixed pairs — `$$…\]`, `\[…$$`, `$…\)`, `\(…$` — and only those. A bracket closer is accepted only when it arrives before any dollar closer would, so well-formed text is never rewritten.

Two guards stop a lone `$` (a price, a shell prompt) from claiming an unrelated `\)` further down the message: no pairing across a matching opener, and none across a paragraph break. Fenced blocks and code spans stay untouched, as before.

## Verification

- 8 new unit tests, including the guards and the fence case
- `npm test --workspace ui` — 186 passed
- `npm run typecheck` — clean

## Not fixed here

`ui/package.json` declares no runtime dependencies: `react-markdown`, `katex`, `remark-*` and `rehype-*` resolve only because npm hoists `web`'s copies to the root. It works in this monorepo and breaks the day `@pi-outpost/ui` is consumed from anywhere else. Worth a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)