### PR TITLE
Cover the untested layers, and gate coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,15 @@ jobs:
       - name: Coverage summary
         if: matrix.os == 'ubuntu-latest' && !cancelled()
         run: node scripts/coverage-summary.mjs server=server/coverage/lcov.info ui=ui/coverage/lcov.info
+      - name: Keep the coverage for the badge job
+        if: matrix.os == 'ubuntu-latest' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: |
+            server/coverage/lcov.info
+            ui/coverage/lcov.info
+          retention-days: 1
 
       - run: npm test --workspace ui
         if: matrix.os != 'ubuntu-latest'
@@ -49,3 +58,46 @@ jobs:
       - run: npm run build
       # A stylesheet can build cleanly and style nothing (#38) — check the artifact.
       - run: npm run check:css
+
+  # The badge, drawn and pushed here rather than by a marketplace action: this is
+  # the only job that may write to the repository, and nothing outside it runs.
+  # Main only — a badge is a claim about the shipped branch.
+  badge:
+    needs: check
+    if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    # One badge writer at a time: two pushes landing together would race on gh-pages.
+    concurrency:
+      group: coverage-badge
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/download-artifact@v4
+        with:
+          name: coverage
+          path: coverage-artifact
+      - run: node scripts/coverage-badge.mjs badge/coverage.svg coverage-artifact/server/coverage/lcov.info coverage-artifact/ui/coverage/lcov.info
+      - name: Publish to gh-pages
+        run: |
+          set -euo pipefail
+          git config user.name  'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+          # An orphan branch holding only the badge: no history of the code, nothing
+          # to review, and a force-free push because it is rebuilt from empty.
+          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+            git fetch --depth=1 origin gh-pages
+            git checkout -B gh-pages origin/gh-pages
+          else
+            git checkout --orphan gh-pages
+            git rm -rf . >/dev/null 2>&1 || true
+          fi
+
+          mkdir -p badges
+          mv badge/coverage.svg badges/coverage.svg
+          git add badges/coverage.svg
+          # Nothing to say when the figure has not moved
+          git diff --staged --quiet || git commit -m 'chore(badge): coverage [skip ci]'
+          git push origin gh-pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,27 @@ jobs:
       - run: npm run typecheck
       - run: npm run build --workspace @pi-outpost/embed
       - run: npm run lint
+
+      # Coverage rides along on one platform rather than in a job of its own: the
+      # suites already run here, and instrumenting them costs seconds. Windows runs
+      # them plain, so a coverage tool can never be what turns that leg red.
+      - run: npm run test:coverage --workspace server
+        if: matrix.os == 'ubuntu-latest'
+        env:
+          CI: true
+      - run: npm run test:coverage --workspace ui
+        if: matrix.os == 'ubuntu-latest'
+      - name: Coverage summary
+        if: matrix.os == 'ubuntu-latest' && !cancelled()
+        run: node scripts/coverage-summary.mjs server=server/coverage/lcov.info ui=ui/coverage/lcov.info
+
       - run: npm test --workspace server
+        if: matrix.os != 'ubuntu-latest'
         env:
           CI: true
       - run: npm test --workspace ui
+        if: matrix.os != 'ubuntu-latest'
+
       - run: npm run build
       # A stylesheet can build cleanly and style nothing (#38) — check the artifact.
       - run: npm run check:css

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,14 @@ jobs:
       - run: npm run build --workspace @pi-outpost/embed
       - run: npm run lint
 
-      # Coverage rides along on one platform rather than in a job of its own: the
-      # suites already run here, and instrumenting them costs seconds. Windows runs
-      # them plain, so a coverage tool can never be what turns that leg red.
+      - run: npm test --workspace server
+        env:
+          CI: true
+
+      # Coverage on one platform only, and over the unit suites alone. The .mjs
+      # suites drive a real server in a subprocess: its coverage is not ours to
+      # claim, and loading them all made node truncate its own report at 10 MB.
+      # Windows runs nothing instrumented, so a coverage tool cannot turn that leg red.
       - run: npm run test:coverage --workspace server
         if: matrix.os == 'ubuntu-latest'
         env:
@@ -38,10 +43,6 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && !cancelled()
         run: node scripts/coverage-summary.mjs server=server/coverage/lcov.info ui=ui/coverage/lcov.info
 
