### PR TITLE
fix(test): take ports from the OS instead of guessing

### DIFF
--- a/server/test/harness.mjs
+++ b/server/test/harness.mjs
@@ -6,6 +6,7 @@
  */
 import { spawn, execSync } from "node:child_process";
 import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import net from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -19,10 +20,28 @@ const ENTRY = path.join(SERVER_DIR, "src", "index.ts");
 // wrapper on Windows combined with `detached: true` produces spawn EINVAL.
 const TSX_LOADER = "--import=tsx/esm";
 
-/** Ports are per-suite so suites can run in parallel without colliding with a dev server. */
-let nextPort = 3400 + Math.floor(Math.random() * 200);
-export function freePort() {
-  return nextPort++;
+/**
+ * A port nothing else is on, from the OS.
+ *
+ * This used to be `3400 + random(200)` per process, incrementing. node --test runs
+ * test files in parallel, so two of them regularly drew the same base — and the
+ * loser's client then talked to the *other* file's server. When that server was
+ * auth.test.mjs's, which requires a token, the connection came back as
+ * `socket closed (4401)` in a test that never configured a token: the release run
+ * for v0.6.6 died that way. Binding port 0 and reading back what the kernel picked
+ * removes the guess.
+ */
+export async function freePort() {
+  const probe = net.createServer();
+  try {
+    await new Promise((resolve, reject) => {
+      probe.once("error", reject);
+      probe.listen(0, "127.0.0.1", resolve);
+    });
+    return probe.address().port;
+  } finally {
+    await new Promise((resolve) => probe.close(resolve));
+  }
 }
 
 /**
@@ -44,7 +63,7 @@ export async function makeWorkspace(files = {}) {
  * absolute). Resolves once /health answers. Always `await server.stop()`.
  */
 export async function startServer(root, config = {}, options = {}) {
-  const port = config.server?.port ?? freePort();
+  const port = config.server?.port ?? (await freePort());
   const full = {
     cwd: root,
     // Sessions, settings and extensions live inside the throwaway workspace: without

--- a/server/test/resource-isolation.test.mjs
+++ b/server/test/resource-isolation.test.mjs
@@ -48,7 +48,7 @@ describe("resource isolation", () => {
         skillPaths: ["./test-skill"],
         noPromptTemplates: true,
         promptPaths: ["./test-prompt.md"],
-        server: { port: freePort() },
+        server: { port: await freePort() },
       });
 
       const client = connect(server.wsUrl());
@@ -106,7 +106,7 @@ describe("resource isolation", () => {
         noExtensions: true,
         noSkills: true,
         noPromptTemplates: true,
-        server: { port: freePort() },
+        server: { port: await freePort() },
       });
 
       const client = connect(server.wsUrl());
@@ -140,7 +140,7 @@ describe("resource isolation", () => {
       const server = await startServer(root, {
         noExtensions: true,
         extensionPaths: [path.join(FIXTURES, "test-extension.ts")],
-        server: { port: freePort() },
+        server: { port: await freePort() },
       });
 
       const client = connect(server.wsUrl());

--- a/server/test/sandbox.test.ts
+++ b/server/test/sandbox.test.ts
@@ -105,7 +105,7 @@ describe("sandbox readExceptions integration", () => {
       noSkills: true,
       skillPaths: [skillDir],
       noPromptTemplates: true,
-      server: { port: freePort() },
+      server: { port: await freePort() },
     });
   });
 


### PR DESCRIPTION
The v0.6.6 release run failed here:

```
not ok 22 - a custom OpenAI-compatible endpoint becomes selectable, and is written where the next start reads it
  error: 'socket closed (4401)'
```

## Diagnosis

`4401` has exactly one source in the codebase (`server/src/index.ts:257`): a WebSocket whose token check failed. But the credentials tests strip `PI_OUTPOST_TOKEN` from the environment of the server they start, so *their* server cannot require one.

The client was therefore talking to a **different server** — `auth.test.mjs`'s, which does require a token.

How it reached it: `freePort()` drew `3400 + random(200)` once per process and incremented from there. `node --test` runs test files in parallel, so with a dozen files two regularly draw the same base (birthday problem over 200 slots). The harness's `/health` poll then succeeds against the neighbour's server, `startServer` returns happily, and the WebSocket connects to the wrong one.

Worth stating plainly since it came up: this has nothing to do with `PI_OFFLINE` or the network. It is loopback TCP between two local test servers.

## Fix

Bind port 0 and read back what the kernel assigned. `freePort()` becomes async; its four call sites `await` it.

## Verification

- `npm test --workspace server` — 252 passed, 83 s
- the port-sensitive files together (credentials, auth, sandbox, resource-isolation, extensions) — 23 passed
- `npm run typecheck --workspace server` — clean

## Release

`v0.6.6` currently points at `2f45c70`, which lacks this. Nothing was published — the run died before the publish step — so the tag can move to the merge commit and the release re-run cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)