### PR TITLE
fix(web): scan the ui workspace for Tailwind classes

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -7,6 +7,11 @@
    utility-class scanning of web/src work the same regardless of which build processes
    this stylesheet. */
 @source "./**/*.{ts,tsx}";
+/* Every component moved to the ui workspace (#20/#21); web/src now holds little
+   more than main.tsx. Without this, Tailwind scans a directory with no components
+   in it and emits no utilities at all — the app renders unstyled. Relative to this
+   stylesheet, so it resolves the same whether web or embed is doing the build. */
+@source "../../ui/src/**/*.{ts,tsx}";
 
 /* data-theme is set by useTheme() on the root element: document.documentElement for
    the standalone app, or the widget's shadow host when embedded (embed/src/mount.tsx)


### PR DESCRIPTION
The app renders **unstyled**: Tailwind emits no utilities at all.

## Cause

`web/src/index.css` declared one scan root:

```css
@source "./**/*.{ts,tsx}";
```

That is `web/src` — which since #20/#21 contains little more than `main.tsx`. Every component moved to the `ui` workspace, and nothing told Tailwind to look there, so it scanned a tree with no components and generated nothing.

## Evidence

Occurrences in the built stylesheet (`web/dist/assets/*.css`), before and after:

| class | before | after |
|---|---|---|
| `rotate-90` | 0 | 1 |
| `max-w-64` | 0 | 1 |
| `shrink-0` | 0 | 1 |
| `prose-chat` | 1 | 1 |

`prose-chat` is written literally in `index.css`, which is why the stylesheet looked like it was loading correctly — the file was there, its utilities were not. The built CSS is 83 KB after the fix.

## Why it went unnoticed

The dev server at `:3141` serves the committed `server/src/embedded-web.ts`, built before the components moved. Only the Vite dev server and a fresh production build expose the regression. Anyone checking `:3141` saw a styled app.

## Note on the published package

`embedded-web.ts` is regenerated at `prepack`, so **v0.6.6 on npm was built from the broken stylesheet** and is very likely unstyled. Worth verifying, and worth a patch release if confirmed — that check is not part of this PR.

The regenerated bundle is deliberately left out of this diff: it is 4.5 MB of base64 and would blow the supply-chain scanner's 1 MB limit, as it did in #26. A checkout still serves the stale bundle on `:3141` until someone runs `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)