-      - run: npm test --workspace server
-        if: matrix.os != 'ubuntu-latest'
-        env:
-          CI: true
       - run: npm test --workspace ui
         if: matrix.os != 'ubuntu-latest'
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Pi Outpost
 
 [![CI](https://github.com/laurentftech/pi-outpost/actions/workflows/ci.yml/badge.svg)](https://github.com/laurentftech/pi-outpost/actions/workflows/ci.yml)
+[![Coverage](https://laurentftech.github.io/pi-outpost/badges/coverage.svg)](https://github.com/laurentftech/pi-outpost/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%E2%89%A524-brightgreen)](https://nodejs.org)
 

--- a/scripts/coverage-badge.mjs
+++ b/scripts/coverage-badge.mjs
@@ -1,0 +1,104 @@
+/**
+ * Write a coverage badge as a self-contained SVG.
+ *
+ *   node scripts/coverage-badge.mjs badges/coverage.svg server/coverage/lcov.info ui/coverage/lcov.info
+ *
+ * The figure is the *lowest* of lines, branches and functions across every lcov
+ * given. A badge that quotes the flattering number is worse than none: it is read
+ * as a summary of the whole, so it says the weakest thing the suites can claim.
+ *
+ * No dependency and no third-party action: the badge is drawn here and pushed by
+ * the workflow with the token GitHub already mints for it, so nothing outside
+ * this repository ever needs write access to it.
+ */
+import { readFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+/** Totals for one lcov file: [hit, found] per metric. */
+function readLcov(file) {
+  const totals = { lines: [0, 0], branches: [0, 0], functions: [0, 0] };
+  const add = (key, index, value) => {
+    totals[key][index] += Number(value);
+  };
+  for (const line of readFileSync(file, "utf8").split("\n")) {
+    if (line.startsWith("LH:")) add("lines", 0, line.slice(3));
+    else if (line.startsWith("LF:")) add("lines", 1, line.slice(3));
+    else if (line.startsWith("BRH:")) add("branches", 0, line.slice(4));
+    else if (line.startsWith("BRF:")) add("branches", 1, line.slice(4));
+    else if (line.startsWith("FNH:")) add("functions", 0, line.slice(4));
+    else if (line.startsWith("FNF:")) add("functions", 1, line.slice(4));
+  }
+  return totals;
+}
+
+/** Green when comfortable, amber when it needs attention, red when it does not hold. */
+function colour(percent) {
+  if (percent >= 90) return "#3fb950";
+  if (percent >= 75) return "#d29922";
+  return "#f85149";
+}
+
+/**
+ * A flat badge, drawn rather than fetched. Character widths are approximated at
+ * 6.3px for the 11px DejaVu-ish stack browsers land on — close enough that the
+ * text never touches the edges, which is all the geometry has to guarantee.
+ */
+function svg(label, value, fill) {
+  const width = (text) => Math.round(text.length * 6.3) + 10;
+  const labelWidth = width(label);
+  const valueWidth = width(value);
+  const total = labelWidth + valueWidth;
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${total}" height="20" role="img" aria-label="${label}: ${value}">
+  <title>${label}: ${value}</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="r"><rect width="${total}" height="20" rx="3" fill="#fff"/></clipPath>
+  <g clip-path="url(#r)">
+    <rect width="${labelWidth}" height="20" fill="#555"/>
+    <rect x="${labelWidth}" width="${valueWidth}" height="20" fill="${fill}"/>
+    <rect width="${total}" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
+    <text x="${labelWidth / 2}" y="15" fill="#010101" fill-opacity=".3">${label}</text>
+    <text x="${labelWidth / 2}" y="14">${label}</text>
+    <text x="${labelWidth + valueWidth / 2}" y="15" fill="#010101" fill-opacity=".3">${value}</text>
+    <text x="${labelWidth + valueWidth / 2}" y="14">${value}</text>
+  </g>
+</svg>
+`;
+}
+
+const [output, ...inputs] = process.argv.slice(2);
+if (!output || inputs.length === 0) {
+  console.error("usage: coverage-badge.mjs <output.svg> <lcov...>");
+  process.exit(1);
+}
+
+const combined = { lines: [0, 0], branches: [0, 0], functions: [0, 0] };
+for (const file of inputs) {
+  if (!existsSync(file)) {
+    console.error(`missing lcov: ${file}`);
+    process.exit(1);
+  }
+  const totals = readLcov(file);
+  for (const key of Object.keys(combined)) {
+    combined[key][0] += totals[key][0];
+    combined[key][1] += totals[key][1];
+  }
+}
+
+const percents = Object.values(combined)
+  .filter(([, found]) => found > 0)
+  .map(([hit, found]) => (hit / found) * 100);
+if (percents.length === 0) {
+  console.error("no coverage data found in the given lcov files");
+  process.exit(1);
+}
+
+const worst = Math.min(...percents);
+const value = `${worst.toFixed(1)}%`;
+mkdirSync(path.dirname(output), { recursive: true });
+writeFileSync(output, svg("coverage", value, colour(worst)));
+console.log(`${output}: ${value} (lowest of lines/branches/functions across ${inputs.length} workspace(s))`);

--- a/scripts/coverage-summary.mjs
+++ b/scripts/coverage-summary.mjs
@@ -1,0 +1,131 @@
+/**
+ * Turn lcov files into a markdown coverage table for the GitHub Actions run summary.
+ *
+ *   node scripts/coverage-summary.mjs server=server/coverage/lcov.info ui=ui/coverage/lcov.info
+ *
+ * Writes to $GITHUB_STEP_SUMMARY when set, stdout otherwise, so the same command
+ * is useful locally.
+ *
+ * One file is deliberately singled out. server/src/index.ts is exercised only by
+ * the integration tests, which spawn the server as a subprocess — the coverage
+ * instrumentation does not follow it there, so it reports near zero however well
+ * tested it is. Folding that into one headline number would understate the suite
+ * by roughly thirty points, so it is reported apart and named.
+ */
+import { readFileSync, existsSync, appendFileSync } from "node:fs";
+import path from "node:path";
+
+/** Files whose coverage is measured elsewhere — reported, but kept out of the total. */
+const SUBPROCESS_ONLY = ["src/index.ts"];
+
+/** Parse an lcov file into per-source-file counters. */
+function parseLcov(file) {
+  const records = [];
+  let current = null;
+  for (const line of readFileSync(file, "utf8").split("\n")) {
+    if (line.startsWith("SF:")) {
+      current = { file: line.slice(3).trim(), lines: [0, 0], branches: [0, 0], functions: [0, 0] };
+      records.push(current);
+    } else if (current === null) {
+      continue;
+    } else if (line.startsWith("LF:")) current.lines[1] = Number(line.slice(3));
+    else if (line.startsWith("LH:")) current.lines[0] = Number(line.slice(3));
+    else if (line.startsWith("BRF:")) current.branches[1] = Number(line.slice(4));
+    else if (line.startsWith("BRH:")) current.branches[0] = Number(line.slice(4));
+    else if (line.startsWith("FNF:")) current.functions[1] = Number(line.slice(4));
+    else if (line.startsWith("FNH:")) current.functions[0] = Number(line.slice(4));
+  }
+  return records;
+}
+
+const pct = (hit, found) => (found === 0 ? null : (hit / found) * 100);
+const show = (value) => (value === null ? "—" : `${value.toFixed(1)}%`);
+
+/** Green above 80, amber above 60, red below — a glance should be enough. */
+function badge(value) {
+  if (value === null) return "";
+  if (value >= 80) return "🟢";
+  if (value >= 60) return "🟡";
+  return "🔴";
+}
+
+function summarise(records) {
+  const total = records.reduce(
+    (acc, record) => ({
+      lines: [acc.lines[0] + record.lines[0], acc.lines[1] + record.lines[1]],
+      branches: [acc.branches[0] + record.branches[0], acc.branches[1] + record.branches[1]],
+      functions: [acc.functions[0] + record.functions[0], acc.functions[1] + record.functions[1]],
+    }),
+    { lines: [0, 0], branches: [0, 0], functions: [0, 0] },
+  );
+  return {
+    lines: pct(...total.lines),
+    branches: pct(...total.branches),
+    functions: pct(...total.functions),
+    counted: total.lines,
+  };
+}
+
+const inputs = process.argv.slice(2).map((arg) => {
+  const [name, file] = arg.split("=");
+  return { name, file };
+});
+
+const out = [];
+out.push("## Coverage\n");
+
+const overall = [];
+const details = [];
+
+for (const { name, file } of inputs) {
+  if (!file || !existsSync(file)) {
+    out.push(`> \`${name}\`: no lcov at \`${file ?? "(unset)"}\` — coverage not reported for this workspace.\n`);
+    continue;
+  }
+  const records = parseLcov(file);
+  const held = records.filter((record) => !SUBPROCESS_ONLY.some((skip) => record.file.endsWith(skip)));
+  const apart = records.filter((record) => SUBPROCESS_ONLY.some((skip) => record.file.endsWith(skip)));
+  const summary = summarise(held);
+
+  overall.push({ name, summary, apart });
+
+  details.push(`<details><summary><strong>${name}</strong> — per file</summary>\n`);
+  details.push("| file | lines | branches | functions |");
+  details.push("| --- | ---: | ---: | ---: |");
+  for (const record of [...held].sort((a, b) => (pct(...a.lines) ?? 0) - (pct(...b.lines) ?? 0))) {
+    const lines = pct(...record.lines);
+    details.push(
+      `| \`${path.posix.normalize(record.file)}\` | ${badge(lines)} ${show(lines)} | ${show(pct(...record.branches))} | ${show(pct(...record.functions))} |`,
+    );
+  }
+  details.push("\n</details>\n");
+}
+
+out.push("| workspace | lines | branches | functions |");
+out.push("| --- | ---: | ---: | ---: |");
+for (const { name, summary } of overall) {
+  out.push(
+    `| **${name}** | ${badge(summary.lines)} ${show(summary.lines)} | ${show(summary.branches)} | ${show(summary.functions)} |`,
+  );
+}
+out.push("");
+
+const excluded = overall.flatMap(({ name, apart }) => apart.map((record) => ({ name, record })));
+if (excluded.length > 0) {
+  out.push("### Measured apart\n");
+  out.push(
+    "These are covered by integration tests that run the server in a subprocess, which the instrumentation does not follow — the figure below is not a measure of how well they are tested.\n",
+  );
+  out.push("| file | lines |");
+  out.push("| --- | ---: |");
+  for (const { record } of excluded) {
+    out.push(`| \`${path.posix.normalize(record.file)}\` | ${show(pct(...record.lines))} |`);
+  }
+  out.push("");
+}
+
+out.push(...details);
+
+const markdown = `${out.join("\n")}\n`;
+if (process.env.GITHUB_STEP_SUMMARY) appendFileSync(process.env.GITHUB_STEP_SUMMARY, markdown);
+else process.stdout.write(markdown);

--- a/scripts/coverage-summary.mjs
+++ b/scripts/coverage-summary.mjs
@@ -110,13 +110,15 @@ for (const { name, summary } of overall) {
 }
 out.push("");
 
+// Always said, whether the file shows up in the report or not: a reader comparing
+// these figures to the repository has to know which code they do not describe.
+out.push(
+  "> Measured over the unit suites. `server/src/index.ts` and the WebSocket wiring are covered by integration tests that drive a real server in a subprocess, which the instrumentation does not follow — their absence here is not an absence of tests.\n",
+);
+
 const excluded = overall.flatMap(({ name, apart }) => apart.map((record) => ({ name, record })));
 if (excluded.length > 0) {
-  out.push("### Measured apart\n");
-  out.push(
-    "These are covered by integration tests that run the server in a subprocess, which the instrumentation does not follow — the figure below is not a measure of how well they are tested.\n",
-  );
-  out.push("| file | lines |");
+  out.push("| measured apart | lines |");
   out.push("| --- | ---: |");
   for (const { record } of excluded) {
     out.push(`| \`${path.posix.normalize(record.file)}\` | ${show(pct(...record.lines))} |`);

--- a/server/package.json
+++ b/server/package.json
@@ -12,7 +12,9 @@
     "build": "tsc --noEmit",
     "build:sea": "node scripts/build-sea.mjs",
     "test": "node --import tsx/esm --test --test-timeout=300000 test/*.test.mjs test/*.test.ts",
-    "test:live": "node --test --test-timeout=180000 test/live/*.test.mjs"
+    "test:live": "node --test --test-timeout=180000 test/live/*.test.mjs",
+    "test:coverage": "node --import tsx/esm --test --experimental-test-coverage --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info --test-timeout=300000 test/*.test.mjs test/*.test.ts",
+    "pretest:coverage": "node -e \"require('node:fs').mkdirSync('coverage',{recursive:true})\""
   },
   "dependencies": {
     "@earendil-works/pi-coding-agent": "^0.84.1",

--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,7 @@
     "build:sea": "node scripts/build-sea.mjs",
     "test": "node --import tsx/esm --test --test-timeout=300000 test/*.test.mjs test/*.test.ts",
     "test:live": "node --test --test-timeout=180000 test/live/*.test.mjs",
-    "test:coverage": "node --import tsx/esm --test --experimental-test-coverage --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info --test-timeout=300000 test/*.test.ts",
+    "test:coverage": "node --import tsx/esm --test --experimental-test-coverage --test-coverage-lines=90 --test-coverage-branches=85 --test-coverage-functions=88 --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info --test-timeout=300000 test/*.test.ts",
     "pretest:coverage": "node -e \"require('node:fs').mkdirSync('coverage',{recursive:true})\""
   },
   "dependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,7 @@
     "build:sea": "node scripts/build-sea.mjs",
     "test": "node --import tsx/esm --test --test-timeout=300000 test/*.test.mjs test/*.test.ts",
     "test:live": "node --test --test-timeout=180000 test/live/*.test.mjs",
-    "test:coverage": "node --import tsx/esm --test --experimental-test-coverage --test-coverage-lines=90 --test-coverage-branches=85 --test-coverage-functions=88 --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info --test-timeout=300000 test/*.test.ts",
+    "test:coverage": "node --import tsx/esm --test --experimental-test-coverage --test-coverage-exclude='test/**' --test-coverage-exclude='src/index.ts' --test-coverage-lines=90 --test-coverage-branches=85 --test-coverage-functions=88 --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info --test-timeout=300000 test/*.test.ts",
     "pretest:coverage": "node -e \"require('node:fs').mkdirSync('coverage',{recursive:true})\""
   },
   "dependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,7 @@
     "build:sea": "node scripts/build-sea.mjs",
     "test": "node --import tsx/esm --test --test-timeout=300000 test/*.test.mjs test/*.test.ts",
     "test:live": "node --test --test-timeout=180000 test/live/*.test.mjs",
-    "test:coverage": "node --import tsx/esm --test --experimental-test-coverage --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info --test-timeout=300000 test/*.test.mjs test/*.test.ts",
+    "test:coverage": "node --import tsx/esm --test --experimental-test-coverage --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info --test-timeout=300000 test/*.test.ts",
     "pretest:coverage": "node -e \"require('node:fs').mkdirSync('coverage',{recursive:true})\""
   },
   "dependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,7 @@
     "build:sea": "node scripts/build-sea.mjs",
     "test": "node --import tsx/esm --test --test-timeout=300000 test/*.test.mjs test/*.test.ts",
     "test:live": "node --test --test-timeout=180000 test/live/*.test.mjs",
-    "test:coverage": "node --import tsx/esm --test --experimental-test-coverage --test-coverage-exclude='test/**' --test-coverage-exclude='src/index.ts' --test-coverage-lines=90 --test-coverage-branches=85 --test-coverage-functions=88 --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info --test-timeout=300000 test/*.test.ts",
+    "test:coverage": "node --import tsx/esm --test --experimental-test-coverage --test-coverage-exclude='test/**' --test-coverage-exclude='src/index.ts' --test-coverage-lines=92 --test-coverage-branches=86 --test-coverage-functions=90 --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info --test-timeout=300000 test/*.test.ts",
     "pretest:coverage": "node -e \"require('node:fs').mkdirSync('coverage',{recursive:true})\""
   },
   "dependencies": {

--- a/server/test/credentials-store.test.ts
+++ b/server/test/credentials-store.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Writing a custom provider to models.json.
+ *
+ * The file holds an API key despite its name suggesting plain configuration, and
+ * it is one the user may have hand-written — so the two properties worth pinning
+ * are that it ends up owner-readable only, and that a file we cannot parse is
+ * never overwritten. The rest is the validation that stands between a client
+ * frame and a provider id becoming a JSON key.
+ */
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync, chmodSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { after, before, beforeEach, describe, test } from "node:test";
+import { CredentialError, providerConfig, providerFileEntry, storeProvider } from "../src/credentials.ts";
+import type { ProviderDeclaration } from "../src/credentials.ts";
+
+function declaration(overrides: Partial<ProviderDeclaration> = {}): ProviderDeclaration {
+  return { provider: "corp", baseUrl: "https://llm.corp.example/v1", apiKey: "sk-corp", models: ["gpt-oss-120b"], ...overrides };
+}
+
+/** The reason a CredentialError carries, or a thrown assertion when it resolved. */
+async function refusal(run: () => Promise<unknown>): Promise<string> {
+  try {
+    await run();
+  } catch (error) {
+    if (error instanceof CredentialError) return error.message;
+    throw error;
+  }
+  throw new Error("expected the call to be refused, but it resolved");
+}
+
+describe("storeProvider", () => {
+  let agentDir: string;
+  let modelsPath: string;
+
+  before(() => {
+    agentDir = mkdtempSync(path.join(tmpdir(), "pi-creds-"));
+    modelsPath = path.join(agentDir, "models.json");
+  });
+  beforeEach(() => {
+    rmSync(modelsPath, { force: true });
+  });
+  after(() => rmSync(agentDir, { recursive: true, force: true }));
+
+  const readFile = () => JSON.parse(readFileSync(modelsPath, "utf8"));
+
+  describe("validation", () => {
+    test("refuses a provider id that could not survive as a JSON key", async () => {
+      for (const provider of ["", "../escape", "a/b", ".hidden", "a".repeat(65)]) {
+        assert.match(await refusal(() => storeProvider(agentDir, declaration({ provider }))), /Invalid provider name/);
+      }
+    });
+
+    test("refuses a base URL that is not http(s)", async () => {
+      for (const baseUrl of ["file:///etc/passwd", "not a url", "ftp://example.com", ""]) {
+        assert.match(await refusal(() => storeProvider(agentDir, declaration({ baseUrl }))), /must be an http\(s\) URL/);
+      }
+    });
+
+    test("refuses a missing or blank API key", async () => {
+      assert.match(await refusal(() => storeProvider(agentDir, declaration({ apiKey: "   " }))), /API key is required/);
+      assert.match(
+        await refusal(() => storeProvider(agentDir, declaration({ apiKey: undefined as unknown as string }))),
+        /API key is required/,
+      );
+    });
+
+    test("refuses a declaration with no usable model id", async () => {
+      for (const models of [[], [""], ["  "], undefined as unknown as string[]]) {
+        assert.match(await refusal(() => storeProvider(agentDir, declaration({ models }))), /At least one model id/);
+      }
+    });
+
+    test("writes nothing when it refuses", async () => {
+      await refusal(() => storeProvider(agentDir, declaration({ provider: "../escape" })));
+      assert.throws(() => readFileSync(modelsPath, "utf8"), /ENOENT/);
+    });
+  });
+
+  describe("writing", () => {
+    test("creates the file with the declared provider", async () => {
+      const written = await storeProvider(agentDir, declaration());
+      assert.equal(written, modelsPath);
+      const file = readFile();
+      assert.equal(file.providers.corp.baseUrl, "https://llm.corp.example/v1");
+      assert.equal(file.providers.corp.apiKey, "sk-corp");
+      assert.deepEqual(file.providers.corp.models, [{ id: "gpt-oss-120b" }]);
+    });
+
+    test("creates the agent directory if it is not there yet", async () => {
+      const fresh = path.join(agentDir, "nested", "deeper");
+      await storeProvider(fresh, declaration());
+      assert.ok(readFileSync(path.join(fresh, "models.json"), "utf8").includes("corp"));
+      rmSync(path.join(agentDir, "nested"), { recursive: true, force: true });
+    });
+
+    test("keeps the file owner-readable only, since it holds a key", async (t) => {
+      if (process.platform === "win32") return t.skip("POSIX permission bits are not meaningful here");
+      await storeProvider(agentDir, declaration());
+      assert.equal(statSync(modelsPath).mode & 0o777, 0o600);
+    });
+
+    test("narrows a file the user left world-readable", async (t) => {
+      if (process.platform === "win32") return t.skip("POSIX permission bits are not meaningful here");
+      // writeFile's mode applies only on creation: a hand-written 0644 file would
+      // keep those permissions and now hold an API key
+      writeFileSync(modelsPath, JSON.stringify({ providers: {} }));
+      chmodSync(modelsPath, 0o644);
+      await storeProvider(agentDir, declaration());
+      assert.equal(statSync(modelsPath).mode & 0o777, 0o600);
+    });
+
+    test("merges into the existing providers rather than replacing them", async () => {
+      writeFileSync(modelsPath, JSON.stringify({ providers: { other: { baseUrl: "https://other" } }, somethingElse: 1 }));
+      await storeProvider(agentDir, declaration());
+      const file = readFile();
+      assert.ok(file.providers.other, "the user's other provider must survive");
+      assert.ok(file.providers.corp);
+      assert.equal(file.somethingElse, 1, "unrelated keys must survive too");
+    });
+
+    test("replaces a provider declared again under the same name", async () => {
+      await storeProvider(agentDir, declaration());
+      await storeProvider(agentDir, declaration({ baseUrl: "https://new.example/v1", apiKey: "sk-new" }));
+      const file = readFile();
+      assert.equal(file.providers.corp.baseUrl, "https://new.example/v1");
+      assert.equal(file.providers.corp.apiKey, "sk-new");
+    });
+
+    test("refuses to clobber a file it cannot parse", async () => {
+      writeFileSync(modelsPath, "{ not json at all");
+      assert.match(await refusal(() => storeProvider(agentDir, declaration())), /not valid JSON — fix or move it first/);
+      // The user's file is still there, untouched
+      assert.equal(readFileSync(modelsPath, "utf8"), "{ not json at all");
+    });
+
+    test("refuses when the path is taken by a directory, without touching it", async () => {
+      // The read fails with EISDIR rather than ENOENT, and only ENOENT is treated as
+      // "no file yet" — so this lands on the do-not-clobber branch. The message names
+      // JSON rather than the real cause, which is imprecise but errs the safe way:
+      // it refuses and leaves the path alone.
+      const blocked = path.join(agentDir, "blocked");
+      mkdirSync(path.join(blocked, "models.json"), { recursive: true });
+      try {
+        assert.match(await refusal(() => storeProvider(blocked, declaration())), /fix or move it first/);
+      } finally {
+        rmSync(blocked, { recursive: true, force: true });
+      }
+    });
+  });
+});
+
+describe("providerFileEntry", () => {
+  test("trims the key and the model ids", () => {
+    const entry = providerFileEntry(declaration({ apiKey: "  sk-corp  ", models: [" gpt-oss-120b "] }));
+    assert.equal(entry.apiKey, "sk-corp");
+    assert.deepEqual(entry.models, [{ id: "gpt-oss-120b" }]);
+  });
+
+  test("declares the OpenAI-completions API", () => {
+    assert.equal(providerFileEntry(declaration()).api, "openai-completions");
+  });
+
+  test("carries compatibility flags when there are any", () => {
+    const entry = providerFileEntry(declaration({ compat: { supportsDeveloperRole: false } }));
+    assert.deepEqual(entry.compat, { supportsDeveloperRole: false });
+  });
+
+  test("omits an empty compat object rather than writing a useless key", () => {
+    assert.ok(!("compat" in providerFileEntry(declaration({ compat: {} }))));
+    assert.ok(!("compat" in providerFileEntry(declaration())));
+  });
+
+  test("keeps every declared model", () => {
+    const entry = providerFileEntry(declaration({ models: ["a", "b", "c"] }));
+    assert.deepEqual(entry.models, [{ id: "a" }, { id: "b" }, { id: "c" }]);
+  });
+});
+
+describe("providerConfig", () => {
+  test("spells out the fields registerProvider needs but the file loader defaults", () => {
+    const [model] = providerConfig(declaration()).models;
+    assert.equal(model.id, "gpt-oss-120b");
+    assert.equal(model.name, "gpt-oss-120b");
+    assert.equal(model.reasoning, false);
+    assert.deepEqual(model.input, ["text"]);
+    assert.equal(model.contextWindow, 128000);
+    assert.equal(model.maxTokens, 16384);
+    assert.deepEqual(model.cost, { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+  });
+
+  test("agrees with the file entry on everything else", () => {
+    const config = providerConfig(declaration({ compat: { supportsReasoningEffort: false } }));
+    const entry = providerFileEntry(declaration({ compat: { supportsReasoningEffort: false } }));
+    assert.equal(config.baseUrl, entry.baseUrl);
+    assert.equal(config.apiKey, entry.apiKey);
+    assert.equal(config.api, entry.api);
+    assert.deepEqual(config.compat, entry.compat);
+  });
+});

--- a/server/test/credentials-validation.test.ts
+++ b/server/test/credentials-validation.test.ts
@@ -1,0 +1,105 @@
+/**
+ * The two validators that stand between client frames and the credential store.
+ *
+ * `set_credential` and `declare_provider` arrive over the WebSocket, and a
+ * provider id becomes a key in auth.json / models.json while a base URL becomes
+ * a host the server will send API keys to. The integration test in
+ * credentials.test.mjs covers the happy path through the socket; these pin the
+ * boundary itself, where a rejection is the whole feature.
+ */
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { tlsHint, validBaseUrl, validProviderId } from "../src/credentials.ts";
+
+describe("validProviderId", () => {
+  test("accepts the shapes real providers use", () => {
+    for (const id of ["openai", "anthropic", "my-gateway", "vllm.local", "ollama_2", "A1", "x"]) {
+      assert.equal(validProviderId(id), true, `${id} should be accepted`);
+    }
+  });
+
+  test("refuses anything that is not a string", () => {
+    for (const value of [undefined, null, 42, {}, [], true, Symbol("x")]) {
+      assert.equal(validProviderId(value), false, `${String(value)} should be refused`);
+    }
+  });
+
+  test("refuses an empty id", () => {
+    assert.equal(validProviderId(""), false);
+  });
+
+  test("refuses an id that does not start alphanumerically", () => {
+    // A leading dot or dash is what a path-traversal attempt looks like here
+    for (const id of [".hidden", "-flag", "_under", "./relative", "../escape"]) {
+      assert.equal(validProviderId(id), false, `${id} should be refused`);
+    }
+  });
+
+  test("refuses separators, so an id can never become a path", () => {
+    for (const id of ["a/b", "a\\b", "a b", "a:b", "a\0b", "a\nb"]) {
+      assert.equal(validProviderId(id), false, `${JSON.stringify(id)} should be refused`);
+    }
+  });
+
+  test("caps the length at 64 characters", () => {
+    assert.equal(validProviderId("a".repeat(64)), true);
+    assert.equal(validProviderId("a".repeat(65)), false);
+  });
+});
+
+describe("validBaseUrl", () => {
+  test("accepts http and https endpoints", () => {
+    for (const url of ["http://localhost:11434", "https://api.example.com", "https://gw.corp/v1/", "http://127.0.0.1:8000/v1"]) {
+      assert.equal(validBaseUrl(url), true, `${url} should be accepted`);
+    }
+  });
+
+  test("refuses anything that is not a string", () => {
+    for (const value of [undefined, null, 42, {}, []]) {
+      assert.equal(validBaseUrl(value), false, `${String(value)} should be refused`);
+    }
+  });
+
+  test("refuses a string that is not a URL at all", () => {
+    for (const url of ["", "   ", "not a url", "example.com", "//example.com"]) {
+      assert.equal(validBaseUrl(url), false, `${JSON.stringify(url)} should be refused`);
+    }
+  });
+
+  test("refuses schemes that are not http(s)", () => {
+    // file: and data: would make the server read local bytes; javascript: is
+    // meaningless here but must not slip through either
+    for (const url of ["file:///etc/passwd", "data:text/plain,hi", "javascript:alert(1)", "ftp://example.com", "ws://example.com"]) {
+      assert.equal(validBaseUrl(url), false, `${url} should be refused`);
+    }
+  });
+});
+
+describe("tlsHint", () => {
+  test("recognises a TLS failure by error code", () => {
+    const hint = tlsHint({ code: "SELF_SIGNED_CERT_IN_CHAIN" });
+    assert.match(hint ?? "", /NODE_EXTRA_CA_CERTS/);
+    assert.match(hint ?? "", /SELF_SIGNED_CERT_IN_CHAIN/);
+  });
+
+  test("recognises one nested in a cause chain", () => {
+    const hint = tlsHint(Object.assign(new Error("fetch failed"), { cause: { code: "UNABLE_TO_VERIFY_LEAF_SIGNATURE" } }));
+    assert.match(hint ?? "", /TLS certificate/);
+  });
+
+  test("recognises one named only in the message", () => {
+    assert.ok(tlsHint(new Error("request to https://gw failed: DEPTH_ZERO_SELF_SIGNED_CERT")));
+  });
+
+  test("says nothing about an unrelated error", () => {
+    assert.equal(tlsHint(new Error("ECONNREFUSED")), undefined);
+    assert.equal(tlsHint(undefined), undefined);
+    assert.equal(tlsHint(null), undefined);
+  });
+
+  test("does not loop forever on a cyclic cause chain", () => {
+    const error: { code: string; cause?: unknown } = { code: "NOPE" };
+    error.cause = error;
+    assert.equal(tlsHint(error), undefined);
+  });
+});

--- a/server/test/extensionRender-html.test.ts
+++ b/server/test/extensionRender-html.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Rendering extension output to HTML.
+ *
+ * Every entry point here is reached with untrusted-ish input — an extension's own
+ * renderer, invoked server-side — so the branches that matter are the ones that
+ * decide to show nothing: not configured, no renderer for this type, a renderer
+ * that threw, or one that produced only whitespace. A card that renders as an
+ * empty box is worse than no card, and a renderer that throws must not take the
+ * response down with it.
+ */
+import assert from "node:assert/strict";
+import { afterEach, describe, test } from "node:test";
+import {
+  configureExtensionRender,
+  normalizeToolContent,
+  renderCustomMessageHtml,
+  renderToolCallHtml,
+  renderToolResultHtml,
+} from "../src/extensionRender.ts";
+
+/** A pi-tui component: renderers return one, and it yields lines of ANSI text. */
+function component(lines: string[]) {
+  return { render: () => lines };
+}
+
+/** Configure with a message renderer for `plan`, and nothing else. */
+function configureWith(render: (message: unknown, options: { expanded: boolean }) => unknown) {
+  configureExtensionRender({
+    getToolDefinition: () => undefined,
+    getMessageRenderer: (customType: string) => (customType === "plan" ? (render as never) : undefined),
+    cwd: process.cwd(),
+  });
+}
+
+afterEach(() => {
+  configureExtensionRender(undefined);
+});
+
+describe("when nothing is configured", () => {
+  test("renders no tool call", () => {
+    configureExtensionRender(undefined);
+    assert.equal(renderToolCallHtml("c1", "bash", { command: "ls" }), undefined);
+  });
+
+  test("renders no tool result", () => {
+    configureExtensionRender(undefined);
+    assert.equal(renderToolResultHtml("c1", "bash", "output", undefined, false), undefined);
+  });
+
+  test("renders no custom message", () => {
+    configureExtensionRender(undefined);
+    assert.equal(renderCustomMessageHtml("plan", "step 1", undefined, true), undefined);
+  });
+});
+
+describe("renderCustomMessageHtml", () => {
+  test("renders what the extension's renderer produced", () => {
+    configureWith(() => component(["step one", "step two"]));
+    const rendered = renderCustomMessageHtml("plan", "content", undefined, true);
+    assert.ok(rendered, "expected HTML");
+    assert.match(rendered!.expanded, /step one/);
+  });
+
+  test("keeps a collapsed preview only when it differs from the expanded one", () => {
+    configureWith((_message, options) => component(options.expanded ? ["long", "form"] : ["short"]));
+    const differing = renderCustomMessageHtml("plan", "content", undefined, true);
+    assert.ok(differing?.collapsed, "a different preview must be kept");
+
+    configureWith(() => component(["same"]));
+    const identical = renderCustomMessageHtml("plan", "content", undefined, true);
+    assert.equal(identical?.collapsed, undefined, "an identical preview is not worth sending");
+  });
+
+  test("renders nothing for a type no extension claims", () => {
+    configureWith(() => component(["step one"]));
+    assert.equal(renderCustomMessageHtml("unclaimed", "content", undefined, true), undefined);
+  });
+
+  test("renders nothing when the renderer produced no lines at all", () => {
+    // An empty card is worse than no card. Note the boundary: a renderer that
+    // returns blank *lines* still produces markup for them, so only a renderer
+    // that emits nothing at all is treated as having nothing to say.
+    configureWith(() => component([]));
+    assert.equal(renderCustomMessageHtml("plan", "content", undefined, true), undefined);
+  });
+
+  test("still renders a line that is only whitespace, since the extension asked for it", () => {
+    configureWith(() => component(["   "]));
+    assert.ok(renderCustomMessageHtml("plan", "content", undefined, true));
+  });
+
+  test("survives a renderer that throws", () => {
+    configureWith(() => {
+      throw new Error("extension bug");
+    });
+    assert.equal(renderCustomMessageHtml("plan", "content", undefined, true), undefined);
+  });
+
+  test("survives a component whose render throws", () => {
+    configureWith(() => ({
+      render: () => {
+        throw new Error("render bug");
+      },
+    }));
+    assert.equal(renderCustomMessageHtml("plan", "content", undefined, true), undefined);
+  });
+
+  test("passes the details and the display flag through to the renderer", () => {
+    let seen: { display?: boolean; details?: unknown } = {};
+    configureWith((message) => {
+      seen = message as { display?: boolean; details?: unknown };
+      return component(["ok"]);
+    });
+    renderCustomMessageHtml("plan", "content", { step: 2 }, false);
+    assert.equal(seen.display, false);
+    assert.deepEqual(seen.details, { step: 2 });
+  });
+
+  test("accepts structured content as well as a string", () => {
+    configureWith(() => component(["ok"]));
+    const rendered = renderCustomMessageHtml("plan", [{ type: "text", text: "hello" }], undefined, true);
+    assert.ok(rendered);
+  });
+});
+
+describe("tool rendering once configured", () => {
+  test("renders nothing for a tool no extension defines", () => {
+    // getToolDefinition returns undefined for everything here: there is no renderer
+    // to ask, and the answer must be "show the plain card", not a crash
+    configureWith(() => component(["ok"]));
+    assert.equal(renderToolCallHtml("c1", "unknown-tool", {}), undefined);
+    assert.equal(renderToolResultHtml("c1", "unknown-tool", "output", undefined, false), undefined);
+  });
+
+  test("normalises the content shapes the SDK may hand over", () => {
+    configureWith(() => component(["ok"]));
+    assert.equal(renderToolResultHtml("c1", "unknown-tool", undefined, undefined, false), undefined);
+    assert.equal(renderToolResultHtml("c1", "unknown-tool", [], undefined, true), undefined);
+  });
+
+  test("falls back to the dark theme for a name it does not know", () => {
+    // An unknown theme name must not leave the renderer unconfigured
+    configureExtensionRender({
+      getToolDefinition: () => undefined,
+      getMessageRenderer: () => (() => component(["themed"])) as never,
+      cwd: process.cwd(),
+      themeName: "no-such-theme",
+    });
+    assert.ok(renderCustomMessageHtml("anything", "content", undefined, true));
+  });
+});
+
+describe("normalizeToolContent", () => {
+  test("wraps a string, drops an empty one, and passes blocks through", () => {
+    assert.deepEqual(normalizeToolContent("hello"), [{ type: "text", text: "hello" }]);
+    assert.deepEqual(normalizeToolContent(""), []);
+    assert.deepEqual(normalizeToolContent(undefined), []);
+    const blocks = [{ type: "image", data: "AAAA", mimeType: "image/png" }];
+    assert.deepEqual(normalizeToolContent(blocks), blocks);
+  });
+});

--- a/server/test/fileBrowser.test.ts
+++ b/server/test/fileBrowser.test.ts
@@ -41,6 +41,8 @@ describe("file browser", () => {
   let root: string;
   /** A sibling of the root — nothing served may ever reach inside it. */
   let outside: string;
+  /** Windows refuses symlink creation without a privilege CI does not have. */
+  let symlinksAvailable = false;
 
   function write(relPath: string, content: string | Buffer) {
     const full = path.join(root, relPath);
@@ -49,14 +51,17 @@ describe("file browser", () => {
   }
 
   before(() => {
-    // realpathSync is not optional: on macOS /var is a symlink to /private/var, so
-    // an unresolved root fails isWithin against every resolved path and each test
-    // below would refuse as "outside-root" for the wrong reason
-    const base = realpathSync(mkdtempSync(path.join(tmpdir(), "pi-fb-")));
-    root = path.join(base, "root");
-    outside = path.join(base, "outside");
-    mkdirSync(root, { recursive: true });
-    mkdirSync(outside, { recursive: true });
+    // realpathSync is not optional, and it has to be applied to the directories
+    // themselves rather than to their parent: on macOS /var is a symlink to
+    // /private/var, and on Windows a temp path can carry an 8.3 short name that
+    // realpath expands. An unresolved root fails isWithin against every resolved
+    // path, and each test below would then refuse as "outside-root" for the wrong
+    // reason — which is exactly how this first ran green locally and red on CI.
+    const base = mkdtempSync(path.join(tmpdir(), "pi-fb-"));
+    mkdirSync(path.join(base, "root"), { recursive: true });
+    mkdirSync(path.join(base, "outside"), { recursive: true });
+    root = realpathSync(path.join(base, "root"));
+    outside = realpathSync(path.join(base, "outside"));
 
     writeFileSync(path.join(outside, "secret.txt"), "SECRET\n");
     write("readme.md", "# hello\n");
@@ -66,10 +71,19 @@ describe("file browser", () => {
     write("big.txt", "x".repeat(MAX_PREVIEW_BYTES + 10));
     mkdirSync(path.join(root, "empty"), { recursive: true });
 
-    // A symlink pointing out of the root: listed, but never followed
-    symlinkSync(path.join(outside, "secret.txt"), path.join(root, "escape-link"));
-    symlinkSync(outside, path.join(root, "escape-dir"));
-    symlinkSync(path.join(root, "src"), path.join(root, "src-link"));
+    // A symlink pointing out of the root: listed, but never followed. Creating one
+    // needs a privilege Windows does not grant by default, so the tests that depend
+    // on these skip rather than fail there — the confinement they check is a POSIX
+    // property of realpath, and the platform that cannot make the link cannot be
+    // walked out through it either.
+    try {
+      symlinkSync(path.join(outside, "secret.txt"), path.join(root, "escape-link"));
+      symlinkSync(outside, path.join(root, "escape-dir"), "dir");
+      symlinkSync(path.join(root, "src"), path.join(root, "src-link"), "dir");
+      symlinksAvailable = true;
+    } catch {
+      symlinksAvailable = false;
+    }
   });
 
   after(() => {
@@ -94,14 +108,16 @@ describe("file browser", () => {
       assert.equal(await reasonOf(() => readFileForPreview(root, "src/../../outside/secret.txt")), "outside-root");
     });
 
-    test("refuses to follow a symlink pointing out of the root", async () => {
+    test("refuses to follow a symlink pointing out of the root", async (t) => {
+      if (!symlinksAvailable) return t.skip("symlinks unavailable on this platform");
       // The link itself lives inside the root; its target does not
       assert.equal(await reasonOf(() => readFileForPreview(root, "escape-link")), "outside-root");
       assert.equal(await reasonOf(() => listDirectory(root, "escape-dir")), "outside-root");
       assert.equal(await reasonOf(() => readFileForPreview(root, "escape-dir/secret.txt")), "outside-root");
     });
 
-    test("follows a symlink that stays inside the root", async () => {
+    test("follows a symlink that stays inside the root", async (t) => {
+      if (!symlinksAvailable) return t.skip("symlinks unavailable on this platform");
       const entries = await listDirectory(root, "src-link");
       assert.deepEqual(
         entries.map((e) => e.name).sort(),
@@ -134,7 +150,8 @@ describe("file browser", () => {
       assert.ok(names.indexOf("binary.bin") < names.indexOf("readme.md"), "files sort by name");
     });
 
-    test("classifies symlinks by what they point at, without following them", async () => {
+    test("classifies symlinks by what they point at, without following them", async (t) => {
+      if (!symlinksAvailable) return t.skip("symlinks unavailable on this platform");
       const entries = await listDirectory(root, "");
       const byName = Object.fromEntries(entries.map((e) => [e.name, e.type]));
       // Shown rather than hidden, so an out-of-root link is visible but inert
@@ -302,7 +319,8 @@ describe("file browser", () => {
       assert.ok((await searchFiles(root, "e", 2)).length <= 2);
     });
 
-    test("skips symlinks, so a cycle cannot hang the walk", async () => {
+    test("skips symlinks, so a cycle cannot hang the walk", async (t) => {
+      if (!symlinksAvailable) return t.skip("symlinks unavailable on this platform");
       const hits = await searchFiles(root, "link");
       assert.deepEqual(hits, [], `symlinks must not be walked, got ${JSON.stringify(hits.map((h) => h.path))}`);
     });

--- a/server/test/fileBrowser.test.ts
+++ b/server/test/fileBrowser.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Unit tests for the file-browser backend.
+ *
+ * This module decides what the sidebar may read and write, so most of what
+ * follows is confinement: the `..` escape, the symlink that points out of the
+ * root, the writable zone inside a readable one. Those paths were only ever
+ * exercised through the HTTP route before, which tests the route as much as the
+ * rule. The size, binary and mtime guards are here for the same reason — they
+ * are the difference between a refused request and a corrupted file.
+ */
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, symlinkSync, writeFileSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { after, before, describe, test } from "node:test";
+import {
+  assertWithinRoot,
+  FileBrowserError,
+  listDirectory,
+  MAX_PREVIEW_BYTES,
+  readFileForPreview,
+  readFileRaw,
+  resolveBrowserRoot,
+  resolveWritableRoot,
+  searchFiles,
+  writeFileFromBrowser,
+} from "../src/fileBrowser.ts";
+
+/** The reason carried by a FileBrowserError, or the error itself when it is another kind. */
+async function reasonOf(run: () => Promise<unknown>): Promise<string> {
+  try {
+    await run();
+  } catch (error) {
+    if (error instanceof FileBrowserError) return error.reason;
+    throw error;
+  }
+  throw new Error("expected the call to be refused, but it resolved");
+}
+
+describe("file browser", () => {
+  let root: string;
+  /** A sibling of the root — nothing served may ever reach inside it. */
+  let outside: string;
+
+  function write(relPath: string, content: string | Buffer) {
+    const full = path.join(root, relPath);
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, content);
+  }
+
+  before(() => {
+    // realpathSync is not optional: on macOS /var is a symlink to /private/var, so
+    // an unresolved root fails isWithin against every resolved path and each test
+    // below would refuse as "outside-root" for the wrong reason
+    const base = realpathSync(mkdtempSync(path.join(tmpdir(), "pi-fb-")));
+    root = path.join(base, "root");
+    outside = path.join(base, "outside");
+    mkdirSync(root, { recursive: true });
+    mkdirSync(outside, { recursive: true });
+
+    writeFileSync(path.join(outside, "secret.txt"), "SECRET\n");
+    write("readme.md", "# hello\n");
+    write("src/main.ts", "console.log('hi');\n");
+    write("src/nested/deep.txt", "deep\n");
+    write("binary.bin", Buffer.from([0x68, 0x69, 0x00, 0x21]));
+    write("big.txt", "x".repeat(MAX_PREVIEW_BYTES + 10));
+    mkdirSync(path.join(root, "empty"), { recursive: true });
+
+    // A symlink pointing out of the root: listed, but never followed
+    symlinkSync(path.join(outside, "secret.txt"), path.join(root, "escape-link"));
+    symlinkSync(outside, path.join(root, "escape-dir"));
+    symlinkSync(path.join(root, "src"), path.join(root, "src-link"));
+  });
+
+  after(() => {
+    rmSync(path.dirname(root), { recursive: true, force: true });
+  });
+
+  // -------------------------------------------------------------------------
+  // Confinement
+  // -------------------------------------------------------------------------
+  describe("confinement", () => {
+    test("refuses a path that climbs out with ..", async () => {
+      assert.equal(await reasonOf(() => listDirectory(root, "../outside")), "outside-root");
+      assert.equal(await reasonOf(() => readFileForPreview(root, "../outside/secret.txt")), "outside-root");
+      assert.equal(await reasonOf(() => readFileRaw(root, "../outside/secret.txt")), "outside-root");
+    });
+
+    test("refuses an absolute path outside the root", async () => {
+      assert.equal(await reasonOf(() => readFileForPreview(root, path.join(outside, "secret.txt"))), "outside-root");
+    });
+
+    test("refuses a path that climbs out and back in", async () => {
+      assert.equal(await reasonOf(() => readFileForPreview(root, "src/../../outside/secret.txt")), "outside-root");
+    });
+
+    test("refuses to follow a symlink pointing out of the root", async () => {
+      // The link itself lives inside the root; its target does not
+      assert.equal(await reasonOf(() => readFileForPreview(root, "escape-link")), "outside-root");
+      assert.equal(await reasonOf(() => listDirectory(root, "escape-dir")), "outside-root");
+      assert.equal(await reasonOf(() => readFileForPreview(root, "escape-dir/secret.txt")), "outside-root");
+    });
+
+    test("follows a symlink that stays inside the root", async () => {
+      const entries = await listDirectory(root, "src-link");
+      assert.deepEqual(
+        entries.map((e) => e.name).sort(),
+        ["main.ts", "nested"],
+      );
+    });
+
+    test("accepts the root itself and paths below it", async () => {
+      await assertWithinRoot(root, "");
+      await assertWithinRoot(root, "src/main.ts");
+      await assertWithinRoot(root, "src/nested/deep.txt");
+    });
+
+    test("confines a path that does not exist on disk", async () => {
+      // The history view asks about paths from old commits, long since deleted
+      await assertWithinRoot(root, "src/was-deleted.ts");
+      assert.equal(await reasonOf(() => assertWithinRoot(root, "../outside/was-deleted.ts")), "outside-root");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Listing
+  // -------------------------------------------------------------------------
+  describe("listDirectory", () => {
+    test("sorts directories first, then names case-insensitively", async () => {
+      const names = (await listDirectory(root, "")).map((e) => e.name);
+      const dirs = names.slice(0, names.indexOf("readme.md"));
+      assert.ok(dirs.includes("src"), `expected directories first, got ${JSON.stringify(names)}`);
+      assert.ok(dirs.includes("empty"));
+      assert.ok(names.indexOf("binary.bin") < names.indexOf("readme.md"), "files sort by name");
+    });
+
+    test("classifies symlinks by what they point at, without following them", async () => {
+      const entries = await listDirectory(root, "");
+      const byName = Object.fromEntries(entries.map((e) => [e.name, e.type]));
+      // Shown rather than hidden, so an out-of-root link is visible but inert
+      assert.equal(byName["escape-link"], "symlink-file");
+      assert.equal(byName["escape-dir"], "symlink-directory");
+      assert.equal(byName["src-link"], "symlink-directory");
+      assert.equal(byName["src"], "directory");
+      assert.equal(byName["readme.md"], "file");
+    });
+
+    test("reports a missing directory as not-found", async () => {
+      assert.equal(await reasonOf(() => listDirectory(root, "no-such-dir")), "not-found");
+    });
+
+    test("lists an empty directory as empty", async () => {
+      assert.deepEqual(await listDirectory(root, "empty"), []);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Reading
+  // -------------------------------------------------------------------------
+  describe("readFileForPreview", () => {
+    test("returns content with its size and mtime", async () => {
+      const result = await readFileForPreview(root, "readme.md");
+      assert.equal(result.content, "# hello\n");
+      assert.equal(result.size, statSync(path.join(root, "readme.md")).size);
+      assert.ok(result.mtimeMs > 0);
+    });
+
+    test("refuses a binary file", async () => {
+      assert.equal(await reasonOf(() => readFileForPreview(root, "binary.bin")), "binary");
+    });
+
+    test("refuses a file over the preview cap", async () => {
+      assert.equal(await reasonOf(() => readFileForPreview(root, "big.txt")), "too-large");
+    });
+
+    test("refuses a directory", async () => {
+      assert.equal(await reasonOf(() => readFileForPreview(root, "src")), "not-found");
+    });
+
+    test("reports a missing file as not-found", async () => {
+      assert.equal(await reasonOf(() => readFileForPreview(root, "nope.txt")), "not-found");
+    });
+  });
+
+  describe("readFileRaw", () => {
+    test("serves binary bytes, unlike the preview", async () => {
+      const bytes = await readFileRaw(root, "binary.bin");
+      assert.deepEqual([...bytes], [0x68, 0x69, 0x00, 0x21]);
+    });
+
+    test("still refuses an oversized file", async () => {
+      assert.equal(await reasonOf(() => readFileRaw(root, "big.txt")), "too-large");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Writing
+  // -------------------------------------------------------------------------
+  describe("writeFileFromBrowser", () => {
+    /** A fresh file per test: writes mutate, and mtime is part of the contract. */
+    function scratch(name: string, content = "before\n") {
+      write(`scratch/${name}`, content);
+      return { rel: `scratch/${name}`, mtimeMs: statSync(path.join(root, "scratch", name)).mtimeMs };
+    }
+
+    test("writes when the mtime matches", async () => {
+      const file = scratch("ok.txt");
+      const result = await writeFileFromBrowser(root, undefined, file.rel, "after\n", file.mtimeMs);
+      assert.equal((await readFileForPreview(root, file.rel)).content, "after\n");
+      assert.ok(result.mtimeMs > 0);
+      assert.equal(result.size, 6);
+    });
+
+    test("refuses a stale mtime as a conflict", async () => {
+      const file = scratch("stale.txt");
+      assert.equal(await reasonOf(() => writeFileFromBrowser(root, undefined, file.rel, "after\n", file.mtimeMs - 5000)), "conflict");
+      assert.equal((await readFileForPreview(root, file.rel)).content, "before\n", "the file must be untouched");
+    });
+
+    test("overwrites a stale mtime when forced", async () => {
+      const file = scratch("forced.txt");
+      await writeFileFromBrowser(root, undefined, file.rel, "after\n", file.mtimeMs - 5000, true);
+      assert.equal((await readFileForPreview(root, file.rel)).content, "after\n");
+    });
+
+    test("refuses to create a file that does not exist", async () => {
+      assert.equal(await reasonOf(() => writeFileFromBrowser(root, undefined, "scratch/new.txt", "x", 0)), "conflict");
+    });
+
+    test("refuses every write when the sandbox is read-only", async () => {
+      const file = scratch("readonly.txt");
+      assert.equal(await reasonOf(() => writeFileFromBrowser(root, null, file.rel, "after\n", file.mtimeMs)), "denied");
+    });
+
+    test("refuses a write outside the writable zone", async () => {
+      const file = scratch("outside-zone.txt");
+      // Only src/ is writable; scratch/ is readable but not writable
+      assert.equal(await reasonOf(() => writeFileFromBrowser(root, "src", file.rel, "after\n", file.mtimeMs)), "denied");
+    });
+
+    test("allows a write inside the writable zone", async () => {
+      const mtimeMs = statSync(path.join(root, "src/main.ts")).mtimeMs;
+      await writeFileFromBrowser(root, "src", "src/main.ts", "console.log('bye');\n", mtimeMs);
+      assert.equal((await readFileForPreview(root, "src/main.ts")).content, "console.log('bye');\n");
+    });
+
+    test("refuses content carrying a NUL byte", async () => {
+      const file = scratch("nul.txt");
+      assert.equal(await reasonOf(() => writeFileFromBrowser(root, undefined, file.rel, "a\0b", file.mtimeMs)), "binary");
+    });
+
+    test("refuses content over the cap", async () => {
+      const file = scratch("toobig.txt");
+      const oversized = "x".repeat(MAX_PREVIEW_BYTES + 1);
+      assert.equal(await reasonOf(() => writeFileFromBrowser(root, undefined, file.rel, oversized, file.mtimeMs)), "too-large");
+    });
+
+    test("refuses content whose UTF-8 encoding crosses the cap", async () => {
+      // Under the cap as UTF-16 code units, over it as bytes — the second check
+      const file = scratch("multibyte.txt");
+      const multibyte = "é".repeat(MAX_PREVIEW_BYTES - 10);
+      assert.ok(multibyte.length < MAX_PREVIEW_BYTES, "the string itself is under the cap");
+      assert.equal(await reasonOf(() => writeFileFromBrowser(root, undefined, file.rel, multibyte, file.mtimeMs)), "too-large");
+    });
+
+    test("refuses a write that escapes the root", async () => {
+      assert.equal(await reasonOf(() => writeFileFromBrowser(root, undefined, "../outside/secret.txt", "x", 0)), "outside-root");
+    });
+
+    test("leaves no temporary file behind", async () => {
+      const file = scratch("atomic.txt");
+      await writeFileFromBrowser(root, undefined, file.rel, "after\n", file.mtimeMs);
+      const leftovers = (await listDirectory(root, "scratch")).filter((e) => e.name.includes(".tmp"));
+      assert.deepEqual(leftovers, []);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Search
+  // -------------------------------------------------------------------------
+  describe("searchFiles", () => {
+    test("matches a substring of the relative path, case-insensitively", async () => {
+      const hits = await searchFiles(root, "MAIN");
+      assert.ok(
+        hits.some((h) => h.path === "src/main.ts"),
+        `expected src/main.ts, got ${JSON.stringify(hits.map((h) => h.path))}`,
+      );
+    });
+
+    test("returns nothing for an empty or whitespace query", async () => {
+      assert.deepEqual(await searchFiles(root, ""), []);
+      assert.deepEqual(await searchFiles(root, "   "), []);
+    });
+
+    test("prefers shorter paths", async () => {
+      const hits = await searchFiles(root, "e");
+      const lengths = hits.map((h) => h.path.length);
+      assert.deepEqual(lengths, [...lengths].sort((a, b) => a - b), "results are ordered by path length");
+    });
+
+    test("honours the limit", async () => {
+      assert.ok((await searchFiles(root, "e", 2)).length <= 2);
+    });
+
+    test("skips symlinks, so a cycle cannot hang the walk", async () => {
+      const hits = await searchFiles(root, "link");
+      assert.deepEqual(hits, [], `symlinks must not be walked, got ${JSON.stringify(hits.map((h) => h.path))}`);
+    });
+
+    test("reports the entry type", async () => {
+      const hits = await searchFiles(root, "nested");
+      assert.equal(hits.find((h) => h.path === "src/nested")?.type, "directory");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Root and writable-zone resolution
+  // -------------------------------------------------------------------------
+  describe("root resolution", () => {
+    test("prefers the sandbox root over the agent cwd", async () => {
+      // cwd points elsewhere on purpose: the sandbox root has to win
+      assert.equal(await resolveBrowserRoot({ cwd: outside, sandbox: { root } } as never), root);
+    });
+
+    test("falls back to the agent cwd when no sandbox is configured", async () => {
+      assert.equal(await resolveBrowserRoot({ cwd: root } as never), root);
+    });
+
+    test("reports no writable zone when there is no sandbox", async () => {
+      assert.equal(await resolveWritableRoot({ cwd: root } as never, root), undefined);
+    });
+
+    test("reports a read-only sandbox as null", async () => {
+      assert.equal(await resolveWritableRoot({ cwd: root, sandbox: { root, allowWrite: false } } as never, root), null);
+    });
+
+    test("reports the whole root as an empty relative path", async () => {
+      assert.equal(await resolveWritableRoot({ cwd: root, sandbox: { root, allowWrite: true } } as never, root), "");
+    });
+
+    test("reports a writable subtree relative to the root, in posix separators", async () => {
+      const writableRoot = path.join(root, "src", "nested");
+      const rel = await resolveWritableRoot({ cwd: root, sandbox: { root, allowWrite: true, writableRoot } } as never, root);
+      assert.equal(rel, "src/nested");
+    });
+  });
+});

--- a/server/test/fileBrowser.test.ts
+++ b/server/test/fileBrowser.test.ts
@@ -9,7 +9,7 @@
  * are the difference between a refused request and a corrupted file.
  */
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, realpathSync, rmSync, symlinkSync, writeFileSync, statSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { after, before, describe, test } from "node:test";
@@ -25,6 +25,7 @@ import {
   searchFiles,
   writeFileFromBrowser,
 } from "../src/fileBrowser.ts";
+import { realResolve } from "../src/sandbox.ts";
 
 /** The reason carried by a FileBrowserError, or the error itself when it is another kind. */
 async function reasonOf(run: () => Promise<unknown>): Promise<string> {
@@ -50,18 +51,18 @@ describe("file browser", () => {
     writeFileSync(full, content);
   }
 
-  before(() => {
-    // realpathSync is not optional, and it has to be applied to the directories
-    // themselves rather than to their parent: on macOS /var is a symlink to
-    // /private/var, and on Windows a temp path can carry an 8.3 short name that
-    // realpath expands. An unresolved root fails isWithin against every resolved
-    // path, and each test below would then refuse as "outside-root" for the wrong
-    // reason — which is exactly how this first ran green locally and red on CI.
+  before(async () => {
+    // Resolve through the module's own primitive rather than realpathSync. The
+    // confinement compares `root` against whatever realResolve returns, and the two
+    // do not agree on every platform — on Windows a temp path can come back with a
+    // \\?\ prefix that path.resolve then reshapes, leaving every path "outside the
+    // browser root". Using the production resolver here makes the fixture agree with
+    // the check by construction instead of by coincidence.
     const base = mkdtempSync(path.join(tmpdir(), "pi-fb-"));
     mkdirSync(path.join(base, "root"), { recursive: true });
     mkdirSync(path.join(base, "outside"), { recursive: true });
-    root = realpathSync(path.join(base, "root"));
-    outside = realpathSync(path.join(base, "outside"));
+    root = await realResolve(path.join(base, "root"));
+    outside = await realResolve(path.join(base, "outside"));
 
     writeFileSync(path.join(outside, "secret.txt"), "SECRET\n");
     write("readme.md", "# hello\n");

--- a/server/test/git.test.ts
+++ b/server/test/git.test.ts
@@ -370,3 +370,168 @@ describe("file history", () => {
     await assert.rejects(() => gitRevisionContent(root, root, "worktree", "docs/notes.txt"), /read from disk/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// The repository is larger than the browser root — the case where the two path
+// conventions actually differ. git reports log paths from the toplevel, while a
+// pathspec is read from cwd, so every conversion in gitFileLog only earns its
+// keep here; with root === toplevel both are the identity.
+// ---------------------------------------------------------------------------
+describe("file history below the repository toplevel", () => {
+  let toplevel: string;
+  let root: string;
+  const sha: Record<string, string> = {};
+
+  function git(...args: string[]) {
+    execFileSync("git", args, { cwd: toplevel, stdio: "pipe" });
+  }
+
+  function commit(relPath: string, content: string, subject: string) {
+    const full = path.join(toplevel, relPath);
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, content);
+    git("add", "-A");
+    git("commit", "-m", subject);
+    sha[subject] = execFileSync("git", ["rev-parse", "HEAD"], { cwd: toplevel, encoding: "utf8" }).trim();
+  }
+
+  before(() => {
+    toplevel = mkdtempSync(path.join(tmpdir(), "pi-git-nested-"));
+    // The browser only exposes workspace/app, two levels below the repository root
+    root = path.join(toplevel, "workspace", "app");
+    git("init", "-b", "main");
+    git("config", "user.email", "test@test");
+    git("config", "user.name", "Test");
+    git("config", "commit.gpgsign", "false");
+
+    commit("workspace/app/index.ts", "one\n", "create index");
+    commit("workspace/app/index.ts", "one\ntwo\n", "extend index");
+    // A file outside the browser root, to prove the pathspec confines the log
+    commit("outside.txt", "not yours\n", "add a file outside the root");
+  });
+
+  after(() => {
+    rmSync(toplevel, { recursive: true, force: true });
+  });
+
+  test("reports paths relative to the browser root, not the toplevel", async () => {
+    const log = await gitFileLog(root, toplevel, "index.ts", 50);
+    assert.equal(log.length, 2, `expected both commits, got ${JSON.stringify(log.map((e) => e.subject))}`);
+    // Not "workspace/app/index.ts": the UI speaks browser-root paths
+    assert.deepEqual(
+      log.map((entry) => entry.path),
+      ["index.ts", "index.ts"],
+    );
+  });
+
+  test("does not list commits that only touched files outside the browser root", async () => {
+    const subjects = (await gitFileLog(root, toplevel, "index.ts", 50)).map((entry) => entry.subject);
+    assert.ok(!subjects.includes("add a file outside the root"), `unexpected outside commit in ${JSON.stringify(subjects)}`);
+  });
+
+  test("reads a revision's content through the toplevel prefix", async () => {
+    assert.equal(await gitRevisionContent(root, toplevel, sha["create index"], "index.ts"), "one\n");
+    assert.equal(await gitRevisionContent(root, toplevel, sha["extend index"], "index.ts"), "one\ntwo\n");
+  });
+
+  test("gitHeadContent agrees with it", async () => {
+    assert.equal(await gitHeadContent(root, toplevel, "index.ts"), "one\ntwo\n");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cases the single-rename fixture above cannot reach: a rename *chain*, which is
+// the only thing that makes the stitch loop run more than once, plus the numstat
+// and pathspec shapes git only produces for particular files.
+// ---------------------------------------------------------------------------
+describe("file history edge cases", () => {
+  let root: string;
+
+  function git(...args: string[]) {
+    execFileSync("git", args, { cwd: root, stdio: "pipe" });
+  }
+
+  function write(relPath: string, content: string | Buffer) {
+    const full = path.join(root, relPath);
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, content);
+  }
+
+  function commit(subject: string) {
+    git("add", "-A");
+    git("commit", "-m", subject);
+  }
+
+  before(() => {
+    root = mkdtempSync(path.join(tmpdir(), "pi-git-edge-"));
+    git("init", "-b", "main");
+    git("config", "user.email", "test@test");
+    git("config", "user.name", "Test");
+    git("config", "commit.gpgsign", "false");
+
+    // A chain of two renames: a.txt -> b.txt -> c.txt, each with an edit so the
+    // rename is detected and each pass of the stitch has something to report
+    write("a.txt", "1\n");
+    commit("first name");
+    git("mv", "a.txt", "b.txt");
+    write("b.txt", "1\n2\n");
+    commit("second name");
+    git("mv", "b.txt", "c.txt");
+    write("c.txt", "1\n2\n3\n");
+    commit("third name");
+    write("c.txt", "1\n2\n3\n4\n");
+    commit("edit under the third name");
+
+    // Binary: git reports "-" for both counts instead of numbers
+    write("logo.bin", Buffer.from([0, 1, 2, 0, 255, 0]));
+    commit("add a binary file");
+
+    // A filename that looks like an option unless the pathspec is separated by --
+    write("-weird.txt", "dashed\n");
+    commit("add a file whose name starts with a dash");
+  });
+
+  after(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("follows a chain of two renames", async () => {
+    const log = await gitFileLog(root, root, "c.txt", 50);
+    const subjects = log.map((entry) => entry.subject);
+    assert.deepEqual(subjects, ["edit under the third name", "third name", "second name", "first name"]);
+  });
+
+  test("reports the name the file had at each link of the chain", async () => {
+    const log = await gitFileLog(root, root, "c.txt", 50);
+    const bySubject = Object.fromEntries(log.map((entry) => [entry.subject, entry.path]));
+    assert.equal(bySubject["third name"], "c.txt");
+    assert.equal(bySubject["second name"], "b.txt");
+    assert.equal(bySubject["first name"], "a.txt");
+  });
+
+  test("spends the limit across the whole chain, not per pass", async () => {
+    assert.equal((await gitFileLog(root, root, "c.txt", 3)).length, 3);
+    assert.equal((await gitFileLog(root, root, "c.txt", 1)).length, 1);
+  });
+
+  test("reads content from before both renames", async () => {
+    const log = await gitFileLog(root, root, "c.txt", 50);
+    const first = log.find((entry) => entry.subject === "first name")!;
+    assert.equal(await gitRevisionContent(root, root, first.sha, first.path), "1\n");
+  });
+
+  test("reports a binary file's counts as zero rather than NaN", async () => {
+    const [entry] = await gitFileLog(root, root, "logo.bin", 50);
+    assert.equal(entry.subject, "add a binary file");
+    // git prints "-" for a binary file's added/deleted
+    assert.equal(entry.added, 0);
+    assert.equal(entry.deleted, 0);
+  });
+
+  test("treats a leading-dash filename as a path, not an option", async () => {
+    const log = await gitFileLog(root, root, "-weird.txt", 50);
+    assert.equal(log.length, 1);
+    assert.equal(log[0].subject, "add a file whose name starts with a dash");
+    assert.equal(await gitRevisionContent(root, root, log[0].sha, "-weird.txt"), "dashed\n");
+  });
+});

--- a/server/test/harness.mjs
+++ b/server/test/harness.mjs
@@ -93,6 +93,12 @@ export async function startServer(root, config = {}, options = {}) {
   // roughly a quarter of runs, which is the whole of #27. These tests assert local
   // onboarding behaviour; a remote catalog has nothing to do with what they check.
   const env = { ...process.env, PI_OUTPOST_CONFIG: configPath, PI_OFFLINE: "1" };
+  // Under `--experimental-test-coverage` node exports NODE_V8_COVERAGE, and a child
+  // that inherits it writes its own coverage file into the same directory. stop()
+  // ends these servers with SIGKILL, so that file is left half-written and the
+  // parent's reporter dies on it ("Unterminated string in JSON"). Their coverage was
+  // never attributable to us anyway — the process is measured, not the source.
+  delete env.NODE_V8_COVERAGE;
   for (const [key, value] of Object.entries(options.env ?? {})) {
     if (value === undefined) delete env[key];
     else env[key] = value;

--- a/server/test/sandbox-tools.test.ts
+++ b/server/test/sandbox-tools.test.ts
@@ -8,7 +8,7 @@
  * and a symlink used to walk out of either.
  */
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { after, before, describe, test } from "node:test";
@@ -42,8 +42,12 @@ describe("realResolve", () => {
   /** Windows refuses symlink creation without a privilege CI does not have. */
   let symlinksAvailable = false;
 
-  before(() => {
-    base = realpathSync(mkdtempSync(path.join(tmpdir(), "pi-resolve-")));
+  before(async () => {
+    // realResolve, not realpathSync: on Windows the async fs.realpath expands an 8.3
+    // short name ("RUNNER~1" -> "runneradmin") and the sync one does not, so a fixture
+    // built with realpathSync compares a short path against an expanded one and every
+    // assertion here fails for a reason that has nothing to do with the code.
+    base = await realResolve(mkdtempSync(path.join(tmpdir(), "pi-resolve-")));
     mkdirSync(path.join(base, "real"), { recursive: true });
     writeFileSync(path.join(base, "real", "file.txt"), "hi\n");
     try {
@@ -83,14 +87,14 @@ describe("createSandboxedTools", () => {
   /** Windows refuses symlink creation without a privilege CI does not have. */
   let symlinksAvailable = false;
 
-  before(() => {
-    // Resolve the directories themselves: a temp path can be a symlink (macOS) or an
-    // 8.3 short name (Windows), and every check here compares resolved paths
+  before(async () => {
+    // Resolve through the same primitive the code under test uses — see the note in
+    // the realResolve suite above for why realpathSync is not interchangeable here
     const parent = mkdtempSync(path.join(tmpdir(), "pi-sandbox-"));
     mkdirSync(path.join(parent, "root", "src"), { recursive: true });
     mkdirSync(path.join(parent, "outside"), { recursive: true });
-    root = realpathSync(path.join(parent, "root"));
-    outside = realpathSync(path.join(parent, "outside"));
+    root = await realResolve(path.join(parent, "root"));
+    outside = await realResolve(path.join(parent, "outside"));
     writable = path.join(root, "src");
     writeFileSync(path.join(root, "readme.md"), "# hi\n");
     writeFileSync(path.join(writable, "main.ts"), "const a = 1;\n");
@@ -168,7 +172,7 @@ describe("createSandboxedTools", () => {
     });
 
     test("keeps refusing paths outside both the root and the exceptions", async () => {
-      const elsewhere = realpathSync(mkdtempSync(path.join(tmpdir(), "pi-elsewhere-")));
+      const elsewhere = await realResolve(mkdtempSync(path.join(tmpdir(), "pi-elsewhere-")));
       try {
         const [read] = await createSandboxedTools(config({ root, readExceptions: [outside] }));
         assert.match((await denial(read, path.join(elsewhere, "x.txt"))) ?? "", /outside the sandbox/);

--- a/server/test/sandbox-tools.test.ts
+++ b/server/test/sandbox-tools.test.ts
@@ -1,0 +1,226 @@
+/**
+ * The tool sandbox itself: which tools the model is handed, and whether the
+ * wrapper actually refuses a path that leaves its zone.
+ *
+ * sandbox.test.ts covers isWithin/isWithinAny — the predicates. This covers what
+ * is built on top of them, which is where the confinement either holds or does
+ * not: a read tool escaping the root, an edit tool escaping the writable zone,
+ * and a symlink used to walk out of either.
+ */
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { after, before, describe, test } from "node:test";
+import { createSandboxedTools, realResolve } from "../src/sandbox.ts";
+import type { SandboxConfig } from "../src/config.ts";
+
+function config(overrides: Partial<SandboxConfig> & { root: string }): SandboxConfig {
+  return { allowWrite: false, allowBash: false, readExceptions: [], ...overrides } as SandboxConfig;
+}
+
+/** Run a tool's execute with just a path, which is all the wrapper inspects. */
+function run(tool: { execute: (...args: never[]) => unknown }, target: string): Promise<unknown> {
+  return Promise.resolve(
+    (tool.execute as unknown as (id: string, params: unknown, signal?: AbortSignal) => unknown)("call-1", { path: target }, undefined),
+  );
+}
+
+/** The error message a refused path produces, or null when the call was allowed through. */
+async function denial(tool: { execute: (...args: never[]) => unknown }, target: string): Promise<string | null> {
+  try {
+    await run(tool, target);
+  } catch (error) {
+    const message = (error as Error).message;
+    return message.startsWith("Access denied") ? message : null;
+  }
+  return null;
+}
+
+describe("realResolve", () => {
+  let base: string;
+  /** Windows refuses symlink creation without a privilege CI does not have. */
+  let symlinksAvailable = false;
+
+  before(() => {
+    base = realpathSync(mkdtempSync(path.join(tmpdir(), "pi-resolve-")));
+    mkdirSync(path.join(base, "real"), { recursive: true });
+    writeFileSync(path.join(base, "real", "file.txt"), "hi\n");
+    try {
+      symlinkSync(path.join(base, "real"), path.join(base, "link"), "dir");
+      symlinksAvailable = true;
+    } catch {
+      symlinksAvailable = false;
+    }
+  });
+  after(() => rmSync(base, { recursive: true, force: true }));
+
+  test("resolves a symlinked directory to its target", async (t) => {
+    if (!symlinksAvailable) return t.skip("symlinks unavailable on this platform");
+    assert.equal(await realResolve(path.join(base, "link", "file.txt")), path.join(base, "real", "file.txt"));
+  });
+
+  test("keeps a tail that does not exist yet", async () => {
+    // A file about to be written must still resolve, or no write could be checked
+    assert.equal(await realResolve(path.join(base, "real", "new.txt")), path.join(base, "real", "new.txt"));
+  });
+
+  test("resolves the existing part of a path with a missing tail", async (t) => {
+    if (!symlinksAvailable) return t.skip("symlinks unavailable on this platform");
+    assert.equal(await realResolve(path.join(base, "link", "deep", "new.txt")), path.join(base, "real", "deep", "new.txt"));
+  });
+
+  test("returns the target unchanged when nothing along it exists", async () => {
+    const nowhere = path.join(base, "no", "such", "place");
+    assert.equal(await realResolve(nowhere), nowhere);
+  });
+});
+
+describe("createSandboxedTools", () => {
+  let root: string;
+  let outside: string;
+  let writable: string;
+  /** Windows refuses symlink creation without a privilege CI does not have. */
+  let symlinksAvailable = false;
+
+  before(() => {
+    // Resolve the directories themselves: a temp path can be a symlink (macOS) or an
+    // 8.3 short name (Windows), and every check here compares resolved paths
+    const parent = mkdtempSync(path.join(tmpdir(), "pi-sandbox-"));
+    mkdirSync(path.join(parent, "root", "src"), { recursive: true });
+    mkdirSync(path.join(parent, "outside"), { recursive: true });
+    root = realpathSync(path.join(parent, "root"));
+    outside = realpathSync(path.join(parent, "outside"));
+    writable = path.join(root, "src");
+    writeFileSync(path.join(root, "readme.md"), "# hi\n");
+    writeFileSync(path.join(writable, "main.ts"), "const a = 1;\n");
+    writeFileSync(path.join(outside, "secret.txt"), "SECRET\n");
+    // A link inside the root pointing out of it
+    try {
+      symlinkSync(outside, path.join(root, "escape"), "dir");
+      symlinksAvailable = true;
+    } catch {
+      symlinksAvailable = false;
+    }
+  });
+  after(() => rmSync(path.dirname(root), { recursive: true, force: true }));
+
+  const names = (tools: Array<{ name: string }>) => tools.map((tool) => tool.name).sort();
+
+  describe("which tools the model gets", () => {
+    test("read-only by default", async () => {
+      const tools = await createSandboxedTools(config({ root }));
+      assert.deepEqual(names(tools), ["find", "grep", "ls", "read"]);
+    });
+
+    test("adds edit and write only when writing is allowed", async () => {
+      const tools = await createSandboxedTools(config({ root, allowWrite: true }));
+      assert.deepEqual(names(tools), ["edit", "find", "grep", "ls", "read", "write"]);
+    });
+
+    test("adds bash only on an explicit opt-in", async () => {
+      const withoutBash = await createSandboxedTools(config({ root }));
+      assert.ok(!names(withoutBash).includes("bash"));
+      const withBash = await createSandboxedTools(config({ root, allowBash: true }));
+      assert.ok(names(withBash).includes("bash"));
+    });
+
+    test("refuses a writable zone that is not inside the root", async () => {
+      await assert.rejects(
+        () => createSandboxedTools(config({ root, allowWrite: true, writableRoot: outside })),
+        /must be inside sandbox\.root/,
+      );
+    });
+  });
+
+  describe("read confinement", () => {
+    test("allows a path inside the root", async () => {
+      const [read] = await createSandboxedTools(config({ root }));
+      assert.equal(await denial(read, "readme.md"), null);
+    });
+
+    test("refuses a path climbing out of the root", async () => {
+      const [read] = await createSandboxedTools(config({ root }));
+      assert.match((await denial(read, "../outside/secret.txt")) ?? "", /outside the sandbox/);
+    });
+
+    test("refuses an absolute path outside the root", async () => {
+      const [read] = await createSandboxedTools(config({ root }));
+      assert.match((await denial(read, path.join(outside, "secret.txt"))) ?? "", /outside the sandbox/);
+    });
+
+    test("refuses to follow a symlink out of the root", async (t) => {
+      if (!symlinksAvailable) return t.skip("symlinks unavailable on this platform");
+      const [read] = await createSandboxedTools(config({ root }));
+      assert.match((await denial(read, "escape/secret.txt")) ?? "", /outside the sandbox/);
+    });
+
+    test("confines every read tool, not just the first", async () => {
+      const tools = await createSandboxedTools(config({ root }));
+      for (const tool of tools) {
+        assert.match((await denial(tool, "../outside/secret.txt")) ?? "", /outside the sandbox/, `${tool.name} must refuse`);
+      }
+    });
+
+    test("lets a path through when it lands in a declared read exception", async () => {
+      const [read] = await createSandboxedTools(config({ root, readExceptions: [outside] }));
+      assert.equal(await denial(read, path.join(outside, "secret.txt")), null);
+    });
+
+    test("keeps refusing paths outside both the root and the exceptions", async () => {
+      const elsewhere = realpathSync(mkdtempSync(path.join(tmpdir(), "pi-elsewhere-")));
+      try {
+        const [read] = await createSandboxedTools(config({ root, readExceptions: [outside] }));
+        assert.match((await denial(read, path.join(elsewhere, "x.txt"))) ?? "", /outside the sandbox/);
+      } finally {
+        rmSync(elsewhere, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe("write confinement", () => {
+    /** edit and write, which are scoped to the writable zone rather than the root. */
+    async function writeTools() {
+      const tools = await createSandboxedTools(config({ root, allowWrite: true, writableRoot: writable }));
+      return tools.filter((tool) => tool.name === "edit" || tool.name === "write");
+    }
+
+    test("allows a path inside the writable zone", async () => {
+      for (const tool of await writeTools()) {
+        assert.equal(await denial(tool, "src/main.ts"), null, `${tool.name} should allow it`);
+      }
+    });
+
+    test("refuses a path that is readable but not writable", async () => {
+      // readme.md sits in the root, which read tools may reach and write tools may not
+      for (const tool of await writeTools()) {
+        assert.match((await denial(tool, "readme.md")) ?? "", /outside the sandbox/, `${tool.name} must refuse`);
+      }
+    });
+
+    test("still lets read tools reach what write tools cannot", async () => {
+      const tools = await createSandboxedTools(config({ root, allowWrite: true, writableRoot: writable }));
+      const read = tools.find((tool) => tool.name === "read")!;
+      assert.equal(await denial(read, "readme.md"), null);
+    });
+
+    test("names the zone it refused against, so the message is actionable", async () => {
+      const [edit] = await writeTools();
+      assert.match((await denial(edit, "readme.md")) ?? "", new RegExp(writable.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    });
+
+    test("read exceptions do not widen the writable zone", async () => {
+      const tools = await createSandboxedTools(config({ root, allowWrite: true, writableRoot: writable, readExceptions: [outside] }));
+      const write = tools.find((tool) => tool.name === "write")!;
+      assert.match((await denial(write, path.join(outside, "secret.txt"))) ?? "", /outside the sandbox/);
+    });
+  });
+
+  test("ignores calls that carry no path at all", async () => {
+    const tools = await createSandboxedTools(config({ root, allowBash: true }));
+    const bash = tools.find((tool) => tool.name === "bash")!;
+    // Bash is deliberately unwrapped: a shell cannot be path-scoped, so the opt-in
+    // is the whole guard. It must not be silently refused by the path wrapper either.
+    assert.equal(await denial(bash, ""), null);
+  });
+});

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage --coverage.provider=v8 --coverage.reporter=text --coverage.reporter=lcov --coverage.thresholds.lines=89 --coverage.thresholds.branches=84 --coverage.thresholds.functions=88"
+    "test:coverage": "vitest run --coverage --coverage.provider=v8 --coverage.reporter=text --coverage.reporter=lcov --coverage.thresholds.lines=91 --coverage.thresholds.branches=85 --coverage.thresholds.functions=93"
   },
   "dependencies": {
     "@pi-outpost/shared": "*",

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage --coverage.provider=v8 --coverage.reporter=text --coverage.reporter=lcov --coverage.thresholds.lines=82 --coverage.thresholds.branches=78 --coverage.thresholds.functions=82"
+    "test:coverage": "vitest run --coverage --coverage.provider=v8 --coverage.reporter=text --coverage.reporter=lcov --coverage.thresholds.lines=87 --coverage.thresholds.branches=82 --coverage.thresholds.functions=86"
   },
   "dependencies": {
     "@pi-outpost/shared": "*",

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage --coverage.provider=v8 --coverage.reporter=text --coverage.reporter=lcov --coverage.thresholds.lines=87 --coverage.thresholds.branches=82 --coverage.thresholds.functions=86"
+    "test:coverage": "vitest run --coverage --coverage.provider=v8 --coverage.reporter=text --coverage.reporter=lcov --coverage.thresholds.lines=89 --coverage.thresholds.branches=84 --coverage.thresholds.functions=88"
   },
   "dependencies": {
     "@pi-outpost/shared": "*",

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage --coverage.provider=v8 --coverage.reporter=text --coverage.reporter=lcov"
+    "test:coverage": "vitest run --coverage --coverage.provider=v8 --coverage.reporter=text --coverage.reporter=lcov --coverage.thresholds.lines=82 --coverage.thresholds.branches=78 --coverage.thresholds.functions=82"
   },
   "dependencies": {
     "@pi-outpost/shared": "*",

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,7 +10,8 @@
   },
   "scripts": {
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage --coverage.provider=v8 --coverage.reporter=text --coverage.reporter=lcov"
   },
   "dependencies": {
     "@pi-outpost/shared": "*",

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -52,6 +52,8 @@ function agentState(overrides: Record<string, unknown> = {}) {
     gitDiff: null,
     gitLog: null,
     gitShow: null,
+    gitFileHistory: null,
+    gitFileDiff: null,
     ...overrides,
   };
 }
@@ -91,6 +93,10 @@ function agentApi(state: ReturnType<typeof agentState>) {
     fetchGitLog: vi.fn(),
     fetchGitShow: vi.fn(),
     clearGitShow: vi.fn(),
+    fetchGitFileHistory: vi.fn(),
+    closeGitFileHistory: vi.fn(),
+    fetchGitFileDiff: vi.fn(),
+    clearGitFileDiff: vi.fn(),
     setCredential: vi.fn(),
     declareProvider: vi.fn(),
     updateConfig: vi.fn(),
@@ -246,5 +252,136 @@ describe("App — session analysis", () => {
     openAnalysis();
     const heading = screen.getByText("tokens", { selector: "h3" });
     expect(within(heading.closest("section") as HTMLElement).getByLabelText("total: 2k")).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wiring: App holds the state the panes share, so these are the handovers
+// between them rather than any single component's behaviour.
+// ---------------------------------------------------------------------------
+/** The sidebar toggle, told apart from the composer's "Attach files" by its glyph. */
+const sidebarToggle = () => screen.getByRole("button", { name: /[◨◧]\s*files/ });
+
+describe("App — panes and handovers", () => {
+  function mount(overrides: Record<string, unknown> = {}) {
+    const api = agentApi(agentState(overrides));
+    mockUseAgent.mockReturnValue(api);
+    const view = render(<App />);
+    return { api, ...view };
+  }
+
+  it("opens and closes the file sidebar", () => {
+    mount();
+    expect(screen.queryByText("Files")).not.toBeInTheDocument();
+    fireEvent.click(sidebarToggle());
+    expect(screen.getByText("Files")).toBeInTheDocument();
+    fireEvent.click(sidebarToggle());
+    expect(screen.queryByText("Files")).not.toBeInTheDocument();
+  });
+
+  it("shows the file viewer over the conversation when a file is open", () => {
+    mount({ openFile: { status: "loaded", path: "src/main.ts", content: "const a = 1;", size: 12, mtimeMs: 1 } });
+    expect(screen.getByRole("button", { name: "Close file viewer" })).toBeInTheDocument();
+  });
+
+  it("asks for a file's history from the viewer", () => {
+    const { api } = mount({
+      gitAvailable: true,
+      openFile: { status: "loaded", path: "src/main.ts", content: "x", size: 1, mtimeMs: 1 },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /history/ }));
+    expect(api.fetchGitFileHistory).toHaveBeenCalledWith("src/main.ts");
+  });
+
+  it("shows the history pane once the answer arrives", () => {
+    mount({
+      gitAvailable: true,
+      openFile: { status: "loaded", path: "src/main.ts", content: "x", size: 1, mtimeMs: 1 },
+      gitFileHistory: { path: "src/main.ts", status: "loaded", entries: [], requestId: "r1" },
+    });
+    expect(screen.getByRole("button", { name: "Close file history" })).toBeInTheDocument();
+    expect(screen.getByText("No commits touch this file yet.")).toBeInTheDocument();
+  });
+
+  it("surfaces errors from the agent", () => {
+    mount({ errors: ["git: not a repository"] });
+    expect(screen.getByText(/not a repository/)).toBeInTheDocument();
+  });
+
+  it("shows an extension notification", () => {
+    mount({ notifications: [{ id: "n1", message: "OmniRoute ready", type: "info" }] });
+    expect(screen.getByText("OmniRoute ready")).toBeInTheDocument();
+  });
+
+  it("queues an extension dialog for an answer", () => {
+    mount({ dialogQueue: [{ type: "extension_ui_request", id: "d1", method: "confirm", title: "Proceed?", message: "Really?" }] });
+    expect(screen.getByText("Proceed?")).toBeInTheDocument();
+  });
+
+  it("remembers the tool-noise filter across mounts", () => {
+    localStorage.clear();
+    const first = mount();
+    fireEvent.click(screen.getByRole("button", { name: /tools/ }));
+    first.unmount();
+
+    mount();
+    expect(screen.getByRole("button", { name: /tools/ })).toHaveAttribute("aria-pressed", "true");
+    localStorage.clear();
+  });
+});
+
+describe("App — attachments", () => {
+  function mount(overrides: Record<string, unknown> = {}) {
+    const api = agentApi(agentState(overrides));
+    mockUseAgent.mockReturnValue(api);
+    const view = render(<App />);
+    return { api, ...view };
+  }
+
+  it("references a file pinned in the tree, and drops it when unpinned", () => {
+    mount({ fileTree: { "": [{ name: "readme.md", type: "file" }] } });
+    fireEvent.click(sidebarToggle());
+    const pin = screen.getByRole("button", { name: "Reference readme.md in the prompt" });
+
+    fireEvent.click(pin);
+    expect(screen.getByRole("button", { name: "Remove readme.md in the prompt" })).toHaveAttribute("aria-pressed", "true");
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove readme.md in the prompt" }));
+    expect(screen.getByRole("button", { name: "Reference readme.md in the prompt" })).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("sends the prompt and clears what was attached to it", () => {
+    const { api } = mount({ fileTree: { "": [{ name: "readme.md", type: "file" }] } });
+    fireEvent.click(sidebarToggle());
+    fireEvent.click(screen.getByRole("button", { name: "Reference readme.md in the prompt" }));
+
+    const box = screen.getByRole("textbox");
+    fireEvent.change(box, { target: { value: "what is this?" } });
+    fireEvent.keyDown(box, { key: "Enter" });
+
+    expect(api.prompt).toHaveBeenCalledWith(expect.stringContaining("@readme.md"), undefined);
+    expect(screen.getByRole("button", { name: "Reference readme.md in the prompt" })).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("closes the viewer on send, since the user wants the conversation back", () => {
+    const { api } = mount({ openFile: { status: "loaded", path: "src/main.ts", content: "x", size: 1, mtimeMs: 1 } });
+    const box = screen.getByRole("textbox");
+    fireEvent.change(box, { target: { value: "carry on" } });
+    fireEvent.keyDown(box, { key: "Enter" });
+    expect(api.closeFilePreview).toHaveBeenCalled();
+  });
+
+  it("keeps the viewer open on send when it holds unsaved edits", () => {
+    const { api } = mount({
+      openFile: { status: "loaded", path: "src/main.ts", content: "x", size: 1, mtimeMs: 1 },
+      sandbox: { root: "/w", allowWrite: true, allowBash: false },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "✎ edit" }));
+    fireEvent.change(screen.getAllByRole("textbox")[0], { target: { value: "edited" } });
+
+    const composer = screen.getAllByRole("textbox").at(-1)!;
+    fireEvent.change(composer, { target: { value: "carry on" } });
+    fireEvent.keyDown(composer, { key: "Enter" });
+    expect(api.closeFilePreview).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import type { ChatItem, TurnUsage } from "@pi-outpost/shared";
 import App from "./App";
 
@@ -383,5 +383,125 @@ describe("App — attachments", () => {
     fireEvent.change(composer, { target: { value: "carry on" } });
     fireEvent.keyDown(composer, { key: "Enter" });
     expect(api.closeFilePreview).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Drag and drop, and the callbacks the panes hand back. These are the parts of
+// App that no single component owns.
+// ---------------------------------------------------------------------------
+describe("App — dropping files", () => {
+  function mount(overrides: Record<string, unknown> = {}) {
+    const api = agentApi(agentState(overrides));
+    mockUseAgent.mockReturnValue(api);
+    const view = render(<App />);
+    return { api, ...view };
+  }
+
+  /** A drag carrying the given payload kinds, as the browser reports them. */
+  const dataTransfer = (types: string[], files: File[] = []) => ({ types, files });
+  const dropZone = () => document.querySelector(".relative.flex.h-full")!;
+
+  it("invites a drop only once files are actually being dragged", () => {
+    mount();
+    fireEvent.dragEnter(dropZone(), { dataTransfer: dataTransfer(["text/plain"]) });
+    expect(screen.queryByText(/Drop files to attach/)).not.toBeInTheDocument();
+
+    fireEvent.dragEnter(dropZone(), { dataTransfer: dataTransfer(["Files"]) });
+    expect(screen.getByText(/Drop files to attach/)).toBeInTheDocument();
+  });
+
+  it("keeps the invitation up while the pointer crosses child elements", () => {
+    // dragenter/dragleave fire for every child crossed, so this counts rather than toggles
+    mount();
+    fireEvent.dragEnter(dropZone(), { dataTransfer: dataTransfer(["Files"]) });
+    fireEvent.dragEnter(dropZone(), { dataTransfer: dataTransfer(["Files"]) });
+    fireEvent.dragLeave(dropZone());
+    expect(screen.getByText(/Drop files to attach/)).toBeInTheDocument();
+
+    fireEvent.dragLeave(dropZone());
+    expect(screen.queryByText(/Drop files to attach/)).not.toBeInTheDocument();
+  });
+
+  it("does not fall below zero when a stray dragleave arrives first", () => {
+    mount();
+    fireEvent.dragLeave(dropZone());
+    fireEvent.dragEnter(dropZone(), { dataTransfer: dataTransfer(["Files"]) });
+    expect(screen.getByText(/Drop files to attach/)).toBeInTheDocument();
+  });
+
+  it("takes the invitation down once the files land", async () => {
+    mount();
+    fireEvent.dragEnter(dropZone(), { dataTransfer: dataTransfer(["Files"]) });
+    const dropped = new File(["hello"], "notes.txt", { type: "text/plain" });
+    fireEvent.drop(dropZone(), { dataTransfer: dataTransfer(["Files"], [dropped]) });
+    await waitFor(() => expect(screen.queryByText(/Drop files to attach/)).not.toBeInTheDocument());
+  });
+
+  it("attaches a dropped text file to the next prompt", async () => {
+    mount();
+    const dropped = new File(["hello"], "notes.txt", { type: "text/plain" });
+    fireEvent.drop(dropZone(), { dataTransfer: dataTransfer(["Files"], [dropped]) });
+    await waitFor(() => expect(screen.getByText("notes.txt")).toBeInTheDocument());
+  });
+
+  it("says why a file it cannot take was refused", async () => {
+    mount();
+    const huge = new File([new Uint8Array(600 * 1024)], "big.txt", { type: "text/plain" });
+    fireEvent.drop(dropZone(), { dataTransfer: dataTransfer(["Files"], [huge]) });
+    await waitFor(() => expect(screen.getByText(/big\.txt/)).toBeInTheDocument());
+  });
+});
+
+describe("App — model bar and tree", () => {
+  function mount(overrides: Record<string, unknown> = {}) {
+    const api = agentApi(agentState(overrides));
+    mockUseAgent.mockReturnValue(api);
+    render(<App />);
+    return api;
+  }
+
+  it("changes the model from the bar", () => {
+    const api = mount({ models: [{ provider: "anthropic", id: "opus", name: "Opus", reasoning: true }] });
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "anthropic/opus" } });
+    expect(api.setModel).toHaveBeenCalledWith("anthropic", "opus");
+  });
+
+  it("asks for the tree when the menu opens, and navigates from it", () => {
+    const api = mount({ tree: [{ entryId: "e1", text: "first turn", onPath: true, children: [] }] });
+    fireEvent.click(screen.getByRole("button", { name: "tree" }));
+    expect(api.listTree).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText("first turn"));
+    expect(api.navigateTree).toHaveBeenCalledWith("e1");
+  });
+
+  it("forks a session from the tree", () => {
+    const api = mount({ tree: [{ entryId: "e1", text: "first turn", onPath: true, children: [] }] });
+    fireEvent.click(screen.getByRole("button", { name: "tree" }));
+    fireEvent.click(screen.getByRole("button", { name: /fork/ }));
+    expect(api.forkSession).toHaveBeenCalledWith("e1");
+  });
+
+  it("opens a file from the tree straight onto its diff", () => {
+    const api = mount({
+      fileTree: { "": [{ name: "readme.md", type: "file" }] },
+      gitStatus: { branch: "main", ahead: 0, behind: 0, files: { "readme.md": "modified" } },
+      gitAvailable: true,
+    });
+    fireEvent.click(screen.getByRole("button", { name: /[◨◧]\s*files/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Show diff of readme.md" }));
+    expect(api.readFile).toHaveBeenCalledWith("readme.md");
+  });
+
+  it("shows the steering and follow-up queue", () => {
+    mount({ queue: { steering: ["stop that"], followUp: ["then this"] } });
+    expect(screen.getByText(/stop that/)).toBeInTheDocument();
+    expect(screen.getByText(/then this/)).toBeInTheDocument();
+  });
+
+  it("shows an extension's widget above the editor", () => {
+    mount({ widgets: { w1: { lines: ["build: passing"], placement: "aboveEditor" } } });
+    expect(screen.getByText("build: passing")).toBeInTheDocument();
   });
 });

--- a/ui/src/authToken.test.ts
+++ b/ui/src/authToken.test.ts
@@ -1,9 +1,18 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { bootstrapToken, storedToken, storeToken } from "./authToken";
 
 beforeEach(() => {
   localStorage.clear();
+  history.replaceState(null, "", "/");
 });
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** Put the page on a URL, as if it had been opened with these parameters. */
+function openAt(url: string) {
+  history.replaceState(null, "", url);
+}
 
 // ---------------------------------------------------------------------------
 // bootstrapToken
@@ -22,6 +31,58 @@ describe("bootstrapToken", () => {
     storeToken("stored-token");
     expect(bootstrapToken()).toBe("stored-token");
   });
+
+  it("captures a token from the URL and persists it", () => {
+    openAt("/?token=from-url");
+    expect(bootstrapToken()).toBe("from-url");
+    expect(storedToken()).toBe("from-url");
+  });
+
+  it("strips the token from the address bar, so it cannot linger in history", () => {
+    // The whole point of the module: a token in the URL survives screenshots,
+    // browser history and shared links until it is taken back out
+    openAt("/?token=from-url");
+    bootstrapToken();
+    expect(window.location.search).not.toContain("token");
+  });
+
+  it("keeps the rest of the URL intact while stripping the token", () => {
+    openAt("/app?token=from-url&view=tree#section");
+    bootstrapToken();
+    expect(window.location.pathname).toBe("/app");
+    expect(window.location.search).toBe("?view=tree");
+    expect(window.location.hash).toBe("#section");
+  });
+
+  it("leaves a URL without a token alone", () => {
+    openAt("/app?view=tree");
+    bootstrapToken();
+    expect(window.location.search).toBe("?view=tree");
+  });
+
+  it("lets a fresh URL token replace a stored one", () => {
+    storeToken("old");
+    openAt("/?token=new");
+    expect(bootstrapToken()).toBe("new");
+    expect(storedToken()).toBe("new");
+  });
+
+  it("still drives the session from the URL when storage is unavailable", () => {
+    // A sandboxed iframe throws on localStorage: the token cannot persist, but it
+    // must still authenticate this session rather than being dropped
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("SecurityError");
+    });
+    openAt("/?token=from-url");
+    expect(bootstrapToken()).toBe("from-url");
+  });
+
+  it("returns null when storage is unavailable and the URL carries nothing", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("SecurityError");
+    });
+    expect(bootstrapToken()).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -29,6 +90,19 @@ describe("bootstrapToken", () => {
 // ---------------------------------------------------------------------------
 describe("storedToken", () => {
   it("returns null when nothing is stored", () => {
+    expect(storedToken()).toBeNull();
+  });
+
+  it("ignores a token in the URL — the host page owns its own parameters", () => {
+    openAt("/?token=from-url");
+    expect(storedToken()).toBeNull();
+    expect(window.location.search).toBe("?token=from-url");
+  });
+
+  it("returns null rather than throwing when storage is unavailable", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("SecurityError");
+    });
     expect(storedToken()).toBeNull();
   });
 
@@ -51,5 +125,12 @@ describe("storeToken", () => {
     storeToken("first");
     storeToken("second");
     expect(storedToken()).toBe("second");
+  });
+
+  it("swallows a storage failure instead of breaking the session", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("SecurityError");
+    });
+    expect(() => storeToken("hello")).not.toThrow();
   });
 });

--- a/ui/src/components/AssistantMessage.test.tsx
+++ b/ui/src/components/AssistantMessage.test.tsx
@@ -118,6 +118,27 @@ describe("AssistantMessage", () => {
     });
   });
 
+  describe("code fences", () => {
+    it("routes a mermaid fence to the diagram renderer", () => {
+      setup({ item: item({ blocks: [{ type: "text", text: "```mermaid\ngraph TD; A-->B;\n```" }] }) });
+      // Before mermaid has drawn anything the renderer shows the source, so finding
+      // it proves the fence reached the renderer rather than a plain <pre>
+      expect(screen.getByText(/graph TD; A-->B;/)).toBeInTheDocument();
+      expect(document.querySelector("pre.my-2")).not.toBeNull();
+    });
+
+    it("leaves any other fence as plain code", () => {
+      setup({ item: item({ blocks: [{ type: "text", text: "```ts\nconst a = 1;\n```" }] }) });
+      expect(screen.getByText(/const a = 1;/)).toBeInTheDocument();
+      expect(document.querySelector("pre.my-2")).toBeNull();
+    });
+
+    it("leaves a fence with no language as plain code", () => {
+      setup({ item: item({ blocks: [{ type: "text", text: "```\nplain\n```" }] }) });
+      expect(document.querySelector("pre.my-2")).toBeNull();
+    });
+  });
+
   describe("failures", () => {
     it("shows what went wrong alongside whatever arrived", () => {
       setup({ item: item({ errorMessage: "The provider refused the request" }) });

--- a/ui/src/components/AssistantMessage.test.tsx
+++ b/ui/src/components/AssistantMessage.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { ChatItem } from "@pi-outpost/shared";
+import { AssistantMessage } from "./AssistantMessage";
+
+type AssistantItem = Extract<ChatItem, { kind: "assistant" }>;
+
+function item(overrides: Partial<AssistantItem> = {}): AssistantItem {
+  return { kind: "assistant", blocks: [{ type: "text", text: "Here is the answer." }], ...overrides };
+}
+
+type Props = React.ComponentProps<typeof AssistantMessage>;
+
+function setup(overrides: Partial<Props> = {}) {
+  const onOpenFile = vi.fn();
+  render(<AssistantMessage item={item()} onOpenFile={onOpenFile} {...overrides} />);
+  return { onOpenFile };
+}
+
+describe("AssistantMessage", () => {
+  describe("blocks", () => {
+    it("renders the reply as markdown", () => {
+      setup({ item: item({ blocks: [{ type: "text", text: "# Title\n\nsome **bold** text" }] }) });
+      expect(screen.getByRole("heading", { name: "Title" })).toBeInTheDocument();
+      expect(screen.getByText("bold").tagName).toBe("STRONG");
+    });
+
+    it("renders every text block", () => {
+      setup({
+        item: item({
+          blocks: [
+            { type: "text", text: "first" },
+            { type: "text", text: "second" },
+          ],
+        }),
+      });
+      expect(screen.getByText("first")).toBeInTheDocument();
+      expect(screen.getByText("second")).toBeInTheDocument();
+    });
+
+    it("keeps thinking folded away until asked for", () => {
+      setup({ item: item({ blocks: [{ type: "thinking", text: "weighing the options" }] }) });
+      expect(screen.queryByText("weighing the options")).not.toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: /thinking/ }));
+      expect(screen.getByText("weighing the options")).toBeInTheDocument();
+    });
+
+    it("folds it back", () => {
+      setup({ item: item({ blocks: [{ type: "thinking", text: "weighing the options" }] }) });
+      const toggle = screen.getByRole("button", { name: /thinking/ });
+      fireEvent.click(toggle);
+      fireEvent.click(toggle);
+      expect(screen.queryByText("weighing the options")).not.toBeInTheDocument();
+    });
+
+    it("mixes thinking and answer in the order they arrived", () => {
+      setup({
+        item: item({
+          blocks: [
+            { type: "thinking", text: "hmm" },
+            { type: "text", text: "the answer" },
+          ],
+        }),
+      });
+      expect(screen.getByRole("button", { name: /thinking/ })).toBeInTheDocument();
+      expect(screen.getByText("the answer")).toBeInTheDocument();
+    });
+  });
+
+  describe("copying", () => {
+    it("offers to copy the finished reply", () => {
+      setup();
+      expect(screen.getByRole("button", { name: /copy/i })).toBeInTheDocument();
+    });
+
+    it("offers nothing while the reply is still arriving", () => {
+      setup({ item: item({ streaming: true }) });
+      expect(screen.queryByRole("button", { name: /copy/i })).not.toBeInTheDocument();
+    });
+
+    it("offers nothing for a reply that is only thinking", () => {
+      setup({ item: item({ blocks: [{ type: "thinking", text: "hmm" }] }) });
+      expect(screen.queryByRole("button", { name: /copy/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe("workspace references", () => {
+    it("loads a relative image through the raw-bytes endpoint", () => {
+      setup({ item: item({ blocks: [{ type: "text", text: "![plot](out/plot.png)" }] }), token: "secret" });
+      const img = screen.getByRole("img", { name: "plot" });
+      expect(img.getAttribute("src")).toContain("/files/raw");
+      expect(img.getAttribute("src")).toContain("secret");
+    });
+
+    it("leaves an external image URL alone", () => {
+      setup({ item: item({ blocks: [{ type: "text", text: "![remote](https://example.com/a.png)" }] }) });
+      expect(screen.getByRole("img", { name: "remote" })).toHaveAttribute("src", "https://example.com/a.png");
+    });
+
+    it("opens a relative link in the viewer instead of navigating away", () => {
+      const { onOpenFile } = setup({ item: item({ blocks: [{ type: "text", text: "see [main](src/main.ts)" }] }) });
+      fireEvent.click(screen.getByRole("link", { name: "main" }));
+      expect(onOpenFile).toHaveBeenCalledWith("src/main.ts");
+    });
+
+    it("sends an external link to a new tab, safely", () => {
+      const { onOpenFile } = setup({ item: item({ blocks: [{ type: "text", text: "[docs](https://example.com)" }] }) });
+      const link = screen.getByRole("link", { name: "docs" });
+      fireEvent.click(link);
+      expect(onOpenFile).not.toHaveBeenCalled();
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", expect.stringContaining("noreferrer"));
+    });
+
+    it("treats a relative link as external when nothing can open it", () => {
+      render(<AssistantMessage item={item({ blocks: [{ type: "text", text: "[main](src/main.ts)" }] })} />);
+      expect(screen.getByRole("link", { name: "main" })).toHaveAttribute("target", "_blank");
+    });
+  });
+
+  describe("failures", () => {
+    it("shows what went wrong alongside whatever arrived", () => {
+      setup({ item: item({ errorMessage: "The provider refused the request" }) });
+      expect(screen.getByText("Here is the answer.")).toBeInTheDocument();
+      expect(screen.getByText("The provider refused the request")).toBeInTheDocument();
+    });
+
+    it("shows an error even when no text arrived at all", () => {
+      setup({ item: item({ blocks: [], errorMessage: "Connection lost" }) });
+      expect(screen.getByText("Connection lost")).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/src/components/CodeHighlight.test.tsx
+++ b/ui/src/components/CodeHighlight.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * Which language the highlighter is asked for, and what shows while it loads.
+ *
+ * highlight.js is mocked at its module boundary: the interesting logic is the
+ * mapping from a path to a language, and the decision to fall back to
+ * auto-detection rather than highlight a file as something it is not.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { CodeHighlight } from "./CodeHighlight";
+
+const highlight = vi.hoisted(() => vi.fn());
+const highlightAuto = vi.hoisted(() => vi.fn());
+const getLanguage = vi.hoisted(() => vi.fn());
+const registerLanguage = vi.hoisted(() => vi.fn());
+
+vi.mock("highlight.js/lib/core", () => ({
+  default: { highlight, highlightAuto, getLanguage, registerLanguage },
+}));
+
+/** The language the component asked for, or "auto" when it fell back to detection. */
+async function languageUsedFor(path: string, code = "const a = 1;") {
+  render(<CodeHighlight code={code} path={path} />);
+  await waitFor(() => {
+    expect(highlight.mock.calls.length + highlightAuto.mock.calls.length).toBeGreaterThan(0);
+  });
+  if (highlight.mock.calls.length > 0) return highlight.mock.calls[0][1].language;
+  return "auto";
+}
+
+describe("CodeHighlight", () => {
+  beforeEach(() => {
+    highlight.mockReset().mockReturnValue({ value: "<span>highlighted</span>" });
+    highlightAuto.mockReset().mockReturnValue({ value: "<span>detected</span>" });
+    // Every curated language is registered; anything outside the map is not
+    getLanguage.mockReset().mockImplementation((name: string) => (name === "unregistered" ? undefined : {}));
+    registerLanguage.mockReset();
+  });
+
+  it("shows the code as plain text until the highlighter has loaded", () => {
+    render(<CodeHighlight code="const a = 1;" path="src/main.ts" />);
+    expect(screen.getByText("const a = 1;")).toBeInTheDocument();
+  });
+
+  it("replaces it with the highlighted markup once it has", async () => {
+    render(<CodeHighlight code="const a = 1;" path="src/main.ts" />);
+    await waitFor(() => expect(screen.getByText("highlighted")).toBeInTheDocument());
+  });
+
+  describe("choosing a language from the path", () => {
+    it("maps the TypeScript family", async () => {
+      for (const path of ["a.ts", "a.tsx", "a.mts", "a.cts"]) {
+        highlight.mockClear();
+        expect(await languageUsedFor(path)).toBe("typescript");
+      }
+    });
+
+    it("maps the JavaScript family", async () => {
+      for (const path of ["a.js", "a.jsx", "a.mjs", "a.cjs"]) {
+        highlight.mockClear();
+        expect(await languageUsedFor(path)).toBe("javascript");
+      }
+    });
+
+    it("maps markup and styles", async () => {
+      const cases: Array<[string, string]> = [
+        ["page.html", "xml"],
+        ["page.htm", "xml"],
+        ["icon.svg", "xml"],
+        ["app.css", "css"],
+        ["app.scss", "scss"],
+      ];
+      for (const [path, language] of cases) {
+        highlight.mockClear();
+        expect(await languageUsedFor(path)).toBe(language);
+      }
+    });
+
+    it("maps the shells to bash", async () => {
+      for (const path of ["run.sh", "run.bash", "run.zsh"]) {
+        highlight.mockClear();
+        expect(await languageUsedFor(path)).toBe("bash");
+      }
+    });
+
+    it("maps the C family", async () => {
+      const cases: Array<[string, string]> = [
+        ["a.c", "c"],
+        ["a.h", "c"],
+        ["a.cpp", "cpp"],
+        ["a.cc", "cpp"],
+        ["a.hpp", "cpp"],
+        ["a.cs", "csharp"],
+      ];
+      for (const [path, language] of cases) {
+        highlight.mockClear();
+        expect(await languageUsedFor(path)).toBe(language);
+      }
+    });
+
+    it("maps TOML onto the ini highlighter, which is close enough to be useful", async () => {
+      expect(await languageUsedFor("config.toml")).toBe("ini");
+    });
+
+    it("recognises a Dockerfile, which has no extension at all", async () => {
+      expect(await languageUsedFor("Dockerfile")).toBe("dockerfile");
+    });
+
+    it("recognises it in a subdirectory too", async () => {
+      expect(await languageUsedFor("docker/Dockerfile")).toBe("dockerfile");
+    });
+
+    it("reads the extension case-insensitively", async () => {
+      expect(await languageUsedFor("README.MD")).toBe("markdown");
+    });
+
+    it("uses the file's own name, not a directory that looks like an extension", async () => {
+      expect(await languageUsedFor("src.ts/notes.py")).toBe("python");
+    });
+  });
+
+  describe("falling back to detection", () => {
+    it("detects rather than guessing for an unknown extension", async () => {
+      expect(await languageUsedFor("notes.xyz")).toBe("auto");
+    });
+
+    it("detects for a file with no extension", async () => {
+      expect(await languageUsedFor("LICENSE")).toBe("auto");
+    });
+
+    it("detects for a dotfile, which is a name and not an extension", async () => {
+      expect(await languageUsedFor(".gitignore")).toBe("auto");
+    });
+
+    it("detects when the mapped language turned out not to be registered", async () => {
+      // The map names a language the curated bundle does not carry: detect rather
+      // than call highlight() with something hljs will reject
+      getLanguage.mockReturnValue(undefined);
+      expect(await languageUsedFor("a.ts")).toBe("auto");
+    });
+  });
+
+  it("re-highlights when the file changes", async () => {
+    const { rerender } = render(<CodeHighlight code="a" path="a.ts" />);
+    await waitFor(() => expect(highlight).toHaveBeenCalledTimes(1));
+    rerender(<CodeHighlight code="b" path="b.py" />);
+    await waitFor(() => expect(highlight).toHaveBeenCalledTimes(2));
+    expect(highlight.mock.calls[1][1].language).toBe("python");
+  });
+});

--- a/ui/src/components/Composer.test.tsx
+++ b/ui/src/components/Composer.test.tsx
@@ -1,0 +1,340 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import type { CommandInfo, FileSearchEntry } from "@pi-outpost/shared";
+import { Composer } from "./Composer";
+import type { Attachment } from "../attachments";
+
+const COMMANDS: CommandInfo[] = [
+  { name: "commit", description: "write a commit message", source: "prompt", argumentHint: "[scope]" },
+  { name: "compact", description: "compact the session", source: "extension" },
+  { name: "review", description: "review the diff", source: "skill" },
+];
+
+const entry = (path: string, type: FileSearchEntry["type"] = "file"): FileSearchEntry => ({ path, type });
+
+type Props = React.ComponentProps<typeof Composer>;
+
+function setup(overrides: Partial<Props> = {}) {
+  const handlers = {
+    onAttach: vi.fn(),
+    onMentionPaths: vi.fn(),
+    onRemoveAttachment: vi.fn(),
+    onSend: vi.fn(),
+    onAbort: vi.fn(),
+    onSearchFiles: vi.fn(),
+    onClearFileSearch: vi.fn(),
+  };
+  const props: Props = {
+    isStreaming: false,
+    connected: true,
+    commands: COMMANDS,
+    fileSearch: null,
+    attachments: [],
+    ...handlers,
+    ...overrides,
+  };
+  const view = render(<Composer {...props} />);
+  const rerenderWith = (next: Partial<Props>) => view.rerender(<Composer {...props} {...next} />);
+  return { ...handlers, ...view, rerenderWith };
+}
+
+const box = () => screen.getByRole("textbox");
+
+/** Type into the textarea, keeping the caret at the end as a real typist would. */
+function type(value: string) {
+  fireEvent.change(box(), { target: { value, selectionStart: value.length } });
+}
+
+describe("Composer", () => {
+  beforeEach(() => vi.useFakeTimers({ shouldAdvanceTime: true }));
+  afterEach(() => vi.useRealTimers());
+
+  describe("sending", () => {
+    it("sends on Enter", () => {
+      const { onSend } = setup();
+      type("hello");
+      fireEvent.keyDown(box(), { key: "Enter" });
+      expect(onSend).toHaveBeenCalledWith("hello", undefined);
+    });
+
+    it("clears the box after sending", () => {
+      setup();
+      type("hello");
+      fireEvent.keyDown(box(), { key: "Enter" });
+      expect(box()).toHaveValue("");
+    });
+
+    it("keeps Shift+Enter for a newline", () => {
+      const { onSend } = setup();
+      type("hello");
+      fireEvent.keyDown(box(), { key: "Enter", shiftKey: true });
+      expect(onSend).not.toHaveBeenCalled();
+    });
+
+    it("does not send mid-composition, so an IME candidate is not a prompt", () => {
+      const { onSend } = setup();
+      type("こんにち");
+      // React reads isComposing off the native event
+      fireEvent.keyDown(box(), { key: "Enter", isComposing: true });
+      expect(onSend).not.toHaveBeenCalled();
+    });
+
+    it("refuses to send whitespace", () => {
+      const { onSend } = setup();
+      type("   \n  ");
+      fireEvent.keyDown(box(), { key: "Enter" });
+      expect(onSend).not.toHaveBeenCalled();
+    });
+
+    it("disables the send button until there is something to send", () => {
+      setup();
+      expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
+      type("hi");
+      expect(screen.getByRole("button", { name: "Send message" })).toBeEnabled();
+    });
+
+    it("sends from the button too", () => {
+      const { onSend } = setup();
+      type("hello");
+      fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+      expect(onSend).toHaveBeenCalled();
+    });
+  });
+
+  describe("attachments", () => {
+    const image: Attachment = { kind: "image", name: "plot.png", mimeType: "image/png", data: "AAAA" };
+    // A path attachment carries the path in `data` — that is what composePrompt appends as @mention
+    const reference: Attachment = { kind: "path", name: "src/main.ts", data: "src/main.ts", mimeType: "text/plain" };
+
+    it("sends image data alongside the text", () => {
+      const { onSend } = setup({ attachments: [image] });
+      type("look");
+      fireEvent.keyDown(box(), { key: "Enter" });
+      expect(onSend).toHaveBeenCalledWith(expect.stringContaining("look"), [{ data: "AAAA", mimeType: "image/png" }]);
+    });
+
+    it("treats a bare path reference as context, not a question", () => {
+      // Opening a preview attaches a reference; a stray Enter must not fire a prompt
+      const { onSend } = setup({ attachments: [reference] });
+      fireEvent.keyDown(box(), { key: "Enter" });
+      expect(onSend).not.toHaveBeenCalled();
+    });
+
+    it("sends a reference once there is a question with it", () => {
+      const { onSend } = setup({ attachments: [reference] });
+      type("what does this do?");
+      fireEvent.keyDown(box(), { key: "Enter" });
+      expect(onSend).toHaveBeenCalled();
+    });
+
+    it("sends an image on its own, since the user supplied it", () => {
+      const { onSend } = setup({ attachments: [image] });
+      fireEvent.keyDown(box(), { key: "Enter" });
+      expect(onSend).toHaveBeenCalled();
+    });
+
+    it("lists attachments with a way to drop each", () => {
+      const { onRemoveAttachment } = setup({ attachments: [image, reference] });
+      expect(screen.getByText("plot.png")).toBeInTheDocument();
+      expect(screen.getByText("src/main.ts")).toBeInTheDocument();
+      fireEvent.click(screen.getAllByTitle("remove attachment")[1]);
+      expect(onRemoveAttachment).toHaveBeenCalledWith(1);
+    });
+
+    it("attaches files pasted into the box", () => {
+      const { onAttach } = setup();
+      const pasted = new File(["x"], "shot.png", { type: "image/png" });
+      fireEvent.paste(box(), { clipboardData: { files: [pasted] } });
+      expect(onAttach).toHaveBeenCalledWith([pasted]);
+    });
+
+    it("leaves an ordinary text paste alone", () => {
+      const { onAttach } = setup();
+      fireEvent.paste(box(), { clipboardData: { files: [] } });
+      expect(onAttach).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("slash commands", () => {
+    it("suggests commands as the name is typed", () => {
+      setup();
+      type("/co");
+      expect(screen.getByText("/commit")).toBeInTheDocument();
+      expect(screen.getByText("/compact")).toBeInTheDocument();
+      expect(screen.queryByText("/review")).not.toBeInTheDocument();
+    });
+
+    it("says where each command comes from", () => {
+      setup();
+      type("/");
+      expect(screen.getByText("prompt")).toBeInTheDocument();
+      expect(screen.getByText("ext")).toBeInTheDocument();
+      expect(screen.getByText("skill")).toBeInTheDocument();
+    });
+
+    it("stops suggesting once the name is followed by an argument", () => {
+      setup();
+      type("/commit scope");
+      expect(screen.queryByText("/commit")).not.toBeInTheDocument();
+    });
+
+    it("completes the selected command with a trailing space", () => {
+      setup();
+      type("/co");
+      fireEvent.keyDown(box(), { key: "Enter" });
+      expect(box()).toHaveValue("/commit ");
+    });
+
+    it("moves the selection with the arrow keys", () => {
+      setup();
+      type("/co");
+      fireEvent.keyDown(box(), { key: "ArrowDown" });
+      fireEvent.keyDown(box(), { key: "Tab" });
+      expect(box()).toHaveValue("/compact ");
+    });
+
+    it("wraps around at the ends of the list", () => {
+      setup();
+      type("/co");
+      fireEvent.keyDown(box(), { key: "ArrowUp" });
+      fireEvent.keyDown(box(), { key: "Enter" });
+      expect(box()).toHaveValue("/compact ");
+    });
+
+    it("completes on click", () => {
+      setup();
+      type("/co");
+      fireEvent.click(screen.getByText("/compact"));
+      expect(box()).toHaveValue("/compact ");
+    });
+
+    it("dismisses the menu on Escape without clearing the text", () => {
+      setup();
+      type("/co");
+      fireEvent.keyDown(box(), { key: "Escape" });
+      expect(screen.queryByText("/commit")).not.toBeInTheDocument();
+      expect(box()).toHaveValue("/co");
+    });
+
+    it("does not send while the menu is taking Enter", () => {
+      const { onSend } = setup();
+      type("/co");
+      fireEvent.keyDown(box(), { key: "Enter" });
+      expect(onSend).not.toHaveBeenCalled();
+    });
+
+    it("sends once the menu has been dismissed", () => {
+      const { onSend } = setup();
+      type("/co");
+      fireEvent.keyDown(box(), { key: "Escape" });
+      fireEvent.keyDown(box(), { key: "Enter" });
+      expect(onSend).toHaveBeenCalled();
+    });
+  });
+
+  describe("@ mentions", () => {
+    it("searches for the mention after a pause, not on every keystroke", () => {
+      const { onSearchFiles } = setup();
+      type("see @mai");
+      expect(onSearchFiles).not.toHaveBeenCalled();
+      act(() => void vi.advanceTimersByTime(200));
+      expect(onSearchFiles).toHaveBeenCalledWith("mai");
+    });
+
+    it("clears the search when the mention is emptied", () => {
+      const { onClearFileSearch } = setup();
+      type("see @");
+      expect(onClearFileSearch).toHaveBeenCalled();
+    });
+
+    it("does not treat an address as a mention", () => {
+      const { onSearchFiles } = setup();
+      type("mail me at ada@example.com");
+      act(() => void vi.advanceTimersByTime(200));
+      expect(onSearchFiles).not.toHaveBeenCalled();
+    });
+
+    it("shows results for the query actually typed", () => {
+      const { rerenderWith } = setup();
+      type("see @mai");
+      rerenderWith({ fileSearch: { status: "loaded", query: "mai", requestId: "s1", results: [entry("src/main.ts")] } });
+      expect(screen.getByText("src/main.ts")).toBeInTheDocument();
+    });
+
+    it("ignores results belonging to a superseded query", () => {
+      const { rerenderWith } = setup();
+      type("see @mai");
+      rerenderWith({ fileSearch: { status: "loaded", query: "old", requestId: "s0", results: [entry("stale.ts")] } });
+      expect(screen.queryByText("stale.ts")).not.toBeInTheDocument();
+    });
+
+    it("completes a file with a trailing space", () => {
+      const { rerenderWith } = setup();
+      type("see @mai");
+      rerenderWith({ fileSearch: { status: "loaded", query: "mai", requestId: "s1", results: [entry("src/main.ts")] } });
+      fireEvent.keyDown(box(), { key: "Enter" });
+      expect(box()).toHaveValue("see @src/main.ts ");
+    });
+
+    it("completes a directory with a trailing slash, ready to keep typing", () => {
+      const { rerenderWith } = setup();
+      type("see @sr");
+      rerenderWith({ fileSearch: { status: "loaded", query: "sr", requestId: "s1", results: [entry("src", "directory")] } });
+      fireEvent.keyDown(box(), { key: "Enter" });
+      expect(box()).toHaveValue("see @src/");
+    });
+
+    it("reports the mentioned paths so the app can attach them", () => {
+      const { onMentionPaths } = setup();
+      type("look at @src/main.ts please");
+      expect(onMentionPaths).toHaveBeenLastCalledWith(["src/main.ts"]);
+    });
+
+    it("prefers the command menu over a mention when both could apply", () => {
+      const { rerenderWith } = setup();
+      type("/co");
+      rerenderWith({ fileSearch: { status: "loaded", query: "co", requestId: "s1", results: [entry("config.ts")] } });
+      expect(screen.getByText("/commit")).toBeInTheDocument();
+      expect(screen.queryByText("config.ts")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("connection and streaming", () => {
+    it("disables the box until connected", () => {
+      setup({ connected: false });
+      expect(box()).toBeDisabled();
+      expect(box()).toHaveAttribute("placeholder", "connecting…");
+    });
+
+    it("offers to stop the agent while it is running", () => {
+      const { onAbort } = setup({ isStreaming: true });
+      fireEvent.click(screen.getByRole("button", { name: "Stop the agent" }));
+      expect(onAbort).toHaveBeenCalled();
+    });
+
+    it("offers no stop button when the agent is idle", () => {
+      setup({ isStreaming: false });
+      expect(screen.queryByRole("button", { name: "Stop the agent" })).not.toBeInTheDocument();
+    });
+
+    it("calls sending steering while the agent runs", () => {
+      setup({ isStreaming: true });
+      expect(screen.getByRole("button", { name: "Steer the agent" })).toBeInTheDocument();
+      expect(box()).toHaveAttribute("placeholder", expect.stringContaining("steer"));
+    });
+  });
+
+  describe("prefill", () => {
+    it("takes the prefilled text", () => {
+      setup({ prefill: { text: "edited prompt", nonce: 1 } });
+      expect(box()).toHaveValue("edited prompt");
+    });
+
+    it("takes it again when a new prefill arrives with the same text", () => {
+      const { rerenderWith } = setup({ prefill: { text: "same", nonce: 1 } });
+      type("typed over it");
+      rerenderWith({ prefill: { text: "same", nonce: 2 } });
+      expect(box()).toHaveValue("same");
+    });
+  });
+});

--- a/ui/src/components/FileTree.test.tsx
+++ b/ui/src/components/FileTree.test.tsx
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import type { DirEntry, GitFileState } from "@pi-outpost/shared";
+import { FileTree } from "./FileTree";
+import type { DirState } from "../useAgent";
+
+const file = (name: string): DirEntry => ({ name, type: "file" });
+const dir = (name: string): DirEntry => ({ name, type: "directory" });
+
+/** Root holds src/ and readme.md; src/ is loaded but only rendered once expanded. */
+function tree(overrides: Record<string, DirState> = {}): Record<string, DirState> {
+  return {
+    "": [dir("src"), file("readme.md")],
+    src: [file("main.ts"), dir("nested")],
+    ...overrides,
+  };
+}
+
+type Props = React.ComponentProps<typeof FileTree>;
+
+function setup(overrides: Partial<Props> = {}) {
+  const handlers = {
+    onExpand: vi.fn(),
+    onSelectFile: vi.fn(),
+    onSelectDiff: vi.fn(),
+    onToggleAttachPath: vi.fn(),
+  };
+  const view = render(<FileTree tree={tree()} {...handlers} {...overrides} />);
+  return { ...handlers, ...view };
+}
+
+/**
+ * The directory toggle for a name. Anchored at both ends: "src" must not also
+ * match "src-gen", which is exactly the confusion one of the tests below is about.
+ * The trailing digits are the change-count badge, which the accessible name runs
+ * straight onto the directory name with no separator.
+ */
+const dirToggle = (name: string) => screen.getByRole("button", { name: new RegExp(`^[▸▾]\\s*${name}\\s*\\d*$`) });
+
+describe("FileTree", () => {
+  describe("expanding", () => {
+    it("lists the root without expanding anything", () => {
+      setup();
+      expect(dirToggle("src")).toBeInTheDocument();
+      expect(screen.getByText("readme.md")).toBeInTheDocument();
+      expect(screen.queryByText("main.ts")).not.toBeInTheDocument();
+    });
+
+    it("reveals children when a directory opens", () => {
+      setup();
+      fireEvent.click(dirToggle("src"));
+      expect(screen.getByText("main.ts")).toBeInTheDocument();
+    });
+
+    it("hides them again when it closes", () => {
+      setup();
+      fireEvent.click(dirToggle("src"));
+      fireEvent.click(dirToggle("src"));
+      expect(screen.queryByText("main.ts")).not.toBeInTheDocument();
+    });
+
+    it("asks for a directory it has never seen", () => {
+      const { onExpand } = setup({ tree: { "": [dir("src")] } });
+      fireEvent.click(dirToggle("src"));
+      expect(onExpand).toHaveBeenCalledWith("src");
+    });
+
+    it("does not re-ask for a directory already in hand", () => {
+      const { onExpand } = setup();
+      fireEvent.click(dirToggle("src"));
+      expect(onExpand).not.toHaveBeenCalled();
+    });
+
+    it("builds nested paths from the parent", () => {
+      const { onExpand } = setup();
+      fireEvent.click(dirToggle("src"));
+      fireEvent.click(dirToggle("nested"));
+      expect(onExpand).toHaveBeenCalledWith("src/nested");
+    });
+
+    it("says a directory is loading", () => {
+      setup({ tree: { "": [dir("src")], src: "loading" } });
+      fireEvent.click(dirToggle("src"));
+      expect(screen.getByText("loading…")).toBeInTheDocument();
+    });
+
+    it("says a directory is empty rather than showing nothing", () => {
+      setup({ tree: { "": [dir("src")], src: [] } });
+      fireEvent.click(dirToggle("src"));
+      expect(screen.getByText("empty")).toBeInTheDocument();
+    });
+
+    it("surfaces a listing error", () => {
+      setup({ tree: { "": [dir("src")], src: { error: "Cannot read \"src\": EACCES" } } });
+      fireEvent.click(dirToggle("src"));
+      expect(screen.getByText(/EACCES/)).toBeInTheDocument();
+    });
+  });
+
+  describe("selecting", () => {
+    it("reports the full path of the chosen file", () => {
+      const { onSelectFile } = setup();
+      fireEvent.click(dirToggle("src"));
+      fireEvent.click(screen.getByText("main.ts"));
+      expect(onSelectFile).toHaveBeenCalledWith("src/main.ts");
+    });
+
+    it("reports a root-level file without a leading slash", () => {
+      const { onSelectFile } = setup();
+      fireEvent.click(screen.getByText("readme.md"));
+      expect(onSelectFile).toHaveBeenCalledWith("readme.md");
+    });
+  });
+
+  describe("the writable zone", () => {
+    it("dims nothing when there is no sandbox", () => {
+      setup({ writableRoot: undefined });
+      // Match the light-mode token only: dark:text-zinc-400 is what an *undimmed*
+      // row carries, so a bare /zinc-400/ would pass on either
+      expect(screen.getByText("readme.md").className).not.toMatch(/(^|\s)text-zinc-400\b/);
+    });
+
+    it("dims everything when the sandbox is read-only", () => {
+      setup({ writableRoot: null });
+      expect(screen.getByText("readme.md").className).toMatch(/(^|\s)text-zinc-400\b/);
+    });
+
+    it("dims only what sits outside the writable subtree", () => {
+      setup({ writableRoot: "src" });
+      fireEvent.click(dirToggle("src"));
+      expect(screen.getByText("main.ts").className).not.toMatch(/(^|\s)text-zinc-400\b/);
+      expect(screen.getByText("readme.md").className).toMatch(/(^|\s)text-zinc-400\b/);
+    });
+
+    it("does not treat a sibling sharing a prefix as inside the zone", () => {
+      setup({ tree: { "": [file("src-generated.ts")] }, writableRoot: "src" });
+      expect(screen.getByText("src-generated.ts").className).toMatch(/(^|\s)text-zinc-400\b/);
+    });
+  });
+
+  describe("git badges", () => {
+    const gitFiles: Record<string, GitFileState> = {
+      "src/main.ts": "modified",
+      "readme.md": "untracked",
+    };
+
+    it("badges a changed file with its state", () => {
+      setup({ gitFiles });
+      fireEvent.click(dirToggle("src"));
+      expect(screen.getByRole("button", { name: "Show diff of main.ts" })).toHaveTextContent("M");
+      expect(screen.getByRole("button", { name: "Show diff of readme.md" })).toHaveTextContent("U");
+    });
+
+    it("leaves an unchanged file unbadged", () => {
+      setup({ gitFiles: { "readme.md": "modified" } });
+      fireEvent.click(dirToggle("src"));
+      expect(screen.queryByRole("button", { name: "Show diff of main.ts" })).not.toBeInTheDocument();
+    });
+
+    it("opens the file straight on its diff", () => {
+      const { onSelectDiff } = setup({ gitFiles });
+      fireEvent.click(dirToggle("src"));
+      fireEvent.click(screen.getByRole("button", { name: "Show diff of main.ts" }));
+      expect(onSelectDiff).toHaveBeenCalledWith("src/main.ts");
+    });
+
+    it("falls back to plain selection when no diff handler is given", () => {
+      const { onSelectFile } = setup({ gitFiles, onSelectDiff: undefined });
+      fireEvent.click(dirToggle("src"));
+      fireEvent.click(screen.getByRole("button", { name: "Show diff of main.ts" }));
+      expect(onSelectFile).toHaveBeenCalledWith("src/main.ts");
+    });
+
+    it("counts changed files on a collapsed directory", () => {
+      setup({ gitFiles: { "src/main.ts": "modified", "src/nested/deep.ts": "added" } });
+      const badge = within(dirToggle("src")).getByTitle("2 changed file(s) inside");
+      expect(badge).toHaveTextContent("2");
+    });
+
+    it("drops the count once the directory is open, since the files speak for themselves", () => {
+      setup({ gitFiles: { "src/main.ts": "modified" } });
+      fireEvent.click(dirToggle("src"));
+      expect(within(dirToggle("src")).queryByTitle(/changed file/)).not.toBeInTheDocument();
+    });
+
+    it("does not count a sibling directory sharing a prefix", () => {
+      setup({ tree: { "": [dir("src"), dir("src-gen")] }, gitFiles: { "src-gen/out.ts": "modified" } });
+      expect(within(dirToggle("src")).queryByTitle(/changed file/)).not.toBeInTheDocument();
+      expect(within(dirToggle("src-gen")).getByTitle("1 changed file(s) inside")).toBeInTheDocument();
+    });
+  });
+
+  describe("prompt references", () => {
+    it("offers a pin per file when attaching is possible", () => {
+      setup();
+      expect(screen.getByRole("button", { name: "Reference readme.md in the prompt" })).toBeInTheDocument();
+    });
+
+    it("omits the pin entirely when attaching is not offered", () => {
+      setup({ onToggleAttachPath: undefined });
+      expect(screen.queryByRole("button", { name: /in the prompt/ })).not.toBeInTheDocument();
+    });
+
+    it("reports the path to attach", () => {
+      const { onToggleAttachPath } = setup();
+      fireEvent.click(screen.getByRole("button", { name: "Reference readme.md in the prompt" }));
+      expect(onToggleAttachPath).toHaveBeenCalledWith("readme.md");
+    });
+
+    it("says the file is already referenced, and offers to drop it", () => {
+      setup({ attachedPaths: ["readme.md"] });
+      const pin = screen.getByRole("button", { name: "Remove readme.md in the prompt" });
+      expect(pin).toHaveAttribute("aria-pressed", "true");
+    });
+
+    it("keeps an attached pin visible rather than hiding it until hover", () => {
+      // Two files: one referenced, one not, so both pin styles are on screen
+      setup({ tree: { "": [file("readme.md"), file("notes.md")] }, attachedPaths: ["readme.md"] });
+      const attached = screen.getByRole("button", { name: /Remove readme.md/ });
+      const plain = screen.getByRole("button", { name: /Reference/ });
+      expect(attached.className).not.toMatch(/opacity-0/);
+      expect(plain.className).toMatch(/opacity-0/);
+    });
+  });
+
+  it("marks the file currently open in the viewer", () => {
+    setup({ openFilePath: "readme.md" });
+    const row = screen.getByText("readme.md").closest("div")!;
+    expect(row.className).toMatch(/bg-zinc-100/);
+  });
+});

--- a/ui/src/components/FileViewer.test.tsx
+++ b/ui/src/components/FileViewer.test.tsx
@@ -1,0 +1,374 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { FileViewer } from "./FileViewer";
+import type { GitDiffState, OpenFile } from "../useAgent";
+
+function loaded(overrides: Partial<Extract<OpenFile, { status: "loaded" }>> = {}): OpenFile {
+  return { status: "loaded", path: "src/main.ts", content: "const a = 1;\n", size: 13, mtimeMs: 1000, ...overrides };
+}
+
+type Props = React.ComponentProps<typeof FileViewer>;
+
+function setup(overrides: Partial<Props> = {}) {
+  const handlers = {
+    onDirtyChange: vi.fn(),
+    onFetchGitDiff: vi.fn(),
+    onClearGitDiff: vi.fn(),
+    onOpenGitHistory: vi.fn(),
+    onClose: vi.fn(),
+    onReload: vi.fn(),
+    onSave: vi.fn(),
+    onImageLoad: vi.fn(),
+  };
+  const props: Props = {
+    file: loaded(),
+    isStreaming: false,
+    gitDiff: null,
+    gitAvailable: false,
+    ...handlers,
+    ...overrides,
+  };
+  const view = render(<FileViewer {...props} />);
+  const rerenderWith = (next: Partial<Props>) => view.rerender(<FileViewer {...props} {...next} />);
+  return { ...handlers, ...view, rerenderWith };
+}
+
+const button = (name: string | RegExp) => screen.getByRole("button", { name });
+const queryButton = (name: string | RegExp) => screen.queryByRole("button", { name });
+
+/** Enter edit mode and type, which is the precondition for most guards below. */
+function edit(text: string) {
+  fireEvent.click(button("✎ edit"));
+  fireEvent.change(screen.getByRole("textbox"), { target: { value: text } });
+}
+
+describe("FileViewer", () => {
+  let confirmSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+  });
+  afterEach(() => {
+    confirmSpy.mockRestore();
+  });
+
+  describe("reading", () => {
+    it("names the open file", () => {
+      setup();
+      expect(screen.getAllByTitle("src/main.ts").length).toBeGreaterThan(0);
+    });
+
+    it("shows the file while it is still loading", () => {
+      setup({ file: { status: "loading", path: "src/main.ts", requestId: "r1" } });
+      expect(screen.getByText("loading…")).toBeInTheDocument();
+    });
+
+    it("surfaces a read error instead of an empty pane", () => {
+      setup({ file: { status: "error", path: "src/main.ts", message: "Binary file — preview not supported" } });
+      expect(screen.getByText("Binary file — preview not supported")).toBeInTheDocument();
+    });
+
+    it("offers a source toggle for markdown only", () => {
+      const { rerenderWith } = setup({ file: loaded({ path: "notes.md", content: "# Title\n" }) });
+      expect(button(/source/)).toBeInTheDocument();
+      rerenderWith({ file: loaded() });
+      expect(queryButton(/source/)).not.toBeInTheDocument();
+    });
+
+    it("switches markdown between rendered and source", () => {
+      setup({ file: loaded({ path: "notes.md", content: "# Title\n" }) });
+      expect(screen.getByRole("heading", { name: "Title" })).toBeInTheDocument();
+      fireEvent.click(button(/source/));
+      expect(screen.queryByRole("heading", { name: "Title" })).not.toBeInTheDocument();
+      expect(button(/rendered/)).toBeInTheDocument();
+    });
+  });
+
+  describe("the writable zone", () => {
+    it("offers editing when everything is writable", () => {
+      setup({ writableRoot: undefined });
+      expect(button("✎ edit")).toBeInTheDocument();
+    });
+
+    it("marks the file read-only when nothing is writable", () => {
+      setup({ writableRoot: null });
+      expect(queryButton("✎ edit")).not.toBeInTheDocument();
+      expect(screen.getByText("🔒 read-only")).toBeInTheDocument();
+    });
+
+    it("offers editing inside the writable subtree", () => {
+      setup({ file: loaded({ path: "src/main.ts" }), writableRoot: "src" });
+      expect(button("✎ edit")).toBeInTheDocument();
+    });
+
+    it("refuses editing outside the writable subtree", () => {
+      setup({ file: loaded({ path: "docs/readme.md" }), writableRoot: "src" });
+      expect(queryButton("✎ edit")).not.toBeInTheDocument();
+    });
+
+    it("does not mistake a sibling with a shared prefix for the writable subtree", () => {
+      // "src-generated" starts with "src" but is not inside it
+      setup({ file: loaded({ path: "src-generated/out.ts" }), writableRoot: "src" });
+      expect(queryButton("✎ edit")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("editing", () => {
+    it("keeps save disabled until something changes", () => {
+      setup();
+      fireEvent.click(button("✎ edit"));
+      expect(button("save")).toBeDisabled();
+    });
+
+    it("submits the draft with the baseline mtime", () => {
+      const { onSave } = setup();
+      edit("const a = 2;\n");
+      fireEvent.click(button("save"));
+      expect(onSave).toHaveBeenCalledWith("src/main.ts", "const a = 2;\n", 1000, false);
+    });
+
+    it("saves on the keyboard shortcut", () => {
+      const { onSave } = setup();
+      edit("const a = 2;\n");
+      fireEvent.keyDown(screen.getByRole("textbox"), { key: "s", metaKey: true });
+      expect(onSave).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores the shortcut when there is nothing to save", () => {
+      const { onSave } = setup();
+      fireEvent.click(button("✎ edit"));
+      fireEvent.keyDown(screen.getByRole("textbox"), { key: "s", ctrlKey: true });
+      expect(onSave).not.toHaveBeenCalled();
+    });
+
+    it("reports the unsaved state so the app can guard the prompt", () => {
+      const { onDirtyChange } = setup();
+      edit("changed\n");
+      expect(onDirtyChange).toHaveBeenLastCalledWith(true);
+    });
+
+    it("marks the filename while the draft differs", () => {
+      setup();
+      edit("changed\n");
+      expect(screen.getByText("●")).toBeInTheDocument();
+    });
+
+    it("asks before discarding a dirty draft on cancel", () => {
+      setup();
+      edit("changed\n");
+      fireEvent.click(button("cancel"));
+      expect(confirmSpy).toHaveBeenCalled();
+      expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    });
+
+    it("keeps the draft when the discard prompt is declined", () => {
+      confirmSpy.mockReturnValue(false);
+      setup();
+      edit("changed\n");
+      fireEvent.click(button("cancel"));
+      expect(screen.getByRole("textbox")).toHaveValue("changed\n");
+    });
+
+    it("leaves a clean draft without asking", () => {
+      setup();
+      fireEvent.click(button("✎ edit"));
+      fireEvent.click(button("cancel"));
+      expect(confirmSpy).not.toHaveBeenCalled();
+      expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    });
+
+    it("shows the save in flight and blocks a second submit", () => {
+      const { rerenderWith, onSave } = setup();
+      edit("const a = 2;\n");
+      rerenderWith({ file: loaded({ pendingSave: { requestId: "w1", content: "const a = 2;\n" } }) });
+      const saveButton = button("saving…");
+      expect(saveButton).toBeDisabled();
+      onSave.mockClear();
+      fireEvent.keyDown(screen.getByRole("textbox"), { key: "s", metaKey: true });
+      expect(onSave).not.toHaveBeenCalled();
+    });
+
+    it("leaves edit mode once the save lands", () => {
+      const { rerenderWith } = setup();
+      edit("const a = 2;\n");
+      fireEvent.click(button("save"));
+      // The write is acknowledged: new content, new mtime
+      rerenderWith({ file: loaded({ content: "const a = 2;\n", mtimeMs: 2000 }) });
+      expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    });
+
+    it("keeps typing that happened during the round-trip", () => {
+      const { rerenderWith } = setup();
+      edit("const a = 2;\n");
+      fireEvent.click(button("save"));
+      fireEvent.change(screen.getByRole("textbox"), { target: { value: "const a = 3;\n" } });
+      rerenderWith({ file: loaded({ content: "const a = 2;\n", mtimeMs: 2000 }) });
+      // Still editing, and the newer draft survived the acknowledgement
+      expect(screen.getByRole("textbox")).toHaveValue("const a = 3;\n");
+    });
+
+    it("shows a save failure that is not a conflict", () => {
+      const { rerenderWith } = setup();
+      edit("changed\n");
+      rerenderWith({ file: loaded({ saveError: { message: "The sandbox is read-only", conflict: false } }) });
+      expect(screen.getByText("The sandbox is read-only")).toBeInTheDocument();
+    });
+  });
+
+  describe("conflicts", () => {
+    it("warns when the file moved on disk under the editor", () => {
+      const { rerenderWith } = setup();
+      edit("mine\n");
+      rerenderWith({ file: loaded({ mtimeMs: 5000 }) });
+      expect(screen.getByText("File changed on disk since you started editing.")).toBeInTheDocument();
+      expect(button("save")).toBeDisabled();
+    });
+
+    it("offers to reload, discarding the draft", () => {
+      const { rerenderWith, onReload } = setup();
+      edit("mine\n");
+      rerenderWith({ file: loaded({ mtimeMs: 5000 }) });
+      fireEvent.click(button(/reload/));
+      expect(onReload).toHaveBeenCalledWith("src/main.ts");
+      expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    });
+
+    it("offers to overwrite, forcing past the mtime check", () => {
+      const { rerenderWith, onSave } = setup();
+      edit("mine\n");
+      rerenderWith({ file: loaded({ mtimeMs: 5000 }) });
+      fireEvent.click(button(/overwrite/));
+      expect(onSave).toHaveBeenCalledWith("src/main.ts", "mine\n", 1000, true);
+    });
+
+    it("treats a server-reported conflict the same way", () => {
+      const { rerenderWith } = setup();
+      edit("mine\n");
+      rerenderWith({ file: loaded({ saveError: { message: "changed on disk", conflict: true } }) });
+      expect(screen.getByText("File changed on disk since you started editing.")).toBeInTheDocument();
+    });
+  });
+
+  describe("closing", () => {
+    it("closes on the button", () => {
+      const { onClose } = setup();
+      fireEvent.click(button("Close file viewer"));
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it("closes on Escape", () => {
+      const { onClose } = setup();
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it("asks before closing over unsaved changes", () => {
+      const { onClose } = setup();
+      edit("changed\n");
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(confirmSpy).toHaveBeenCalled();
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it("stays open when the discard prompt is declined", () => {
+      confirmSpy.mockReturnValue(false);
+      const { onClose } = setup();
+      edit("changed\n");
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it("reports the file clean on unmount, whatever the draft held", () => {
+      const { onDirtyChange, unmount } = setup();
+      edit("changed\n");
+      unmount();
+      expect(onDirtyChange).toHaveBeenLastCalledWith(false);
+    });
+  });
+
+  describe("git surface", () => {
+    it("offers the diff toggle only for a file carrying changes", () => {
+      const { rerenderWith } = setup({ gitState: undefined });
+      expect(queryButton("± diff")).not.toBeInTheDocument();
+      rerenderWith({ gitState: "modified" });
+      expect(button("± diff")).toBeInTheDocument();
+    });
+
+    it("fetches the diff when the toggle goes on and clears it when off", () => {
+      const { onFetchGitDiff, onClearGitDiff } = setup({ gitState: "modified" });
+      fireEvent.click(button("± diff"));
+      expect(onFetchGitDiff).toHaveBeenCalledWith("src/main.ts");
+      expect(button("± diff")).toHaveAttribute("aria-pressed", "true");
+      fireEvent.click(button("± diff"));
+      expect(onClearGitDiff).toHaveBeenCalled();
+    });
+
+    it("opens straight onto the diff when asked", () => {
+      const { onFetchGitDiff } = setup({ gitState: "modified", initialShowGitDiff: true });
+      expect(onFetchGitDiff).toHaveBeenCalledWith("src/main.ts");
+      expect(button("± diff")).toHaveAttribute("aria-pressed", "true");
+    });
+
+    it("waits rather than showing another file's diff", () => {
+      const other: GitDiffState = { path: "other.ts", before: "a", after: "b" };
+      setup({ gitState: "modified", initialShowGitDiff: true, gitDiff: other });
+      expect(screen.getByText("loading diff…")).toBeInTheDocument();
+    });
+
+    it("renders the diff once it arrives for this file", () => {
+      const mine: GitDiffState = { path: "src/main.ts", before: "const a = 1;\n", after: "const a = 2;\n" };
+      setup({ gitState: "modified", initialShowGitDiff: true, gitDiff: mine });
+      expect(screen.queryByText("loading diff…")).not.toBeInTheDocument();
+      expect(screen.getAllByText(/const a = 2;/).length).toBeGreaterThan(0);
+    });
+
+    it("shows a diff failure in the pane", () => {
+      const failed: GitDiffState = { path: "src/main.ts", error: "Binary file — diff not supported" };
+      setup({ gitState: "modified", initialShowGitDiff: true, gitDiff: failed });
+      expect(screen.getByText("Binary file — diff not supported")).toBeInTheDocument();
+    });
+
+    it("drops the fetched diff when the viewer goes away", () => {
+      const { onClearGitDiff, unmount } = setup({ gitState: "modified" });
+      unmount();
+      expect(onClearGitDiff).toHaveBeenCalled();
+    });
+
+    it("offers the history affordance for any tracked file, changed or not", () => {
+      const { onOpenGitHistory } = setup({ gitAvailable: true, gitState: undefined });
+      fireEvent.click(button("⎇ history"));
+      expect(onOpenGitHistory).toHaveBeenCalledWith("src/main.ts");
+    });
+
+    it("hides the history affordance when git is unavailable", () => {
+      setup({ gitAvailable: false });
+      expect(queryButton("⎇ history")).not.toBeInTheDocument();
+    });
+
+    it("hides both git affordances while editing", () => {
+      setup({ gitAvailable: true, gitState: "modified" });
+      fireEvent.click(button("✎ edit"));
+      expect(queryButton("⎇ history")).not.toBeInTheDocument();
+      expect(queryButton("± diff")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("images", () => {
+    it("loads an image from the raw route rather than the text protocol", () => {
+      setup({ file: { status: "error", path: "plot.png", message: "Binary file — preview not supported" } });
+      const img = screen.getByRole("img", { name: "plot.png" });
+      expect(img).toHaveAttribute("src", expect.stringContaining("/files/raw"));
+    });
+
+    it("confirms the image decoded before it can become an attachment", () => {
+      const { onImageLoad } = setup({ file: { status: "error", path: "plot.png", message: "binary" } });
+      fireEvent.load(screen.getByRole("img", { name: "plot.png" }));
+      expect(onImageLoad).toHaveBeenCalledWith("plot.png");
+    });
+
+    it("carries the auth token on the raw URL, since img cannot send headers", () => {
+      setup({ file: { status: "error", path: "plot.png", message: "binary" }, token: "secret-token" });
+      expect(screen.getByRole("img", { name: "plot.png" })).toHaveAttribute("src", expect.stringContaining("secret-token"));
+    });
+  });
+});

--- a/ui/src/components/GitCommitView.test.tsx
+++ b/ui/src/components/GitCommitView.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { GitCommitView } from "./GitCommitView";
+import type { GitShowState } from "../useAgent";
+
+const PATCH = [
+  "diff --git a/src/main.ts b/src/main.ts",
+  "index 1234567..89abcde 100644",
+  "--- a/src/main.ts",
+  "+++ b/src/main.ts",
+  "@@ -1,3 +1,3 @@",
+  " const unchanged = 1;",
+  "-const before = 2;",
+  "+const after = 2;",
+  "",
+].join("\n");
+
+function show(overrides: Partial<GitShowState> = {}): GitShowState {
+  return { sha: "abcdef1234567890", patch: PATCH, truncated: false, ...overrides };
+}
+
+function setup(overrides: Partial<GitShowState> = {}) {
+  const onClose = vi.fn();
+  const view = render(<GitCommitView show={show(overrides)} onClose={onClose} />);
+  return { onClose, ...view };
+}
+
+/**
+ * The rendered row carrying this text, so we can inspect how it was classified.
+ * Added and removed rows render their glyph as a separate text node, so the row's
+ * text has to be matched as a whole rather than by an exact string.
+ */
+function row(text: string) {
+  return screen.getByText((_, element) => element?.textContent?.trim() === text && element.children.length === 0);
+}
+
+describe("GitCommitView", () => {
+  it("abbreviates the commit id in the header", () => {
+    setup();
+    expect(screen.getByText("abcdef123456")).toBeInTheDocument();
+  });
+
+  it("marks added and removed lines differently", () => {
+    setup();
+    // The leading +/- is stripped from the text and replaced by a rendered glyph
+    expect(row("+ const after = 2;").className).toMatch(/emerald/);
+    expect(row("− const before = 2;").className).toMatch(/red/);
+  });
+
+  it("leaves context lines unhighlighted", () => {
+    setup();
+    const context = row("const unchanged = 1;").className;
+    expect(context).not.toMatch(/emerald|red/);
+    expect(context).toMatch(/zinc/);
+  });
+
+  it("picks out the hunk header", () => {
+    setup();
+    expect(row("@@ -1,3 +1,3 @@").className).toMatch(/sky/);
+  });
+
+  it("treats the file header as a heading, without its diff --git noise", () => {
+    setup();
+    // "diff --git " is stripped; what remains names the file on both sides
+    expect(screen.getByText("a/src/main.ts b/src/main.ts").className).toMatch(/font-bold/);
+  });
+
+  it("does not mistake the +++/--- file markers for added and removed lines", () => {
+    setup();
+    expect(row("+++ b/src/main.ts").className).toMatch(/sky/);
+    expect(row("--- a/src/main.ts").className).toMatch(/sky/);
+  });
+
+  it("says nothing about truncation for a complete patch", () => {
+    setup();
+    expect(screen.queryByText(/truncated/i)).not.toBeInTheDocument();
+  });
+
+  it("warns when the patch was cut short", () => {
+    setup({ truncated: true });
+    expect(screen.getByText(/Patch truncated/)).toBeInTheDocument();
+  });
+
+  it("closes on the button", () => {
+    const { onClose } = setup();
+    fireEvent.click(screen.getByRole("button", { name: "Close commit diff" }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("closes on Escape", () => {
+    const { onClose } = setup();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("ignores other keys", () => {
+    const { onClose } = setup();
+    fireEvent.keyDown(document, { key: "Enter" });
+    fireEvent.keyDown(document, { key: "a" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("stops listening once unmounted", () => {
+    const { onClose, unmount } = setup();
+    unmount();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("renders an empty patch without collapsing", () => {
+    setup({ patch: "" });
+    expect(screen.getByText("abcdef123456")).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/GitMenu.test.tsx
+++ b/ui/src/components/GitMenu.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import type { GitLogEntry } from "@pi-outpost/shared";
+import { GitMenu } from "./GitMenu";
+import type { GitStatusState } from "../useAgent";
+
+function status(overrides: Partial<GitStatusState> = {}): GitStatusState {
+  return { branch: "main", ahead: 0, behind: 0, files: {}, ...overrides };
+}
+
+const LOG: GitLogEntry[] = [
+  { sha: "aaaaaaa1111", author: "Ada", date: new Date().toISOString(), subject: "most recent" },
+  { sha: "bbbbbbb2222", author: "Grace", date: new Date(Date.now() - 3 * 86400_000).toISOString(), subject: "three days back" },
+];
+
+function setup(props: Partial<React.ComponentProps<typeof GitMenu>> = {}) {
+  const onFetchLog = vi.fn();
+  const onShowCommit = vi.fn();
+  const view = render(<GitMenu status={status()} log={LOG} onFetchLog={onFetchLog} onShowCommit={onShowCommit} {...props} />);
+  return { onFetchLog, onShowCommit, ...view };
+}
+
+/** The branch chip, which is also the menu's toggle. */
+function chip() {
+  return screen.getByRole("button", { name: /⎇/ });
+}
+
+describe("GitMenu", () => {
+  it("shows the current branch", () => {
+    setup();
+    expect(chip()).toHaveTextContent("main");
+  });
+
+  it("waits for the branch rather than inventing one", () => {
+    setup({ status: null });
+    expect(chip()).toHaveTextContent("…");
+  });
+
+  it("shows ahead and behind counts only when there is something to report", () => {
+    const { rerender } = setup();
+    expect(chip()).not.toHaveTextContent("↑");
+    rerender(<GitMenu status={status({ ahead: 2, behind: 3 })} log={LOG} onFetchLog={vi.fn()} onShowCommit={vi.fn()} />);
+    expect(chip()).toHaveTextContent("↑2");
+    expect(chip()).toHaveTextContent("↓3");
+  });
+
+  it("keeps the menu closed until asked", () => {
+    setup();
+    expect(screen.queryByText("most recent")).not.toBeInTheDocument();
+  });
+
+  it("fetches the log when it opens, not on every render", () => {
+    const { onFetchLog, rerender } = setup();
+    expect(onFetchLog).not.toHaveBeenCalled();
+    fireEvent.click(chip());
+    expect(onFetchLog).toHaveBeenCalledTimes(1);
+    rerender(<GitMenu status={status()} log={LOG} onFetchLog={onFetchLog} onShowCommit={vi.fn()} />);
+    expect(onFetchLog).toHaveBeenCalledTimes(1);
+  });
+
+  it("lists the commits once open", () => {
+    setup();
+    fireEvent.click(chip());
+    expect(screen.getByText("most recent")).toBeInTheDocument();
+    expect(screen.getByText("three days back")).toBeInTheDocument();
+  });
+
+  it("abbreviates the commit id", () => {
+    setup();
+    fireEvent.click(chip());
+    expect(screen.getByText("aaaaaaa")).toBeInTheDocument();
+    expect(screen.queryByText("aaaaaaa1111")).not.toBeInTheDocument();
+  });
+
+  it("dates commits relative to now", () => {
+    setup();
+    fireEvent.click(chip());
+    expect(screen.getByText(/Ada · now/)).toBeInTheDocument();
+    expect(screen.getByText(/Grace · 3d ago/)).toBeInTheDocument();
+  });
+
+  it("reports the chosen commit and closes", () => {
+    const { onShowCommit } = setup();
+    fireEvent.click(chip());
+    fireEvent.click(screen.getByText("three days back"));
+    expect(onShowCommit).toHaveBeenCalledWith("bbbbbbb2222");
+    expect(screen.queryByText("three days back")).not.toBeInTheDocument();
+  });
+
+  it("says it is loading rather than showing an empty list", () => {
+    setup({ log: null });
+    fireEvent.click(chip());
+    expect(screen.getByText("loading…")).toBeInTheDocument();
+  });
+
+  it("distinguishes a repository with no commits from one still loading", () => {
+    setup({ log: [] });
+    fireEvent.click(chip());
+    expect(screen.getByText("no commits")).toBeInTheDocument();
+    expect(screen.queryByText("loading…")).not.toBeInTheDocument();
+  });
+
+  it("closes when the pointer goes down outside it", () => {
+    setup();
+    fireEvent.click(chip());
+    expect(screen.getByText("most recent")).toBeInTheDocument();
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByText("most recent")).not.toBeInTheDocument();
+  });
+
+  it("stays open when the pointer goes down inside it", () => {
+    setup();
+    fireEvent.click(chip());
+    fireEvent.mouseDown(within(screen.getByText("most recent")).getByText("most recent"));
+    expect(screen.getByText("most recent")).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/Header.test.tsx
+++ b/ui/src/components/Header.test.tsx
@@ -1,0 +1,343 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act, within } from "@testing-library/react";
+import type { SessionSummary } from "@pi-outpost/shared";
+import { Header } from "./Header";
+
+function session(overrides: Partial<SessionSummary> = {}): SessionSummary {
+  return {
+    path: "/sessions/a.jsonl",
+    id: "a",
+    firstMessage: "how do I start?",
+    modified: "2026-08-01T10:00:00.000Z",
+    messageCount: 4,
+    ...overrides,
+  };
+}
+
+const SESSIONS = [
+  session(),
+  session({ path: "/sessions/b.jsonl", id: "b", name: "refactor the parser", firstMessage: "split it up", messageCount: 12 }),
+];
+
+type Props = React.ComponentProps<typeof Header>;
+
+function setup(overrides: Partial<Props> = {}) {
+  const handlers = {
+    onUpdateConfig: vi.fn(),
+    onToggleSidebar: vi.fn(),
+    onToggleHideTools: vi.fn(),
+    onToggleTheme: vi.fn(),
+    onNewSession: vi.fn(),
+    onSwitchSession: vi.fn(),
+    onDeleteSession: vi.fn(),
+    onListSessions: vi.fn(),
+    onRenameSession: vi.fn(),
+    onSearchSessions: vi.fn(),
+    onClearSessionSearch: vi.fn(),
+    onListTree: vi.fn(),
+    onNavigateTree: vi.fn(),
+    onForkSession: vi.fn(),
+    onFetchGitLog: vi.fn(),
+    onShowCommit: vi.fn(),
+  };
+  const props: Props = {
+    sessions: SESSIONS,
+    sessionSearch: null,
+    sessionId: "a",
+    tree: null,
+    isStreaming: false,
+    connected: true,
+    theme: "light",
+    showThemeToggle: true,
+    statuses: {},
+    sidebarOpen: false,
+    hideTools: false,
+    gitAvailable: false,
+    gitStatus: null,
+    gitLog: null,
+    extensionPaths: [],
+    sandbox: null,
+    ...handlers,
+    ...overrides,
+  };
+  const view = render(<Header {...props} />);
+  const rerenderWith = (next: Partial<Props>) => view.rerender(<Header {...props} {...next} />);
+  return { ...handlers, ...view, rerenderWith };
+}
+
+const openSessions = () => fireEvent.click(screen.getByRole("button", { name: "sessions" }));
+const searchBox = () => screen.getByRole("searchbox", { name: "Search sessions" });
+
+describe("Header", () => {
+  let confirmSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    confirmSpy.mockRestore();
+  });
+
+  describe("chrome", () => {
+    it("shows the title when one is branded", () => {
+      setup({ title: "π dev" });
+      expect(screen.getByText("π dev")).toBeInTheDocument();
+    });
+
+    it("renders extension statuses verbatim", () => {
+      setup({ statuses: { omni: "OmniRoute ✓", other: "2 jobs" } });
+      expect(screen.getByText("OmniRoute ✓")).toBeInTheDocument();
+      expect(screen.getByText("2 jobs")).toBeInTheDocument();
+    });
+
+    it("offers the theme toggle only when branding allows it", () => {
+      const { rerenderWith, onToggleTheme } = setup({ theme: "light" });
+      fireEvent.click(screen.getByRole("button", { name: "Switch to dark theme" }));
+      expect(onToggleTheme).toHaveBeenCalled();
+      rerenderWith({ showThemeToggle: false });
+      expect(screen.queryByRole("button", { name: /Switch to/ })).not.toBeInTheDocument();
+    });
+
+    it("names the toggle after where it takes you", () => {
+      setup({ theme: "dark" });
+      expect(screen.getByRole("button", { name: "Switch to light theme" })).toBeInTheDocument();
+    });
+
+    it("shows the branch chip only when git is available", () => {
+      const { rerenderWith } = setup({ gitAvailable: false });
+      expect(screen.queryByRole("button", { name: /⎇/ })).not.toBeInTheDocument();
+      rerenderWith({ gitAvailable: true, gitStatus: { branch: "main", ahead: 0, behind: 0, files: {} } });
+      expect(screen.getByRole("button", { name: /main/ })).toBeInTheDocument();
+    });
+
+    it("starts a new session", () => {
+      const { onNewSession } = setup();
+      fireEvent.click(screen.getByRole("button", { name: /new/ }));
+      expect(onNewSession).toHaveBeenCalled();
+    });
+  });
+
+  describe("the session menu", () => {
+    it("asks for the list when it opens, from a clean slate", () => {
+      const { onListSessions, onClearSessionSearch } = setup();
+      openSessions();
+      expect(onListSessions).toHaveBeenCalled();
+      expect(onClearSessionSearch).toHaveBeenCalled();
+    });
+
+    it("lists sessions by name, falling back to the first message", () => {
+      setup();
+      openSessions();
+      expect(screen.getByText("refactor the parser")).toBeInTheDocument();
+      expect(screen.getByText("how do I start?")).toBeInTheDocument();
+    });
+
+    it("marks the current session", () => {
+      setup({ sessionId: "b" });
+      openSessions();
+      expect(screen.getByText(/· current/)).toBeInTheDocument();
+    });
+
+    it("switches session and closes", () => {
+      const { onSwitchSession } = setup();
+      openSessions();
+      fireEvent.click(screen.getByText("refactor the parser"));
+      expect(onSwitchSession).toHaveBeenCalledWith("/sessions/b.jsonl");
+      expect(screen.queryByRole("searchbox")).not.toBeInTheDocument();
+    });
+
+    it("says when there is nothing saved", () => {
+      setup({ sessions: [] });
+      openSessions();
+      expect(screen.getByText("no saved sessions")).toBeInTheDocument();
+    });
+
+    it("says it is loading rather than claiming there is nothing", () => {
+      setup({ sessions: null });
+      openSessions();
+      expect(screen.getByText("loading…")).toBeInTheDocument();
+    });
+
+    it("closes when the pointer goes down outside", () => {
+      setup();
+      openSessions();
+      fireEvent.mouseDown(document.body);
+      expect(screen.queryByRole("searchbox")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("deleting", () => {
+    it("asks before deleting", () => {
+      const { onDeleteSession } = setup();
+      openSessions();
+      fireEvent.click(screen.getByRole("button", { name: "Delete session" }));
+      expect(confirmSpy).toHaveBeenCalled();
+      expect(onDeleteSession).toHaveBeenCalledWith("/sessions/b.jsonl");
+    });
+
+    it("does nothing when the prompt is declined", () => {
+      confirmSpy.mockReturnValue(false);
+      const { onDeleteSession } = setup();
+      openSessions();
+      fireEvent.click(screen.getByRole("button", { name: "Delete session" }));
+      expect(onDeleteSession).not.toHaveBeenCalled();
+    });
+
+    it("offers no delete for the session you are in", () => {
+      setup({ sessionId: "a" });
+      openSessions();
+      // Only the other session can be deleted
+      expect(screen.getAllByRole("button", { name: "Delete session" })).toHaveLength(1);
+    });
+  });
+
+  describe("renaming", () => {
+    it("commits a new name on Enter", () => {
+      const { onRenameSession } = setup();
+      openSessions();
+      fireEvent.click(screen.getAllByRole("button", { name: "Rename session" })[0]);
+      const field = screen.getByRole("textbox", { name: "Session name" });
+      fireEvent.change(field, { target: { value: "onboarding notes" } });
+      fireEvent.keyDown(field, { key: "Enter" });
+      expect(onRenameSession).toHaveBeenCalledWith("/sessions/a.jsonl", "onboarding notes");
+    });
+
+    it("starts from the existing name", () => {
+      setup();
+      openSessions();
+      fireEvent.click(screen.getAllByRole("button", { name: "Rename session" })[1]);
+      expect(screen.getByRole("textbox", { name: "Session name" })).toHaveValue("refactor the parser");
+    });
+
+    it("clears the name when committed empty", () => {
+      const { onRenameSession } = setup();
+      openSessions();
+      fireEvent.click(screen.getAllByRole("button", { name: "Rename session" })[1]);
+      const field = screen.getByRole("textbox", { name: "Session name" });
+      fireEvent.change(field, { target: { value: "" } });
+      fireEvent.keyDown(field, { key: "Enter" });
+      expect(onRenameSession).toHaveBeenCalledWith("/sessions/b.jsonl", "");
+    });
+
+    it("abandons the rename on Escape", () => {
+      const { onRenameSession } = setup();
+      openSessions();
+      fireEvent.click(screen.getAllByRole("button", { name: "Rename session" })[0]);
+      fireEvent.keyDown(screen.getByRole("textbox", { name: "Session name" }), { key: "Escape" });
+      expect(onRenameSession).not.toHaveBeenCalled();
+      expect(screen.queryByRole("textbox", { name: "Session name" })).not.toBeInTheDocument();
+    });
+  });
+
+  describe("searching sessions", () => {
+    it("ignores a query too short to be worth a server scan", () => {
+      const { onSearchSessions } = setup();
+      openSessions();
+      fireEvent.change(searchBox(), { target: { value: "a" } });
+      act(() => void vi.advanceTimersByTime(500));
+      expect(onSearchSessions).not.toHaveBeenCalled();
+    });
+
+    it("searches after a pause, not on every keystroke", () => {
+      const { onSearchSessions } = setup();
+      openSessions();
+      fireEvent.change(searchBox(), { target: { value: "par" } });
+      expect(onSearchSessions).not.toHaveBeenCalled();
+      act(() => void vi.advanceTimersByTime(500));
+      expect(onSearchSessions).toHaveBeenCalledWith("par");
+    });
+
+    it("keeps waiting rather than calling a query a miss mid-flight", () => {
+      setup();
+      openSessions();
+      fireEvent.change(searchBox(), { target: { value: "par" } });
+      act(() => void vi.advanceTimersByTime(500));
+      expect(screen.getByText("loading…")).toBeInTheDocument();
+      expect(screen.queryByText("no matches")).not.toBeInTheDocument();
+    });
+
+    it("ignores results belonging to an older query", () => {
+      const { rerenderWith } = setup();
+      openSessions();
+      fireEvent.change(searchBox(), { target: { value: "par" } });
+      rerenderWith({ sessionSearch: { status: "loaded", query: "old", requestId: "s0", results: [] } });
+      expect(screen.getByText("loading…")).toBeInTheDocument();
+    });
+
+    it("shows matches with the excerpt that explains them", () => {
+      const { rerenderWith } = setup();
+      openSessions();
+      fireEvent.change(searchBox(), { target: { value: "par" } });
+      const hit = session({ path: "/sessions/b.jsonl", id: "b", name: "refactor the parser", snippet: "…split the parser…" });
+      rerenderWith({ sessionSearch: { status: "loaded", query: "par", requestId: "s1", results: [hit] } });
+      expect(screen.getByText("…split the parser…")).toBeInTheDocument();
+    });
+
+    it("says a search found nothing, distinctly from an empty library", () => {
+      const { rerenderWith } = setup();
+      openSessions();
+      fireEvent.change(searchBox(), { target: { value: "zzz" } });
+      rerenderWith({ sessionSearch: { status: "loaded", query: "zzz", requestId: "s1", results: [] } });
+      expect(screen.getByText("no matches")).toBeInTheDocument();
+    });
+
+    it("re-runs the search after a rename, since results are a server snapshot", () => {
+      const { rerenderWith, onSearchSessions } = setup();
+      openSessions();
+      fireEvent.change(searchBox(), { target: { value: "par" } });
+      const hit = session({ path: "/sessions/b.jsonl", id: "b", name: "refactor the parser" });
+      rerenderWith({ sessionSearch: { status: "loaded", query: "par", requestId: "s1", results: [hit] } });
+      act(() => void vi.advanceTimersByTime(500));
+      onSearchSessions.mockClear();
+
+      fireEvent.click(screen.getByRole("button", { name: "Rename session" }));
+      const field = screen.getByRole("textbox", { name: "Session name" });
+      fireEvent.change(field, { target: { value: "parser work" } });
+      fireEvent.keyDown(field, { key: "Enter" });
+      expect(onSearchSessions).toHaveBeenCalledWith("par");
+    });
+
+    it("drops the search when the box is emptied", () => {
+      const { onClearSessionSearch } = setup();
+      openSessions();
+      fireEvent.change(searchBox(), { target: { value: "par" } });
+      onClearSessionSearch.mockClear();
+      fireEvent.change(searchBox(), { target: { value: "" } });
+      expect(onClearSessionSearch).toHaveBeenCalled();
+    });
+  });
+
+  describe("tool noise", () => {
+    it("toggles the tool filter and says which state it is in", () => {
+      const { onToggleHideTools, rerenderWith } = setup({ hideTools: false });
+      const toggle = screen.getByRole("button", { name: /tools/ });
+      expect(toggle).toHaveAttribute("aria-pressed", "false");
+      fireEvent.click(toggle);
+      expect(onToggleHideTools).toHaveBeenCalled();
+      rerenderWith({ hideTools: true });
+      expect(screen.getByRole("button", { name: /tools/ })).toHaveAttribute("aria-pressed", "true");
+    });
+  });
+
+  it("toggles the sidebar", () => {
+    const { onToggleSidebar } = setup();
+    fireEvent.click(screen.getByRole("button", { name: /files/ }));
+    expect(onToggleSidebar).toHaveBeenCalled();
+  });
+
+  it("reports the connection state", () => {
+    const { rerenderWith } = setup({ connected: true });
+    expect(screen.getByTitle("connected")).toBeInTheDocument();
+    rerenderWith({ connected: false });
+    expect(screen.getByTitle(/disconnected|connecting/i)).toBeInTheDocument();
+  });
+
+  it("keeps the tree menu out of the way until asked", () => {
+    const { onListTree } = setup();
+    expect(within(screen.getByRole("banner")).getByRole("button", { name: "tree" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "tree" }));
+    expect(onListTree).toHaveBeenCalled();
+  });
+});

--- a/ui/src/components/Mermaid.test.tsx
+++ b/ui/src/components/Mermaid.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * The wrapper around mermaid, not mermaid itself.
+ *
+ * The library is mocked at the module boundary because what matters here is our
+ * side of it: the diagram source stays on screen until a rendering succeeds, an
+ * error is shown beside the source rather than replacing it, and a render that
+ * lands after the component is gone is dropped. Those are the behaviours that
+ * decide whether a failed diagram costs the reader the content or just the
+ * picture.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import { Mermaid } from "./Mermaid";
+
+const renderDiagram = vi.hoisted(() => vi.fn());
+const initialize = vi.hoisted(() => vi.fn());
+
+vi.mock("mermaid", () => ({ default: { initialize, render: renderDiagram } }));
+
+const CODE = "graph TD; A-->B;";
+
+/** Let the 300 ms debounce elapse and the mocked render settle. */
+async function settle() {
+  await act(async () => {
+    vi.advanceTimersByTime(400);
+  });
+}
+
+describe("Mermaid", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    renderDiagram.mockReset().mockResolvedValue({ svg: "<svg id='diagram'></svg>" });
+    initialize.mockReset();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows the source while the diagram is still being drawn", () => {
+    render(<Mermaid code={CODE} />);
+    // Nothing has been rendered yet: the reader sees the diagram's source, not a blank
+    expect(screen.getByText(CODE)).toBeInTheDocument();
+  });
+
+  it("waits out the debounce before drawing, so a streamed diagram is drawn once", async () => {
+    render(<Mermaid code={CODE} />);
+    expect(renderDiagram).not.toHaveBeenCalled();
+    await settle();
+    expect(renderDiagram).toHaveBeenCalledTimes(1);
+  });
+
+  it("draws only the code it settled on", async () => {
+    const { rerender } = render(<Mermaid code="graph TD; A" />);
+    rerender(<Mermaid code="graph TD; A-->B" />);
+    rerender(<Mermaid code={CODE} />);
+    await settle();
+    expect(renderDiagram).toHaveBeenCalledTimes(1);
+    expect(renderDiagram).toHaveBeenCalledWith(expect.any(String), CODE);
+  });
+
+  it("replaces the source with the drawing once it arrives", async () => {
+    const { container } = render(<Mermaid code={CODE} />);
+    await settle();
+    await waitFor(() => expect(container.querySelector("#diagram")).not.toBeNull());
+  });
+
+  it("keeps the source, and says why, when the drawing fails", async () => {
+    renderDiagram.mockRejectedValue(new Error("Parse error on line 2"));
+    render(<Mermaid code={CODE} />);
+    await settle();
+    // Both: a broken diagram must not cost the reader its content
+    await waitFor(() => expect(screen.getByText("Parse error on line 2")).toBeInTheDocument());
+    expect(screen.getByText(CODE)).toBeInTheDocument();
+  });
+
+  it("reports a non-Error rejection rather than swallowing it", async () => {
+    renderDiagram.mockRejectedValue("something went wrong");
+    render(<Mermaid code={CODE} />);
+    await settle();
+    await waitFor(() => expect(screen.getByText("something went wrong")).toBeInTheDocument());
+  });
+
+  it("keeps mermaid from injecting its own error markup into the page", async () => {
+    // The module remembers that it has initialized, so this needs a fresh copy of it
+    // rather than a fresh mock — otherwise the call happened in an earlier test
+    vi.resetModules();
+    const { Mermaid: Fresh } = await import("./Mermaid");
+    render(<Fresh code={CODE} />);
+    await settle();
+    expect(initialize).toHaveBeenCalledWith(expect.objectContaining({ suppressErrorRendering: true, securityLevel: "strict" }));
+  });
+
+  it("offers the source beside a drawn diagram", async () => {
+    render(<Mermaid code={CODE} />);
+    await settle();
+    const toggle = await screen.findByTitle("Show code");
+    fireEvent.click(toggle);
+    expect(screen.getByText(CODE)).toBeInTheDocument();
+    fireEvent.click(screen.getByTitle("Show diagram"));
+    expect(screen.queryByTitle("Show code")).toBeInTheDocument();
+  });
+
+  it("offers to copy the source", async () => {
+    render(<Mermaid code={CODE} />);
+    await settle();
+    expect(await screen.findByRole("button", { name: /copy/i })).toBeInTheDocument();
+  });
+
+  it("drops a drawing that lands after the diagram is gone", async () => {
+    const { unmount } = render(<Mermaid code={CODE} />);
+    unmount();
+    await settle();
+    // The debounce timer was cleared with the component: nothing was ever asked for
+    expect(renderDiagram).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/components/Onboarding.test.tsx
+++ b/ui/src/components/Onboarding.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { CredentialStatus } from "@pi-outpost/shared";
+import { Onboarding } from "./Onboarding";
+
+function credentials(overrides: Partial<CredentialStatus> = {}): CredentialStatus {
+  return {
+    providers: [
+      { id: "anthropic", name: "Anthropic", configured: false },
+      { id: "openai", name: "OpenAI", configured: false },
+    ],
+    usableModel: false,
+    agentDir: "/home/ada/.pi/agent",
+    ...overrides,
+  } as CredentialStatus;
+}
+
+type Props = React.ComponentProps<typeof Onboarding>;
+
+function setup(overrides: Partial<Props> = {}) {
+  const onSetCredential = vi.fn();
+  const onDeclareProvider = vi.fn();
+  const props: Props = { credentials: credentials(), errors: [], onSetCredential, onDeclareProvider, ...overrides };
+  render(<Onboarding {...props} />);
+  return { onSetCredential, onDeclareProvider };
+}
+
+const submit = () => fireEvent.click(screen.getByRole("button", { name: "Save and start" }));
+const fill = (label: RegExp | string, value: string) => fireEvent.change(screen.getByLabelText(label), { target: { value } });
+
+describe("Onboarding", () => {
+  describe("a provider the server already knows", () => {
+    it("opens on the key form when there are known providers", () => {
+      setup();
+      expect(screen.getByLabelText("Provider")).toBeInTheDocument();
+    });
+
+    it("stores a key for the chosen provider", () => {
+      const { onSetCredential } = setup();
+      fireEvent.change(screen.getByLabelText("Provider"), { target: { value: "openai" } });
+      fill("API key", "sk-abc");
+      submit();
+      expect(onSetCredential).toHaveBeenCalledWith("openai", "sk-abc");
+    });
+
+    it("trims the key, since a copy-paste often brings whitespace", () => {
+      const { onSetCredential } = setup();
+      fill("API key", "  sk-abc  ");
+      submit();
+      expect(onSetCredential).toHaveBeenCalledWith("anthropic", "sk-abc");
+    });
+
+    it("does nothing without a key", () => {
+      const { onSetCredential } = setup();
+      fill("API key", "   ");
+      submit();
+      expect(onSetCredential).not.toHaveBeenCalled();
+    });
+
+    it("says which providers are already configured", () => {
+      // usableModel matters here: a configured provider with nothing usable takes the
+      // "configured but unusable" branch instead, which renders no form at all
+      setup({
+        credentials: credentials({
+          providers: [{ id: "anthropic", name: "Anthropic", configured: true }],
+          usableModel: true,
+        } as Partial<CredentialStatus>),
+      });
+      expect(screen.getByRole("option", { name: /already configured/ })).toBeInTheDocument();
+    });
+  });
+
+  describe("an endpoint of your own", () => {
+    const openCustom = () => fireEvent.click(screen.getByRole("button", { name: "OpenAI-compatible endpoint" }));
+
+    it("opens there when the server knows no provider at all", () => {
+      setup({ credentials: credentials({ providers: [] }) });
+      expect(screen.getByLabelText("Base URL")).toBeInTheDocument();
+    });
+
+    it("declares the endpoint with its single model", () => {
+      const { onDeclareProvider } = setup();
+      openCustom();
+      fill("Name", "corp");
+      fill("Base URL", "https://llm.corp.example/v1");
+      fill("Model id", "gpt-oss-120b");
+      fill("API key", "sk-corp");
+      submit();
+      expect(onDeclareProvider).toHaveBeenCalledWith({
+        provider: "corp",
+        baseUrl: "https://llm.corp.example/v1",
+        apiKey: "sk-corp",
+        models: ["gpt-oss-120b"],
+        compat: { supportsDeveloperRole: true, supportsReasoningEffort: true },
+      });
+    });
+
+    it("refuses an incomplete declaration rather than sending half of one", () => {
+      const { onDeclareProvider } = setup();
+      openCustom();
+      fill("Name", "corp");
+      fill("API key", "sk-corp");
+      submit();
+      expect(onDeclareProvider).not.toHaveBeenCalled();
+    });
+
+    it("carries the compatibility answers, which decide whether every turn works", () => {
+      const { onDeclareProvider } = setup();
+      openCustom();
+      fill("Name", "corp");
+      fill("Base URL", "https://llm.corp.example/v1");
+      fill("Model id", "gpt-oss-120b");
+      fill("API key", "sk-corp");
+      fireEvent.click(screen.getByRole("checkbox", { name: /developer/ }));
+      fireEvent.click(screen.getByRole("checkbox", { name: /reasoning_effort/ }));
+      submit();
+      expect(onDeclareProvider).toHaveBeenCalledWith(
+        expect.objectContaining({ compat: { supportsDeveloperRole: false, supportsReasoningEffort: false } }),
+      );
+    });
+
+    it("offers the compatibility questions only for a custom endpoint", () => {
+      setup();
+      expect(screen.queryByRole("checkbox", { name: /developer/ })).not.toBeInTheDocument();
+      openCustom();
+      expect(screen.getByRole("checkbox", { name: /developer/ })).toBeInTheDocument();
+    });
+  });
+
+  describe("configured but unusable", () => {
+    const unusable = credentials({
+      providers: [{ id: "anthropic", name: "Anthropic", configured: true }],
+      usableModel: false,
+    } as Partial<CredentialStatus>);
+
+    it("does not ask for a key that is not what is missing", () => {
+      setup({ credentials: unusable });
+      expect(screen.getByText("No model is available.")).toBeInTheDocument();
+      expect(screen.queryByLabelText("API key")).not.toBeInTheDocument();
+    });
+
+    it("names allowedModels as the thing to widen", () => {
+      setup({ credentials: unusable });
+      expect(screen.getByText(/allowedModels/)).toBeInTheDocument();
+    });
+  });
+
+  describe("feedback", () => {
+    it("shows what the server complained about", () => {
+      setup({ errors: ["Cannot write to /home/ada/.pi/agent", "Certificate could not be verified"] });
+      expect(screen.getByText("Cannot write to /home/ada/.pi/agent")).toBeInTheDocument();
+      expect(screen.getByText("Certificate could not be verified")).toBeInTheDocument();
+    });
+
+    it("says where a key would be stored", () => {
+      setup();
+      expect(screen.getByText(/Stored in \/home\/ada\/\.pi\/agent/)).toBeInTheDocument();
+    });
+
+    it("keeps the key out of view while it is typed", () => {
+      setup();
+      expect(screen.getByLabelText("API key")).toHaveAttribute("type", "password");
+    });
+
+    it("uses the branded title when there is one", () => {
+      setup({ title: "π dev" });
+      expect(screen.getByText("π dev")).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/src/components/SettingsMenu.test.tsx
+++ b/ui/src/components/SettingsMenu.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SettingsMenu } from "./SettingsMenu";
+
+type Props = React.ComponentProps<typeof SettingsMenu>;
+type Sandbox = NonNullable<Props["sandbox"]>;
+
+function sandbox(overrides: Partial<Sandbox> = {}): Sandbox {
+  return { root: "/work", allowWrite: true, allowBash: false, ...overrides };
+}
+
+function setup(overrides: Partial<Props> = {}) {
+  const onUpdateConfig = vi.fn();
+  const props: Props = { extensionPaths: [], sandbox: sandbox(), onUpdateConfig, ...overrides };
+  const view = render(<SettingsMenu {...props} />);
+  const rerenderWith = (next: Partial<Props>) => view.rerender(<SettingsMenu {...props} {...next} />);
+  return { onUpdateConfig, ...view, rerenderWith };
+}
+
+const openMenu = () => fireEvent.click(screen.getByRole("button", { name: "Settings" }));
+const field = (name: RegExp) => screen.getByRole("textbox", { name });
+const check = (name: RegExp) => screen.getByRole("checkbox", { name });
+const applyButton = () => screen.getByRole("button", { name: /Apply/ });
+
+describe("SettingsMenu", () => {
+  it("stays closed until asked", () => {
+    setup();
+    expect(screen.queryByRole("heading", { name: "Settings" })).not.toBeInTheDocument();
+    openMenu();
+    expect(screen.getByRole("heading", { name: "Settings" })).toBeInTheDocument();
+  });
+
+  it("closes when the pointer goes down outside", () => {
+    setup();
+    openMenu();
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByRole("heading", { name: "Settings" })).not.toBeInTheDocument();
+  });
+
+  describe("extensions", () => {
+    it("says when none are loaded", () => {
+      setup({ extensionPaths: [] });
+      openMenu();
+      expect(screen.getByText("No extensions loaded")).toBeInTheDocument();
+    });
+
+    it("lists the loaded ones", () => {
+      setup({ extensionPaths: ["/ext/openlore", "/ext/omni"] });
+      openMenu();
+      expect(screen.getByText("/ext/openlore")).toBeInTheDocument();
+      expect(screen.getByText("/ext/omni")).toBeInTheDocument();
+    });
+  });
+
+  describe("the sandbox form", () => {
+    it("says when there is no sandbox to configure", () => {
+      setup({ sandbox: null });
+      openMenu();
+      expect(screen.getByText("No sandbox configured")).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /Apply/ })).not.toBeInTheDocument();
+    });
+
+    it("starts from the current configuration", () => {
+      setup({ sandbox: sandbox({ root: "/work", writableRoot: "src", allowWrite: true, allowBash: true }) });
+      openMenu();
+      expect(field(/^Root/)).toHaveValue("/work");
+      expect(field(/Writable root/)).toHaveValue("src");
+      expect(check(/Allow write/)).toBeChecked();
+      expect(check(/Allow bash/)).toBeChecked();
+    });
+
+    it("takes a fresh configuration when the server acknowledges one", () => {
+      const { rerenderWith } = setup();
+      openMenu();
+      rerenderWith({ sandbox: sandbox({ root: "/elsewhere", allowBash: true }) });
+      expect(field(/^Root/)).toHaveValue("/elsewhere");
+      expect(check(/Allow bash/)).toBeChecked();
+    });
+
+    it("sends every field, since the server validates the whole payload", () => {
+      const { onUpdateConfig } = setup();
+      openMenu();
+      fireEvent.change(field(/^Root/), { target: { value: "/new-root" } });
+      fireEvent.click(check(/Allow bash/));
+      fireEvent.click(applyButton());
+      expect(onUpdateConfig).toHaveBeenCalledWith({
+        root: "/new-root",
+        allowWrite: true,
+        allowBash: true,
+        writableRoot: undefined,
+      });
+    });
+
+    it("treats a blank writable root as absent rather than empty", () => {
+      const { onUpdateConfig } = setup({ sandbox: sandbox({ writableRoot: "src" }) });
+      openMenu();
+      fireEvent.change(field(/Writable root/), { target: { value: "   " } });
+      fireEvent.click(applyButton());
+      expect(onUpdateConfig).toHaveBeenCalledWith(expect.objectContaining({ writableRoot: undefined }));
+    });
+
+    it("passes a writable root through when one is given", () => {
+      const { onUpdateConfig } = setup();
+      openMenu();
+      fireEvent.change(field(/Writable root/), { target: { value: "src/app" } });
+      fireEvent.click(applyButton());
+      expect(onUpdateConfig).toHaveBeenCalledWith(expect.objectContaining({ writableRoot: "src/app" }));
+    });
+
+    it("closes after applying", () => {
+      setup();
+      openMenu();
+      fireEvent.click(applyButton());
+      expect(screen.queryByRole("heading", { name: "Settings" })).not.toBeInTheDocument();
+    });
+
+    it("refuses to apply without a root", () => {
+      const { onUpdateConfig } = setup();
+      openMenu();
+      fireEvent.change(field(/^Root/), { target: { value: "  " } });
+      expect(applyButton()).toBeDisabled();
+      fireEvent.click(applyButton());
+      expect(onUpdateConfig).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("locked fields", () => {
+    it("disables what the server has locked, and says so", () => {
+      setup({ sandbox: sandbox({ locks: { root: true, allowBash: true } }) });
+      openMenu();
+      expect(field(/^Root/)).toBeDisabled();
+      expect(check(/Allow bash/)).toBeDisabled();
+      // The others stay editable
+      expect(field(/Writable root/)).toBeEnabled();
+      expect(check(/Allow write/)).toBeEnabled();
+    });
+
+    it("still sends the locked values, which the server re-checks", () => {
+      // Omitting them would fail the server's typeof validation on a missing boolean
+      const { onUpdateConfig } = setup({ sandbox: sandbox({ locks: { root: true, allowBash: true }, allowBash: true }) });
+      openMenu();
+      fireEvent.click(applyButton());
+      expect(onUpdateConfig).toHaveBeenCalledWith(expect.objectContaining({ root: "/work", allowBash: true }));
+    });
+  });
+
+  describe("versions", () => {
+    it("shows them when the server reported them", () => {
+      setup({ versions: { piOutpost: "0.6.7", piSdk: "1.2.3" } });
+      openMenu();
+      expect(screen.getByText("0.6.7")).toBeInTheDocument();
+      expect(screen.getByText("1.2.3")).toBeInTheDocument();
+    });
+
+    it("omits the section when it has nothing to report", () => {
+      setup({ versions: null });
+      openMenu();
+      expect(screen.queryByRole("heading", { name: /Versions/i })).not.toBeInTheDocument();
+    });
+  });
+});

--- a/ui/src/components/Sidebar.test.tsx
+++ b/ui/src/components/Sidebar.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { DirEntry } from "@pi-outpost/shared";
+import { Sidebar } from "./Sidebar";
+import type { DirState, OpenFile } from "../useAgent";
+
+const file = (name: string): DirEntry => ({ name, type: "file" });
+
+type Props = React.ComponentProps<typeof Sidebar>;
+
+function setup(overrides: Partial<Props> = {}) {
+  const handlers = { onExpand: vi.fn(), onSelectFile: vi.fn() };
+  const props: Props = { tree: { "": [file("readme.md")] }, openFile: null, ...handlers, ...overrides };
+  const view = render(<Sidebar {...props} />);
+  return { ...handlers, ...view };
+}
+
+describe("Sidebar", () => {
+  it("asks for the root listing on mount, when it has none", () => {
+    const { onExpand } = setup({ tree: {} as Record<string, DirState> });
+    expect(onExpand).toHaveBeenCalledWith("");
+  });
+
+  it("does not re-ask for a root it already holds", () => {
+    const { onExpand } = setup();
+    expect(onExpand).not.toHaveBeenCalled();
+  });
+
+  it("asks only once, however often it re-renders", () => {
+    const onExpand = vi.fn();
+    const { rerender } = render(<Sidebar tree={{}} openFile={null} onExpand={onExpand} onSelectFile={vi.fn()} />);
+    rerender(<Sidebar tree={{}} openFile={null} onExpand={onExpand} onSelectFile={vi.fn()} />);
+    expect(onExpand).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the tree under a heading", () => {
+    setup();
+    expect(screen.getByText("Files")).toBeInTheDocument();
+    expect(screen.getByText("readme.md")).toBeInTheDocument();
+  });
+
+  it("passes a file selection straight through", () => {
+    const { onSelectFile } = setup();
+    fireEvent.click(screen.getByText("readme.md"));
+    expect(onSelectFile).toHaveBeenCalledWith("readme.md");
+  });
+
+  it("tells the tree which file the viewer has open", () => {
+    const open: OpenFile = { status: "loaded", path: "readme.md", content: "", size: 0, mtimeMs: 1 };
+    setup({ openFile: open });
+    expect(screen.getByText("readme.md").closest("div")!.className).toMatch(/bg-zinc-100/);
+  });
+
+  it("forwards the git badges it is given", () => {
+    setup({ gitFiles: { "readme.md": "modified" } });
+    expect(screen.getByRole("button", { name: "Show diff of readme.md" })).toBeInTheDocument();
+  });
+
+  it("forwards the writable zone, so the tree can dim what is read-only", () => {
+    setup({ writableRoot: null });
+    expect(screen.getByText("readme.md").className).toMatch(/(^|\s)text-zinc-400\b/);
+  });
+});

--- a/ui/src/components/TreeMenu.render.test.tsx
+++ b/ui/src/components/TreeMenu.render.test.tsx
@@ -1,0 +1,248 @@
+/**
+ * The rendered menu. The lane maths lives in TreeMenu.test.tsx, which exercises
+ * layoutGraph directly; this covers what the component does around it — fetching,
+ * searching, and the three ways a turn can be acted on.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import type { TreeNode } from "@pi-outpost/shared";
+import { TreeMenu } from "./TreeMenu";
+
+function node(entryId: string, text: string, onPath: boolean, children: TreeNode[] = [], extra: Partial<TreeNode> = {}): TreeNode {
+  return { entryId, text, onPath, children, ...extra };
+}
+
+/**
+ *   root ── a ── a1        (current)
+ *        └─ b              (abandoned, carries a label)
+ */
+const TREE: TreeNode[] = [
+  node("root", "start the project", true, [
+    node("a", "add the parser", true, [node("a1", "fix the parser", true, [], { tipId: "a1-tip" })]),
+    node("b", "try a different parser", false, [], { label: "parser spike" }),
+  ]),
+];
+
+type Props = React.ComponentProps<typeof TreeMenu>;
+
+function setup(overrides: Partial<Props> = {}) {
+  const handlers = { onListTree: vi.fn(), onNavigate: vi.fn(), onFork: vi.fn() };
+  const props: Props = { tree: TREE, isStreaming: false, ...handlers, ...overrides };
+  const view = render(<TreeMenu {...props} />);
+  const rerenderWith = (next: Partial<Props>) => view.rerender(<TreeMenu {...props} {...next} />);
+  return { ...handlers, ...view, rerenderWith };
+}
+
+const toggle = () => screen.getByRole("button", { name: "tree" });
+const openMenu = () => fireEvent.click(toggle());
+const searchBox = () => screen.getByRole("searchbox", { name: "Search conversation tree" });
+/** The row whose turn text this is — rows are a div wrapping the navigate button. */
+const row = (text: string) => screen.getByText(text).closest("div")!;
+
+describe("TreeMenu", () => {
+  describe("opening", () => {
+    it("stays closed until asked", () => {
+      setup();
+      expect(screen.queryByText("Conversation tree")).not.toBeInTheDocument();
+      openMenu();
+      expect(screen.getByText("Conversation tree")).toBeInTheDocument();
+    });
+
+    it("asks for the tree when it opens", () => {
+      const { onListTree } = setup();
+      openMenu();
+      expect(onListTree).toHaveBeenCalled();
+    });
+
+    it("refetches rather than stranding an open menu on a reset tree", () => {
+      // A session switch nulls the tree while the menu is open
+      const { onListTree, rerenderWith } = setup();
+      openMenu();
+      onListTree.mockClear();
+      rerenderWith({ tree: null });
+      expect(onListTree).toHaveBeenCalled();
+      expect(screen.getByText("loading…")).toBeInTheDocument();
+    });
+
+    it("says a fresh session has no turns yet", () => {
+      setup({ tree: [] });
+      openMenu();
+      expect(screen.getByText("no messages yet")).toBeInTheDocument();
+    });
+
+    it("closes on a second click, and on a click outside", () => {
+      setup();
+      openMenu();
+      fireEvent.click(toggle());
+      expect(screen.queryByText("Conversation tree")).not.toBeInTheDocument();
+      openMenu();
+      fireEvent.mouseDown(document.body);
+      expect(screen.queryByText("Conversation tree")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("the header count", () => {
+    it("counts turns and branch points", () => {
+      setup();
+      openMenu();
+      expect(screen.getByText("4 turns · 1 branch point")).toBeInTheDocument();
+    });
+
+    it("says it in the singular when there is one of each", () => {
+      setup({ tree: [node("only", "just this", true)] });
+      openMenu();
+      expect(screen.getByText("1 turn · 0 branch points")).toBeInTheDocument();
+    });
+  });
+
+  describe("acting on a turn", () => {
+    it("restores the state after the exchange when the turn has a reply", () => {
+      const { onNavigate } = setup();
+      openMenu();
+      fireEvent.click(screen.getByText("fix the parser"));
+      expect(onNavigate).toHaveBeenCalledWith("a1-tip");
+    });
+
+    it("rewinds to before the turn when it has no reply yet", () => {
+      const { onNavigate } = setup();
+      openMenu();
+      fireEvent.click(screen.getByText("try a different parser"));
+      expect(onNavigate).toHaveBeenCalledWith("b");
+    });
+
+    it("rewinds to before the message on redo, reply or not", () => {
+      const { onNavigate } = setup();
+      openMenu();
+      fireEvent.click(within(row("fix the parser")).getByRole("button", { name: "Rewind to before this message" }));
+      expect(onNavigate).toHaveBeenCalledWith("a1");
+    });
+
+    it("forks a new session from the turn", () => {
+      const { onFork } = setup();
+      openMenu();
+      fireEvent.click(within(row("try a different parser")).getByRole("button", { name: /fork/ }));
+      expect(onFork).toHaveBeenCalledWith("b");
+    });
+
+    it("closes after acting", () => {
+      setup();
+      openMenu();
+      fireEvent.click(screen.getByText("fix the parser"));
+      expect(screen.queryByText("Conversation tree")).not.toBeInTheDocument();
+    });
+
+    it("refuses navigation while the agent is running, but still allows a fork", () => {
+      const { onFork } = setup({ isStreaming: true });
+      openMenu();
+      // While streaming the title stops describing the action and says why it is refused
+      expect(within(row("fix the parser")).getByTitle("unavailable while the agent is running")).toBeDisabled();
+      // Forking makes a new session, so a running agent is no reason to refuse it
+      fireEvent.click(within(row("fix the parser")).getByRole("button", { name: /fork/ }));
+      expect(onFork).toHaveBeenCalled();
+    });
+
+    it("labels an empty turn rather than rendering a blank row", () => {
+      setup({ tree: [node("empty", "", true)] });
+      openMenu();
+      expect(screen.getByText("(empty)")).toBeInTheDocument();
+    });
+  });
+
+  describe("chips", () => {
+    it("marks where the conversation stands", () => {
+      setup();
+      openMenu();
+      expect(within(row("fix the parser")).getByText("current")).toBeInTheDocument();
+    });
+
+    it("counts the branches at a fork", () => {
+      setup();
+      openMenu();
+      expect(within(row("add the parser")).queryByText(/branches/)).not.toBeInTheDocument();
+      expect(within(row("start the project")).getByText("2 branches")).toBeInTheDocument();
+    });
+
+    it("numbers each branch, and says when an off-leaf turn is still on the current one", () => {
+      setup();
+      openMenu();
+      expect(within(row("add the parser")).getByText("branch 1 · current")).toBeInTheDocument();
+      expect(within(row("try a different parser")).getByText("branch 2")).toBeInTheDocument();
+    });
+
+    it("shows the label the agent gave an abandoned branch", () => {
+      setup();
+      openMenu();
+      expect(within(row("try a different parser")).getByText("parser spike")).toBeInTheDocument();
+    });
+  });
+
+  describe("searching", () => {
+    it("filters turns by their text", () => {
+      setup();
+      openMenu();
+      fireEvent.change(searchBox(), { target: { value: "different" } });
+      expect(screen.getByText("try a different parser")).toBeInTheDocument();
+      expect(screen.queryByText("start the project")).not.toBeInTheDocument();
+    });
+
+    it("matches case-insensitively", () => {
+      setup();
+      openMenu();
+      fireEvent.change(searchBox(), { target: { value: "PARSER" } });
+      expect(screen.getByText("add the parser")).toBeInTheDocument();
+    });
+
+    it("searches labels too, the most memorable handle on an abandoned branch", () => {
+      setup();
+      openMenu();
+      fireEvent.change(searchBox(), { target: { value: "spike" } });
+      expect(screen.getByText("try a different parser")).toBeInTheDocument();
+      expect(screen.queryByText("add the parser")).not.toBeInTheDocument();
+    });
+
+    it("says when nothing matches", () => {
+      setup();
+      openMenu();
+      fireEvent.change(searchBox(), { target: { value: "zzz" } });
+      expect(screen.getByText("no matches")).toBeInTheDocument();
+    });
+
+    it("returns to the graph when the query is cleared", () => {
+      setup();
+      openMenu();
+      fireEvent.change(searchBox(), { target: { value: "different" } });
+      fireEvent.change(searchBox(), { target: { value: "  " } });
+      expect(screen.getByText("start the project")).toBeInTheDocument();
+    });
+
+    it("marks which results sit on the current branch", () => {
+      setup();
+      openMenu();
+      fireEvent.change(searchBox(), { target: { value: "parser" } });
+      expect(within(row("add the parser")).getByText("on current branch")).toBeInTheDocument();
+      expect(within(row("try a different parser")).queryByText("on current branch")).not.toBeInTheDocument();
+    });
+
+    it("acts on a result the same way as on a graph row", () => {
+      const { onNavigate, onFork } = setup();
+      openMenu();
+      fireEvent.change(searchBox(), { target: { value: "fix" } });
+      fireEvent.click(within(row("fix the parser")).getByTitle(/restore the conversation/));
+      expect(onNavigate).toHaveBeenCalledWith("a1-tip");
+
+      openMenu();
+      fireEvent.change(searchBox(), { target: { value: "fix" } });
+      fireEvent.click(within(row("fix the parser")).getByRole("button", { name: /fork/ }));
+      expect(onFork).toHaveBeenCalledWith("a1");
+    });
+
+    it("starts from a blank query each time the menu opens", () => {
+      setup();
+      openMenu();
+      fireEvent.change(searchBox(), { target: { value: "different" } });
+      fireEvent.click(toggle());
+      openMenu();
+      expect(searchBox()).toHaveValue("");
+    });
+  });
+});

--- a/ui/src/components/UserMessage.test.tsx
+++ b/ui/src/components/UserMessage.test.tsx
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { ChatItem } from "@pi-outpost/shared";
+import { UserMessage } from "./UserMessage";
+
+type UserItem = Extract<ChatItem, { kind: "user" }>;
+
+function item(overrides: Partial<UserItem> = {}): UserItem {
+  return { kind: "user", text: "how do I start?", entryId: "e1", ...overrides };
+}
+
+type Props = React.ComponentProps<typeof UserMessage>;
+
+function setup(overrides: Partial<Props> = {}) {
+  const onEdit = vi.fn();
+  const props: Props = { item: item(), canEdit: true, onEdit, ...overrides };
+  const view = render(<UserMessage {...props} />);
+  const rerenderWith = (next: Partial<Props>) => view.rerender(<UserMessage {...props} {...next} />);
+  return { onEdit, ...view, rerenderWith };
+}
+
+const editButton = () => screen.getByRole("button", { name: "Edit this prompt" });
+const draftBox = () => screen.getByRole("textbox", { name: "Edit prompt" });
+const startEditing = () => fireEvent.click(editButton());
+
+describe("UserMessage", () => {
+  it("shows the prompt as sent", () => {
+    setup();
+    expect(screen.getByText("how do I start?")).toBeInTheDocument();
+  });
+
+  it("keeps the text's own line breaks", () => {
+    setup({ item: item({ text: "line one\nline two" }) });
+    expect(screen.getByText(/line one/).className).toMatch(/whitespace-pre-wrap/);
+  });
+
+  it("shows attached images", () => {
+    setup({ item: item({ images: [{ data: "AAAA", mimeType: "image/png" }] }) });
+    expect(screen.getByRole("presentation")).toHaveAttribute("src", "data:image/png;base64,AAAA");
+  });
+
+  describe("when editing is possible", () => {
+    it("offers the edit affordance", () => {
+      setup();
+      expect(editButton()).toBeInTheDocument();
+    });
+
+    it("hides it while the agent is running", () => {
+      setup({ canEdit: false });
+      expect(screen.queryByRole("button", { name: "Edit this prompt" })).not.toBeInTheDocument();
+    });
+
+    it("hides it for a turn with no persisted entry to rewind to", () => {
+      setup({ item: item({ entryId: undefined }) });
+      expect(screen.queryByRole("button", { name: "Edit this prompt" })).not.toBeInTheDocument();
+    });
+  });
+
+  describe("editing", () => {
+    it("opens on the current text", () => {
+      setup();
+      startEditing();
+      expect(draftBox()).toHaveValue("how do I start?");
+    });
+
+    it("re-asks from this turn on Enter", () => {
+      const { onEdit } = setup();
+      startEditing();
+      fireEvent.change(draftBox(), { target: { value: "how do I finish?" } });
+      fireEvent.keyDown(draftBox(), { key: "Enter" });
+      expect(onEdit).toHaveBeenCalledWith("e1", "how do I finish?", undefined);
+    });
+
+    it("carries the attached images into the new ask", () => {
+      const images = [{ data: "AAAA", mimeType: "image/png" }];
+      const { onEdit } = setup({ item: item({ images }) });
+      startEditing();
+      fireEvent.change(draftBox(), { target: { value: "and this one?" } });
+      fireEvent.click(screen.getByRole("button", { name: "send" }));
+      expect(onEdit).toHaveBeenCalledWith("e1", "and this one?", images);
+    });
+
+    it("keeps Shift+Enter for a newline", () => {
+      const { onEdit } = setup();
+      startEditing();
+      fireEvent.change(draftBox(), { target: { value: "changed" } });
+      fireEvent.keyDown(draftBox(), { key: "Enter", shiftKey: true });
+      expect(onEdit).not.toHaveBeenCalled();
+    });
+
+    it("does not submit mid-composition, so an IME candidate is not an edit", () => {
+      const { onEdit } = setup();
+      startEditing();
+      fireEvent.change(draftBox(), { target: { value: "こんにち" } });
+      fireEvent.keyDown(draftBox(), { key: "Enter", isComposing: true });
+      expect(onEdit).not.toHaveBeenCalled();
+    });
+
+    it("closes without asking again when the text came back unchanged", () => {
+      const { onEdit } = setup();
+      startEditing();
+      fireEvent.keyDown(draftBox(), { key: "Enter" });
+      expect(onEdit).not.toHaveBeenCalled();
+      expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    });
+
+    it("refuses to send an empty draft", () => {
+      const { onEdit } = setup();
+      startEditing();
+      fireEvent.change(draftBox(), { target: { value: "   " } });
+      expect(screen.getByRole("button", { name: "send" })).toBeDisabled();
+      fireEvent.keyDown(draftBox(), { key: "Enter" });
+      expect(onEdit).not.toHaveBeenCalled();
+    });
+
+    it("abandons the draft on Escape", () => {
+      const { onEdit } = setup();
+      startEditing();
+      fireEvent.change(draftBox(), { target: { value: "changed" } });
+      fireEvent.keyDown(draftBox(), { key: "Escape" });
+      expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+      expect(onEdit).not.toHaveBeenCalled();
+    });
+
+    it("abandons it on cancel too", () => {
+      setup();
+      startEditing();
+      fireEvent.click(screen.getByRole("button", { name: "cancel" }));
+      expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    });
+
+    it("holds the draft open rather than swallowing it when the agent starts running", () => {
+      // Losing typed text to a state change the user did not cause is worse than
+      // making them wait: the draft stays, the send button goes quiet
+      const { rerenderWith, onEdit } = setup();
+      startEditing();
+      fireEvent.change(draftBox(), { target: { value: "changed" } });
+      rerenderWith({ canEdit: false });
+      expect(draftBox()).toHaveValue("changed");
+      expect(screen.getByRole("button", { name: "send" })).toBeDisabled();
+      fireEvent.keyDown(draftBox(), { key: "Enter" });
+      expect(onEdit).not.toHaveBeenCalled();
+    });
+
+    it("says why the send is unavailable", () => {
+      const { rerenderWith } = setup();
+      startEditing();
+      expect(screen.getByText(/asks again from here/)).toBeInTheDocument();
+      rerenderWith({ canEdit: false });
+      expect(screen.getByText(/the agent is running/)).toBeInTheDocument();
+    });
+
+    it("drops the draft when the turn underneath it changes", () => {
+      // Navigating the tree replaces the items in place: submitting the old draft
+      // would edit whatever message now occupies this slot
+      const { rerenderWith } = setup();
+      startEditing();
+      fireEvent.change(draftBox(), { target: { value: "changed" } });
+      rerenderWith({ item: item({ entryId: "e2", text: "a different turn" }) });
+      expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+      expect(screen.getByText("a different turn")).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/src/test-setup.ts
+++ b/ui/src/test-setup.ts
@@ -2,6 +2,13 @@ import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 import { afterEach } from "vitest";
 
+// jsdom implements no layout, so it ships no scrollIntoView. Components that keep a
+// selected row in view call it on every selection change; without this they throw
+// during render and the test reports a crash rather than the behaviour it asked about.
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
 afterEach(() => {
   cleanup();
 });

--- a/ui/src/useAgent.test.ts
+++ b/ui/src/useAgent.test.ts
@@ -751,3 +751,256 @@ describe("credentials_changed", () => {
     expect(result.current.state.errors).toHaveLength(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// The transcript as the server builds it. These are the messages that arrive on
+// every turn, and the reducer's job is to fold each into the right item rather
+// than append a new one — a streaming reply is one bubble, not a hundred.
+// ---------------------------------------------------------------------------
+describe("assembling a turn", () => {
+  it("appends the prompt the server echoes back", async () => {
+    const result = await connected();
+    act(() => mockWs!.receive({ type: "user", text: "hello", images: [{ data: "AA", mimeType: "image/png" }] }));
+    await waitFor(() => expect(result.current.state.items).toHaveLength(1));
+    expect(result.current.state.items[0]).toMatchObject({ kind: "user", text: "hello" });
+  });
+
+  it("grows one assistant bubble as the deltas arrive", async () => {
+    const result = await connected();
+    act(() => mockWs!.receive({ type: "assistant_start" }));
+    act(() => mockWs!.receive({ type: "block_delta", block: "text", delta: "Hel", contentIndex: 0 }));
+    act(() => mockWs!.receive({ type: "block_delta", block: "text", delta: "lo", contentIndex: 0 }));
+
+    await waitFor(() => expect(result.current.state.items).toHaveLength(1));
+    const item = result.current.state.items[0] as { blocks: { text: string }[]; streaming?: boolean };
+    expect(item.blocks[0].text).toBe("Hello");
+    expect(item.streaming).toBe(true);
+  });
+
+  it("keeps thinking and text as separate blocks of the same reply", async () => {
+    const result = await connected();
+    act(() => mockWs!.receive({ type: "assistant_start" }));
+    act(() => mockWs!.receive({ type: "block_delta", block: "thinking", delta: "hmm", contentIndex: 0 }));
+    act(() => mockWs!.receive({ type: "block_delta", block: "text", delta: "answer", contentIndex: 1 }));
+
+    const item = result.current.state.items[0] as { blocks: { type: string }[] };
+    await waitFor(() => expect(item.blocks).toHaveLength(2));
+    expect(result.current.state.items).toHaveLength(1);
+  });
+
+  it("replaces the streamed bubble with the server's final version", async () => {
+    const result = await connected();
+    act(() => mockWs!.receive({ type: "assistant_start" }));
+    act(() => mockWs!.receive({ type: "block_delta", block: "text", delta: "partial", contentIndex: 0 }));
+    act(() =>
+      mockWs!.receive({
+        type: "assistant_end",
+        item: { kind: "assistant", blocks: [{ type: "text", text: "the whole answer" }] },
+      }),
+    );
+
+    await waitFor(() => expect(result.current.state.items).toHaveLength(1));
+    expect(result.current.state.items[0]).toMatchObject({ blocks: [{ text: "the whole answer" }] });
+  });
+
+  it("stops marking the reply as streaming when the turn ends", async () => {
+    const result = await connected();
+    act(() => mockWs!.receive({ type: "agent_start" }));
+    act(() => mockWs!.receive({ type: "assistant_start" }));
+    act(() => mockWs!.receive({ type: "agent_end" }));
+
+    await waitFor(() => expect(result.current.state.isStreaming).toBe(false));
+    expect(result.current.state.items[0]).toMatchObject({ streaming: false });
+  });
+
+  it("folds a tool's start, output and end into one card", async () => {
+    const result = await connected();
+    act(() => mockWs!.receive({ type: "tool_start", toolCallId: "t1", toolName: "bash", args: { command: "ls" } }));
+    act(() => mockWs!.receive({ type: "tool_update", toolCallId: "t1", text: "a.txt" }));
+    act(() => mockWs!.receive({ type: "tool_end", toolCallId: "t1", text: "a.txt\nb.txt", isError: false }));
+
+    await waitFor(() => expect(result.current.state.items).toHaveLength(1));
+    expect(result.current.state.items[0]).toMatchObject({ kind: "tool", toolName: "bash", output: "a.txt\nb.txt", running: false });
+  });
+
+  it("keeps two concurrent tool calls apart", async () => {
+    const result = await connected();
+    act(() => mockWs!.receive({ type: "tool_start", toolCallId: "t1", toolName: "read", args: {} }));
+    act(() => mockWs!.receive({ type: "tool_start", toolCallId: "t2", toolName: "grep", args: {} }));
+    act(() => mockWs!.receive({ type: "tool_end", toolCallId: "t1", text: "first", isError: false }));
+
+    await waitFor(() => expect(result.current.state.items).toHaveLength(2));
+    expect(result.current.state.items[0]).toMatchObject({ output: "first", running: false });
+    expect(result.current.state.items[1]).toMatchObject({ running: true });
+  });
+
+  it("appends an extension's own message kind", async () => {
+    const result = await connected();
+    act(() => mockWs!.receive({ type: "custom_message", item: { kind: "custom", customType: "plan", text: "step 1" } }));
+    await waitFor(() => expect(result.current.state.items[0]).toMatchObject({ kind: "custom", customType: "plan" }));
+  });
+
+  it("tracks the thinking level the server confirms", async () => {
+    const result = await connected();
+    act(() => mockWs!.receive({ type: "thinking_changed", level: "high" }));
+    await waitFor(() => expect(result.current.state.thinkingLevel).toBe("high"));
+  });
+
+  it("tracks the queue and the context usage", async () => {
+    const result = await connected();
+    act(() => mockWs!.receive({ type: "queue", steering: ["stop"], followUp: ["then this"] }));
+    act(() => mockWs!.receive({ type: "context_usage", usage: { tokens: 100, contextWindow: 1000, percent: 10 } }));
+
+    await waitFor(() => expect(result.current.state.queue.steering).toEqual(["stop"]));
+    expect(result.current.state.contextUsage).toMatchObject({ percent: 10 });
+  });
+});
+
+describe("compaction", () => {
+  it("reports it while it runs", async () => {
+    const result = await connected();
+    act(() => mockWs!.receive({ type: "compaction_start" }));
+    await waitFor(() => expect(result.current.state.isCompacting).toBe(true));
+    act(() => mockWs!.receive({ type: "compaction_end" }));
+    await waitFor(() => expect(result.current.state.isCompacting).toBe(false));
+  });
+
+  it("surfaces a compaction that failed", async () => {
+    const result = await connected();
+    act(() => mockWs!.receive({ type: "compaction_start" }));
+    act(() => mockWs!.receive({ type: "compaction_end", errorMessage: "context still too large" }));
+    await waitFor(() => expect(result.current.state.errors).toContain("context still too large"));
+    expect(result.current.state.isCompacting).toBe(false);
+  });
+});
+
+describe("the file browser", () => {
+  it("keeps one entry per directory listed", async () => {
+    const result = await connected();
+    act(() => mockWs!.receive({ type: "directory_listing", requestId: "d1", path: "", entries: [{ name: "src", type: "directory" }] }));
+    act(() => mockWs!.receive({ type: "directory_listing", requestId: "d2", path: "src", entries: [{ name: "main.ts", type: "file" }] }));
+
+    await waitFor(() => expect(Object.keys(result.current.state.fileTree)).toHaveLength(2));
+    expect(result.current.state.fileTree["src"]).toHaveLength(1);
+  });
+
+  it("refuses to submit a save while disconnected, since nothing would answer it", async () => {
+    const result = await connected();
+    act(() => mockWs!.receive({ type: "file_content", requestId: "x", path: "a.ts", content: "a", size: 1, mtimeMs: 1 }));
+    act(() => result.current.readFile("a.ts"));
+    const requestId = lastRequestId();
+    act(() => mockWs!.receive({ type: "file_content", requestId, path: "a.ts", content: "a", size: 1, mtimeMs: 1 }));
+    await waitFor(() => expect(result.current.state.openFile).toMatchObject({ status: "loaded" }));
+
+    act(() => mockWs!.disconnect(1006));
+    await waitFor(() => expect(result.current.state.connected).toBe(false));
+    act(() => result.current.writeFile("a.ts", "b", 1));
+    expect(result.current.state.openFile).not.toHaveProperty("pendingSave");
+  });
+
+  it("closes the preview on request", async () => {
+    const result = await connected();
+    act(() => result.current.readFile("a.ts"));
+    const requestId = lastRequestId();
+    act(() => mockWs!.receive({ type: "file_content", requestId, path: "a.ts", content: "a", size: 1, mtimeMs: 1 }));
+    await waitFor(() => expect(result.current.state.openFile).not.toBeNull());
+
+    act(() => result.current.closeFilePreview());
+    await waitFor(() => expect(result.current.state.openFile).toBeNull());
+  });
+});
+
+describe("the file-history pane", () => {
+  /** Open the pane and return the requestId the hook used to ask for the log. */
+  async function openHistory(result: Awaited<ReturnType<typeof connected>>) {
+    act(() => result.current.fetchGitFileHistory("src/main.ts"));
+    await waitFor(() => expect(result.current.state.gitFileHistory).toMatchObject({ status: "loading" }));
+    return result.current.state.gitFileHistory!.requestId;
+  }
+
+  it("takes the log it asked for", async () => {
+    const result = await connected();
+    const requestId = await openHistory(result);
+    act(() => mockWs!.receive({ type: "git_file_log", requestId, path: "src/main.ts", entries: [{ sha: "a", parents: [], author: "Ada", date: "", subject: "first", path: "src/main.ts", added: 1, deleted: 0 }] }));
+    await waitFor(() => expect(result.current.state.gitFileHistory).toMatchObject({ status: "loaded" }));
+    expect(result.current.state.gitFileHistory!.entries).toHaveLength(1);
+  });
+
+  it("ignores a log for a pane that has moved on", async () => {
+    const result = await connected();
+    await openHistory(result);
+    act(() => mockWs!.receive({ type: "git_file_log", requestId: "stale", path: "other.ts", entries: [] }));
+    expect(result.current.state.gitFileHistory).toMatchObject({ status: "loading" });
+  });
+
+  it("reports a failed log inside the pane rather than in the error list", async () => {
+    const result = await connected();
+    const requestId = await openHistory(result);
+    act(() => mockWs!.receive({ type: "git_error", requestId, message: "not a git repository" }));
+    await waitFor(() => expect(result.current.state.gitFileHistory).toMatchObject({ status: "error", error: "not a git repository" }));
+    expect(result.current.state.errors).toHaveLength(0);
+  });
+
+  it("keeps the previous diff on screen while the next one is fetched", async () => {
+    const result = await connected();
+    const base = { rev: "a", path: "src/main.ts" };
+    const target = { rev: "b", path: "src/main.ts" };
+    act(() => result.current.fetchGitFileDiff(base, target));
+    const requestId = result.current.state.gitFileDiff!.requestId;
+    act(() => mockWs!.receive({ type: "git_file_diff", requestId, base, target, beforeText: "one", afterText: "two" }));
+    await waitFor(() => expect(result.current.state.gitFileDiff).toMatchObject({ status: "loaded" }));
+
+    act(() => result.current.fetchGitFileDiff(base, { rev: "c", path: "src/main.ts" }));
+    // Still showing the old texts, marked as loading, so the pane dims rather than blanks
+    expect(result.current.state.gitFileDiff).toMatchObject({ status: "loading", beforeText: "one", afterText: "two" });
+  });
+
+  it("drops a diff whose pair the selection has moved past", async () => {
+    const result = await connected();
+    const base = { rev: "a", path: "src/main.ts" };
+    act(() => result.current.fetchGitFileDiff(base, { rev: "b", path: "src/main.ts" }));
+    const requestId = result.current.state.gitFileDiff!.requestId;
+    act(() =>
+      mockWs!.receive({ type: "git_file_diff", requestId, base, target: { rev: "OTHER", path: "src/main.ts" }, beforeText: "x", afterText: "y" }),
+    );
+    expect(result.current.state.gitFileDiff).toMatchObject({ status: "loading" });
+  });
+
+  it("reports a failed diff inside the pane", async () => {
+    const result = await connected();
+    act(() => result.current.fetchGitFileDiff({ rev: "a", path: "a.ts" }, { rev: "b", path: "a.ts" }));
+    const requestId = result.current.state.gitFileDiff!.requestId;
+    act(() => mockWs!.receive({ type: "git_error", requestId, message: "Binary file" }));
+    await waitFor(() => expect(result.current.state.gitFileDiff).toMatchObject({ status: "error", error: "Binary file" }));
+    expect(result.current.state.errors).toHaveLength(0);
+  });
+
+  it("forgets everything when the pane closes", async () => {
+    const result = await connected();
+    await openHistory(result);
+    act(() => result.current.closeGitFileHistory());
+    await waitFor(() => expect(result.current.state.gitFileHistory).toBeNull());
+    expect(result.current.state.gitFileDiff).toBeNull();
+  });
+});
+
+describe("git errors that belong nowhere in particular", () => {
+  it("land in the error list", async () => {
+    const result = await connected();
+    act(() => mockWs!.receive({ type: "git_error", requestId: "gitlog:1", message: "git is not available" }));
+    await waitFor(() => expect(result.current.state.errors).toContain("git: git is not available"));
+  });
+
+  it("but a viewer diff failure lands in the viewer", async () => {
+    const result = await connected();
+    act(() => result.current.readFile("a.ts"));
+    const readId = lastRequestId();
+    act(() => mockWs!.receive({ type: "file_content", requestId: readId, path: "a.ts", content: "a", size: 1, mtimeMs: 1 }));
+    await waitFor(() => expect(result.current.state.openFile).toMatchObject({ status: "loaded" }));
+
+    act(() => result.current.fetchGitDiff("a.ts"));
+    act(() => mockWs!.receive({ type: "git_error", requestId: lastRequestId(), message: "Binary file" }));
+    await waitFor(() => expect(result.current.state.gitDiff).toMatchObject({ path: "a.ts", error: "Binary file" }));
+    expect(result.current.state.errors).toHaveLength(0);
+  });
+});

--- a/ui/src/useAgent.test.ts
+++ b/ui/src/useAgent.test.ts
@@ -1004,3 +1004,112 @@ describe("git errors that belong nowhere in particular", () => {
     expect(result.current.state.errors).toHaveLength(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// The outgoing commands. Each is a one-liner, but its frame is the contract the
+// server validates: a wrong `type` or a missing field is refused there and shows
+// up here as a button that silently does nothing.
+// ---------------------------------------------------------------------------
+describe("commands on the wire", () => {
+  /** The last frame the hook sent, parsed. */
+  function lastFrame() {
+    return JSON.parse(mockWs!.sent[mockWs!.sent.length - 1]) as Record<string, unknown>;
+  }
+
+  const cases: Array<[string, (api: Awaited<ReturnType<typeof connected>>["current"]) => void, Record<string, unknown>]> = [
+    ["prompt", (api) => api.prompt("hello"), { type: "prompt", text: "hello" }],
+    ["prompt with images", (api) => api.prompt("look", [{ data: "AA", mimeType: "image/png" }]), { type: "prompt", text: "look", images: [{ data: "AA", mimeType: "image/png" }] }],
+    ["abort", (api) => api.abort(), { type: "abort" }],
+    ["setModel", (api) => api.setModel("anthropic", "opus"), { type: "set_model", provider: "anthropic", id: "opus" }],
+    ["setThinking", (api) => api.setThinking("high"), { type: "set_thinking", level: "high" }],
+    ["newSession", (api) => api.newSession(), { type: "new_session" }],
+    ["switchSession", (api) => api.switchSession("/s/a.jsonl"), { type: "switch_session", path: "/s/a.jsonl" }],
+    ["deleteSession", (api) => api.deleteSession("/s/a.jsonl"), { type: "delete_session", path: "/s/a.jsonl" }],
+    ["listSessions", (api) => api.listSessions(), { type: "list_sessions" }],
+    ["renameSession", (api) => api.renameSession("/s/a.jsonl", "notes"), { type: "rename_session", path: "/s/a.jsonl", name: "notes" }],
+    ["listTree", (api) => api.listTree(), { type: "list_tree" }],
+    ["navigateTree", (api) => api.navigateTree("e1"), { type: "navigate_tree", entryId: "e1" }],
+    ["forkSession", (api) => api.forkSession("e1"), { type: "fork_session", entryId: "e1" }],
+    ["editPrompt", (api) => api.editPrompt("e1", "again"), { type: "edit_prompt", entryId: "e1", text: "again" }],
+    ["compact", (api) => api.compact(), { type: "compact" }],
+    ["fetchGitLog", (api) => api.fetchGitLog(20), { type: "git_log", limit: 20 }],
+    ["fetchGitShow", (api) => api.fetchGitShow("abc1234"), { type: "git_show", sha: "abc1234" }],
+    ["setCredential", (api) => api.setCredential("openai", "sk-x"), { type: "set_credential", provider: "openai", apiKey: "sk-x" }],
+    [
+      "declareProvider",
+      (api) => api.declareProvider({ provider: "corp", baseUrl: "https://x/v1", apiKey: "k", models: ["m"] }),
+      { type: "declare_provider", provider: "corp", baseUrl: "https://x/v1", apiKey: "k", models: ["m"] },
+    ],
+    [
+      "updateConfig",
+      (api) => api.updateConfig({ root: "/w", allowWrite: true, allowBash: false }),
+      { type: "update_config", sandbox: { root: "/w", allowWrite: true, allowBash: false } },
+    ],
+  ];
+
+  for (const [name, call, expected] of cases) {
+    it(`sends the right frame for ${name}`, async () => {
+      const result = await connected();
+      act(() => call(result.current));
+      expect(lastFrame()).toMatchObject(expected);
+    });
+  }
+
+  it("omits an empty image list rather than sending one", async () => {
+    const result = await connected();
+    act(() => result.current.prompt("hello", []));
+    expect(lastFrame()).not.toHaveProperty("images");
+  });
+
+  it("omits the limit when none was asked for", async () => {
+    const result = await connected();
+    act(() => result.current.fetchGitLog());
+    expect(lastFrame()).not.toHaveProperty("limit");
+  });
+
+  it("answers a dialog and pops it from the queue", async () => {
+    const result = await connected();
+    act(() =>
+      mockWs!.receive({ type: "extension_ui_request", id: "d1", method: "confirm", title: "Proceed?", message: "Really?" }),
+    );
+    await waitFor(() => expect(result.current.state.dialogQueue).toHaveLength(1));
+
+    act(() => result.current.respondToDialog({ id: "d1", confirmed: true }));
+    expect(lastFrame()).toMatchObject({ type: "extension_ui_response", id: "d1", confirmed: true });
+    await waitFor(() => expect(result.current.state.dialogQueue).toHaveLength(0));
+  });
+
+  it("searches sessions and files under their own request ids", async () => {
+    const result = await connected();
+    act(() => result.current.searchSessions("parser"));
+    expect(lastFrame()).toMatchObject({ type: "search_sessions", query: "parser" });
+    expect(result.current.state.sessionSearch).toMatchObject({ status: "loading", query: "parser" });
+
+    act(() => result.current.searchFiles("main"));
+    expect(lastFrame()).toMatchObject({ type: "search_files", query: "main" });
+    expect(result.current.state.fileSearch).toMatchObject({ status: "loading", query: "main" });
+  });
+
+  it("clears each search locally, without asking the server", async () => {
+    const result = await connected();
+    act(() => result.current.searchSessions("parser"));
+    act(() => result.current.searchFiles("main"));
+    const before = mockWs!.sent.length;
+
+    act(() => result.current.clearSessionSearch());
+    act(() => result.current.clearFileSearch());
+    expect(mockWs!.sent).toHaveLength(before);
+    expect(result.current.state.sessionSearch).toBeNull();
+    expect(result.current.state.fileSearch).toBeNull();
+  });
+
+  it("dismisses a notification locally", async () => {
+    const result = await connected();
+    act(() => mockWs!.receive({ type: "extension_ui_request", id: "n1", method: "notify", message: "done" }));
+    await waitFor(() => expect(result.current.state.notifications).toHaveLength(1));
+    const id = result.current.state.notifications[0].id;
+
+    act(() => result.current.dismissNotification(id));
+    await waitFor(() => expect(result.current.state.notifications).toHaveLength(0));
+  });
+});

--- a/ui/src/util/toolOutput.test.ts
+++ b/ui/src/util/toolOutput.test.ts
@@ -68,3 +68,80 @@ describe("getFormattedToolOutput", () => {
     expect(getFormattedToolOutput('"simple string"')).toBe("simple string");
   });
 });
+
+/**
+ * The recovery paths: what happens when the tool's JSON never finished arriving.
+ * These are the branches that decide between showing a partial summary and showing
+ * nothing, and they are the ones a malformed payload actually reaches.
+ */
+describe("getFormattedToolOutput — partial and unusual payloads", () => {
+  it("formats the search mode and the summary", () => {
+    const output = JSON.stringify({ searchMode: "semantic", summary: "Four call sites." });
+    expect(getFormattedToolOutput(output)).toBe("Mode: semantic\nFour call sites.");
+  });
+
+  it("formats nextStepsText the same way as nextSteps", () => {
+    const output = JSON.stringify({ title: "Orient", nextStepsText: ["read the spec", "run the tests"] });
+    expect(getFormattedToolOutput(output)).toContain("- read the spec");
+  });
+
+  it("caps the long lists at five entries", () => {
+    const many = ["a", "b", "c", "d", "e", "f", "g"];
+    const output = JSON.stringify({ title: "T", nextSteps: many, relevantFunctions: many.map((name) => ({ name })) });
+    const formatted = getFormattedToolOutput(output) ?? "";
+    expect(formatted).toContain("- e");
+    expect(formatted).not.toContain("- f");
+  });
+
+  it("names a function whose file is reported under `file` rather than `filePath`", () => {
+    const output = JSON.stringify({ relevantFunctions: [{ name: "runGit", file: "server/src/git.ts" }] });
+    expect(getFormattedToolOutput(output)).toContain("- runGit (server/src/git.ts)");
+  });
+
+  it("says the file is unknown rather than printing undefined", () => {
+    const output = JSON.stringify({ relevantFunctions: [{ name: "runGit" }] });
+    expect(getFormattedToolOutput(output)).toContain("- runGit (unknown)");
+  });
+
+  it("falls back to the raw value for a function that is not an object", () => {
+    const output = JSON.stringify({ relevantFunctions: ["runGit"] });
+    expect(getFormattedToolOutput(output)).toContain("- runGit");
+  });
+
+  it("recovers a complete object followed by trailing rubbish", () => {
+    // A tool that appended a log line after its JSON: the object is intact, so the
+    // summary should still be shown rather than dropped for the trailing bytes
+    const output = `${JSON.stringify({ title: "Orient", summary: "Two hits." })}\nwarning: cache stale`;
+    expect(getFormattedToolOutput(output)).toBe("**Orient**\nTwo hits.");
+  });
+
+  it("shows nothing rather than a guess when the outer object never closed", () => {
+    // The brace-counting recovery needs a closing brace for the outermost object.
+    // A payload cut off before that has no prefix that parses, so there is nothing
+    // honest to show — better empty than a summary invented from half a field.
+    const output = '{"title":"Orient","summary":"Two hits.","relevantFiles":["a.ts","b.t';
+    expect(getFormattedToolOutput(output)).toBeUndefined();
+  });
+
+  it("recovers the object when the truncation landed after it closed", () => {
+    const output = '{"title":"Orient","summary":"Two hits."} trailing bytes {"partial":';
+    expect(getFormattedToolOutput(output)).toContain("Two hits.");
+  });
+
+  it("gives up rather than guessing when nothing parses", () => {
+    expect(getFormattedToolOutput('{"title": "Orient"')).toBeUndefined();
+    expect(getFormattedToolOutput("{{{{")).toBeUndefined();
+    expect(getFormattedToolOutput("plain text output")).toBeUndefined();
+  });
+
+  it("returns nothing for a JSON value that is not an object or string", () => {
+    expect(getFormattedToolOutput("42")).toBeUndefined();
+    expect(getFormattedToolOutput("null")).toBeUndefined();
+    expect(getFormattedToolOutput("true")).toBeUndefined();
+  });
+
+  it("prefers the render envelope over the fields beside it", () => {
+    const output = JSON.stringify({ __pi_render: { text: "rendered" }, title: "ignored" });
+    expect(getFormattedToolOutput(output)).toBe("rendered");
+  });
+});


### PR DESCRIPTION
## Why

`report_coverage_gaps` ranks untested code by how load-bearing it is rather than listing it flat. Two things came off the top of that list:

- **`server/src/fileBrowser.ts` had no direct test at all.** The module that decides what the sidebar may read and write was only ever exercised through the HTTP route, which tests the route as much as the rule.
- **`ui/src/components/FileViewer.tsx` sat at 0%**, 422 lines, and it is where an editing mistake costs data.

What started there grew into closing every file the report showed in red, and then into making coverage something CI refuses to lose rather than a number someone remembers to look at.

## Coverage

| | before | after |
|---|---|---|
| **Server** lines / branches / functions | — | **94.3% / 88.3% / 92.7%** |
| **UI** lines / branches / functions | 66.2% / 54.6% / 58.7% | **93.6% / 87.4% / 95.3%** |

Per file, worst first before this branch:

| file | before | after |
|---|---|---|
| `FileViewer.tsx` | **0%** | 87.8% |
| `Sidebar.tsx` | **0%** | 100% |
| `FileTree.tsx` | 2.4% | 100% |
| `Mermaid.tsx` | 6.2% | 100% |
| `AssistantMessage.tsx` | 33.3% | 100% |
| `Header.tsx` | 33.8% | 96.4% |
| `Composer.tsx` | 35.3% | 94.0% |
| `UserMessage.tsx` | 37.5% | 100% |
| `Onboarding.tsx` | 40% | 100% |
| `SettingsMenu.tsx` | 43.2% | 97.0% |
| `App.tsx` | 48.1% | 87.8% |
| `authToken.ts` | 68.8% | 100% |
| `useAgent.ts` | 71.1% | 85.8% |
| `toolOutput.ts` | 71.2% | 91.5% |
| `CodeHighlight.tsx` | 77.8% (19% branches) | 100% (94% branches) |
| `TreeMenu.tsx` | — | 97.1% |
| `fileBrowser.ts` | **no direct test** | 97.4% |
| `sandbox.ts` | 66.7% | 100% |
| `extensionRender.ts` | 79.9% (59% branches) | 98.1% (88% branches) |
| `credentials.ts` | 69.6% | 86.8% |
| `git.ts` | — | 97.7% |

740 UI tests, 419 server tests.

## Coverage in CI, and a gate

The ubuntu leg now runs the suites instrumented and writes a **markdown coverage table into the run summary** — visible on the Actions page, with a per-file breakdown sorted worst-first. No third-party service, no token, no extra job. Windows runs the suites plain, so a coverage tool can never be what turns that leg red.

Both `test:coverage` scripts carry **thresholds** (server 92/86/90, ui 91/85/93), each set a little under where the suite stands.

`server/src/index.ts` is excluded by name and the summary says so. Its integration tests spawn the server as a subprocess, which the instrumentation does not follow, so it measures ~11% however well tested it is — folding that in would understate the server by thirty points and invite exactly the wrong fix.

## What the tests aim at

Not lines — damage.

**`fileBrowser`**: the escapes that matter — `..`, an absolute path, a climb out and back in, and a symlink whose target sits outside the root — plus the size, binary and mtime guards that separate a refused request from a corrupted file.

**`sandbox`**: `createSandboxedTools` decides which tools the model is handed and whether each refuses a path leaving its zone. A read tool escaping the root, an edit tool escaping the writable zone while read tools may still reach it, and a read exception that must not widen what write tools can touch.

**`credentials`**: the validators standing between a client frame and a key written to disk — a provider id becomes a filename, a base URL becomes a host the server will send API keys to — and `storeProvider`, which must land at 0600 even when the existing file was 0644, merge rather than clobber, and leave a file it cannot parse alone.

**`FileViewer`**: the mtime baseline a save carries, the conflict banner when the file moves underneath the editor, and typing *during* the save round-trip, where the newer draft must survive the acknowledgement.

**`Composer`**: mostly what must **not** be sent — whitespace, an Enter mid-IME-composition, and a bare path reference, since opening a preview attaches one and a stray Enter must not turn that into a question.

**`UserMessage`**: an edit rewinds the session, so the cases are the ones where text could vanish. The agent starting mid-edit leaves the draft open rather than swallowing it; a tree navigation that replaces the turn underneath drops it, because submitting would edit whatever message now sits there.

**`authToken`**: its whole purpose is taking the token back out of the address bar so it cannot survive in history, screenshots or a shared link — and nothing asserted that it did.

**`Mermaid`**: I had written this off as a third-party renderer. Only the renderer is. The wrapper decides whether a diagram that fails to draw costs the reader the content or just the picture: the source stays on screen until a drawing succeeds, an error appears beside it rather than replacing it, and mermaid is kept from injecting its own error markup into the page.

**`useAgent`**: the reducer folding server messages into the transcript, where a streaming reply becomes one bubble rather than a hundred — plus the command senders, whose frames are the contract the server validates.

**`App`**: the handovers no single component owns, and a drop zone that counts dragenter/dragleave rather than toggling, because both fire for every child crossed.

## A gap in the git tests I had missed

Every call in `git.test.ts` passed `root, root`. The case where the repository is larger than the browser root — the only shape where the toplevel-relative and cwd-relative path conventions actually differ, and the one the `git` spec claims — was never exercised. It passes, but nothing proved it. Also added: a chain of two renames (the only thing that makes the stitch loop run more than once), a binary file's `-` numstat counts, and a filename starting with a dash.

## Things found while writing these

1. **jsdom ships no `scrollIntoView`** (it implements no layout). A component keeping its selected row in view called it on every selection change and **threw during render** — the test reported a crash rather than the behaviour under test. Stubbed in the shared setup.
2. **Two of my own fixtures were malformed** and vitest does not type-check: an `Attachment` missing `data`, and a configured provider without `usableModel` that pushed the component into an entirely different branch.
3. **One test I wrote was hollow** — `statSync(root) && x` evaluates to `x`, asserting nothing. Replaced.
4. **`toolOutput`'s brace-counting recovery is narrower than it looks**: a payload cut off before its outer object closed has no prefix that parses. The test now says plainly that it shows nothing rather than a summary invented from half a field.
5. **`extensionRender`'s "empty" guard is narrower than its comment suggested**: a renderer emitting blank *lines* still produces markup, so only one emitting no lines at all is treated as silent.

## Four CI failures, each a different cause

Worth recording, because three of them were only visible on CI:

1. **Windows, fixture roots.** `fs.realpath` (async) expands an 8.3 short name — `RUNNER~1` → `runneradmin` — and `realpathSync` does not. A fixture built with the sync call compared a short path against an expanded one, so every path read as "outside the browser root". Fixtures now resolve through the same primitive the code under test uses. Two of my attempts at this were guesses before the CI output named it.
2. **Child servers under instrumentation.** `--experimental-test-coverage` exports `NODE_V8_COVERAGE`; the servers the harness spawns inherited it and are ended with SIGKILL, leaving half-written coverage files the parent's reporter died parsing.
3. **A 10 MB truncation.** Loading every suite under instrumentation made node truncate its own report. Coverage now runs over the unit suites alone — 42 KB of lcov instead of a report too large to parse.
4. **The gate catching itself.** Its first failure was not a regression: CI folded `index.ts` and the test files into the total while a local run did not, so the threshold had been calibrated against a number that never reproduced. Both are now excluded by name.

## Still uncovered, deliberately

`config.ts` (83.9%) and `credentials.ts` (86.8%) plateau on code needing a real `ModelRegistry` or system error paths — integration territory, not unit. `App.tsx` branches (76.5%) are three- and four-way state combinations whose tests would cost more than they protect.

And structural coverage is not behavioural verification: openlore says so itself — "reachable from a test" is not "a test asserts it".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
