### PR TITLE
chore(release): v0.6.6

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-outpost",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "type": "module",
   "description": "A web interface for the pi coding agent: a browser chat UI you run with npx — no clone, no build.",
   "license": "MIT",

--- a/embed/package.json
+++ b/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-outpost/embed",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "type": "module",
   "description": "Mount pi-outpost as a Shadow-DOM-isolated widget inside another web app.",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
     },
     "cli": {
       "name": "pi-outpost",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "^0.84.1",
@@ -43,7 +43,7 @@
     },
     "embed": {
       "name": "@pi-outpost/embed",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "license": "MIT",
       "devDependencies": {
         "@microsoft/api-extractor": "^7.58.9",


### PR DESCRIPTION
Version bump for `pi-outpost` and `@pi-outpost/embed`, 0.6.5 → 0.6.6. Merging this does **not** publish; pushing the `v0.6.6` tag afterwards does.

## What ships since v0.6.5

**Fixes users will notice**
- Math in assistant replies no longer breaks when the model mixes LaTeX delimiters (`$$…\]`). One malformed formula used to take down every formula after it in the same message (#33)
- New `offline` setting — config `"offline": true`, `--offline`, or `PI_OFFLINE` — for hosts that cannot reach the remote model catalogs. Without it, every credential change stalls 20 s on such a host (#34)

**Security**
- All 14 open Dependabot alerts cleared, including the agent SDK's nested `undici` and `brace-expansion` (#26)
- Polynomial ReDoS in `mentionedPaths` replaced with a linear scan (#32, CodeQL #9)

**Reliability / internals**
- The credentials onboarding flake is fixed at the root: `ModelRuntime.refresh()` reaches the network, and the test harness now runs offline (#31). Server test suite went 188 s → 87 s along the way (#28), and the SDK calls behind `set_credential` are bounded (#29)
- `@pi-outpost/ui` declares the dependencies it actually imports (#35)
- npm keywords widened so the package is findable by "web interface" (#30) — takes effect with this publish

## Release checklist

- [x] both packages at 0.6.6, lockfile updated
- [ ] merge
- [ ] `git tag v0.6.6 && git push origin v0.6.6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)