### PR TITLE
Test the wiring and the hub, not just the parts

### DIFF
--- a/server/test/convert.test.ts
+++ b/server/test/convert.test.ts
@@ -352,6 +352,28 @@ describe("historyToItems — turn usage", () => {
     assert.equal(assistant?.usage?.cost, 0.004);
   });
 
+  test("the live and replay paths report a turn identically", () => {
+    // The bug this guards against is a divergence, not a wrong figure: a session
+    // reopened must report what it reported while it ran, and the two paths build
+    // the assistant item separately.
+    const tokens = { input: 10, output: 5, cacheRead: 2, cacheWrite: 1, totalTokens: 18 };
+    const messages = [
+      { role: "assistant", content: [{ type: "text", text: "done" }], usage: { ...tokens, cost: { total: 0.02 } } },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call-1", name: "read", arguments: {} }],
+        usage: { ...tokens, cost: { total: 0.01 } },
+      },
+    ];
+    for (const message of messages) {
+      const replayed = historyToItems([{ role: "user", content: "hi" }, message]).find(
+        (item) => item.kind === "assistant",
+      );
+      const live = assistantToItem(message);
+      assert.deepEqual(replayed?.usage, live.kind === "assistant" ? live.usage : undefined);
+    }
+  });
+
   test("a tool-only turn without usage stays out of the transcript", () => {
     const items = historyToItems([
       { role: "user", content: "hi" },

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import type { ChatItem, TurnUsage } from "@pi-outpost/shared";
 import App from "./App";
 
 // Mock useAgent to return a controlled state without WebSocket dependency
@@ -13,6 +14,89 @@ vi.mock("./theme/useTheme", () => ({
   useTheme: () => ({ theme: "dark" as const, toggle: vi.fn(), setTheme: vi.fn() }),
 }));
 
+/** The agent state App reads, with only the fields a test cares about overridden. */
+function agentState(overrides: Record<string, unknown> = {}) {
+  return {
+    connected: true,
+    authRequired: false,
+    branding: { title: "Test App" },
+    sessionId: "sess_1",
+    model: "anthropic/claude-opus-5",
+    thinkingLevel: "off",
+    modelSupportsReasoning: false,
+    models: [{ provider: "anthropic", id: "claude-opus-5" }],
+    commands: [],
+    sessions: null,
+    sessionSearch: null,
+    tree: null,
+    isStreaming: false,
+    items: [] as ChatItem[],
+    queue: { steering: [], followUp: [] },
+    errors: [],
+    contextUsage: null,
+    isCompacting: false,
+    dialogQueue: [],
+    notifications: [],
+    statuses: {},
+    widgets: {},
+    editorPrefill: null,
+    fileTree: {},
+    openFile: null,
+    credentials: null,
+    fileSearch: null,
+    extensionPaths: [],
+    sandbox: null,
+    versions: null,
+    gitAvailable: false,
+    gitStatus: null,
+    gitDiff: null,
+    gitLog: null,
+    gitShow: null,
+    ...overrides,
+  };
+}
+
+/** Every callback App destructures from useAgent, each a spy. */
+function agentApi(state: ReturnType<typeof agentState>) {
+  return {
+    state,
+    authToken: null,
+    submitToken: vi.fn(),
+    prompt: vi.fn(),
+    abort: vi.fn(),
+    setModel: vi.fn(),
+    setThinking: vi.fn(),
+    newSession: vi.fn(),
+    switchSession: vi.fn(),
+    deleteSession: vi.fn(),
+    listSessions: vi.fn(),
+    renameSession: vi.fn(),
+    searchSessions: vi.fn(),
+    clearSessionSearch: vi.fn(),
+    listTree: vi.fn(),
+    navigateTree: vi.fn(),
+    forkSession: vi.fn(),
+    editPrompt: vi.fn(),
+    compact: vi.fn(),
+    respondToDialog: vi.fn(),
+    dismissNotification: vi.fn(),
+    listDirectory: vi.fn(),
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    closeFilePreview: vi.fn(),
+    searchFiles: vi.fn(),
+    clearFileSearch: vi.fn(),
+    fetchGitDiff: vi.fn(),
+    clearGitDiff: vi.fn(),
+    fetchGitLog: vi.fn(),
+    fetchGitShow: vi.fn(),
+    clearGitShow: vi.fn(),
+    setCredential: vi.fn(),
+    declareProvider: vi.fn(),
+    updateConfig: vi.fn(),
+  };
+}
+
 beforeEach(() => {
   mockUseAgent.mockReset();
 });
@@ -22,79 +106,7 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 describe("App — authRequired", () => {
   beforeEach(() => {
-    mockUseAgent.mockReturnValue({
-      state: {
-        connected: false,
-        authRequired: true,
-        branding: { title: "Test App" },
-        sessionId: "",
-        model: "",
-        thinkingLevel: "off",
-        modelSupportsReasoning: false,
-        models: [],
-        commands: [],
-        sessions: null,
-        sessionSearch: null,
-        tree: null,
-        isStreaming: false,
-        items: [],
-        queue: { steering: [], followUp: [] },
-        errors: [],
-        contextUsage: null,
-        isCompacting: false,
-        dialogQueue: [],
-        notifications: [],
-        statuses: {},
-        widgets: {},
-        editorPrefill: null,
-        fileTree: {},
-        openFile: null,
-        credentials: null,
-        fileSearch: null,
-        extensionPaths: [],
-        sandbox: null,
-        versions: null,
-        gitAvailable: false,
-        gitStatus: null,
-        gitDiff: null,
-        gitLog: null,
-        gitShow: null,
-      },
-      authToken: null,
-      submitToken: vi.fn(),
-      prompt: vi.fn(),
-      abort: vi.fn(),
-      setModel: vi.fn(),
-      setThinking: vi.fn(),
-      newSession: vi.fn(),
-      switchSession: vi.fn(),
-      deleteSession: vi.fn(),
-      listSessions: vi.fn(),
-      renameSession: vi.fn(),
-      searchSessions: vi.fn(),
-      clearSessionSearch: vi.fn(),
-      listTree: vi.fn(),
-      navigateTree: vi.fn(),
-      forkSession: vi.fn(),
-      editPrompt: vi.fn(),
-      compact: vi.fn(),
-      respondToDialog: vi.fn(),
-      dismissNotification: vi.fn(),
-      listDirectory: vi.fn(),
-      readFile: vi.fn(),
-      writeFile: vi.fn(),
-      closeFilePreview: vi.fn(),
-      searchFiles: vi.fn(),
-      clearFileSearch: vi.fn(),
-      fetchGitDiff: vi.fn(),
-      clearGitDiff: vi.fn(),
-      fetchGitLog: vi.fn(),
-      fetchGitShow: vi.fn(),
-      clearGitShow: vi.fn(),
-      setCredential: vi.fn(),
-      declareProvider: vi.fn(),
-      updateConfig: vi.fn(),
-    });
+    mockUseAgent.mockReturnValue(agentApi(agentState({ connected: false, authRequired: true, sessionId: "" })));
   });
 
   it("renders the TokenGate when auth is required", () => {
@@ -109,84 +121,130 @@ describe("App — authRequired", () => {
 // ---------------------------------------------------------------------------
 describe("App — onboarding", () => {
   beforeEach(() => {
-    mockUseAgent.mockReturnValue({
-      state: {
-        connected: true,
-        authRequired: false,
-        branding: { title: "Pi" },
-        sessionId: "sess_1",
-        model: "",
-        thinkingLevel: "off",
-        modelSupportsReasoning: false,
-        models: [],
-        commands: [],
-        sessions: null,
-        sessionSearch: null,
-        tree: null,
-        isStreaming: false,
-        items: [],
-        queue: { steering: [], followUp: [] },
-        errors: [],
-        contextUsage: null,
-        isCompacting: false,
-        dialogQueue: [],
-        notifications: [],
-        statuses: {},
-        widgets: {},
-        editorPrefill: null,
-        fileTree: {},
-        openFile: null,
-        credentials: { usableModel: false, hasProvider: true, hasKey: false, providers: [] },
-        fileSearch: null,
-        extensionPaths: [],
-        sandbox: null,
-        versions: null,
-        gitAvailable: false,
-        gitStatus: null,
-        gitDiff: null,
-        gitLog: null,
-        gitShow: null,
-      },
-      authToken: null,
-      submitToken: vi.fn(),
-      prompt: vi.fn(),
-      abort: vi.fn(),
-      setModel: vi.fn(),
-      setThinking: vi.fn(),
-      newSession: vi.fn(),
-      switchSession: vi.fn(),
-      deleteSession: vi.fn(),
-      listSessions: vi.fn(),
-      renameSession: vi.fn(),
-      searchSessions: vi.fn(),
-      clearSessionSearch: vi.fn(),
-      listTree: vi.fn(),
-      navigateTree: vi.fn(),
-      forkSession: vi.fn(),
-      editPrompt: vi.fn(),
-      compact: vi.fn(),
-      respondToDialog: vi.fn(),
-      dismissNotification: vi.fn(),
-      listDirectory: vi.fn(),
-      readFile: vi.fn(),
-      writeFile: vi.fn(),
-      closeFilePreview: vi.fn(),
-      searchFiles: vi.fn(),
-      clearFileSearch: vi.fn(),
-      fetchGitDiff: vi.fn(),
-      clearGitDiff: vi.fn(),
-      fetchGitLog: vi.fn(),
-      fetchGitShow: vi.fn(),
-      clearGitShow: vi.fn(),
-      setCredential: vi.fn(),
-      declareProvider: vi.fn(),
-      updateConfig: vi.fn(),
-    });
+    mockUseAgent.mockReturnValue(
+      agentApi(
+        agentState({
+          branding: { title: "Pi" },
+          model: "",
+          models: [],
+          credentials: { usableModel: false, hasProvider: true, hasKey: false, providers: [] },
+        }),
+      ),
+    );
   });
 
   it("renders the onboarding screen when no usable model", () => {
     render(<App />);
     // Should not render the main chat
     expect(screen.queryByPlaceholderText(/message/i)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session analysis — the conversation side of the panel: anchors and jumps.
+// The panel's own content is covered in components/SessionAnalysis.test.tsx;
+// what matters here is that the two agree about where an item lives.
+// ---------------------------------------------------------------------------
+describe("App — session analysis", () => {
+  const usage = (cost?: number): TurnUsage => ({
+    input: 1000,
+    output: 200,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 1200,
+    ...(cost === undefined ? {} : { cost }),
+  });
+
+  const items: ChatItem[] = [
+    { kind: "user", text: "read the config" },
+    // A turn that only called tools: nothing to show, but it is a turn and it
+    // carries usage, so the analysis can point at it.
+    { kind: "assistant", blocks: [], usage: usage(0.01) },
+    { kind: "tool", toolCallId: "call-1", toolName: "read", args: { path: "a.ts" }, output: "contents" },
+    { kind: "assistant", blocks: [{ type: "text", text: "done" }], usage: usage(0.02) },
+  ];
+
+  function renderApp(hideTools = false) {
+    localStorage.setItem("pi-outpost:hide-tools", hideTools ? "1" : "0");
+    mockUseAgent.mockReturnValue(agentApi(agentState({ items })));
+    return render(<App />);
+  }
+
+  function anchor(index: number) {
+    return document.querySelector(`[data-item-index="${index}"]`);
+  }
+
+  function openAnalysis() {
+    fireEvent.click(screen.getByTitle(/turns? ·/));
+  }
+
+  beforeEach(() => {
+    // jsdom has no layout, so scrollIntoView is not implemented.
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("anchors every item the analysis can point at, including tool-only turns", () => {
+    renderApp();
+    expect(anchor(0)).not.toBeNull(); // user message
+    expect(anchor(1)).not.toBeNull(); // tool-only assistant turn: nothing rendered, still anchored
+    expect(anchor(2)).not.toBeNull(); // tool card
+    expect(anchor(3)).not.toBeNull(); // assistant message
+  });
+
+  it("opens and closes the analysis from the usage figure", () => {
+    renderApp();
+    expect(screen.queryByRole("complementary", { name: "Session analysis" })).toBeNull();
+
+    openAnalysis();
+    expect(screen.getByRole("complementary", { name: "Session analysis" })).toBeTruthy();
+
+    fireEvent.click(screen.getByLabelText("Close session analysis"));
+    expect(screen.queryByRole("complementary", { name: "Session analysis" })).toBeNull();
+  });
+
+  it("scrolls to the turn behind a chart point and marks it", () => {
+    renderApp();
+    openAnalysis();
+    fireEvent.click(screen.getAllByRole("button", { name: /^Turn 2:/ })[0]);
+
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+    expect(anchor(3)?.className).toContain("ring-2");
+    expect(anchor(0)?.className).not.toContain("ring-2");
+  });
+
+  it("scrolls to a turn that shows nothing without marking a neighbour instead", () => {
+    // A tool-only turn has no card of its own; its anchor carries no mark, and
+    // marking the message next to it would point at the wrong turn.
+    renderApp();
+    openAnalysis();
+    fireEvent.click(screen.getAllByRole("button", { name: /^Turn 1:/ })[0]);
+
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+    expect(anchor(3)?.className).not.toContain("ring-2");
+    expect(anchor(0)?.className).not.toContain("ring-2");
+  });
+
+  it("reveals a hidden tool call before scrolling to it", () => {
+    renderApp(true);
+    expect(anchor(2)).toBeNull(); // tool cards filtered out of the conversation
+
+    openAnalysis();
+    fireEvent.click(screen.getByRole("button", { name: /Jump to the read call/ }));
+
+    expect(anchor(2)).not.toBeNull();
+    expect(anchor(2)?.className).toContain("ring-2");
+  });
+
+  it("reports the same token total in the bar and in the panel", () => {
+    renderApp();
+    expect(screen.getByTitle(/2 turns ·/).textContent).toContain("2k tok");
+
+    openAnalysis();
+    const heading = screen.getByText("tokens", { selector: "h3" });
+    expect(within(heading.closest("section") as HTMLElement).getByLabelText("total: 2k")).toBeTruthy();
   });
 });

--- a/ui/src/components/ModelBar.test.tsx
+++ b/ui/src/components/ModelBar.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { ModelBar } from "./ModelBar";
+import { THINKING_LEVELS } from "@pi-outpost/shared";
 import type { SessionUsage } from "../util/sessionUsage";
 
 const NOTHING: SessionUsage = {
@@ -95,5 +96,108 @@ describe("ModelBar usage indicator", () => {
     renderBar({ ...NOTHING, turns: 1, totalTokens: 1_000, cost: 0.01 }, onToggleAnalysis);
     fireEvent.click(screen.getByTitle(/1 turn/));
     expect(onToggleAnalysis).toHaveBeenCalledOnce();
+  });
+});
+
+describe("ModelBar controls", () => {
+  function renderFull(overrides: Partial<React.ComponentProps<typeof ModelBar>> = {}) {
+    const props = {
+      model: "anthropic/claude-opus-5",
+      models: [
+        { provider: "anthropic", id: "claude-opus-5" },
+        { provider: "openai", id: "gpt-5" },
+      ],
+      thinkingLevel: "off",
+      modelSupportsReasoning: true,
+      isStreaming: false,
+      contextUsage: null,
+      sessionUsage: NOTHING,
+      analysisOpen: false,
+      onToggleAnalysis: vi.fn(),
+      isCompacting: false,
+      onSetModel: vi.fn(),
+      onSetThinking: vi.fn(),
+      onCompact: vi.fn(),
+      ...overrides,
+    };
+    render(<ModelBar {...props} />);
+    return props;
+  }
+
+  it("switches to the model the user picked, provider and id apart", () => {
+    const props = renderFull();
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "openai/gpt-5" } });
+    expect(props.onSetModel).toHaveBeenCalledWith("openai", "gpt-5");
+  });
+
+  it("keeps a model the server reports but does not list", () => {
+    // Otherwise the select would silently show someone else's model.
+    renderFull({ model: "local/qwen3" });
+    expect(screen.getByRole("option", { name: "local/qwen3" })).toBeTruthy();
+  });
+
+  it("hides the thinking control for a model that cannot reason", () => {
+    renderFull({ modelSupportsReasoning: false });
+    expect(screen.queryByTitle("thinking level")).toBeNull();
+  });
+
+  it("sets the thinking level from the slider", () => {
+    const props = renderFull();
+    fireEvent.click(screen.getByTitle("thinking level"));
+    fireEvent.change(screen.getByLabelText("Thinking level"), { target: { value: "2" } });
+    expect(props.onSetThinking).toHaveBeenCalledWith(THINKING_LEVELS[2]);
+  });
+
+  it("closes the thinking popover on Escape", () => {
+    renderFull();
+    fireEvent.click(screen.getByTitle("thinking level"));
+    expect(screen.getByLabelText("Thinking level")).toBeTruthy();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByLabelText("Thinking level")).toBeNull();
+  });
+
+  it("locks the controls that would race a running turn", () => {
+    renderFull({ isStreaming: true });
+    expect(screen.getByRole("combobox")).toBeDisabled();
+    expect(screen.getByTitle("thinking level")).toBeDisabled();
+  });
+
+  it("reports how full the context is, and what compaction would act on", () => {
+    renderFull({ contextUsage: { tokens: 45_000, contextWindow: 200_000, percent: 22.5 } });
+    const button = screen.getByTitle(/45,000 \/ 200,000 tokens/);
+    expect(button.textContent).toContain("23%");
+  });
+
+  it("says nothing about a context it cannot measure", () => {
+    renderFull({ contextUsage: { tokens: null, contextWindow: 200_000, percent: null } });
+    expect(screen.getByText("context")).toBeTruthy();
+  });
+
+  it("compacts on request, and not while already compacting", () => {
+    const props = renderFull({ isCompacting: true });
+    const button = screen.getByText("compacting…").closest("button") as HTMLButtonElement;
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(props.onCompact).not.toHaveBeenCalled();
+  });
+
+  it("leaves the figure inert for a host that renders no analysis", () => {
+    render(
+      <ModelBar
+        model="anthropic/claude-opus-5"
+        models={[{ provider: "anthropic", id: "claude-opus-5" }]}
+        thinkingLevel="off"
+        modelSupportsReasoning={false}
+        isStreaming={false}
+        contextUsage={null}
+        sessionUsage={{ ...NOTHING, turns: 1, totalTokens: 1_000 }}
+        isCompacting={false}
+        onSetModel={() => {}}
+        onSetThinking={() => {}}
+        onCompact={() => {}}
+      />,
+    );
+    expect(screen.getByTitle(/1 turn/).tagName).toBe("SPAN");
   });
 });

--- a/ui/src/components/SessionAnalysis.test.tsx
+++ b/ui/src/components/SessionAnalysis.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import type { ChatItem, TurnUsage } from "@pi-outpost/shared";
 import { SessionAnalysisPanel } from "./SessionAnalysis";
@@ -29,9 +29,9 @@ function section(title: string) {
   return within(element);
 }
 
-function renderPanel(items: ChatItem[], onJump = vi.fn()) {
-  render(<SessionAnalysisPanel analysis={analyzeSession(items)} onJump={onJump} onClose={() => {}} />);
-  return onJump;
+function renderPanel(items: ChatItem[], onJump = vi.fn(), onClose = vi.fn()) {
+  render(<SessionAnalysisPanel analysis={analyzeSession(items)} onJump={onJump} onClose={onClose} />);
+  return { onJump, onClose };
 }
 
 describe("SessionAnalysisPanel", () => {
@@ -72,13 +72,13 @@ describe("SessionAnalysisPanel", () => {
   });
 
   it("jumps to the turn behind a chart point", () => {
-    const onJump = renderPanel([user("go"), turn(), turn()]);
+    const { onJump } = renderPanel([user("go"), turn(), turn()]);
     fireEvent.click(screen.getByRole("button", { name: /Turn 2:/ }));
     expect(onJump).toHaveBeenCalledWith(2);
   });
 
   it("ranks tool calls by the chosen criterion", () => {
-    const onJump = renderPanel([
+    const { onJump } = renderPanel([
       user("go"),
       turn(),
       tool({ toolCallId: "small", output: "a", args: { path: "a/very/long/path/to/a/file.ts" } }),
@@ -125,7 +125,7 @@ describe("SessionAnalysisPanel", () => {
   });
 
   it("ranks requests by consumption and jumps to the user message", () => {
-    const onJump = renderPanel([
+    const { onJump } = renderPanel([
       user("light one"),
       turn({ totalTokens: 10 }),
       user("heavy one"),
@@ -163,5 +163,67 @@ describe("SessionAnalysisPanel", () => {
       />,
     );
     expect(section("tokens").getByLabelText("total: 3k")).toBeTruthy();
+  });
+});
+
+describe("SessionAnalysisPanel — narrow screens", () => {
+  const wide = window.innerWidth;
+
+  function resize(width: number) {
+    Object.defineProperty(window, "innerWidth", { value: width, configurable: true, writable: true });
+  }
+
+  afterEach(() => resize(wide));
+
+  it("closes itself on a jump when it covers the conversation", () => {
+    // Below the breakpoint the drawer is full-width: landing behind it would
+    // show the user nothing.
+    resize(500);
+    const { onJump, onClose } = renderPanel([user("go"), turn(), turn()]);
+    fireEvent.click(screen.getAllByRole("button", { name: /^Turn 1:/ })[0]);
+    expect(onJump).toHaveBeenCalledWith(1);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("stays open on a jump when the conversation is beside it", () => {
+    resize(1400);
+    const { onJump, onClose } = renderPanel([user("go"), turn(), turn()]);
+    fireEvent.click(screen.getAllByRole("button", { name: /^Turn 1:/ })[0]);
+    expect(onJump).toHaveBeenCalledWith(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});
+
+describe("SessionAnalysisPanel — chart geometry", () => {
+  /** y of the plotted point for a series, read off the rendered SVG. */
+  function pointYs(className: string) {
+    return [...document.querySelectorAll(`circle.${className}`)].map((c) => Number(c.getAttribute("cy")));
+  }
+
+  it("plots a heavier turn above a lighter one", () => {
+    renderPanel([user("go"), turn({ input: 100, totalTokens: 100 }), turn({ input: 5000, totalTokens: 5000 })]);
+    const [light, heavy] = pointYs("text-emerald-500");
+    // SVG y grows downward: the heavier turn sits at the smaller coordinate.
+    expect(heavy).toBeLessThan(light);
+  });
+
+  it("keeps every point on the plot when a turn consumed nothing", () => {
+    // A zero maximum would divide by zero and put the line off the chart.
+    renderPanel([
+      user("go"),
+      turn({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 }),
+      turn({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 }),
+    ]);
+    for (const y of pointYs("text-emerald-500")) {
+      expect(Number.isFinite(y)).toBe(true);
+      expect(y).toBeGreaterThan(0);
+    }
+  });
+
+  it("scales the chart to fit however many turns it has", () => {
+    renderPanel([user("go"), ...Array.from({ length: 40 }, () => turn())]);
+    const chart = section("tokens per turn").getByRole("group", { name: "Per-turn chart" });
+    // Fixed spacing per turn: a long session scrolls rather than collapsing.
+    expect(Number(chart.getAttribute("width"))).toBeGreaterThan(40 * 20);
   });
 });

--- a/ui/src/useAgent.test.ts
+++ b/ui/src/useAgent.test.ts
@@ -79,6 +79,41 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+
+// ---------------------------------------------------------------------------
+// Shared harness: a connected hook with a session already established.
+// ---------------------------------------------------------------------------
+/** Renders the hook, opens the socket, and replays a `hello` with `items`. */
+async function connected(items: unknown[] = []) {
+  const { result } = renderHook(() => useAgent());
+  act(() => mockWs!.open());
+  await waitFor(() => expect(result.current.state.connected).toBe(true));
+  act(() =>
+    mockWs!.receive({
+      type: "hello",
+      sessionId: "sess_1",
+      branding: {},
+      model: "",
+      thinkingLevel: "off",
+      models: [],
+      commands: [],
+      isStreaming: false,
+      items,
+      contextUsage: null,
+      gitAvailable: false,
+    }),
+  );
+  await waitFor(() => expect(result.current.state.sessionId).toBe("sess_1"));
+  return result;
+}
+
+/** The requestId of the last frame the hook sent. */
+function lastRequestId() {
+  return JSON.parse(mockWs!.sent[mockWs!.sent.length - 1]).requestId as string;
+}
+
+const userItem = (text: string) => ({ kind: "user", text });
+
 // ---------------------------------------------------------------------------
 // Connect lifecycle
 // ---------------------------------------------------------------------------
@@ -278,5 +313,441 @@ describe("API methods", () => {
 
     expect(mockWs!.sent).toHaveLength(1);
     expect(JSON.parse(mockWs!.sent[0]).type).toBe("abort");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// user_entries — pairing bubbles to session entries
+//
+// The riskiest reducer in the hook: an entryId is what an edit rewinds to, so a
+// mispaired bubble silently rewinds the wrong turn.
+// ---------------------------------------------------------------------------
+describe("user_entries pairing", () => {
+  it("pairs bubbles to entries from the end", async () => {
+    const result = await connected([userItem("first"), userItem("second")]);
+
+    act(() =>
+      mockWs!.receive({
+        type: "user_entries",
+        entries: [
+          { entryId: "e1", text: "first" },
+          { entryId: "e2", text: "second" },
+        ],
+      }),
+    );
+
+    await waitFor(() => {
+      const items = result.current.state.items;
+      expect(items[0].kind === "user" && items[0].entryId).toBe("e1");
+      expect(items[1].kind === "user" && items[1].entryId).toBe("e2");
+    });
+  });
+
+  it("pairs only the suffix when compaction dropped older entries", async () => {
+    // The server keeps the whole branch; the transcript starts mid-way.
+    const result = await connected([userItem("second"), userItem("third")]);
+
+    act(() =>
+      mockWs!.receive({
+        type: "user_entries",
+        entries: [
+          { entryId: "e1", text: "first" },
+          { entryId: "e2", text: "second" },
+          { entryId: "e3", text: "third" },
+        ],
+      }),
+    );
+
+    await waitFor(() => {
+      const items = result.current.state.items;
+      expect(items[0].kind === "user" && items[0].entryId).toBe("e2");
+      expect(items[1].kind === "user" && items[1].entryId).toBe("e3");
+    });
+  });
+
+  it("stops at the first mismatch instead of shifting every id", async () => {
+    // "local only" was never persisted (an extension command, an aborted steer).
+    // Pairing past it would hand each older bubble its neighbour's entry.
+    const result = await connected([userItem("first"), userItem("local only"), userItem("third")]);
+
+    act(() =>
+      mockWs!.receive({
+        type: "user_entries",
+        entries: [
+          { entryId: "e1", text: "first" },
+          { entryId: "e3", text: "third" },
+        ],
+      }),
+    );
+
+    await waitFor(() => {
+      const items = result.current.state.items;
+      expect(items[2].kind === "user" && items[2].entryId).toBe("e3");
+      // Everything before the mismatch loses its id rather than getting a wrong one.
+      expect(items[1].kind === "user" && items[1].entryId).toBeUndefined();
+      expect(items[0].kind === "user" && items[0].entryId).toBeUndefined();
+    });
+  });
+
+  it("drops an id that no longer pairs", async () => {
+    const result = await connected([userItem("first")]);
+
+    act(() => mockWs!.receive({ type: "user_entries", entries: [{ entryId: "e1", text: "first" }] }));
+    await waitFor(() => expect(result.current.state.items[0].kind === "user" && result.current.state.items[0].entryId).toBe("e1"));
+
+    act(() => mockWs!.receive({ type: "user_entries", entries: [{ entryId: "e9", text: "something else" }] }));
+    await waitFor(() => {
+      const item = result.current.state.items[0];
+      expect(item.kind === "user" && "entryId" in item).toBe(false);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stale answers — every one of these guards a silent wrong-data bug
+// ---------------------------------------------------------------------------
+describe("stale responses", () => {
+  it("ignores file content for a read the user has moved on from", async () => {
+    const result = await connected();
+
+    act(() => result.current.readFile("a.ts"));
+    const first = lastRequestId();
+    act(() => result.current.readFile("b.ts"));
+
+    act(() =>
+      mockWs!.receive({ type: "file_content", requestId: first, path: "a.ts", content: "old", size: 3, mtimeMs: 1 }),
+    );
+
+    await waitFor(() => expect(result.current.state.openFile?.status).toBe("loading"));
+    expect(result.current.state.openFile?.path).toBe("b.ts");
+  });
+
+  it("ignores file search results from a superseded query", async () => {
+    const result = await connected();
+
+    act(() => result.current.searchFiles("a"));
+    const first = lastRequestId();
+    act(() => result.current.searchFiles("ab"));
+
+    act(() => mockWs!.receive({ type: "file_search_results", requestId: first, results: ["stale.ts"] }));
+
+    await waitFor(() => expect(result.current.state.fileSearch?.status).toBe("loading"));
+    expect(result.current.state.fileSearch?.results).toEqual([]);
+  });
+
+  it("ignores session search results from a superseded query", async () => {
+    const result = await connected();
+
+    act(() => result.current.searchSessions("a"));
+    const first = lastRequestId();
+    act(() => result.current.searchSessions("ab"));
+
+    act(() => mockWs!.receive({ type: "session_search_results", requestId: first, sessions: [{ id: "s1" }] }));
+
+    await waitFor(() => expect(result.current.state.sessionSearch?.status).toBe("loading"));
+    expect(result.current.state.sessionSearch?.results).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// File writes and errors — routed by requestId prefix
+// ---------------------------------------------------------------------------
+describe("file writes", () => {
+  async function withLoadedFile() {
+    const result = await connected();
+    act(() => result.current.readFile("a.ts"));
+    act(() =>
+      mockWs!.receive({
+        type: "file_content",
+        requestId: lastRequestId(),
+        path: "a.ts",
+        content: "before",
+        size: 6,
+        mtimeMs: 10,
+      }),
+    );
+    await waitFor(() => expect(result.current.state.openFile?.status).toBe("loaded"));
+    return result;
+  }
+
+  it("commits the saved buffer when the write is acknowledged", async () => {
+    const result = await withLoadedFile();
+
+    act(() => result.current.writeFile("a.ts", "after", 10));
+    act(() => mockWs!.receive({ type: "file_written", requestId: lastRequestId(), size: 5, mtimeMs: 20 }));
+
+    await waitFor(() => {
+      const file = result.current.state.openFile;
+      expect(file?.status === "loaded" && file.content).toBe("after");
+      expect(file?.status === "loaded" && file.mtimeMs).toBe(20);
+    });
+  });
+
+  it("reports a conflicting write as a retryable save error", async () => {
+    const result = await withLoadedFile();
+
+    act(() => result.current.writeFile("a.ts", "after", 10));
+    act(() =>
+      mockWs!.receive({
+        type: "file_browser_error",
+        requestId: lastRequestId(),
+        path: "a.ts",
+        message: "changed on disk",
+        reason: "conflict",
+      }),
+    );
+
+    await waitFor(() => {
+      const file = result.current.state.openFile;
+      expect(file?.status === "loaded" && file.saveError?.conflict).toBe(true);
+      expect(file?.status === "loaded" && file.pendingSave).toBeUndefined();
+      // The buffer on disk is not adopted: the editor keeps what the user typed.
+      expect(file?.status === "loaded" && file.content).toBe("before");
+    });
+  });
+
+  it("surfaces a lost connection instead of leaving the editor saving", async () => {
+    const result = await withLoadedFile();
+
+    act(() => result.current.writeFile("a.ts", "after", 10));
+    act(() => mockWs!.disconnect(1006));
+
+    await waitFor(() => {
+      const file = result.current.state.openFile;
+      expect(file?.status === "loaded" && file.pendingSave).toBeUndefined();
+      expect(file?.status === "loaded" && file.saveError?.message).toMatch(/Connection lost/);
+    });
+  });
+
+  it("routes a directory error to that directory, not the error banner", async () => {
+    const result = await connected();
+
+    act(() => result.current.listDirectory("src"));
+    act(() =>
+      mockWs!.receive({
+        type: "file_browser_error",
+        requestId: lastRequestId(),
+        path: "src",
+        message: "permission denied",
+      }),
+    );
+
+    await waitFor(() => expect(result.current.state.fileTree["src"]).toEqual({ error: "permission denied" }));
+    expect(result.current.state.errors).toEqual([]);
+  });
+
+  it("reports a failed read on the file preview itself", async () => {
+    const result = await connected();
+
+    act(() => result.current.readFile("missing.ts"));
+    act(() =>
+      mockWs!.receive({
+        type: "file_browser_error",
+        requestId: lastRequestId(),
+        path: "missing.ts",
+        message: "no such file",
+      }),
+    );
+
+    await waitFor(() => expect(result.current.state.openFile?.status).toBe("error"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Git
+// ---------------------------------------------------------------------------
+describe("git messages", () => {
+  it("keys the working-tree status by path", async () => {
+    const result = await connected();
+
+    act(() =>
+      mockWs!.receive({
+        type: "git_status",
+        branch: "main",
+        ahead: 1,
+        behind: 0,
+        files: [{ path: "a.ts", status: "modified" }],
+      }),
+    );
+
+    await waitFor(() => expect(result.current.state.gitStatus?.files["a.ts"]).toBe("modified"));
+    expect(result.current.state.gitStatus?.branch).toBe("main");
+  });
+
+  it("shows a diff failure in the diff pane, where the viewer covers the banner", async () => {
+    const result = await connected();
+    act(() => result.current.readFile("a.ts"));
+    act(() =>
+      mockWs!.receive({ type: "file_content", requestId: lastRequestId(), path: "a.ts", content: "x", size: 1, mtimeMs: 1 }),
+    );
+    await waitFor(() => expect(result.current.state.openFile?.status).toBe("loaded"));
+
+    act(() => result.current.fetchGitDiff("a.ts"));
+    act(() => mockWs!.receive({ type: "git_error", requestId: lastRequestId(), message: "not a git repo" }));
+
+    await waitFor(() => expect(result.current.state.gitDiff).toEqual({ path: "a.ts", error: "not a git repo" }));
+    expect(result.current.state.errors).toEqual([]);
+  });
+
+  it("shows any other git failure in the error banner", async () => {
+    const result = await connected();
+
+    act(() => mockWs!.receive({ type: "git_error", requestId: "gitlog:1", message: "bad revision" }));
+
+    await waitFor(() => expect(result.current.state.errors).toEqual(["git: bad revision"]));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Streaming and tool lifecycle
+// ---------------------------------------------------------------------------
+describe("streaming lifecycle", () => {
+  it("keeps two content blocks apart while they interleave", async () => {
+    const result = await connected();
+
+    act(() => mockWs!.receive({ type: "agent_start" }));
+    act(() => mockWs!.receive({ type: "block_delta", contentIndex: 0, block: "thinking", delta: "hmm" }));
+    act(() => mockWs!.receive({ type: "block_delta", contentIndex: 1, block: "text", delta: "answer" }));
+    act(() => mockWs!.receive({ type: "block_delta", contentIndex: 0, block: "thinking", delta: "…still" }));
+
+    await waitFor(() => {
+      const item = result.current.state.items[0];
+      if (item.kind !== "assistant") throw new Error("expected an assistant item");
+      expect(item.blocks).toHaveLength(2);
+      expect(item.blocks[0]).toMatchObject({ type: "thinking", text: "hmm…still" });
+      expect(item.blocks[1]).toMatchObject({ type: "text", text: "answer" });
+    });
+  });
+
+  it("replaces the streaming bubble with the finished turn, usage and all", async () => {
+    const result = await connected();
+
+    act(() => mockWs!.receive({ type: "agent_start" }));
+    act(() => mockWs!.receive({ type: "block_delta", contentIndex: 0, block: "text", delta: "part" }));
+    act(() =>
+      mockWs!.receive({
+        type: "assistant_end",
+        item: {
+          kind: "assistant",
+          blocks: [{ type: "text", text: "partial then whole" }],
+          usage: { input: 10, output: 4, cacheRead: 0, cacheWrite: 0, totalTokens: 14, cost: 0.001 },
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      // One bubble, not two: the finished item replaces the in-flight one.
+      expect(result.current.state.items).toHaveLength(1);
+      const item = result.current.state.items[0];
+      expect(item.kind === "assistant" && item.usage?.totalTokens).toBe(14);
+    });
+  });
+
+  it("updates a tool card in place and clears its running flag", async () => {
+    const result = await connected();
+
+    act(() => mockWs!.receive({ type: "agent_start" }));
+    act(() =>
+      mockWs!.receive({ type: "tool_start", toolCallId: "call-1", toolName: "read", args: { path: "a.ts" } }),
+    );
+    act(() => mockWs!.receive({ type: "block_delta", contentIndex: 0, block: "text", delta: "meanwhile" }));
+    act(() => mockWs!.receive({ type: "tool_end", toolCallId: "call-1", text: "contents", isError: false }));
+
+    await waitFor(() => {
+      const tools = result.current.state.items.filter((item) => item.kind === "tool");
+      expect(tools).toHaveLength(1); // updated in place, not appended twice
+      expect(tools[0].kind === "tool" && tools[0].output).toBe("contents");
+      expect(tools[0].kind === "tool" && tools[0].running).toBe(false);
+    });
+  });
+
+  it("stops claiming work is in flight when the agent ends", async () => {
+    const result = await connected();
+
+    act(() => mockWs!.receive({ type: "agent_start" }));
+    act(() => mockWs!.receive({ type: "tool_start", toolCallId: "call-1", toolName: "read", args: {} }));
+    act(() => mockWs!.receive({ type: "block_delta", contentIndex: 0, block: "text", delta: "hi" }));
+    act(() => mockWs!.receive({ type: "agent_end" }));
+
+    await waitFor(() => expect(result.current.state.isStreaming).toBe(false));
+    // A card left spinning after the run ended is the visible symptom of this bug.
+    for (const item of result.current.state.items) {
+      if (item.kind === "tool") expect(item.running).toBe(false);
+      if (item.kind === "assistant") expect(item.streaming).toBeFalsy();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Extension UI bridge
+// ---------------------------------------------------------------------------
+describe("extension UI", () => {
+  const request = (fields: Record<string, unknown>) => ({ type: "extension_ui_request", id: "r1", ...fields });
+
+  it("sets and clears a status entry", async () => {
+    const result = await connected();
+
+    act(() => mockWs!.receive(request({ method: "setStatus", statusKey: "lint", statusText: "running" })));
+    await waitFor(() => expect(result.current.state.statuses.lint).toBe("running"));
+
+    act(() => mockWs!.receive(request({ method: "setStatus", statusKey: "lint" })));
+    await waitFor(() => expect("lint" in result.current.state.statuses).toBe(false));
+  });
+
+  it("defaults a widget to the editor's top placement and removes it when cleared", async () => {
+    const result = await connected();
+
+    act(() => mockWs!.receive(request({ method: "setWidget", widgetKey: "todo", widgetLines: ["one"] })));
+    await waitFor(() => expect(result.current.state.widgets.todo).toEqual({ lines: ["one"], placement: "aboveEditor" }));
+
+    act(() => mockWs!.receive(request({ method: "setWidget", widgetKey: "todo" })));
+    await waitFor(() => expect("todo" in result.current.state.widgets).toBe(false));
+  });
+
+  it("queues dialogs and drops the answered one", async () => {
+    const result = await connected();
+
+    act(() => mockWs!.receive(request({ id: "d1", method: "confirm", message: "sure?" })));
+    act(() => mockWs!.receive(request({ id: "d2", method: "input", message: "name?" })));
+    await waitFor(() => expect(result.current.state.dialogQueue).toHaveLength(2));
+
+    act(() => result.current.respondToDialog({ id: "d1", result: true }));
+    await waitFor(() => expect(result.current.state.dialogQueue).toHaveLength(1));
+    expect(result.current.state.dialogQueue[0].id).toBe("d2");
+  });
+
+  it("dismisses one notification without touching the others", async () => {
+    const result = await connected();
+
+    act(() => mockWs!.receive(request({ id: "n1", method: "notify", message: "first", notifyType: "info" })));
+    act(() => mockWs!.receive(request({ id: "n2", method: "notify", message: "second", notifyType: "warn" })));
+    await waitFor(() => expect(result.current.state.notifications).toHaveLength(2));
+
+    act(() => result.current.dismissNotification("n1"));
+    await waitFor(() => expect(result.current.state.notifications).toHaveLength(1));
+    expect(result.current.state.notifications[0].id).toBe("n2");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Credentials
+// ---------------------------------------------------------------------------
+describe("credentials_changed", () => {
+  it("adopts the new model list without eating the error that came with it", async () => {
+    const result = await connected();
+
+    act(() => mockWs!.receive({ type: "error", message: "allowedModels leaves no usable model" }));
+    act(() =>
+      mockWs!.receive({
+        type: "credentials_changed",
+        model: "anthropic/claude-opus-5",
+        models: [{ provider: "anthropic", id: "claude-opus-5", reasoning: true }],
+        credentials: { usableModel: true, hasProvider: true, hasKey: true, providers: [] },
+      }),
+    );
+
+    await waitFor(() => expect(result.current.state.model).toBe("anthropic/claude-opus-5"));
+    expect(result.current.state.modelSupportsReasoning).toBe(true);
+    expect(result.current.state.errors).toHaveLength(1);
   });
 });

--- a/ui/src/useAgent.ts
+++ b/ui/src/useAgent.ts
@@ -218,7 +218,6 @@ function upsertTool(items: ChatItem[], toolCallId: string, toolName: string, pat
 
 function applySnapshot(state: AgentState, message: ServerMessage & { sessionId: string }): AgentState {
   if (message.type !== "hello" && message.type !== "session_replaced" && message.type !== "update_config_ack") return state;
-  console.log("[applySnapshot] sandbox from message:", message.sandbox, "type:", message.type, "sessionId:", message.sessionId, "fileTree keys:", Object.keys(state.fileTree).join(",") || "(empty)");
   const current = message.models.find((m) => `${m.provider}/${m.id}` === message.model);
   return {
     ...state,


### PR DESCRIPTION
Follow-up to #41, in two passes: first the session-analysis wiring, then the hub the whole UI routes through.

## Pass 1 — the session-analysis wiring

The feature shipped well covered where coverage was easy (`sessionAnalysis.ts` 99%, `sessionUsage.ts` 100%, the panel 93%) and untested exactly where it breaks: between the panel and the conversation.

- **The jump was tested against a fake conversation.** `useConversationJump.test.tsx` builds its own anchored divs, so nothing failed if `App` stopped emitting `data-item-index`. `App.test.tsx` now drives a real conversation through `App`: every pointable item carries an anchor — including the tool-only assistant turn, which renders nothing and is the one a refactor drops first — the usage figure opens and closes the drawer, a chart point scrolls to its turn and marks it, and a tool call hidden by the tool filter is revealed before the scroll.
- **The narrow-screen path had no test.** Below the breakpoint the drawer covers the conversation and a jump must close it; above it, closing would be gratuitous. Both directions pinned.
- **Charts were asserted through their labels only**, so a scaling regression shipped green. A heavier turn now provably plots above a lighter one, and an all-zero session keeps its points on the plot instead of dividing by a zero maximum.
- **Server**: the live and replay paths report a turn identically. That divergence — not a wrong figure, a disagreement between two code paths — is what let a reopened session under-report before #41.

One honest limitation surfaced and is now documented by a test: a tool-only turn has no card of its own, so its `sr-only` anchor cannot carry a highlight. The jump scrolls to the right place and marks nothing; marking the neighbouring message would point at the wrong turn.

## Pass 2 — `useAgent.ts`, the hub

Imported by fifteen files, sitting at 42% statements: the largest concentration of untested risk in the UI. The gaps were not obscure branches but the reducer's silent-wrong-data guards, where a failure looks like stale content rather than an error.

- **`user_entries` pairing**, the riskiest reducer in the file: an entryId is what an edit rewinds to, so pairing past a bubble the server never persisted hands each older bubble its neighbour's entry and rewinds the wrong turn. From-the-end pairing, the compacted-prefix case, the stop-at-mismatch rule, and id removal all covered.
- **Stale answers**: a superseded file read, file search and session search each leave the newer request alone.
- **Writes**: an acknowledged save commits the buffer; a conflict becomes a retryable error without adopting what is on disk; a disconnect mid-save reports itself instead of leaving the editor on "saving…".
- **Error routing by requestId prefix**: a directory error to that directory, a diff failure to the diff pane (the banner renders under an overlay nobody can see), everything else to the banner.
- **Streaming**: interleaved content blocks stay apart, `assistant_end` replaces the in-flight bubble rather than appending a second, a tool card updates in place, and `agent_end` stops every spinner it started.
- **Extension bridge**: delete-on-undefined for statuses and widgets, dialog queueing, per-id notification dismissal.

`ModelBar` came along for the ride (35% → 90%): provider and id kept apart on a switch, an unlisted model stays visible instead of being silently swapped, Escape closes the thinking popover, streaming locks the controls that would race it.

## One production change

Writing the hub tests turned up a `console.log` left in `applySnapshot`, printing the sandbox config and file-tree keys to every user's console on every session snapshot. Removed — the only non-test line in this PR.

## Coverage

| file | before | after |
|---|---|---|
| `useAgent.ts` | 42.0 stmt / 38.6 br | 74.0 / 70.4 |
| `components/ModelBar.tsx` | 35.4 / 42.4 | 89.6 / 79.7 |
| `App.tsx` | 31.8 / 23.0 | 43.9 / 46.0 |
| `components/SessionAnalysis.tsx` | 92.6 / 71.7 | 94.4 / 75.5 |
| ui total | 44.2 / 34.6 | 58.7 / 46.7 |

ui 285 tests pass, server 271 pass, typecheck clean.

Still open, deliberately: nothing exercises the drawer in a browser (z-index against the header menus, real scrolling, dark theme) — `web/test/*.e2e.spec.ts` needs a live server with a model, so it is not in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)