### PR TITLE
chore(release): v0.6.7

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-outpost",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "type": "module",
   "description": "A web interface for the pi coding agent: a browser chat UI you run with npx — no clone, no build.",
   "license": "MIT",

--- a/embed/package.json
+++ b/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-outpost/embed",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "type": "module",
   "description": "Mount pi-outpost as a Shadow-DOM-isolated widget inside another web app.",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
     },
     "cli": {
       "name": "pi-outpost",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "^0.84.1",
@@ -43,7 +43,7 @@
     },
     "embed": {
       "name": "@pi-outpost/embed",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "license": "MIT",
       "devDependencies": {
         "@microsoft/api-extractor": "^7.58.9",


### PR DESCRIPTION
Patch release for one thing: **0.6.6 ships an unstyled UI.**

Verified against the published tarball — `package/dist/web/assets/index-BoGDjn3h.css`, 43 KB, containing zero Tailwind utilities:

| class | in published 0.6.6 | after #38 |
|---|---|---|
| `rotate-90` | 0 | 1 |
| `max-w-64` | 0 | 1 |
| `shrink-0` | 0 | 1 |

`npx pi-outpost@0.6.6` renders the interface with no styling at all. #38 fixes the cause: the stylesheet only scanned `web/src`, which stopped holding components when they moved to the `ui` workspace in #20/#21.

Nothing else is in this release. The per-turn usage feature stays on its branch for review.

## Checklist

- [x] both packages at 0.6.7, lockfile updated
- [ ] merge
- [ ] `git tag v0.6.7 && git push origin v0.6.7`
- [ ] verify the published CSS actually carries utilities this time

🤖 Generated with [Claude Code](https://claude.com/claude-code)