### PR TITLE
chore: ignore .pi/, and declare ui's real dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,10 @@ coverage/
 .pi-outpost-test-agent/
 scratch/
 
+# Agent resources the running agent discovers from cwd (prompts, skills). Local to
+# each checkout — the project's own copies live in .claude/.
+.pi/
+
 # Interactive test ephemeral data
 interactive-test/workspace/
 interactive-test/.pi-agent/

--- a/package-lock.json
+++ b/package-lock.json
@@ -10363,12 +10363,24 @@
     },
     "ui": {
       "name": "@pi-outpost/ui",
+      "dependencies": {
+        "@pi-outpost/shared": "*",
+        "highlight.js": "^11.11.1",
+        "mermaid": "^11.16.0",
+        "react-markdown": "^10.1.0",
+        "rehype-katex": "^7.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-math": "^6.0.0"
+      },
       "devDependencies": {
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
         "@vitest/coverage-v8": "^4.1.10",
         "jsdom": "^30.0.0",
         "vitest": "^4.1.10"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
       }
     },
     "web": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -12,6 +12,18 @@
     "test": "vitest run",
     "test:watch": "vitest"
   },
+  "dependencies": {
+    "@pi-outpost/shared": "*",
+    "highlight.js": "^11.11.1",
+    "mermaid": "^11.16.0",
+    "react-markdown": "^10.1.0",
+    "rehype-katex": "^7.0.1",
+    "remark-gfm": "^4.0.1",
+    "remark-math": "^6.0.0"
+  },
+  "peerDependencies": {
+    "react": "^19.2.7"
+  },
   "devDependencies": {
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",


### PR DESCRIPTION
Two bits of hygiene, no behaviour change.

## 1. Ignore `.pi/`

The running agent discovers prompts and skills from `cwd/.pi`, so every checkout grows one and it sat in `git status` as untracked. The project's own copies of those resources are versioned under `.claude/`.

## 2. `@pi-outpost/ui` declares nothing it uses

`ui/package.json` had `dependencies: {}` and `peerDependencies: {}`, while `ui/src` imports:

`react` · `react-markdown` · `remark-math` · `remark-gfm` · `rehype-katex` · `highlight.js` · `mermaid` (dynamically, in `Mermaid.tsx`) · `@pi-outpost/shared`

They resolved only because npm workspaces hoists **web's** copies into the root `node_modules`.

**Nothing is broken today** — `ui` is private, and the published `embed` bundle inlines everything except react/react-dom (`embed/vite.config.ts:54`), so consumers get a self-contained artifact. The real cost is that `ui`'s dependency contract lived in another package's file: editing `web/package.json` silently changes what `ui` builds against, and Dependabot bumps land on `web` while `ui` is what runs the code.

`react` goes in `peerDependencies` so the tree keeps a single copy; the rest become `dependencies` at the ranges `web` already pins.

`katex` is deliberately left out: `ui` never imports it, and `rehype-katex` depends on it directly. The stylesheet stays web's to import.

## Verification

- `npm install` — tree already satisfied, lockfile gains only the new edges
- `npm run typecheck` — clean, all workspaces
- `npm test --workspace ui` — 186 passed
- `npm run build --workspace @pi-outpost/embed` — builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)