### PR TITLE
feat(server): offline mode, so credential changes stop hanging

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Not sure which file won, or why a setting has the value it has? **`pi-outpost co
 
 **Profiles.** `--profile work` (or `$PI_OUTPOST_PROFILE`) reads `<user config dir>/profiles/work.json`. A profile is an ordinary config file — same keys, same rules — so `pi-outpost --profile work` from anywhere gives you the setup you configured once.
 
-**Precedence.** For any setting that appears in more than one place: **flag > environment variable > config file > default**. Environment variables: `PI_OUTPOST_PORT` (falling back to `PORT`, which platforms inject), `PI_OUTPOST_HOST`, `PI_OUTPOST_CWD`, `PI_OUTPOST_AGENT_DIR`, `PI_OUTPOST_TOKEN`.
+**Precedence.** For any setting that appears in more than one place: **flag > environment variable > config file > default**. Environment variables: `PI_OUTPOST_PORT` (falling back to `PORT`, which platforms inject), `PI_OUTPOST_HOST`, `PI_OUTPOST_CWD`, `PI_OUTPOST_AGENT_DIR`, `PI_OUTPOST_TOKEN`, `PI_OFFLINE` (the pi SDK's own variable, honoured here so one spelling covers both layers).
 
 One exception, and it is deliberate: **a sandbox that grants write or bash, but names no `sandbox.root`, refuses a `--cwd`/`PI_OUTPOST_CWD` override.** Such a sandbox falls back to `cwd`, so an inherited variable (a shell profile, a CI job, a compose file) could otherwise turn "write inside my project" into "write inside `/`" without touching the file that granted it. Name the root, and the grant says what it covers. A read-only sandbox has no such hazard and simply follows the workspace.
 
@@ -195,6 +195,7 @@ See [`pi-outpost.config.example.json`](pi-outpost.config.example.json).
 | `systemPrompt` / `systemPromptFile` | Replace pi's built-in system prompt entirely (mutually exclusive; `systemPromptFile` is a path to a text file). Project context files, skills, and `appendSystemPrompt` are still layered on top |
 | `appendSystemPrompt` | Array of extra paragraphs appended after the (built-in or custom) system prompt |
 | `webContext` | Inject a short web-UI context block into the system prompt so the agent knows its replies render in this UI (markdown, inline images, file links). Default `true`; set `false` for tightly curated prompts |
+| `offline` | Never fetch remote model catalogs. On a host that cannot reach them — air-gapped, or behind a proxy that does not route them — that request hangs and stalls every credential change by 20 s. Built-in and `models.json` providers are unaffected: the catalog only adds metadata for models the SDK already knows. Default `false`; `--offline` and `PI_OFFLINE` also turn it on |
 | `server.port` | Port to listen on (default `3141`). `--port` and `PI_OUTPOST_PORT`/`PORT` override it |
 | `server.host` | Host to bind to (default `127.0.0.1` — only change this if you understand the security note above) |
 | `server.allowedOrigins` | Extra exact Origins accepted on the WebSocket (embed the UI as a tab in another app) |

--- a/openspec/specs/config/spec.md
+++ b/openspec/specs/config/spec.md
@@ -46,6 +46,27 @@ For every setting that can come from more than one place, the server SHALL apply
 - **WHEN** the CLI is invoked with an unknown `--token` flag
 - **THEN** it exits with an error, because a secret passed on the command line is readable by any process listing
 
+### Requirement: OfflineModelCatalogs
+
+The server SHALL support an `offline` setting — config file `offline`, the `--offline` flag, or the pi SDK's own `PI_OFFLINE` environment variable — that keeps the model runtime from fetching remote model catalogs. When it is set, the server SHALL make the SDK aware of it before the model runtime is constructed, because the SDK reads that variable once at construction.
+
+Off a network that can reach the catalogs, the fetch runs on every credential change; on a host that cannot — air-gapped, or behind a proxy that does not route it — the request hangs until the server's ceiling cuts it, stalling each change by that ceiling. Built-in models and providers declared in `models.json` remain available either way: the catalog only adds metadata for models the SDK already knows.
+
+#### Scenario: OfflineFromTheConfigFile
+- **GIVEN** a config file with `"offline": true`
+- **WHEN** the server starts
+- **THEN** no remote model catalog is fetched, and the startup log says so
+
+#### Scenario: OfflineFromTheEnvironment
+- **GIVEN** `PI_OFFLINE` set to a non-empty value
+- **WHEN** the server starts
+- **THEN** offline mode is on, whatever the config file says
+
+#### Scenario: AbsentFlagDoesNotOverrideTheFile
+- **GIVEN** a config file with `"offline": true`
+- **WHEN** the server starts without `--offline`
+- **THEN** offline mode stays on, because a flag that was not passed is not a value
+
 ### Requirement: ConfigProfiles
 
 The server SHALL accept a profile name (`--profile <name>` or `PI_OUTPOST_PROFILE`) and SHALL load `profiles/<name>.json` from the user config directory. A profile file SHALL be an ordinary config file, subject to the same validation and the same relative-path resolution. Naming both a profile and an explicit `--config` path SHALL be an error. A named profile that does not exist SHALL be an error.

--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -53,6 +53,7 @@ Options
   --agent-dir <dir>  pi config/session store (default: ~/.pi/agent)
   --port <n>         port to listen on (default: 3141)
   --host <addr>      address to bind (default: 127.0.0.1)
+  --offline          never fetch remote model catalogs (air-gapped hosts)
   -h, --help         show this help
   -v, --version      show the version
 
@@ -121,6 +122,7 @@ export function parseCli(argv: string[]): ParsedCli {
         "agent-dir": { type: "string" },
         port: { type: "string" },
         host: { type: "string" },
+        offline: { type: "boolean", default: false },
         global: { type: "boolean", default: false },
         force: { type: "boolean", default: false },
         provider: { type: "string" },
@@ -150,6 +152,8 @@ export function parseCli(argv: string[]): ParsedCli {
     agentDir: values["agent-dir"],
     port: integerFlag(values.port, "--port"),
     host: values.host,
+    // Only an override when actually passed: a bare false must not beat the file.
+    ...(values.offline ? { offline: true } : {}),
   };
 
   const kind = values.help ? "help" : values.version ? "version" : (command ?? "serve");

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -133,6 +133,15 @@ export interface AppConfig {
    * deployments with a tightly curated prompt.
    */
   webContext: boolean;
+  /**
+   * Keep the model runtime off the network. The SDK otherwise re-fetches remote
+   * model catalogs whenever credentials change, and on a host that cannot reach
+   * them — air-gapped, or behind a proxy that does not route them — that request
+   * hangs until the server's own ceiling cuts it, stalling every credential
+   * change by 20 s. Built-in and models.json-declared models still work: the
+   * catalog only adds metadata for models the SDK already knows about.
+   */
+  offline: boolean;
   port: number;
   host: string;
   /** Extra exact Origins allowed on the WebSocket (for embedding in another app). */
@@ -155,6 +164,7 @@ export interface CliOptions {
   agentDir?: string;
   port?: number;
   host?: string;
+  offline?: boolean;
 }
 
 /** Thrown when no config file exists anywhere: the CLI turns it into `init` advice. */
@@ -298,6 +308,7 @@ export function loadConfig(
     promptPaths: [],
     appendSystemPrompt: [],
     webContext: true,
+    offline: false,
     port: 3141,
     host: "127.0.0.1",
     allowedOrigins: [],
@@ -407,6 +418,7 @@ export function loadConfig(
   }
   config.appendSystemPrompt = optionalStringArray(raw, "appendSystemPrompt") ?? [];
   config.webContext = optionalBoolean(raw, "webContext", true);
+  config.offline = optionalBoolean(raw, "offline", false);
 
   if (raw.server !== undefined) {
     const server = asObject(raw.server, "server");
@@ -502,6 +514,11 @@ export function applyDirectories(config: AppConfig, flags: CliOptions, env: Node
  * There is deliberately no token flag: argv is readable by any process listing.
  */
 export function applyRuntime(config: AppConfig, flags: CliOptions, env: NodeJS.ProcessEnv): void {
+  // Same precedence as the rest: file, then environment, then flag. PI_OFFLINE is
+  // the SDK's own variable — honouring it here keeps one spelling for both layers.
+  if (env.PI_OFFLINE !== undefined && env.PI_OFFLINE !== "") config.offline = true;
+  if (flags.offline) config.offline = true;
+
   // Bare PORT is honoured too: PaaS hosts inject it, and it costs one `??`.
   const port = env.PI_OUTPOST_PORT ?? env.PORT;
   if (port !== undefined && port !== "") {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -498,6 +498,11 @@ const createRuntime: CreateAgentSessionRuntimeFactory = async ({
   };
 };
 
+// The SDK decides this once, when it constructs its ModelRuntime — it reads
+// `process.env.PI_OFFLINE` there and keeps the answer — so the variable has to be
+// set before the runtime exists, not merely present in our config object.
+if (config.offline) process.env.PI_OFFLINE = "1";
+
 const runtime = await createAgentSessionRuntime(createRuntime, {
   cwd: AGENT_CWD,
   agentDir: AGENT_DIR,
@@ -1971,6 +1976,9 @@ if (config.sandbox) {
   console.log(`[pi] sandbox ${config.sandbox.root} · ${extras}`);
 }
 console.log(`[pi] file browser root ${BROWSER_ROOT}`);
+// Worth a line: it changes where models come from, and its absence is what makes
+// credential changes hang for 20 s on a host that cannot reach the catalogs.
+if (config.offline) console.log("[pi] offline — model catalogs are not fetched");
 // The old warning ("No models available") named neither the cause nor a way out, and
 // the failure only surfaced on the user's first message. Say it at startup, name the
 // directory the credentials are missing from, and point at both ways to supply them.

--- a/server/test/cli.test.ts
+++ b/server/test/cli.test.ts
@@ -34,6 +34,15 @@ describe("parseCli", () => {
     assert.equal(result.command, "help");
   });
 
+  test("--offline sets the flag", () => {
+    assert.equal(parseCli(["--offline"]).flags.offline, true);
+  });
+
+  test("without --offline the flag is absent, not false", () => {
+    // Present-and-false would beat `"offline": true` in the config file.
+    assert.equal("offline" in parseCli([]).flags, false);
+  });
+
   test("--version returns version command", () => {
     const result = parseCli(["--version"]);
     assert.equal(result.command, "version");

--- a/server/test/config.test.ts
+++ b/server/test/config.test.ts
@@ -191,6 +191,7 @@ describe("applyDirectories", () => {
       promptPaths: [],
       appendSystemPrompt: [],
       webContext: true,
+      offline: false,
       port: 3141,
       host: "127.0.0.1",
       allowedOrigins: [],
@@ -247,6 +248,7 @@ describe("applyRuntime", () => {
       promptPaths: [],
       appendSystemPrompt: [],
       webContext: true,
+      offline: false,
       port: 3141,
       host: "127.0.0.1",
       allowedOrigins: [],
@@ -277,6 +279,37 @@ describe("applyRuntime", () => {
     const config = baseConfig();
     applyRuntime(config, {}, { PI_OUTPOST_PORT: "4003", PORT: "4002" });
     assert.equal(config.port, 4003);
+  });
+
+  test("offline defaults to off", () => {
+    const config = baseConfig();
+    applyRuntime(config, {}, {});
+    assert.equal(config.offline, false);
+  });
+
+  test("PI_OFFLINE turns offline on", () => {
+    const config = baseConfig();
+    applyRuntime(config, {}, { PI_OFFLINE: "1" });
+    assert.equal(config.offline, true);
+  });
+
+  test("an empty PI_OFFLINE is not a value", () => {
+    const config = baseConfig();
+    applyRuntime(config, {}, { PI_OFFLINE: "" });
+    assert.equal(config.offline, false);
+  });
+
+  test("--offline turns offline on", () => {
+    const config = baseConfig();
+    applyRuntime(config, { offline: true }, {});
+    assert.equal(config.offline, true);
+  });
+
+  test("no flag leaves an offline config file alone", () => {
+    // The flag defaults to false in the parser; it must not undo `"offline": true`.
+    const config = { ...baseConfig(), offline: true };
+    applyRuntime(config, {}, {});
+    assert.equal(config.offline, true);
   });
 
   test("PI_OUTPOST_PORT must be a valid port number", () => {
@@ -349,6 +382,7 @@ describe("requireTokenOffLoopback", () => {
       promptPaths: [],
       appendSystemPrompt: [],
       webContext: true,
+      offline: false,
       port: 3141,
       allowedOrigins: [],
       branding: {},


### PR DESCRIPTION
Follows #31, which fixed this for the test harness only. A real deployment behind a corporate proxy — or air-gapped — hits it in production.

## Why

`ModelRuntime` re-fetches remote model catalogs whenever credentials change. Where those catalogs are unreachable, the request hangs until the ceiling from #29 cuts it, so **every credential change costs 20 s** before the UI answers. That is exactly the cause found in #27; the fix there set `PI_OFFLINE` in the harness and stopped at the test boundary.

The SDK decides this once:

```js
new ModelRuntime(..., process.env.PI_OFFLINE === undefined)
```

It reads the variable **at construction**, so setting it later has no effect — the server has to set it before the runtime exists.

## What

A first-class setting, three ways in:

| | |
|---|---|
| config file | `"offline": true` |
| flag | `--offline` |
| environment | `PI_OFFLINE` (the SDK's own variable, so one spelling covers both layers) |

Precedence follows the existing rule — flag > env > file > default — with one subtlety worth naming: the flag counts only when actually passed. `parseArgs` defaults booleans to `false`, and a present-and-false flag would silently undo `"offline": true` in a config file. There is a test for exactly that.

Startup logs `[pi] offline — model catalogs are not fetched`, because its *absence* is what makes credential changes hang, and that deserves to be visible.

Built-in models and `models.json` providers work the same either way: the catalog only adds metadata for models the SDK already knows about.

## Verification

- `npm test --workspace server` — 252 passed (245 + 7 new)
- `npm run typecheck --workspace server` — clean
- README config table, precedence note, `--help`, and the `config` spec (`OfflineModelCatalogs`) all updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)