### PR TITLE
Route tool results through a presentation registry

### DIFF
--- a/openspec/changes/add-tool-result-presentations/design.md
+++ b/openspec/changes/add-tool-result-presentations/design.md
@@ -1,0 +1,171 @@
+# Design: tool-result presentations
+
+## Context
+
+`ToolCard` is the only renderer of tool results. It branches on tool name and
+result shape inline, and every new case widens the same component. This design
+names the seam, fixes the matcher set, and states the HTML trust boundary that
+the previous draft left implicit.
+
+## Decision 1 — matching is a closed table, not a heuristic search
+
+The previous draft said selection uses "a stable tool identity and, when
+necessary, a validated result shape". That defers the hard part. pi-outpost
+substitutes its own toolset (`server/src/sandbox.ts:96-131`), so the identity set
+is closed and can be written down:
+
+`bash` · `read` · `ls` · `grep` · `find` · `edit` · `write`
+
+Matchers, in priority order. First match wins; ties are impossible because the
+table is total and ordered.
+
+| Priority | Presentation | Match condition | Renders with |
+|---|---|---|---|
+| 1 | Extension-rendered | `item.outputHtml` present | `RenderedHtml` (existing) |
+| 2 | File edit | `toolName === "edit"` and `args.edits` has ≥1 `{oldText,newText}` pair | `SplitDiffBlock` + `diffLines` (existing) |
+| 3 | File write | `toolName === "write"` and `args.content` is a string | `DiffBlock` (existing) |
+| 4 | Git diff | `toolName === "bash"` and `args.command` matches `/^\s*git\s+(diff|show)\b/` | `DiffBlock` + `diffLines` (existing) |
+| 5 | Code search | `toolName === "grep"` | new hit-list renderer |
+| 6 | Render envelope | output carries a `__pi_render.text` envelope | `ReactMarkdown` (existing) |
+| 7 | Orient summary | output carries the openlore `orient` field shape | `ReactMarkdown` (existing) |
+| 8 | Raw | always | `<pre>` (existing) |
+
+Priorities 1–3 and 6–8 are today's behaviour in `ToolCard`, relocated. Only 4 and
+5 are new.
+
+Rows 6 and 7 are one function today (`getFormattedToolOutput`), which is why they
+were one row in the first draft. See decision 6.
+
+Rows 4 and 5 are the only judgement calls. Row 4 is a heuristic on a command
+string, but a *narrow, anchored* one: the regex is anchored at the start of the
+command, and a false positive degrades to a diff view of something that is
+already diff-shaped. Row 5 needs no heuristic — `grep` is a distinct identity.
+
+The rejected alternative was open-ended sniffing (scan any `bash` output for
+diff-like or test-like structure). It fails because a false positive silently
+reshapes a result the user needs to read verbatim, and because the matcher set
+can never be closed or fully tested.
+
+## Decision 2 — selection is stable across the running→done transition
+
+`ToolCard` already resynchronizes its open state when output arrives mid-stream
+(`ui/src/components/ToolCard.tsx:63-65`). If the registry re-runs on that
+transition and picks a different row, the card swaps renderer under the user.
+
+Rule: rows 2–5 match on `(toolName, args)` only, both of which are known at
+`tool_start` (`shared/src/protocol.ts:361`). Rows 6–8 depend on output and are
+therefore the only rows that may change when output lands, and only by replacing
+the raw fallback. A specialized presentation chosen at `tool_start` is never
+revoked.
+
+**Exception, found during implementation: row 1.** Extension-rendered HTML was
+assumed to be args-stable and is not — `outputHtml` is produced at `tool_end`
+(`server/src/index.ts:1024`), so an extension-rendered result can only ever be
+detected late. Rather than demote it, row 1 is exempt from the no-revoke rule:
+`renderer.toolRenderer` is set only when an installed extension registers one
+(`server/src/extensionRender.ts:99,115`), so its presence is a deliberate claim by
+that extension on the tool's presentation, and it outranks our built-in guess. The
+exemption is narrow — exactly one row, only ever widening authority, never
+narrowing it — and is recorded in the spec rather than left as a silent
+divergence.
+
+## Decision 3 — the HTML trust boundary is named, not assumed
+
+The previous draft's requirement ("SHALL NOT insert raw tool output as executable
+HTML") read as a blanket ban and directly contradicted a ratified requirement:
+`components/SharedPresentationPrimitives` → scenario `RenderExtensionHtml`
+blesses `RenderedHtml`, which does `dangerouslySetInnerHTML`
+(`ui/src/components/RenderedHtml.tsx:18`).
+
+Both can be true once the two channels are distinguished:
+
+**Trusted channel — extension-rendered HTML.** `outputHtml`, `outputHtmlCollapsed`,
+and `callHtml` are produced server-side by `server/src/extensionRender.ts`, which
+calls pi's ANSI-to-HTML renderer. That renderer escapes `&`, `<`, `>` at source
+and emits only `<span style=…>` wrappers. Safety rests on **escaping at source**,
+not on sanitization — there is no DOMPurify and no allowlist anywhere in the
+repo. This is the same trust level as the server itself: an installed extension
+already runs code in the server process, so an extension able to emit raw markup
+is not a new privilege. Unchanged by this change.
+
+**Untrusted channel — tool output.** `item.output` is a model- or
+command-produced string. It is inert text everywhere: `<pre>` at row 7, and
+markdown at row 6 through `ReactMarkdown`, which does not enable
+`rehype-raw`. New presentations MUST keep it that way.
+
+The residual risk — a third-party extension renderer that emits raw markup
+instead of escaped spans — is real but pre-existing, out of scope here, and
+worth its own change. This design records it rather than silently inheriting it.
+
+## Decision 4 — actions are a closed enum over existing `useAgent` actions
+
+The previous draft routed actions "through the application's existing command and
+approval boundary". **That boundary does not exist.** There is no per-tool-call
+approval anywhere in `server/src`, `ui/src`, or `shared/src`; tools run unattended
+within the static sandbox config (`server/src/sandbox.ts:112,124`), changed only
+by `updateConfig`. The only confirmations in the codebase are `window.confirm` for
+destructive UI operations and extension-initiated dialogs.
+
+Building an approval boundary is a separate change. The invariant this change can
+enforce is stronger and cheaper: a presentation does not describe an action, it
+**names one from a closed enum**, and the card maps that name to an existing
+`useAgent` action.
+
+| Action name | Maps to | Used by |
+|---|---|---|
+| `openFile` | `readFile(path)` (`ui/src/useAgent.ts:864`) | code search, Git diff |
+| `openFileHistory` | `fetchGitFileHistory(path)` (`:896`) | Git diff |
+| `openWorktreeDiff` | `fetchGitDiff(path)` (`:886`) | Git diff |
+| `searchWorkspace` | `searchFiles(query)` (`:877`) | code search |
+| `copy` | clipboard via `CopyButton` (existing) | all |
+
+A presentation cannot construct a wire message, cannot call `sendMessage`, and
+cannot reach `prompt`/`editPrompt` — the two actions that cause agent work. That
+closes the escalation path by construction rather than by policy, which is why no
+approval step is needed for the actions shipped here.
+
+## Decision 5 — one spec domain, one dispatch path
+
+`components/ConversationItemRendering` currently enumerates ToolCard's renderers.
+Adding a `tool-result-presentations` capability without touching it leaves two
+requirements describing the same component. This change modifies
+`ConversationItemRendering` so `ToolCard` delegates, and the new capability owns
+selection, provenance, actions, and the raw-output guarantee.
+
+## Decision 6 — the vendor-specific summary becomes its own row
+
+`getFormattedToolOutput` (`ui/src/util/toolOutput.ts`) does two unrelated things
+under one generic name:
+
+1. **Generic.** Reads a `__pi_render.text` envelope, and recovers a truncated JSON
+   result by stripping the truncation suffix or by brace-counting. Any tool can
+   emit the envelope. This is what `utilities/FormatToolOutput` specifies.
+2. **Vendor-specific.** `formatParsedObject` (`:17-47`) formats a fixed field list
+   — `task`, `searchMode`, `relevantFiles`, `relevantFunctions`, `nextSteps`,
+   `nextStepsText`. That is the openlore `orient()` payload; the function's own
+   docstring says so (`:3`), and its tests name it (`ui/src/util/toolOutput.test.ts:84,122`).
+
+The ratified requirement `utilities/FormatToolOutput` describes only (1). The field
+formatting is undocumented drift, and because it sits on the catch-all path it
+fires for *any* tool whose JSON happens to carry a `title` or `summary` key — not
+just openlore's.
+
+Splitting it is the point of having a registry: a vendor-shaped renderer should be
+a visible row with a named match, not a hidden branch inside a utility.
+
+- `getFormattedToolOutput` keeps (1) and narrows to what the spec already says. Its
+  loose-JSON recovery is exported so the new row can reuse it rather than
+  re-implement it.
+- `formatOrientSummary` moves to `ui/src/presentations/orientSummary.ts` and gets
+  row 7, matching on the openlore field shape.
+
+Rendered output is unchanged for every input. The cost is test relocation: the
+field-formatting cases move from `toolOutput.test.ts` to `orientSummary.test.ts`,
+and `utilities/FormatToolOutput` needs a MODIFIED delta because the function now
+returns `undefined` for a JSON object with no envelope, which its current wording
+does not allow.
+
+## Open question
+
+Whether row 7 should be dropped once openlore emits a `__pi_render` envelope of its
+own, which would make it redundant. Left in place until that happens.

--- a/openspec/changes/add-tool-result-presentations/proposal.md
+++ b/openspec/changes/add-tool-result-presentations/proposal.md
@@ -1,0 +1,108 @@
+# Change: Add tool-result presentations
+
+## Why
+
+A tool result is shown as a block of text unless `ToolCard` happens to special-case
+it. A `grep` sweep, a `git diff`, and an `edit` all carry different information and
+should be scanned differently, but only `edit` and `write` get a purpose-built view
+today.
+
+### What already exists
+
+This change is a refactor plus an extension, not a greenfield feature. The
+starting point:
+
+- **`ToolCard` already dispatches on result shape**, hardcoded inside one
+  component (`ui/src/components/ToolCard.tsx:46-68`): `editPairs()` →
+  `SplitDiffBlock`, `writeContent()` → `DiffBlock`, `item.outputHtml` →
+  `RenderedHtml`, `getFormattedToolOutput()` → markdown, else `<pre>`. That is an
+  ad-hoc registry with no seam for a fifth case.
+- **`outputHtmlCollapsed` is produced and delivered but never consumed.** The
+  server renders it (`server/src/extensionRender.ts:108`, plumbed through
+  `server/src/convert.ts:222-225` and `server/src/index.ts:1024`) and the client
+  stores it (`ui/src/useAgent.ts:503`), but no component reads it. The collapsed
+  preview this change wants is already paid for on the server.
+- **Tool identity is stable and closed.** pi-outpost embeds pi as a library and
+  substitutes its own sandboxed toolset (`server/src/sandbox.ts:96-131`). The
+  identities the UI can rely on are `bash`, `read`, `ls`, `grep`, `find`, `edit`,
+  `write` — nothing else.
+- **`openspec/specs/components/spec.md` already governs this surface** via
+  `ConversationItemRendering` (scenario `ToolOutputUsesSpecializedRenderers`) and
+  `SharedPresentationPrimitives` (scenario `RenderExtensionHtml`). This change
+  modifies that requirement rather than opening a competing one.
+
+### What is actually missing
+
+A named seam, a collapsed view, and two presentations (`grep`, `git diff`) that
+the existing primitives can already draw.
+
+## What changes
+
+- **Extract** the dispatch currently inlined in `ToolCard` into a presentation
+  registry: one module that maps a completed tool call to at most one renderer,
+  with deterministic priority and a raw fallback. `ToolCard` becomes a consumer of
+  the registry, not a competitor to it — there is exactly one dispatch path
+  afterwards.
+- **Add a common result card** carrying status, the raw input, and a guaranteed
+  raw-output fallback, so provenance survives every specialized view.
+- **Wire `outputHtmlCollapsed`** into the collapsed state of the result card,
+  replacing the unconditional `getFormattedToolOutput()` path when an extension
+  supplied a collapsed rendering.
+- **Deliver two presentations in this change**: code search (`grep`) and Git diff
+  (`bash` whose command is a `git diff` / `git show` invocation).
+- **Let a presentation expose contextual actions**, drawn from a closed enumeration
+  of `useAgent` actions that already exist — `readFile`, `fetchGitDiff`,
+  `fetchGitFileHistory`, `searchFiles`, `prompt`. A presentation cannot construct
+  a new wire message and cannot execute a tool.
+- **Keep extension-rendered HTML on its existing trusted channel**, and state that
+  trust boundary explicitly rather than implying tool output and extension output
+  are the same thing. See `design.md`.
+
+## Deferred, with reasons
+
+- **Test-result presentation.** There is no test tool identity — a test run arrives
+  as `bash`, so matching means sniffing a command string and parsing arbitrary
+  runner output (vitest, jest, pytest, go test, …). High cost, brittle, and the
+  matcher set cannot be closed. Revisit if pi ships a dedicated test tool, or scope
+  it to this repo's own `vitest` invocation as a separate change.
+- **Delegated-agent presentation.** There is no delegated-agent concept in the
+  protocol or the toolset — `shared/src/protocol.ts` has no sub-agent item and
+  `server/src/sandbox.ts` exposes no spawn tool. The presentation has no data
+  source. Cut until one exists.
+
+## Non-goals
+
+- Replacing the conversation transcript or changing the tool-call protocol.
+- A user-installable renderer/plugin marketplace.
+- Rendering arbitrary HTML, JavaScript, or remote URLs originating in **tool
+  output**. (Extension-rendered HTML is a separate, pre-existing channel — see
+  `design.md`.)
+- Adding a per-tool-call approval prompt. None exists today; tools run unattended
+  inside the sandbox configured by `updateConfig`. Introducing one is its own
+  change.
+- Automatically applying changes suggested by a result.
+
+## Impact
+
+- **Affected capability**: `tool-result-presentations` (new).
+- **Modified capability**: `components` — `ConversationItemRendering` is rewritten
+  so `ToolCard` delegates to the registry instead of enumerating renderers itself.
+- **Affected code**: `ui/src/components/ToolCard.tsx` (loses its dispatch),
+  new `ui/src/presentations/*`, `ui/src/util/toolOutput.ts` (becomes one
+  registered presentation among several rather than a privileged path).
+- **Affected contracts**: none on the wire. The tool-call view model gains
+  UI-only presentation metadata; `toolName`, `args`, `output`, `outputHtml`,
+  `outputHtmlCollapsed` are unchanged.
+
+## Risks
+
+- **Selection instability during streaming.** Output arrives after the card mounts
+  (`ui/src/components/ToolCard.tsx:63-65` already resynchronizes `open` for this
+  reason). If the registry re-selects when output lands, cards change renderer and
+  collapse under the cursor. Mitigated by requiring selection to be a pure function
+  of `(toolName, args)` where possible, and forbidding a running→done transition
+  from narrowing an already-chosen presentation.
+- **Fallback must be total.** An unknown or malformed result must never hide data.
+  Covered by an explicit requirement and unit tests.
+- **Two dispatch systems.** Mitigated by deleting the inline branches in `ToolCard`
+  in the same change, not alongside it.

--- a/openspec/changes/add-tool-result-presentations/specs/components/spec.md
+++ b/openspec/changes/add-tool-result-presentations/specs/components/spec.md
@@ -1,0 +1,66 @@
+## MODIFIED Requirements
+
+### Requirement: ConversationItemRendering
+
+The component layer SHALL provide dedicated renderers for assistant, user, tool, and custom
+conversation items. `AssistantMessage` SHALL support normalized markdown, Mermaid blocks,
+workspace-file references, and copy actions. `ToolCard` SHALL delegate the choice of tool
+renderer to the tool-result presentation registry rather than enumerating renderers itself,
+and SHALL present the selected presentation together with the tool status and access to the
+original input and output. When an extension supplies a collapsed rendering for a tool result,
+`ToolCard` SHALL use it for the collapsed state. `CustomMessageCard` SHALL support
+extension-rendered HTML and normalized markdown.
+
+#### Scenario: AssistantContentIsRendered
+- **GIVEN** an assistant item supplied by the application
+- **WHEN** `AssistantMessage` renders the item
+- **THEN** its supported markdown, diagram, workspace-reference, and copy affordances are presented through the component layer
+
+#### Scenario: ToolOutputUsesSpecializedRenderers
+- **GIVEN** a tool item supplied by the application
+- **WHEN** `ToolCard` renders the item
+- **THEN** it renders the presentation the registry selected for that item
+- **AND** it does not itself inspect the tool identity or result shape to choose one
+
+#### Scenario: CollapsedExtensionRenderingIsUsed
+- **GIVEN** a tool item carrying a collapsed extension rendering
+- **WHEN** `ToolCard` renders the item collapsed
+- **THEN** the collapsed extension rendering is the content shown
+
+#### Scenario: CustomExtensionMessageIsRendered
+- **GIVEN** a custom conversation item supplied by an extension
+- **WHEN** `CustomMessageCard` renders the item
+- **THEN** supported rendered HTML or normalized markdown is displayed
+
+### Requirement: SharedPresentationPrimitives
+
+The domain SHALL provide shared presentation primitives for copying text, syntax highlighting,
+Mermaid diagrams, unified and split diffs, and rendered HTML. Higher-level components SHALL reuse
+these primitives through the observed component relationships instead of embedding duplicate
+presentations. `RenderedHtml` SHALL present only HTML produced by the server-side extension
+render pipeline; content originating in a tool's own output SHALL NOT be routed to it.
+
+#### Scenario: CopyPresentedText
+- **GIVEN** text supplied to `CopyButton`
+- **WHEN** the user activates the copy action
+- **THEN** the supplied text is the content offered for copying
+
+#### Scenario: RenderCodeWithPathContext
+- **GIVEN** source text and a path supplied to `CodeHighlight`
+- **WHEN** the component renders
+- **THEN** it presents the source using the path as language context
+
+#### Scenario: RenderDiffRows
+- **GIVEN** diff lines supplied to `DiffBlock` or `SplitDiffBlock`
+- **WHEN** the component renders
+- **THEN** the lines are presented in the requested unified or split form
+
+#### Scenario: RenderExtensionHtml
+- **GIVEN** rendered HTML supplied to `RenderedHtml` by the extension render pipeline
+- **WHEN** the component renders
+- **THEN** the HTML is presented through the shared rendered-HTML surface
+
+#### Scenario: ToolOutputIsNotRoutedToRenderedHtml
+- **GIVEN** a tool result whose own output contains markup
+- **WHEN** a presentation renders that output
+- **THEN** the output is presented as inert text rather than through `RenderedHtml`

--- a/openspec/changes/add-tool-result-presentations/specs/tool-result-presentations/spec.md
+++ b/openspec/changes/add-tool-result-presentations/specs/tool-result-presentations/spec.md
@@ -1,0 +1,132 @@
+## ADDED Requirements
+
+### Requirement: A single registry selects at most one presentation
+
+The system SHALL resolve a tool call to at most one presentation through one
+ordered registry. Selection SHALL be a total function: every tool call resolves,
+and the last entry SHALL be a raw-output presentation that matches unconditionally.
+No component outside the registry SHALL branch on tool identity or result shape to
+choose a renderer.
+
+#### Scenario: A code-search tool completes
+
+- **WHEN** a `grep` tool call completes
+- **THEN** the conversation shows the code-search presentation
+- **AND** the raw input and raw output remain reachable
+
+#### Scenario: A tool matches no specialized entry
+
+- **WHEN** no specialized registry entry matches a tool call
+- **THEN** the conversation shows the raw-output presentation
+- **AND** no part of the result is discarded
+
+#### Scenario: Two entries could match the same call
+
+- **WHEN** a tool call satisfies the conditions of more than one registry entry
+- **THEN** the entry earlier in the registry order is selected
+- **AND** the selection does not depend on registration order at runtime
+
+### Requirement: Selection is stable while a tool call streams
+
+The system SHALL choose a presentation from the tool identity and input as soon as
+they are known, and SHALL NOT replace a specialized presentation with a different
+one when the output arrives. An output-dependent presentation MAY replace only the
+raw-output presentation.
+
+A rendering supplied by an installed extension is the single exception: it MAY
+replace an already-chosen presentation, because the extension's claim on the
+tool's presentation outranks a built-in one.
+
+#### Scenario: Output arrives after the card is shown
+
+- **WHEN** a tool call is rendered while running and its output arrives afterwards
+- **THEN** the presentation chosen while running is still the one shown
+- **AND** the card's expanded or collapsed state is not reset by the arrival
+
+#### Scenario: A structured summary becomes available
+
+- **WHEN** a running call shows the raw-output presentation and its completed
+  output carries a recognized structured summary
+- **THEN** the card may adopt the summary presentation
+- **AND** the raw output remains reachable
+
+#### Scenario: An extension rendering arrives with the output
+
+- **WHEN** a call already showing a specialized presentation completes with a
+  rendering supplied by an installed extension
+- **THEN** the extension's rendering is shown instead
+
+### Requirement: Every presentation preserves provenance
+
+The system SHALL display the tool status and SHALL keep the original tool input
+and complete original output reachable from every presentation, including
+specialized ones.
+
+#### Scenario: A user inspects a summarized Git diff
+
+- **WHEN** the Git-diff presentation shows a per-file summary
+- **THEN** the user can reveal the complete original command output
+- **AND** can identify the tool call it came from
+
+#### Scenario: A presentation cannot read its result
+
+- **WHEN** a selected presentation receives malformed or incomplete output
+- **THEN** the card falls back to the raw-output presentation
+- **AND** no renderer error is surfaced in the conversation
+- **AND** the error is reported to the developer console
+
+### Requirement: Presentation actions are drawn from a closed enumeration
+
+A presentation SHALL offer contextual actions only by naming an entry in a fixed
+enumeration of workspace-navigation actions the application already provides. The
+system SHALL NOT allow a presentation to construct a server message, invoke a
+tool, or submit a prompt.
+
+#### Scenario: A user opens a code-search hit
+
+- **WHEN** the code-search presentation offers an open action for a hit and the
+  user chooses it
+- **THEN** the application opens that path through its existing file-preview action
+
+#### Scenario: A presentation names an unknown action
+
+- **WHEN** a presentation names an action outside the enumeration
+- **THEN** the action is not offered
+- **AND** no message is sent to the server
+
+### Requirement: Tool output is never executable content
+
+The system SHALL treat a tool's own output as inert. It SHALL NOT parse tool
+output as HTML, insert it as markup, or execute script contained in it. This
+requirement governs tool output only; HTML produced by the server-side extension
+render pipeline is a separate trusted channel governed by the components
+capability.
+
+#### Scenario: A command prints HTML containing a script element
+
+- **WHEN** a `bash` result's output contains HTML including a script element
+- **THEN** the output is shown as escaped text or as a structured non-markup view
+- **AND** the script does not run
+
+#### Scenario: A tool prints markdown containing raw HTML
+
+- **WHEN** a result rendered by a markdown presentation contains raw HTML
+- **THEN** the raw HTML is shown as text rather than parsed as markup
+
+### Requirement: Initial presentations cover search and Git diffs
+
+The system SHALL provide a code-search presentation for `grep` results and a
+Git-diff presentation for shell calls whose command is a `git diff` or `git show`
+invocation, reusing the existing shared diff primitives.
+
+#### Scenario: A Git diff is produced through the shell tool
+
+- **WHEN** a `bash` call whose command begins with `git diff` completes
+- **THEN** its output is presented with the shared diff primitives
+- **AND** each changed file offers actions to open the file and its history
+
+#### Scenario: A search returns hits across several files
+
+- **WHEN** a `grep` call returns matches in more than one file
+- **THEN** the presentation groups the matches by file
+- **AND** each match offers an action to open its file

--- a/openspec/changes/add-tool-result-presentations/specs/utilities/spec.md
+++ b/openspec/changes/add-tool-result-presentations/specs/utilities/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: FormatToolOutput
+
+- **Implementation**: `getFormattedToolOutput::ui/src/util/toolOutput.ts`, `parseLooseJson::ui/src/util/toolOutput.ts`
+
+The system SHALL format a tool result for display from an authoritative
+`__pi_render` envelope. It SHALL recover from truncated JSON by stripping the
+truncation suffix and, failing that, by brace-counting, and SHALL expose that
+recovery so other presentations parse a tool result the same way rather than
+re-implementing it. It SHALL return `undefined` for content that is not JSON, is
+unrecoverable, or carries no envelope — never a partially parsed object presented
+as complete.
+
+Formatting that is specific to one tool vendor's payload SHALL NOT live in this
+utility; it belongs to a presentation with a named match.
+
+#### Scenario: OutputCarriesARenderEnvelope
+- **GIVEN** a result containing a `__pi_render` envelope
+- **WHEN** it is formatted
+- **THEN** the envelope is authoritative and is used as-is
+
+#### Scenario: OutputWasTruncatedMidObject
+- **GIVEN** a JSON result cut off partway through
+- **WHEN** it is formatted
+- **THEN** recovery is attempted before giving up
+- **AND** unrecoverable content yields `undefined` rather than a partial render
+
+#### Scenario: OutputIsJsonWithoutAnEnvelope
+- **GIVEN** a JSON result carrying no `__pi_render` envelope
+- **WHEN** it is formatted
+- **THEN** the result is `undefined`
+- **AND** the parsed object is available to presentations through the shared recovery

--- a/openspec/changes/add-tool-result-presentations/tasks.md
+++ b/openspec/changes/add-tool-result-presentations/tasks.md
@@ -1,0 +1,36 @@
+## 1. Registry seam
+
+- [x] 1.1 Add `ui/src/presentations/registry.ts`: a `Presentation` type (`id`, `match(item)`, `Component`) and an ordered array matching the table in `design.md`. Export `selectPresentation(item): Presentation` — total, last entry matches unconditionally.
+- [x] 1.2 Add `ui/src/presentations/registry.test.ts`: order/priority, totality, malformed `args`, malformed `output`, and the running→done stability rule (a specialized pick is never revoked).
+
+## 2. Relocate existing behaviour (no visible change)
+
+- [x] 2.1 Move `editPairs` (`ToolCard.tsx:28`) and `writeContent` (`:40`) into presentation entries; keep `SplitDiffBlock`/`DiffBlock`/`diffLines` as the renderers.
+- [x] 2.2 Move the `outputHtml` → `RenderedHtml` branch (`:125`), the `getFormattedToolOutput` branch (`:53`), and the `<pre>` fallback (`:128`) into entries.
+- [x] 2.2a Split `getFormattedToolOutput` (design.md decision 6): export `parseLooseJson` from `ui/src/util/toolOutput.ts` and narrow the function to the `__pi_render` envelope; move `formatParsedObject` to `ui/src/presentations/orientSummary.ts` as `formatOrientSummary`, matching on the openlore field shape. Relocate the affected cases from `toolOutput.test.ts` to `orientSummary.test.ts`. Rendered output must be unchanged for every input.
+- [x] 2.3 Rewrite `ToolCard.tsx` to call `selectPresentation` and render the result inside the common card (status dot, `argsSummary` header, expand toggle, raw-output reveal). Delete every inline branch — no dual dispatch.
+- [x] 2.4 Confirm `ToolCard.test.tsx` still passes unmodified. Any required edit to it is a behaviour change and must be justified.
+
+## 3. Wire the collapsed extension rendering
+
+- [x] 3.1 Consume `item.outputHtmlCollapsed` (already delivered via `ui/src/useAgent.ts:503`, currently unread) for the collapsed state; fall back to the summary presentation. *Shipped without the intermediate `outputHtml` fallback: an extension that supplied no compact rendering keeps today's bare folded header, because showing the full body while folded is not a preview of itself.*
+- [x] 3.2 Test: collapsed state prefers `outputHtmlCollapsed`; expanded state still shows `outputHtml`.
+
+## 4. Actions
+
+- [x] 4.1 Define the closed action enum from `design.md` (`openFile`, `openFileHistory`, `openWorktreeDiff`, `searchWorkspace`) and a dispatcher mapping each to the existing `useAgent` action. Presentations receive the dispatcher, never `sendMessage`. *`copy` is not an enum member: `design.md` maps it to the existing `CopyButton` component, which needs no dispatch, so an enum entry would be dead.*
+- [x] 4.2 Thread the dispatcher from `ui/src/App.tsx` (where `useAgent` is already destructured) down to `ToolCard`.
+- [x] 4.3 Test: an unknown action name is not offered and sends nothing.
+
+## 5. New presentations
+
+- [x] 5.1 Code search (`grep`): parse `path:line:text` hits, group by file, cap the visible list with a reveal, `openFile` per hit. Falls back to raw when parsing yields no hits.
+- [x] 5.2 Git diff (`bash` + `/^\s*git\s+(diff|show)\b/`): parse unified diff into per-file blocks, render with `DiffBlock`, offer `openFile` / `openFileHistory` per file.
+- [x] 5.3 Tests for both: happy path, empty result, unparseable output → raw fallback, actions fire the right dispatcher entry.
+
+## 6. Verification
+
+- [x] 6.1 Test that a tool output containing `<script>` renders as escaped text under every presentation, and that `RenderedHtml` is never reached from `item.output`.
+- [x] 6.2 Run the full UI suite and the coverage gate (CI already gates line coverage).
+- [x] 6.3 `openspec validate add-tool-result-presentations --strict`.
+- [ ] 6.4 Manually verify keyboard navigation and narrow-width behaviour on both new presentations.

--- a/ui/src/components/ToolCard.presentation.test.tsx
+++ b/ui/src/components/ToolCard.presentation.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { ToolCard } from "./ToolCard";
+import type { ChatItem } from "@pi-outpost/shared";
+
+vi.mock("react-markdown", () => ({
+  default: ({ children }: any) => <div data-testid="markdown">{children}</div>,
+}));
+vi.mock("rehype-katex", () => ({ default: () => ({}) }));
+vi.mock("remark-gfm", () => ({ default: () => ({}) }));
+vi.mock("remark-math", () => ({ default: () => ({}) }));
+
+type ToolItem = Extract<ChatItem, { kind: "tool" }>;
+
+function tool(partial: Partial<ToolItem>): ToolItem {
+  return { kind: "tool", toolName: "bash", running: false, isError: false, ...partial } as ToolItem;
+}
+
+function cardRoot(container: HTMLElement): HTMLElement {
+  return container.children[0] as HTMLElement;
+}
+
+describe("ToolCard collapsed extension rendering", () => {
+  it("shows the compact rendering the extension supplied while folded", () => {
+    const { container } = render(
+      <ToolCard
+        item={tool({
+          outputHtml: "<b>full body</b>",
+          outputHtmlCollapsed: "<i>compact</i>",
+        })}
+      />,
+    );
+
+    const root = cardRoot(container);
+    expect(root.children.length).toBe(2);
+    expect(root).toHaveTextContent("compact");
+    expect(root).not.toHaveTextContent("full body");
+  });
+
+  it("shows the full rendering once expanded", () => {
+    const { container } = render(
+      <ToolCard item={tool({ outputHtml: "<b>full body</b>", outputHtmlCollapsed: "<i>compact</i>" })} />,
+    );
+
+    fireEvent.click(cardRoot(container).querySelector("button")!);
+    expect(cardRoot(container)).toHaveTextContent("full body");
+  });
+
+  it("stays a bare header when the extension supplied no compact rendering", () => {
+    const { container } = render(<ToolCard item={tool({ outputHtml: "<b>full body</b>" })} />);
+
+    const root = cardRoot(container);
+    expect(root.children.length).toBe(1);
+    expect(root.children[0].tagName).toBe("BUTTON");
+  });
+});
+
+describe("ToolCard output is inert", () => {
+  const HOSTILE = '<script>alert(1)</script><img src=x onerror="alert(2)">';
+
+  it("never parses a tool's own output as markup", () => {
+    const { container } = render(<ToolCard item={tool({ output: HOSTILE })} />);
+    fireEvent.click(cardRoot(container).querySelector("button")!);
+
+    expect(container.querySelector("script")).toBeNull();
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.querySelector("pre")?.textContent).toBe(HOSTILE);
+  });
+
+  it("never reaches the HTML pipeline from output alone", () => {
+    const { container } = render(<ToolCard item={tool({ output: HOSTILE })} />);
+    fireEvent.click(cardRoot(container).querySelector("button")!);
+
+    // RenderedHtml is the only innerHTML sink; it is reached from outputHtml and
+    // callHtml — the extension channel — and from nothing the tool itself wrote.
+    expect(container.querySelector(".rendered-ansi")).toBeNull();
+  });
+
+  it("keeps the raw output reachable behind a reveal when a presentation reshapes it", () => {
+    const output = ["src/a.ts:1:hit", "src/a.ts:2:hit again"].join("\n");
+    const { container } = render(<ToolCard item={tool({ toolName: "grep", args: { pattern: "hit" }, output })} />);
+
+    fireEvent.click(cardRoot(container).querySelector("button")!);
+    expect(container.querySelector("pre")).toBeNull();
+
+    fireEvent.click(screen.getByText("raw output"));
+    expect(container.querySelector("pre")?.textContent).toBe(output);
+  });
+});
+
+describe("ToolCard presentation stability", () => {
+  it("does not swap renderer when the output of a running call lands", () => {
+    const running = tool({ args: { command: "git diff" }, running: true });
+    const { container, rerender } = render(<ToolCard item={running} />);
+
+    fireEvent.click(cardRoot(container).querySelector("button")!);
+    expect(cardRoot(container)).toHaveTextContent("running…");
+
+    // The command was a diff; the output is an error. The card keeps the
+    // presentation it already showed and falls back inside it.
+    rerender(<ToolCard item={tool({ args: { command: "git diff" }, output: "fatal: not a git repository" })} />);
+    expect(container.querySelector("pre")?.textContent).toBe("fatal: not a git repository");
+    expect(screen.getByText("raw output")).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/ToolCard.tsx
+++ b/ui/src/components/ToolCard.tsx
@@ -1,16 +1,9 @@
-import { useEffect, useMemo, useState } from "react";
-import ReactMarkdown from "react-markdown";
-import rehypeKatex from "rehype-katex";
-import remarkGfm from "remark-gfm";
-import remarkMath from "remark-math";
-import type { ChatItem } from "@pi-outpost/shared";
-import { normalizeMathDelimiters } from "../util/markdownMath";
-import { diffLines } from "../util/diff";
-import { DiffBlock, SplitDiffBlock } from "./DiffBlocks";
+import { useEffect, useRef, useState } from "react";
 import { RenderedHtml } from "./RenderedHtml";
-import { getFormattedToolOutput } from "../util/toolOutput";
-
-type ToolItem = Extract<ChatItem, { kind: "tool" }>;
+import { noopDispatch } from "../presentations/actions";
+import { RawBody } from "../presentations/builtin";
+import { selectPresentation } from "../presentations/registry";
+import type { ActionDispatch, ToolItem } from "../presentations/types";
 
 /** One-line summary of tool args (command for bash, path for file tools…). */
 function argsSummary(args: unknown): string {
@@ -24,48 +17,24 @@ function argsSummary(args: unknown): string {
   return json === "{}" ? "" : json;
 }
 
-/** The edit tool's before/after pairs, when this call has them. */
-function editPairs(item: ToolItem): { oldText: string; newText: string }[] | null {
-  if (item.toolName !== "edit" || item.args === null || typeof item.args !== "object") return null;
-  const edits = (item.args as { edits?: unknown }).edits;
-  if (!Array.isArray(edits)) return null;
-  const pairs = edits.filter(
-    (e): e is { oldText: string; newText: string } =>
-      e !== null && typeof e === "object" && typeof (e as Record<string, unknown>).oldText === "string" && typeof (e as Record<string, unknown>).newText === "string",
-  );
-  return pairs.length > 0 ? pairs : null;
-}
+export function ToolCard({ item, dispatch = noopDispatch }: { item: ToolItem; dispatch?: ActionDispatch }) {
+  // The presentation already on screen, so a specialized choice made while the
+  // call was running survives its output landing (see presentations/registry.ts).
+  const shown = useRef<string | undefined>(undefined);
+  const presentation = selectPresentation(item, shown.current);
+  shown.current = presentation.id;
 
-/** The write tool's new content (rendered as an all-additions diff). */
-function writeContent(item: ToolItem): string | null {
-  if (item.toolName !== "write" || item.args === null || typeof item.args !== "object") return null;
-  const content = (item.args as { content?: unknown }).content;
-  return typeof content === "string" ? content : null;
-}
+  const startsExpanded = presentation.startsExpanded === true;
+  const [open, setOpen] = useState(startsExpanded);
+  // A call that turns into a diff mid-stream opens itself; the reader did not
+  // choose the folded state, so replacing it is not overriding them.
+  useEffect(() => { setOpen(startsExpanded); }, [startsExpanded]);
+  const [showRaw, setShowRaw] = useState(false);
 
-export function ToolCard({ item }: { item: ToolItem }) {
-  const hasHtml = Boolean(item.outputHtml);
-  const pairs = hasHtml ? null : editPairs(item);
-  const written = hasHtml ? null : writeContent(item);
-  const hasDiff = pairs !== null || written !== null;
-  
-  // Check if tool has formatted output (either HTML from extension or __pi_render envelope)
-  const formattedOutput = item.output ? getFormattedToolOutput(item.output) : undefined;
-  const hasFormattedOutput = Boolean(formattedOutput);
-  // Stable plugin references to prevent ReactMarkdown re-renders
-  const markdownPlugins = useMemo(() => [remarkGfm, remarkMath], []);
-  const rehypePluginsMemo = useMemo(() => [rehypeKatex], []);
-  
-  // Start collapsed to show formatted output; expanded state shows raw JSON for inspection
-  // For edit/write tools with diffs, start expanded to show the diff
-  // For tools with HTML from extension, start expanded to show the rendered HTML
-  // For tools with formatted output, start collapsed to show the formatted MD
-  const [open, setOpen] = useState(hasDiff);
-  // Keep open state in sync when hasDiff changes mid-stream (e.g. tool output arrives after mount)
-  useEffect(() => { setOpen(hasDiff); }, [hasDiff]);
   const summary = argsSummary(item.args);
-  // In collapsed mode, show formatted MD output if available; otherwise show nothing
-  const showFormattedCollapsed = !open && hasFormattedOutput;
+  const Collapsed = presentation.Collapsed;
+  const showCollapsed =
+    !open && Collapsed !== undefined && (presentation.hasCollapsed?.(item) ?? true);
 
   return (
     <div
@@ -95,43 +64,29 @@ export function ToolCard({ item }: { item: ToolItem }) {
         )}
         <span className="ml-auto text-xs text-zinc-400 dark:text-zinc-600">{open ? "▾" : "▸"}</span>
       </button>
-      {showFormattedCollapsed && formattedOutput && (
+      {showCollapsed && Collapsed !== undefined && (
         <div className="border-t border-zinc-200 px-3 py-2 dark:border-zinc-800">
-          <div className="prose-chat max-h-96 overflow-auto text-zinc-700 dark:text-zinc-300">
-            <ReactMarkdown
-              remarkPlugins={markdownPlugins}
-              rehypePlugins={rehypePluginsMemo}
-            >
-              {normalizeMathDelimiters(formattedOutput)}
-            </ReactMarkdown>
-          </div>
+          <Collapsed item={item} dispatch={dispatch} />
         </div>
       )}
       {open && (
         <div className="border-t border-zinc-200 px-3 py-2 dark:border-zinc-800">
-          {pairs !== null && (
-            <div className="mb-2 flex flex-col gap-2">
-              {pairs.map((pair, i) => (
-                <SplitDiffBlock key={i} lines={diffLines(pair.oldText, pair.newText)} />
-              ))}
+          <presentation.Expanded item={item} dispatch={dispatch} />
+          {presentation.showsRawReveal === true && (
+            <div className="mt-2">
+              <button
+                type="button"
+                onClick={() => setShowRaw(!showRaw)}
+                className="text-xs text-zinc-400 hover:text-zinc-600 dark:text-zinc-600 dark:hover:text-zinc-400"
+              >
+                {showRaw ? "hide raw output" : "raw output"}
+              </button>
+              {showRaw && (
+                <div className="mt-1">
+                  <RawBody item={item} />
+                </div>
+              )}
             </div>
-          )}
-          {written !== null && (
-            <div className="mb-2">
-              <DiffBlock lines={written.split("\n").map((text) => ({ type: "add" as const, text }))} />
-            </div>
-          )}
-          
-          {item.outputHtml ? (
-            <RenderedHtml html={item.outputHtml} className="max-h-96 text-zinc-700 dark:text-zinc-300" />
-          ) : item.output ? (
-            <pre className="max-h-96 overflow-auto whitespace-pre-wrap font-mono text-xs text-zinc-700 dark:text-zinc-300">
-              {item.output}
-            </pre>
-          ) : (
-            <pre className="max-h-96 overflow-auto whitespace-pre-wrap font-mono text-xs text-zinc-700 dark:text-zinc-300">
-              {item.running ? "running…" : "(no output)"}
-            </pre>
           )}
         </div>
       )}

--- a/ui/src/presentations/CodeSearchView.tsx
+++ b/ui/src/presentations/CodeSearchView.tsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+import { countHits, parseSearchHits } from "./parseSearchHits";
+import { RawBody } from "./builtin";
+import type { PresentationProps, ToolItem } from "./types";
+
+const FILES_SHOWN = 8;
+const HITS_PER_FILE = 5;
+
+export function CodeSearchView({ item, dispatch }: PresentationProps) {
+  const groups = parseSearchHits(item.output ?? "");
+  const [showAll, setShowAll] = useState(false);
+
+  // Not a hit list — an error, a "no matches" note, or a format we do not read.
+  if (groups.length === 0) return <RawBody item={item} />;
+
+  const shown = showAll ? groups : groups.slice(0, FILES_SHOWN);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="text-xs text-zinc-500">
+        {countHits(groups)} match{countHits(groups) === 1 ? "" : "es"} in {groups.length} file
+        {groups.length === 1 ? "" : "s"}
+      </div>
+      {shown.map((group) => (
+        <div key={group.path} className="flex flex-col">
+          <button
+            type="button"
+            onClick={() => dispatch({ kind: "openFile", path: group.path })}
+            className="flex items-center gap-2 truncate text-left font-mono text-xs text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+          >
+            <span className="truncate">{group.path}</span>
+            <span className="shrink-0 text-zinc-400 dark:text-zinc-600">{group.hits.length}</span>
+          </button>
+          <div className="overflow-x-auto rounded border border-zinc-200 font-mono text-xs dark:border-zinc-800">
+            {group.hits.slice(0, HITS_PER_FILE).map((hit, i) => (
+              <div key={i} className="flex gap-2 px-2">
+                <span className="shrink-0 select-none text-zinc-400 dark:text-zinc-600">{hit.line}</span>
+                <span className="whitespace-pre text-zinc-700 dark:text-zinc-300">{hit.text}</span>
+              </div>
+            ))}
+            {group.hits.length > HITS_PER_FILE && (
+              <div className="px-2 text-zinc-400 dark:text-zinc-600">
+                +{group.hits.length - HITS_PER_FILE} more in this file
+              </div>
+            )}
+          </div>
+        </div>
+      ))}
+      {!showAll && groups.length > FILES_SHOWN && (
+        <button
+          type="button"
+          onClick={() => setShowAll(true)}
+          className="self-start text-xs text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300"
+        >
+          show {groups.length - FILES_SHOWN} more file{groups.length - FILES_SHOWN === 1 ? "" : "s"}
+        </button>
+      )}
+    </div>
+  );
+}
+
+export const codeSearchPresentation = {
+  id: "code-search",
+  match: (item: ToolItem) => item.toolName === "grep",
+  stable: true,
+  showsRawReveal: true,
+  Expanded: CodeSearchView,
+} as const;

--- a/ui/src/presentations/GitDiffView.tsx
+++ b/ui/src/presentations/GitDiffView.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+import { DiffBlock } from "../components/DiffBlocks";
+import { parseUnifiedDiff } from "./parseUnifiedDiff";
+import { RawBody } from "./builtin";
+import type { PresentationProps, ToolItem } from "./types";
+
+/** Anchored at the start of the command: a narrow claim, not a scan for diff-shaped text. */
+const GIT_DIFF_COMMAND = /^\s*git\s+(diff|show)\b/;
+
+export function gitDiffCommand(item: ToolItem): string | null {
+  if (item.toolName !== "bash" || item.args === null || typeof item.args !== "object") return null;
+  const command = (item.args as { command?: unknown }).command;
+  if (typeof command !== "string" || !GIT_DIFF_COMMAND.test(command)) return null;
+  return command;
+}
+
+const FILES_SHOWN = 6;
+
+function ActionButton({ onClick, children }: { onClick: () => void; children: string }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="rounded px-1.5 py-0.5 text-xs text-zinc-400 hover:bg-zinc-100 hover:text-zinc-700 dark:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+    >
+      {children}
+    </button>
+  );
+}
+
+export function GitDiffView({ item, dispatch }: PresentationProps) {
+  const files = parseUnifiedDiff(item.output ?? "");
+  const [showAll, setShowAll] = useState(false);
+
+  // Nothing recognizable as a diff: the command matched but the output did not.
+  if (files.length === 0) return <RawBody item={item} />;
+
+  const shown = showAll ? files : files.slice(0, FILES_SHOWN);
+
+  return (
+    <div className="flex flex-col gap-2">
+      {shown.map((file) => (
+        <div key={file.path} className="flex flex-col gap-1">
+          <div className="flex items-center gap-2">
+            <span className="truncate font-mono text-xs text-zinc-600 dark:text-zinc-400">{file.path}</span>
+            <span className="shrink-0 font-mono text-xs">
+              <span className="text-emerald-600 dark:text-emerald-400">+{file.added}</span>{" "}
+              <span className="text-red-600 dark:text-red-400">−{file.removed}</span>
+            </span>
+            <span className="ml-auto flex shrink-0 items-center">
+              <ActionButton onClick={() => dispatch({ kind: "openFile", path: file.path })}>open</ActionButton>
+              <ActionButton onClick={() => dispatch({ kind: "openFileHistory", path: file.path })}>history</ActionButton>
+            </span>
+          </div>
+          <DiffBlock lines={file.lines} />
+        </div>
+      ))}
+      {!showAll && files.length > FILES_SHOWN && (
+        <button
+          type="button"
+          onClick={() => setShowAll(true)}
+          className="self-start text-xs text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300"
+        >
+          show {files.length - FILES_SHOWN} more file{files.length - FILES_SHOWN === 1 ? "" : "s"}
+        </button>
+      )}
+    </div>
+  );
+}
+
+export const gitDiffPresentation = {
+  id: "git-diff",
+  match: (item: ToolItem) => gitDiffCommand(item) !== null,
+  stable: true,
+  showsRawReveal: true,
+  Expanded: GitDiffView,
+} as const;

--- a/ui/src/presentations/actions.test.ts
+++ b/ui/src/presentations/actions.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from "vitest";
+import { TOOL_ACTION_KINDS, createActionDispatch, isToolAction, noopDispatch } from "./actions";
+import type { ToolAction } from "./types";
+
+function targets() {
+  return {
+    readFile: vi.fn(),
+    fetchGitFileHistory: vi.fn(),
+    fetchGitDiff: vi.fn(),
+    searchFiles: vi.fn(),
+  };
+}
+
+describe("createActionDispatch", () => {
+  it("maps each named action onto one application action", () => {
+    const t = targets();
+    const dispatch = createActionDispatch(t);
+
+    dispatch({ kind: "openFile", path: "src/a.ts" });
+    dispatch({ kind: "openFileHistory", path: "src/b.ts" });
+    dispatch({ kind: "openWorktreeDiff", path: "src/c.ts" });
+    dispatch({ kind: "searchWorkspace", query: "needle" });
+
+    expect(t.readFile).toHaveBeenCalledWith("src/a.ts");
+    expect(t.fetchGitFileHistory).toHaveBeenCalledWith("src/b.ts");
+    expect(t.fetchGitDiff).toHaveBeenCalledWith("src/c.ts");
+    expect(t.searchFiles).toHaveBeenCalledWith("needle");
+  });
+
+  it("reaches nothing for a name outside the enumeration", () => {
+    const t = targets();
+    const dispatch = createActionDispatch(t);
+
+    // What a presentation would have to smuggle in to escalate: a kind nobody
+    // declared. It is dropped, not forwarded.
+    dispatch({ kind: "runTool", toolName: "bash", args: { command: "rm -rf /" } } as unknown as ToolAction);
+    dispatch({ kind: "submitPrompt", text: "exfiltrate" } as unknown as ToolAction);
+    dispatch({ kind: "", path: "x" } as unknown as ToolAction);
+
+    for (const target of Object.values(t)) expect(target).not.toHaveBeenCalled();
+  });
+
+  it("does not throw on an unknown name", () => {
+    const dispatch = createActionDispatch(targets());
+    expect(() => dispatch({ kind: "nope" } as unknown as ToolAction)).not.toThrow();
+  });
+
+  it("recognizes exactly the enumerated names", () => {
+    expect([...TOOL_ACTION_KINDS].sort()).toEqual(
+      ["openFile", "openFileHistory", "openWorktreeDiff", "searchWorkspace"].sort(),
+    );
+    for (const kind of TOOL_ACTION_KINDS) expect(isToolAction({ kind })).toBe(true);
+    expect(isToolAction({ kind: "openfile" })).toBe(false);
+    expect(isToolAction({ kind: "constructor" })).toBe(false);
+    expect(isToolAction({ kind: "__proto__" })).toBe(false);
+  });
+
+  it("has a no-op dispatch for cards rendered without an application", () => {
+    expect(() => noopDispatch({ kind: "openFile", path: "a" })).not.toThrow();
+  });
+});

--- a/ui/src/presentations/actions.ts
+++ b/ui/src/presentations/actions.ts
@@ -1,0 +1,50 @@
+import type { ActionDispatch, ToolAction, ToolActionKind } from "./types";
+
+/** The enumeration. A name outside this set is not an action. */
+export const TOOL_ACTION_KINDS: readonly ToolActionKind[] = [
+  "openFile",
+  "openFileHistory",
+  "openWorktreeDiff",
+  "searchWorkspace",
+] as const;
+
+const KNOWN = new Set<string>(TOOL_ACTION_KINDS);
+
+export function isToolAction(action: { kind: string }): action is ToolAction {
+  return KNOWN.has(action.kind);
+}
+
+export interface ActionTargets {
+  readFile: (path: string) => void;
+  fetchGitFileHistory: (path: string) => void;
+  fetchGitDiff: (path: string) => void;
+  searchFiles: (query: string) => void;
+}
+
+/**
+ * Maps a named action onto the application actions that already exist. A name
+ * outside the enumeration reaches nothing: no target is called and no message
+ * leaves the client.
+ */
+export function createActionDispatch(targets: ActionTargets): ActionDispatch {
+  return (action) => {
+    if (!isToolAction(action)) return;
+    switch (action.kind) {
+      case "openFile":
+        targets.readFile(action.path);
+        return;
+      case "openFileHistory":
+        targets.fetchGitFileHistory(action.path);
+        return;
+      case "openWorktreeDiff":
+        targets.fetchGitDiff(action.path);
+        return;
+      case "searchWorkspace":
+        targets.searchFiles(action.query);
+        return;
+    }
+  };
+}
+
+/** No-op dispatch, for cards rendered outside an application that wires actions. */
+export const noopDispatch: ActionDispatch = () => {};

--- a/ui/src/presentations/builtin.tsx
+++ b/ui/src/presentations/builtin.tsx
@@ -1,0 +1,143 @@
+import { useMemo } from "react";
+import ReactMarkdown from "react-markdown";
+import rehypeKatex from "rehype-katex";
+import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import { normalizeMathDelimiters } from "../util/markdownMath";
+import { getFormattedToolOutput, parseLooseJson } from "../util/toolOutput";
+import { diffLines } from "../util/diff";
+import { DiffBlock, SplitDiffBlock } from "../components/DiffBlocks";
+import { RenderedHtml } from "../components/RenderedHtml";
+import { formatOrientSummary } from "./orientSummary";
+import type { PresentationProps, ToolItem } from "./types";
+
+/** Markdown as tool cards render it: GFM, math, KaTeX, stable plugin identity. */
+export function ToolMarkdown({ text }: { text: string }) {
+  const remarkPlugins = useMemo(() => [remarkGfm, remarkMath], []);
+  const rehypePlugins = useMemo(() => [rehypeKatex], []);
+  return (
+    <div className="prose-chat max-h-96 overflow-auto text-zinc-700 dark:text-zinc-300">
+      <ReactMarkdown remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins}>
+        {normalizeMathDelimiters(text)}
+      </ReactMarkdown>
+    </div>
+  );
+}
+
+/**
+ * The tool's own output, inert. Never parsed as markup — this is the untrusted
+ * channel (see design.md, decision 3).
+ */
+export function RawBody({ item }: { item: ToolItem }) {
+  return (
+    <pre className="max-h-96 overflow-auto whitespace-pre-wrap font-mono text-xs text-zinc-700 dark:text-zinc-300">
+      {item.output ? item.output : item.running ? "running…" : "(no output)"}
+    </pre>
+  );
+}
+
+export const rawPresentation = {
+  id: "raw",
+  match: () => true,
+  stable: false,
+  Expanded: RawBody,
+} as const;
+
+/* ── Extension-rendered ─────────────────────────────────────────────────────── */
+
+export const extensionHtmlPresentation = {
+  id: "extension-html",
+  match: (item: ToolItem) => Boolean(item.outputHtml),
+  stable: false,
+  extensionOwned: true,
+  showsRawReveal: true,
+  // Only the compact rendering is a preview. An extension that supplied none gets
+  // the folded header alone, as before — the full body is not a summary of itself.
+  hasCollapsed: (item: ToolItem) => Boolean(item.outputHtmlCollapsed),
+  Collapsed: ({ item }: PresentationProps) => (
+    <RenderedHtml html={item.outputHtmlCollapsed ?? ""} className="max-h-96 text-zinc-700 dark:text-zinc-300" />
+  ),
+  Expanded: ({ item }: PresentationProps) => (
+    <RenderedHtml html={item.outputHtml ?? ""} className="max-h-96 text-zinc-700 dark:text-zinc-300" />
+  ),
+} as const;
+
+/* ── File edit ──────────────────────────────────────────────────────────────── */
+
+/** The edit tool's before/after pairs, when this call has them. */
+export function editPairs(item: ToolItem): { oldText: string; newText: string }[] | null {
+  if (item.toolName !== "edit" || item.args === null || typeof item.args !== "object") return null;
+  const edits = (item.args as { edits?: unknown }).edits;
+  if (!Array.isArray(edits)) return null;
+  const pairs = edits.filter(
+    (e): e is { oldText: string; newText: string } =>
+      e !== null &&
+      typeof e === "object" &&
+      typeof (e as Record<string, unknown>).oldText === "string" &&
+      typeof (e as Record<string, unknown>).newText === "string",
+  );
+  return pairs.length > 0 ? pairs : null;
+}
+
+export const fileEditPresentation = {
+  id: "file-edit",
+  match: (item: ToolItem) => editPairs(item) !== null,
+  stable: true,
+  startsExpanded: true,
+  showsRawReveal: true,
+  Expanded: ({ item }: PresentationProps) => (
+    <div className="flex flex-col gap-2">
+      {(editPairs(item) ?? []).map((pair, i) => (
+        <SplitDiffBlock key={i} lines={diffLines(pair.oldText, pair.newText)} />
+      ))}
+    </div>
+  ),
+} as const;
+
+/* ── File write ─────────────────────────────────────────────────────────────── */
+
+/** The write tool's new content (rendered as an all-additions diff). */
+export function writeContent(item: ToolItem): string | null {
+  if (item.toolName !== "write" || item.args === null || typeof item.args !== "object") return null;
+  const content = (item.args as { content?: unknown }).content;
+  return typeof content === "string" ? content : null;
+}
+
+export const fileWritePresentation = {
+  id: "file-write",
+  match: (item: ToolItem) => writeContent(item) !== null,
+  stable: true,
+  startsExpanded: true,
+  showsRawReveal: true,
+  Expanded: ({ item }: PresentationProps) => (
+    <DiffBlock lines={(writeContent(item) ?? "").split("\n").map((text) => ({ type: "add" as const, text }))} />
+  ),
+} as const;
+
+/* ── Render envelope ────────────────────────────────────────────────────────── */
+
+/**
+ * A tool that declared its own display text. Shown folded, as it was before the
+ * registry existed: the summary is the preview, the raw output is the detail.
+ */
+export const renderEnvelopePresentation = {
+  id: "pi-render",
+  match: (item: ToolItem) => (item.output ? getFormattedToolOutput(item.output) !== undefined : false),
+  stable: false,
+  Collapsed: ({ item }: PresentationProps) => (
+    <ToolMarkdown text={getFormattedToolOutput(item.output ?? "") ?? ""} />
+  ),
+  Expanded: RawBody,
+} as const;
+
+/* ── Orient summary (vendor-shaped) ─────────────────────────────────────────── */
+
+export const orientSummaryPresentation = {
+  id: "orient-summary",
+  match: (item: ToolItem) => (item.output ? formatOrientSummary(parseLooseJson(item.output)) !== undefined : false),
+  stable: false,
+  Collapsed: ({ item }: PresentationProps) => (
+    <ToolMarkdown text={formatOrientSummary(parseLooseJson(item.output ?? "")) ?? ""} />
+  ),
+  Expanded: RawBody,
+} as const;

--- a/ui/src/presentations/orientSummary.test.ts
+++ b/ui/src/presentations/orientSummary.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { formatOrientSummary } from "./orientSummary";
+import { parseLooseJson } from "../util/toolOutput";
+
+/** These cases moved here from `toolOutput.test.ts` with the formatting itself. */
+function format(output: string): string | undefined {
+  return formatOrientSummary(parseLooseJson(output));
+}
+
+describe("formatOrientSummary", () => {
+  it("formats an object with task and title", () => {
+    const result = format(JSON.stringify({ task: "Refactor", title: "Extract Module", summary: "Moved code" }));
+    expect(result).toContain("**Refactor**");
+    expect(result).toContain("**Extract Module**");
+    expect(result).toContain("Moved code");
+  });
+
+  it("formats the search mode and the summary", () => {
+    expect(format(JSON.stringify({ searchMode: "semantic", summary: "Four call sites." }))).toBe(
+      "Mode: semantic\nFour call sites.",
+    );
+  });
+
+  it("formats relevantFiles", () => {
+    const result = format(JSON.stringify({ relevantFiles: ["a.ts", "b.ts", "c.ts"] }));
+    expect(result).toContain("Relevant files:");
+    expect(result).toContain("- a.ts");
+    expect(result).toContain("- b.ts");
+  });
+
+  it("limits relevantFiles to 5 entries", () => {
+    const files = Array.from({ length: 10 }, (_, i) => `file${i}.ts`);
+    const result = format(JSON.stringify({ relevantFiles: files }));
+    expect(result!.match(/- file/g)).toHaveLength(5);
+  });
+
+  it("formats relevantFunctions with name and filePath", () => {
+    const result = format(
+      JSON.stringify({ relevantFunctions: [{ name: "foo", filePath: "a.ts" }, { name: "bar", filePath: "b.ts" }] }),
+    );
+    expect(result).toContain("foo (a.ts)");
+    expect(result).toContain("bar (b.ts)");
+  });
+
+  it("formats nextSteps", () => {
+    const result = format(JSON.stringify({ nextSteps: ["Step 1", "Step 2"] }));
+    expect(result).toContain("Next steps:");
+    expect(result).toContain("- Step 1");
+  });
+
+  it("formats nextStepsText the same way as nextSteps", () => {
+    expect(format(JSON.stringify({ title: "Orient", nextStepsText: ["read the spec", "run the tests"] }))).toContain(
+      "- read the spec",
+    );
+  });
+
+  it("caps the long lists at five entries", () => {
+    const many = ["a", "b", "c", "d", "e", "f", "g"];
+    const output = JSON.stringify({ title: "T", nextSteps: many, relevantFunctions: many.map((name) => ({ name })) });
+    const formatted = format(output) ?? "";
+    expect(formatted).toContain("- e");
+    expect(formatted).not.toContain("- f");
+  });
+
+  it("names a function whose file is reported under `file` rather than `filePath`", () => {
+    expect(format(JSON.stringify({ relevantFunctions: [{ name: "runGit", file: "server/src/git.ts" }] }))).toContain(
+      "- runGit (server/src/git.ts)",
+    );
+  });
+
+  it("says the file is unknown rather than printing undefined", () => {
+    expect(format(JSON.stringify({ relevantFunctions: [{ name: "runGit" }] }))).toContain("- runGit (unknown)");
+  });
+
+  it("falls back to the raw value for a function that is not an object", () => {
+    expect(format(JSON.stringify({ relevantFunctions: ["runGit"] }))).toContain("- runGit");
+  });
+
+  it("formats a truncated payload from what survived", () => {
+    const base = JSON.stringify({ task: "Analysis", searchMode: "deep", relevantFiles: ["a.ts", "b.ts"] });
+    const result = format(`${base}\n… [truncated, 1234 more chars]`);
+    expect(result).toContain("**Analysis**");
+    expect(result).toContain("deep");
+    expect(result).toContain("a.ts");
+  });
+
+  it("does not apply to an object with none of the recognized fields", () => {
+    expect(format(JSON.stringify({ raw: "data", value: 42 }))).toBeUndefined();
+  });
+
+  it("does not apply to content that never parsed", () => {
+    expect(format("plain text output")).toBeUndefined();
+    expect(format("42")).toBeUndefined();
+    expect(format('"a bare string"')).toBeUndefined();
+  });
+});

--- a/ui/src/presentations/orientSummary.ts
+++ b/ui/src/presentations/orientSummary.ts
@@ -1,0 +1,53 @@
+/**
+ * Formats the openlore `orient()` payload as readable markdown.
+ *
+ * This is deliberately vendor-shaped: the field list below is one tool family's
+ * response, not a general convention. It lives here, behind a named match in the
+ * registry, rather than inside a generically-named utility where it silently
+ * claimed every JSON result carrying a `title` or `summary` key.
+ */
+
+const LIST_CAP = 5;
+
+interface FunctionRef {
+  name?: unknown;
+  filePath?: unknown;
+  file?: unknown;
+}
+
+function describeFunction(entry: unknown): string {
+  if (entry !== null && typeof entry === "object" && (entry as FunctionRef).name) {
+    const ref = entry as FunctionRef;
+    return `- ${String(ref.name)} (${String(ref.filePath ?? ref.file ?? "unknown")})`;
+  }
+  return `- ${String(entry)}`;
+}
+
+function pushList(lines: string[], heading: string, value: unknown, format: (entry: unknown) => string) {
+  if (!Array.isArray(value) || value.length === 0) return;
+  lines.push(`\n${heading}`);
+  for (const entry of value.slice(0, LIST_CAP)) lines.push(format(entry));
+}
+
+/**
+ * Returns the markdown summary for a parsed tool result, or `undefined` when the
+ * result carries none of the recognized fields — which is the signal that this
+ * presentation does not apply.
+ */
+export function formatOrientSummary(parsed: unknown): string | undefined {
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+  const record = parsed as Record<string, unknown>;
+  const lines: string[] = [];
+
+  if (record.task) lines.push(`**${String(record.task)}**`);
+  if (record.searchMode) lines.push(`Mode: ${String(record.searchMode)}`);
+  if (record.title) lines.push(`**${String(record.title)}**`);
+  if (record.summary) lines.push(String(record.summary));
+  pushList(lines, "Relevant files:", record.relevantFiles, (f) => `- ${String(f)}`);
+  pushList(lines, "Relevant functions:", record.relevantFunctions, describeFunction);
+  pushList(lines, "Next steps:", record.nextSteps, (s) => `- ${String(s)}`);
+  pushList(lines, "Next steps:", record.nextStepsText, (s) => `- ${String(s)}`);
+
+  const summary = lines.join("\n").trim();
+  return summary === "" ? undefined : summary;
+}

--- a/ui/src/presentations/parseSearchHits.ts
+++ b/ui/src/presentations/parseSearchHits.ts
@@ -1,0 +1,45 @@
+export interface SearchHit {
+  line: number;
+  text: string;
+}
+
+export interface SearchFileGroup {
+  path: string;
+  hits: SearchHit[];
+}
+
+/** `path:line:text`, where the path may itself contain colons on Windows-style drives. */
+const HIT = /^(.*?):(\d+):(.*)$/;
+
+/**
+ * Groups `path:line:text` search output by file, preserving the order files were
+ * first seen.
+ *
+ * Returns an empty array when no line matches, which the presentation reads as
+ * "this is not a hit list" and falls back to the raw output. A search that
+ * genuinely found nothing also yields an empty array — the raw output says so
+ * better than an empty file list would.
+ */
+export function parseSearchHits(output: string): SearchFileGroup[] {
+  const groups: SearchFileGroup[] = [];
+  const byPath = new Map<string, SearchFileGroup>();
+
+  for (const raw of output.split("\n")) {
+    const match = HIT.exec(raw);
+    if (match === null) continue;
+    const [, path, line, text] = match;
+    if (path === "") continue;
+    let group = byPath.get(path);
+    if (group === undefined) {
+      group = { path, hits: [] };
+      byPath.set(path, group);
+      groups.push(group);
+    }
+    group.hits.push({ line: Number(line), text });
+  }
+  return groups;
+}
+
+export function countHits(groups: SearchFileGroup[]): number {
+  return groups.reduce((total, group) => total + group.hits.length, 0);
+}

--- a/ui/src/presentations/parseUnifiedDiff.ts
+++ b/ui/src/presentations/parseUnifiedDiff.ts
@@ -1,0 +1,89 @@
+import type { DiffLine } from "../util/diff";
+
+export interface DiffFile {
+  /** Worktree-relative path, taken from the `b/` side unless the file was deleted. */
+  path: string;
+  lines: DiffLine[];
+  added: number;
+  removed: number;
+}
+
+/** Strips one leading `a/` or `b/` prefix; `/dev/null` becomes null. */
+function stripPrefix(raw: string): string | null {
+  const path = raw.trim();
+  if (path === "/dev/null" || path === "") return null;
+  return path.replace(/^[ab]\//, "");
+}
+
+/**
+ * Parses `git diff` / `git show` output into per-file line lists.
+ *
+ * Deliberately tolerant: anything outside a hunk (commit headers, mode changes,
+ * binary notices) is skipped rather than rejected, so a `git show` result parses
+ * the same way a bare diff does. A result with no recognizable hunk yields an
+ * empty array, which the presentation treats as "not a diff after all".
+ */
+export function parseUnifiedDiff(output: string): DiffFile[] {
+  const files: DiffFile[] = [];
+  let current: DiffFile | null = null;
+  let pendingOld: string | null = null;
+  let inHunk = false;
+
+  const push = () => {
+    if (current && current.lines.length > 0) files.push(current);
+    current = null;
+  };
+
+  for (const line of output.split("\n")) {
+    if (line.startsWith("diff --git ")) {
+      push();
+      inHunk = false;
+      pendingOld = null;
+      // `diff --git a/x b/x` — take the b-side, which survives a rename.
+      const match = /^diff --git (.+?) (.+)$/.exec(line);
+      const path = match ? (stripPrefix(match[2]) ?? stripPrefix(match[1])) : null;
+      current = path === null ? null : { path, lines: [], added: 0, removed: 0 };
+      continue;
+    }
+    if (line.startsWith("--- ")) {
+      inHunk = false;
+      pendingOld = stripPrefix(line.slice(4));
+      continue;
+    }
+    if (line.startsWith("+++ ")) {
+      inHunk = false;
+      const path = stripPrefix(line.slice(4)) ?? pendingOld;
+      // A diff without a `diff --git` header (plain `diff -u`) still names its file here.
+      if (path !== null && (current === null || current.lines.length > 0)) {
+        push();
+        current = { path, lines: [], added: 0, removed: 0 };
+      } else if (path !== null && current !== null) {
+        current.path = path;
+      }
+      continue;
+    }
+    if (line.startsWith("@@")) {
+      inHunk = current !== null;
+      continue;
+    }
+    if (!inHunk || current === null) continue;
+
+    if (line.startsWith("+")) {
+      current.lines.push({ type: "add", text: line.slice(1) });
+      current.added++;
+    } else if (line.startsWith("-")) {
+      current.lines.push({ type: "del", text: line.slice(1) });
+      current.removed++;
+    } else if (line.startsWith(" ")) {
+      current.lines.push({ type: "same", text: line.slice(1) });
+    } else if (line.startsWith("\\")) {
+      // "\ No newline at end of file" — not a content line.
+      continue;
+    } else {
+      // Anything else ends the hunk (next file header, commit trailer, blank tail).
+      inHunk = false;
+    }
+  }
+  push();
+  return files;
+}

--- a/ui/src/presentations/registry.test.ts
+++ b/ui/src/presentations/registry.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import { PRESENTATIONS, selectPresentation } from "./registry";
+import type { ToolItem } from "./types";
+
+function tool(partial: Partial<ToolItem>): ToolItem {
+  return {
+    kind: "tool",
+    toolName: "bash",
+    running: false,
+    isError: false,
+    ...partial,
+  } as ToolItem;
+}
+
+const GIT_DIFF_OUTPUT = [
+  "diff --git a/a.ts b/a.ts",
+  "--- a/a.ts",
+  "+++ b/a.ts",
+  "@@ -1,2 +1,2 @@",
+  "-old",
+  "+new",
+].join("\n");
+
+describe("selectPresentation", () => {
+  it("is total: an unknown tool with no output still gets a presentation", () => {
+    expect(selectPresentation(tool({ toolName: "nope" })).id).toBe("raw");
+  });
+
+  it("ends with an entry that matches unconditionally", () => {
+    const last = PRESENTATIONS[PRESENTATIONS.length - 1];
+    expect(last.id).toBe("raw");
+    expect(last.match(tool({ toolName: "anything" }))).toBe(true);
+  });
+
+  it("gives every entry a distinct id", () => {
+    const ids = PRESENTATIONS.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("lets an extension's own rendering outrank a built-in one", () => {
+    const item = tool({
+      toolName: "edit",
+      args: { edits: [{ oldText: "a", newText: "b" }] },
+      outputHtml: "<div>rendered</div>",
+    });
+    expect(selectPresentation(item).id).toBe("extension-html");
+  });
+
+  it("picks the file-edit presentation from args alone", () => {
+    const item = tool({ toolName: "edit", args: { edits: [{ oldText: "a", newText: "b" }] } });
+    expect(selectPresentation(item).id).toBe("file-edit");
+  });
+
+  it("picks the file-write presentation from args alone", () => {
+    expect(selectPresentation(tool({ toolName: "write", args: { content: "x" } })).id).toBe("file-write");
+  });
+
+  it("picks the git-diff presentation for a git diff command", () => {
+    const item = tool({ args: { command: "git diff --stat" }, output: GIT_DIFF_OUTPUT });
+    expect(selectPresentation(item).id).toBe("git-diff");
+  });
+
+  it("does not claim a command that merely mentions a diff", () => {
+    const item = tool({ args: { command: "echo git diff" }, output: GIT_DIFF_OUTPUT });
+    expect(selectPresentation(item).id).toBe("raw");
+  });
+
+  it("picks the code-search presentation for the grep tool", () => {
+    expect(selectPresentation(tool({ toolName: "grep", args: { pattern: "x" } })).id).toBe("code-search");
+  });
+
+  it("picks the render envelope over the raw fallback", () => {
+    const item = tool({ toolName: "custom", output: JSON.stringify({ __pi_render: { text: "# hi" } }) });
+    expect(selectPresentation(item).id).toBe("pi-render");
+  });
+
+  it("picks the vendor summary only when no envelope is present", () => {
+    const orient = tool({ toolName: "orient", output: JSON.stringify({ title: "Orient", summary: "s" }) });
+    expect(selectPresentation(orient).id).toBe("orient-summary");
+
+    const both = tool({
+      toolName: "orient",
+      output: JSON.stringify({ __pi_render: { text: "envelope" }, title: "Orient", summary: "s" }),
+    });
+    expect(selectPresentation(both).id).toBe("pi-render");
+  });
+
+  describe("malformed input", () => {
+    it("declines rather than throws on args of the wrong shape", () => {
+      for (const args of [null, "a string", 42, [], { edits: "not an array" }, { content: 7 }]) {
+        expect(() => selectPresentation(tool({ toolName: "edit", args } as Partial<ToolItem>))).not.toThrow();
+      }
+      expect(selectPresentation(tool({ toolName: "edit", args: { edits: [{ oldText: 1 }] } })).id).toBe("raw");
+    });
+
+    it("declines rather than throws when reading args throws", () => {
+      const args = new Proxy(
+        {},
+        {
+          get() {
+            throw new Error("boom");
+          },
+        },
+      );
+      const item = tool({ toolName: "edit", args });
+      expect(() => selectPresentation(item)).not.toThrow();
+      expect(selectPresentation(item).id).toBe("raw");
+    });
+
+    it("declines rather than throws on output that is not the JSON it looks like", () => {
+      const item = tool({ toolName: "custom", output: '{"__pi_render": {"text": ' });
+      expect(() => selectPresentation(item)).not.toThrow();
+      expect(selectPresentation(item).id).toBe("raw");
+    });
+  });
+
+  describe("stability while streaming", () => {
+    it("keeps a specialized choice when the output lands", () => {
+      const running = tool({ args: { command: "git diff" }, running: true });
+      const chosen = selectPresentation(running);
+      expect(chosen.id).toBe("git-diff");
+
+      const done = tool({ args: { command: "git diff" }, output: "fatal: not a git repository" });
+      expect(selectPresentation(done, chosen.id).id).toBe("git-diff");
+    });
+
+    it("widens the raw fallback once output gives something better to show", () => {
+      const running = tool({ toolName: "custom", running: true });
+      expect(selectPresentation(running).id).toBe("raw");
+
+      const done = tool({ toolName: "custom", output: JSON.stringify({ __pi_render: { text: "hi" } }) });
+      expect(selectPresentation(done, "raw").id).toBe("pi-render");
+    });
+
+    it("yields to an extension rendering that arrives after the choice was made", () => {
+      const done = tool({
+        args: { command: "git diff" },
+        output: GIT_DIFF_OUTPUT,
+        outputHtml: "<div>rendered</div>",
+      });
+      expect(selectPresentation(done, "git-diff").id).toBe("extension-html");
+    });
+
+    it("drops a stale choice that no longer applies", () => {
+      const item = tool({ toolName: "bash", args: { command: "ls" }, output: "a\nb" });
+      expect(selectPresentation(item, "git-diff").id).toBe("raw");
+    });
+
+    it("ignores a previous id that is not in the table", () => {
+      const item = tool({ toolName: "grep", args: { pattern: "x" } });
+      expect(selectPresentation(item, "removed-long-ago").id).toBe("code-search");
+    });
+  });
+});

--- a/ui/src/presentations/registry.ts
+++ b/ui/src/presentations/registry.ts
@@ -1,0 +1,72 @@
+import {
+  extensionHtmlPresentation,
+  fileEditPresentation,
+  fileWritePresentation,
+  orientSummaryPresentation,
+  rawPresentation,
+  renderEnvelopePresentation,
+} from "./builtin";
+import { gitDiffPresentation } from "./GitDiffView";
+import { codeSearchPresentation } from "./CodeSearchView";
+import type { Presentation, ToolItem } from "./types";
+
+/**
+ * The ordered table from design.md. First match wins, so order is the priority:
+ * an extension's own rendering outranks a built-in one, a specific tool identity
+ * outranks a shape guess, and the last entry matches unconditionally so selection
+ * is total.
+ */
+export const PRESENTATIONS: readonly Presentation[] = [
+  extensionHtmlPresentation,
+  fileEditPresentation,
+  fileWritePresentation,
+  gitDiffPresentation,
+  codeSearchPresentation,
+  renderEnvelopePresentation,
+  orientSummaryPresentation,
+  rawPresentation,
+];
+
+function firstMatch(item: ToolItem): Presentation {
+  for (const presentation of PRESENTATIONS) {
+    let matched = false;
+    try {
+      matched = presentation.match(item);
+    } catch {
+      // A matcher that throws on a malformed result declines it; it never breaks
+      // the card, and the error stays out of the conversation.
+      matched = false;
+    }
+    if (matched) return presentation;
+  }
+  // Unreachable: the last entry matches unconditionally. Kept so the signature is
+  // total by construction rather than by convention.
+  return rawPresentation;
+}
+
+/**
+ * Chooses the presentation for a tool call.
+ *
+ * `previousId` is the presentation already on screen, if any. A specialized
+ * choice made while the call was running is not revoked when its output lands —
+ * otherwise the card would swap renderer under the reader (design.md, decision 2).
+ * Two things may still override it: an extension's own rendering, which outranks
+ * a built-in guess, and any entry replacing the raw fallback, which is a widening.
+ */
+export function selectPresentation(item: ToolItem, previousId?: string): Presentation {
+  const next = firstMatch(item);
+  if (previousId === undefined || previousId === next.id) return next;
+
+  const previous = PRESENTATIONS.find((p) => p.id === previousId);
+  if (previous === undefined || previous.id === rawPresentation.id) return next;
+  if (next.extensionOwned === true) return next;
+
+  // Keep the established choice while it still applies.
+  let stillMatches = false;
+  try {
+    stillMatches = previous.match(item);
+  } catch {
+    stillMatches = false;
+  }
+  return stillMatches ? previous : next;
+}

--- a/ui/src/presentations/types.ts
+++ b/ui/src/presentations/types.ts
@@ -1,0 +1,60 @@
+import type { ComponentType } from "react";
+import type { ChatItem } from "@pi-outpost/shared";
+
+export type ToolItem = Extract<ChatItem, { kind: "tool" }>;
+
+/**
+ * The closed set of things a presentation may ask the application to do.
+ * A presentation names an action; it never constructs a wire message, never
+ * invokes a tool, and never submits a prompt — that escalation path is closed
+ * by construction rather than by an approval prompt (see design.md, decision 4).
+ */
+export type ToolAction =
+  | { kind: "openFile"; path: string }
+  | { kind: "openFileHistory"; path: string }
+  | { kind: "openWorktreeDiff"; path: string }
+  | { kind: "searchWorkspace"; query: string };
+
+export type ToolActionKind = ToolAction["kind"];
+
+/** Runs a named action. Unknown names are dropped, not sent. */
+export type ActionDispatch = (action: ToolAction) => void;
+
+export interface PresentationProps {
+  item: ToolItem;
+  dispatch: ActionDispatch;
+}
+
+/**
+ * One entry of the ordered registry. `Collapsed` is the preview shown while the
+ * card is folded; `Expanded` is the body shown when it is open. A presentation
+ * that reshapes its result sets `showsRawReveal` so the original output stays
+ * reachable from the expanded body.
+ */
+export interface Presentation {
+  id: string;
+  match: (item: ToolItem) => boolean;
+  /**
+   * True when `match` reads only `toolName`/`args` — both known at tool_start,
+   * so the choice cannot change when output arrives.
+   */
+  stable: boolean;
+  /**
+   * True when an installed extension supplied this rendering. Such an entry may
+   * replace an already-chosen presentation once output lands: the extension owns
+   * the tool's presentation more authoritatively than our built-in guess.
+   */
+  extensionOwned?: boolean;
+  /** Card opens expanded (the body is the point of the card, as for a diff). */
+  startsExpanded?: boolean;
+  /** The expanded body reshapes the output, so offer the original alongside it. */
+  showsRawReveal?: boolean;
+  /**
+   * Whether `Collapsed` has anything to show for this call. Defaults to "yes,
+   * whenever `Collapsed` exists"; an entry whose preview depends on a field that
+   * may be absent answers per item so the card does not grow an empty panel.
+   */
+  hasCollapsed?: (item: ToolItem) => boolean;
+  Collapsed?: ComponentType<PresentationProps>;
+  Expanded: ComponentType<PresentationProps>;
+}

--- a/ui/src/presentations/views.test.tsx
+++ b/ui/src/presentations/views.test.tsx
@@ -1,0 +1,185 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { CodeSearchView, codeSearchPresentation } from "./CodeSearchView";
+import { GitDiffView, gitDiffCommand, gitDiffPresentation } from "./GitDiffView";
+import { parseSearchHits, countHits } from "./parseSearchHits";
+import { parseUnifiedDiff } from "./parseUnifiedDiff";
+import type { ToolItem } from "./types";
+
+vi.mock("../components/DiffBlocks", () => ({
+  DiffBlock: ({ lines }: any) => <div data-testid="diff-block">{lines.length} lines</div>,
+  SplitDiffBlock: ({ lines }: any) => <div data-testid="split-diff-block">{lines.length} lines</div>,
+}));
+
+function tool(partial: Partial<ToolItem>): ToolItem {
+  return { kind: "tool", toolName: "bash", running: false, isError: false, ...partial } as ToolItem;
+}
+
+const DIFF = [
+  "diff --git a/src/a.ts b/src/a.ts",
+  "index 111..222 100644",
+  "--- a/src/a.ts",
+  "+++ b/src/a.ts",
+  "@@ -1,3 +1,3 @@",
+  " keep",
+  "-old",
+  "+new",
+  "+also new",
+  "diff --git a/src/b.ts b/src/b.ts",
+  "--- /dev/null",
+  "+++ b/src/b.ts",
+  "@@ -0,0 +1,1 @@",
+  "+created",
+].join("\n");
+
+describe("parseUnifiedDiff", () => {
+  it("splits per file and counts additions and removals", () => {
+    const files = parseUnifiedDiff(DIFF);
+    expect(files.map((f) => f.path)).toEqual(["src/a.ts", "src/b.ts"]);
+    expect(files[0]).toMatchObject({ added: 2, removed: 1 });
+    expect(files[0].lines).toHaveLength(4);
+    expect(files[1]).toMatchObject({ added: 1, removed: 0 });
+  });
+
+  it("reads a git show result, commit header and all", () => {
+    const show = ["commit abc123", "Author: Someone", "", "    a message", "", DIFF].join("\n");
+    expect(parseUnifiedDiff(show).map((f) => f.path)).toEqual(["src/a.ts", "src/b.ts"]);
+  });
+
+  it("yields nothing for output that is not a diff", () => {
+    expect(parseUnifiedDiff("fatal: not a git repository")).toEqual([]);
+    expect(parseUnifiedDiff("")).toEqual([]);
+  });
+});
+
+describe("gitDiffCommand", () => {
+  it("claims only a command that starts with git diff or git show", () => {
+    expect(gitDiffCommand(tool({ args: { command: "git diff" } }))).toBe("git diff");
+    expect(gitDiffCommand(tool({ args: { command: "  git show HEAD" } }))).toBe("  git show HEAD");
+    expect(gitDiffCommand(tool({ args: { command: "git difftool" } }))).toBeNull();
+    expect(gitDiffCommand(tool({ args: { command: "echo git diff" } }))).toBeNull();
+    expect(gitDiffCommand(tool({ toolName: "read", args: { command: "git diff" } }))).toBeNull();
+    expect(gitDiffCommand(tool({ args: null }))).toBeNull();
+  });
+});
+
+describe("GitDiffView", () => {
+  it("shows a header per file with its added and removed counts", () => {
+    render(<GitDiffView item={tool({ args: { command: "git diff" }, output: DIFF })} dispatch={vi.fn()} />);
+
+    expect(screen.getByText("src/a.ts")).toBeInTheDocument();
+    expect(screen.getByText("src/b.ts")).toBeInTheDocument();
+    expect(screen.getByText("+2")).toBeInTheDocument();
+    expect(screen.getByText("−1")).toBeInTheDocument();
+    expect(screen.getAllByTestId("diff-block")).toHaveLength(2);
+  });
+
+  it("names an action rather than acting: open and history dispatch by path", () => {
+    const dispatch = vi.fn();
+    render(<GitDiffView item={tool({ args: { command: "git diff" }, output: DIFF })} dispatch={dispatch} />);
+
+    fireEvent.click(screen.getAllByText("open")[0]);
+    fireEvent.click(screen.getAllByText("history")[0]);
+
+    expect(dispatch).toHaveBeenNthCalledWith(1, { kind: "openFile", path: "src/a.ts" });
+    expect(dispatch).toHaveBeenNthCalledWith(2, { kind: "openFileHistory", path: "src/a.ts" });
+  });
+
+  it("falls back to the raw output when the command matched but the output is not a diff", () => {
+    const { container } = render(
+      <GitDiffView item={tool({ args: { command: "git diff" }, output: "fatal: not a git repository" })} dispatch={vi.fn()} />,
+    );
+    expect(container.querySelector("pre")?.textContent).toBe("fatal: not a git repository");
+  });
+
+  it("holds back the tail of a large diff behind one reveal", () => {
+    const many = Array.from({ length: 9 }, (_, i) =>
+      [`diff --git a/src/f${i}.ts b/src/f${i}.ts`, `--- a/src/f${i}.ts`, `+++ b/src/f${i}.ts`, "@@ -1 +1 @@", "+x"].join("\n"),
+    ).join("\n");
+    render(<GitDiffView item={tool({ args: { command: "git diff" }, output: many })} dispatch={vi.fn()} />);
+
+    expect(screen.queryByText("src/f8.ts")).toBeNull();
+    fireEvent.click(screen.getByText("show 3 more files"));
+    expect(screen.getByText("src/f8.ts")).toBeInTheDocument();
+  });
+
+  it("matches on the command alone, before any output exists", () => {
+    expect(gitDiffPresentation.match(tool({ args: { command: "git diff" }, running: true }))).toBe(true);
+    expect(gitDiffPresentation.stable).toBe(true);
+  });
+});
+
+const HITS = [
+  "src/a.ts:12:const needle = 1;",
+  "src/a.ts:40:  needle();",
+  "src/b.ts:3:// needle",
+  "not a hit line",
+].join("\n");
+
+describe("parseSearchHits", () => {
+  it("groups by file in first-seen order", () => {
+    const groups = parseSearchHits(HITS);
+    expect(groups.map((g) => g.path)).toEqual(["src/a.ts", "src/b.ts"]);
+    expect(groups[0].hits).toEqual([
+      { line: 12, text: "const needle = 1;" },
+      { line: 40, text: "  needle();" },
+    ]);
+    expect(countHits(groups)).toBe(3);
+  });
+
+  it("yields nothing for output with no path:line:text lines", () => {
+    expect(parseSearchHits("No matches found")).toEqual([]);
+  });
+});
+
+describe("CodeSearchView", () => {
+  it("counts matches and files", () => {
+    render(<CodeSearchView item={tool({ toolName: "grep", output: HITS })} dispatch={vi.fn()} />);
+    expect(screen.getByText("3 matches in 2 files")).toBeInTheDocument();
+  });
+
+  it("opens a file by dispatching, not by messaging the server", () => {
+    const dispatch = vi.fn();
+    render(<CodeSearchView item={tool({ toolName: "grep", output: HITS })} dispatch={dispatch} />);
+
+    fireEvent.click(screen.getByText("src/b.ts"));
+    expect(dispatch).toHaveBeenCalledWith({ kind: "openFile", path: "src/b.ts" });
+  });
+
+  it("falls back to the raw output when nothing parses as a hit", () => {
+    const { container } = render(
+      <CodeSearchView item={tool({ toolName: "grep", output: "No matches found" })} dispatch={vi.fn()} />,
+    );
+    expect(container.querySelector("pre")?.textContent).toBe("No matches found");
+  });
+
+  it("holds back the tail of a long hit list behind one reveal", () => {
+    const many = Array.from({ length: 10 }, (_, i) => `src/f${i}.ts:1:hit`).join("\n");
+    render(<CodeSearchView item={tool({ toolName: "grep", output: many })} dispatch={vi.fn()} />);
+
+    expect(screen.queryByText("src/f9.ts")).toBeNull();
+    fireEvent.click(screen.getByText("show 2 more files"));
+    expect(screen.getByText("src/f9.ts")).toBeInTheDocument();
+  });
+
+  it("caps the hits shown per file and says how many it kept back", () => {
+    const many = Array.from({ length: 7 }, (_, i) => `src/a.ts:${i + 1}:hit`).join("\n");
+    render(<CodeSearchView item={tool({ toolName: "grep", output: many })} dispatch={vi.fn()} />);
+
+    expect(screen.getByText("+2 more in this file")).toBeInTheDocument();
+  });
+
+  it("matches on the tool identity alone, before any output exists", () => {
+    expect(codeSearchPresentation.match(tool({ toolName: "grep", running: true }))).toBe(true);
+    expect(codeSearchPresentation.match(tool({ toolName: "bash", output: HITS }))).toBe(false);
+    expect(codeSearchPresentation.stable).toBe(true);
+  });
+
+  it("keeps matched text inert — a hit that looks like markup stays text", () => {
+    const { container } = render(
+      <CodeSearchView item={tool({ toolName: "grep", output: "src/a.ts:1:<script>alert(1)</script>" })} dispatch={vi.fn()} />,
+    );
+    expect(container.querySelector("script")).toBeNull();
+    expect(container).toHaveTextContent("<script>alert(1)</script>");
+  });
+});

--- a/ui/src/util/toolOutput.test.ts
+++ b/ui/src/util/toolOutput.test.ts
@@ -1,63 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { getFormattedToolOutput } from "./toolOutput";
+import { getFormattedToolOutput, parseLooseJson } from "./toolOutput";
 
 describe("getFormattedToolOutput", () => {
   it("returns undefined for non-JSON content", () => {
     expect(getFormattedToolOutput("plain text output")).toBeUndefined();
   });
 
-  it("renderes __pi_render envelope", () => {
+  it("renders the __pi_render envelope", () => {
     const result = getFormattedToolOutput(JSON.stringify({ __pi_render: { text: "Rendered content" } }));
     expect(result).toBe("Rendered content");
-  });
-
-  it("formats an object with task and title", () => {
-    const result = getFormattedToolOutput(JSON.stringify({ task: "Refactor", title: "Extract Module", summary: "Moved code" }));
-    expect(result).toContain("**Refactor**");
-    expect(result).toContain("**Extract Module**");
-    expect(result).toContain("Moved code");
-  });
-
-  it("formats relevantFiles", () => {
-    const result = getFormattedToolOutput(JSON.stringify({ relevantFiles: ["a.ts", "b.ts", "c.ts"] }));
-    expect(result).toContain("Relevant files:");
-    expect(result).toContain("- a.ts");
-    expect(result).toContain("- b.ts");
-  });
-
-  it("limits relevantFiles to 5 entries", () => {
-    const files = Array.from({ length: 10 }, (_, i) => `file${i}.ts`);
-    const result = getFormattedToolOutput(JSON.stringify({ relevantFiles: files }));
-    const matches = result!.match(/- file/g);
-    expect(matches).toHaveLength(5);
-  });
-
-  it("formats relevantFunctions with name and filePath", () => {
-    const result = getFormattedToolOutput(JSON.stringify({
-      relevantFunctions: [{ name: "foo", filePath: "a.ts" }, { name: "bar", filePath: "b.ts" }],
-    }));
-    expect(result).toContain("foo (a.ts)");
-    expect(result).toContain("bar (b.ts)");
-  });
-
-  it("formats nextSteps", () => {
-    const result = getFormattedToolOutput(JSON.stringify({ nextSteps: ["Step 1", "Step 2"] }));
-    expect(result).toContain("Next steps:");
-    expect(result).toContain("- Step 1");
-  });
-
-  it("returns undefined for pure JSON with no formatted fields", () => {
-    const result = getFormattedToolOutput(JSON.stringify({ raw: "data", value: 42 }));
-    expect(result).toBeUndefined();
-  });
-
-  it("handles truncated JSON output", () => {
-    const base = JSON.stringify({ task: "Analysis", searchMode: "deep", relevantFiles: ["a.ts", "b.ts"] });
-    const truncated = base + "\n… [truncated, 1234 more chars]";
-    const result = getFormattedToolOutput(truncated);
-    expect(result).toContain("**Analysis**");
-    expect(result).toContain("deep");
-    expect(result).toContain("a.ts");
   });
 
   it("returns undefined for empty output", () => {
@@ -67,71 +18,11 @@ describe("getFormattedToolOutput", () => {
   it("returns a bare JSON string as-is", () => {
     expect(getFormattedToolOutput('"simple string"')).toBe("simple string");
   });
-});
 
-/**
- * The recovery paths: what happens when the tool's JSON never finished arriving.
- * These are the branches that decide between showing a partial summary and showing
- * nothing, and they are the ones a malformed payload actually reaches.
- */
-describe("getFormattedToolOutput — partial and unusual payloads", () => {
-  it("formats the search mode and the summary", () => {
-    const output = JSON.stringify({ searchMode: "semantic", summary: "Four call sites." });
-    expect(getFormattedToolOutput(output)).toBe("Mode: semantic\nFour call sites.");
-  });
-
-  it("formats nextStepsText the same way as nextSteps", () => {
-    const output = JSON.stringify({ title: "Orient", nextStepsText: ["read the spec", "run the tests"] });
-    expect(getFormattedToolOutput(output)).toContain("- read the spec");
-  });
-
-  it("caps the long lists at five entries", () => {
-    const many = ["a", "b", "c", "d", "e", "f", "g"];
-    const output = JSON.stringify({ title: "T", nextSteps: many, relevantFunctions: many.map((name) => ({ name })) });
-    const formatted = getFormattedToolOutput(output) ?? "";
-    expect(formatted).toContain("- e");
-    expect(formatted).not.toContain("- f");
-  });
-
-  it("names a function whose file is reported under `file` rather than `filePath`", () => {
-    const output = JSON.stringify({ relevantFunctions: [{ name: "runGit", file: "server/src/git.ts" }] });
-    expect(getFormattedToolOutput(output)).toContain("- runGit (server/src/git.ts)");
-  });
-
-  it("says the file is unknown rather than printing undefined", () => {
-    const output = JSON.stringify({ relevantFunctions: [{ name: "runGit" }] });
-    expect(getFormattedToolOutput(output)).toContain("- runGit (unknown)");
-  });
-
-  it("falls back to the raw value for a function that is not an object", () => {
-    const output = JSON.stringify({ relevantFunctions: ["runGit"] });
-    expect(getFormattedToolOutput(output)).toContain("- runGit");
-  });
-
-  it("recovers a complete object followed by trailing rubbish", () => {
-    // A tool that appended a log line after its JSON: the object is intact, so the
-    // summary should still be shown rather than dropped for the trailing bytes
-    const output = `${JSON.stringify({ title: "Orient", summary: "Two hits." })}\nwarning: cache stale`;
-    expect(getFormattedToolOutput(output)).toBe("**Orient**\nTwo hits.");
-  });
-
-  it("shows nothing rather than a guess when the outer object never closed", () => {
-    // The brace-counting recovery needs a closing brace for the outermost object.
-    // A payload cut off before that has no prefix that parses, so there is nothing
-    // honest to show — better empty than a summary invented from half a field.
-    const output = '{"title":"Orient","summary":"Two hits.","relevantFiles":["a.ts","b.t';
-    expect(getFormattedToolOutput(output)).toBeUndefined();
-  });
-
-  it("recovers the object when the truncation landed after it closed", () => {
-    const output = '{"title":"Orient","summary":"Two hits."} trailing bytes {"partial":';
-    expect(getFormattedToolOutput(output)).toContain("Two hits.");
-  });
-
-  it("gives up rather than guessing when nothing parses", () => {
-    expect(getFormattedToolOutput('{"title": "Orient"')).toBeUndefined();
-    expect(getFormattedToolOutput("{{{{")).toBeUndefined();
-    expect(getFormattedToolOutput("plain text output")).toBeUndefined();
+  it("returns undefined for a JSON object carrying no envelope", () => {
+    // Formatting a particular vendor's payload belongs to a presentation, not here
+    expect(getFormattedToolOutput(JSON.stringify({ title: "Orient", summary: "Two hits." }))).toBeUndefined();
+    expect(getFormattedToolOutput(JSON.stringify({ raw: "data", value: 42 }))).toBeUndefined();
   });
 
   it("returns nothing for a JSON value that is not an object or string", () => {
@@ -140,8 +31,63 @@ describe("getFormattedToolOutput — partial and unusual payloads", () => {
     expect(getFormattedToolOutput("true")).toBeUndefined();
   });
 
-  it("prefers the render envelope over the fields beside it", () => {
-    const output = JSON.stringify({ __pi_render: { text: "rendered" }, title: "ignored" });
-    expect(getFormattedToolOutput(output)).toBe("rendered");
+  it("reads the envelope out of a truncated payload", () => {
+    const base = JSON.stringify({ __pi_render: { text: "Rendered content" } });
+    expect(getFormattedToolOutput(`${base}\n… [truncated, 1234 more chars]`)).toBe("Rendered content");
+  });
+});
+
+/**
+ * The recovery paths: what happens when the tool's JSON never finished arriving.
+ * These are the branches that decide between showing a partial summary and showing
+ * nothing, and they are the ones a malformed payload actually reaches.
+ */
+describe("parseLooseJson", () => {
+  it("parses a well-formed object", () => {
+    expect(parseLooseJson('{"title":"Orient"}')).toEqual({ title: "Orient" });
+  });
+
+  it("strips the truncation suffix before parsing", () => {
+    const base = JSON.stringify({ task: "Analysis", searchMode: "deep" });
+    expect(parseLooseJson(`${base}\n… [truncated, 1234 more chars]`)).toEqual({
+      task: "Analysis",
+      searchMode: "deep",
+    });
+  });
+
+  it("recovers a complete object followed by trailing rubbish", () => {
+    // A tool that appended a log line after its JSON: the object is intact, so the
+    // summary should still be shown rather than dropped for the trailing bytes
+    const output = `${JSON.stringify({ title: "Orient", summary: "Two hits." })}\nwarning: cache stale`;
+    expect(parseLooseJson(output)).toEqual({ title: "Orient", summary: "Two hits." });
+  });
+
+  it("recovers the object when the truncation landed after it closed", () => {
+    const output = '{"title":"Orient","summary":"Two hits."} trailing bytes {"partial":';
+    expect(parseLooseJson(output)).toEqual({ title: "Orient", summary: "Two hits." });
+  });
+
+  it("gives up rather than guessing when the outer object never closed", () => {
+    // The brace-counting recovery needs a closing brace for the outermost object.
+    // A payload cut off before that has no prefix that parses, so there is nothing
+    // honest to show — better empty than a summary invented from half a field.
+    expect(parseLooseJson('{"title":"Orient","summary":"Two hits.","relevantFiles":["a.ts","b.t')).toBeUndefined();
+  });
+
+  it("gives up when a brace inside a string makes the count lie", () => {
+    // Brace counting does not know about string literals: it sees the outer object
+    // close early. The slice it hands to JSON.parse is invalid, and an invalid
+    // slice yields nothing rather than a partial object.
+    expect(parseLooseJson('{"pattern":"}"')).toBeUndefined();
+  });
+
+  it("gives up when only a nested object ever closed", () => {
+    expect(parseLooseJson('{"a": {"b": 1}, "c": ')).toBeUndefined();
+  });
+
+  it("gives up rather than guessing when nothing parses", () => {
+    expect(parseLooseJson('{"title": "Orient"')).toBeUndefined();
+    expect(parseLooseJson("{{{{")).toBeUndefined();
+    expect(parseLooseJson("plain text output")).toBeUndefined();
   });
 });

--- a/ui/src/util/toolOutput.ts
+++ b/ui/src/util/toolOutput.ts
@@ -1,114 +1,76 @@
-/** Extract formatted user-facing text from tool output.
- * Checks for authoritative __pi_render envelope first, otherwise returns undefined.
- * For openlore tools, also formats known fields as readable markdown.
- * Handles truncated JSON by stripping the truncation suffix before parsing.
- * Falls back to brace-counting recovery for mid-truncation cases.
- * Returns undefined only for non-JSON or completely unparseable content.
+/**
+ * Parse a tool result that is meant to be JSON but may not have finished arriving.
+ *
+ * Strips the truncation suffix the server appends, then falls back to
+ * brace-counting so an object followed by trailing bytes still parses. Returns
+ * `undefined` when nothing honest can be recovered — a half-parsed object is
+ * never returned as if it were complete.
+ *
+ * Exported so presentations parse a tool result the same way instead of each
+ * re-implementing the recovery.
  */
-export function getFormattedToolOutput(output: string): string | undefined {
-  // Try to parse as JSON - handle truncated output by stripping the truncation suffix
-  let jsonToParse = output;
+export function parseLooseJson(output: string): unknown {
   const truncationMarker = "\n… [truncated,";
-  if (output.includes(truncationMarker)) {
-    jsonToParse = output.split(truncationMarker)[0];
+  const jsonToParse = output.includes(truncationMarker)
+    ? output.split(truncationMarker)[0]
+    : output;
+
+  try {
+    return JSON.parse(jsonToParse);
+  } catch {
+    // Not valid on its own — try to recover a complete object from the front.
   }
 
-  // Helper to format a parsed JSON object
-  const formatParsedObject = (parsed: Record<string, unknown>): string | undefined => {
-    const lines: string[] = [];
-    if (parsed.task) lines.push(`**${String(parsed.task)}**`);
-    if (parsed.searchMode) lines.push(`Mode: ${String(parsed.searchMode)}`);
-    if (parsed.title) lines.push(`**${String(parsed.title)}**`);
-    if (parsed.summary) lines.push(String(parsed.summary));
-    if (Array.isArray(parsed.relevantFiles) && parsed.relevantFiles.length > 0) {
-      lines.push("\nRelevant files:");
-      for (const f of (parsed.relevantFiles as string[]).slice(0, 5)) lines.push(`- ${f}`);
-    }
-    if (Array.isArray(parsed.relevantFunctions) && parsed.relevantFunctions.length > 0) {
-      lines.push("\nRelevant functions:");
-      for (const fn of (parsed.relevantFunctions as any[]).slice(0, 5)) {
-        if (fn && fn.name) lines.push(`- ${fn.name} (${fn.filePath ?? fn.file ?? "unknown"})`);
-        else lines.push(`- ${String(fn)}`);
+  let braceCount = 0;
+  let lastCompleteIndex = -1;
+  let lastClosingIndex = -1;
+  for (let i = 0; i < jsonToParse.length; i++) {
+    if (jsonToParse[i] === "{") braceCount++;
+    if (jsonToParse[i] === "}") {
+      braceCount--;
+      lastClosingIndex = i;
+      if (braceCount === 0) {
+        lastCompleteIndex = i;
+        break;
       }
     }
-    if (Array.isArray(parsed.nextSteps) && parsed.nextSteps.length > 0) {
-      lines.push("\nNext steps:");
-      for (const s of (parsed.nextSteps as string[]).slice(0, 5)) lines.push(`- ${s}`);
-    }
-    if (Array.isArray(parsed.nextStepsText) && parsed.nextStepsText.length > 0) {
-      lines.push("\nNext steps:");
-      for (const s of (parsed.nextStepsText as string[]).slice(0, 5)) lines.push(`- ${s}`);
-    }
-    const summary = lines.join("\n").trim();
-    if (summary) return summary;
-
-    // No formatted output for pure JSON - return undefined to show nothing in collapsed state
-    return undefined;
-  };
-
-  // First, try to parse as valid JSON
-  try {
-    const parsed = JSON.parse(jsonToParse);
-    if (parsed && typeof parsed === "object") {
-      // Check for authoritative __pi_render envelope first
-      if (parsed.__pi_render?.text) {
-        return String(parsed.__pi_render.text);
-      }
-
-      return formatParsedObject(parsed as Record<string, unknown>);
-    }
-    // If parsed is a string, return it as-is (could be already formatted markdown)
-    if (typeof parsed === "string") {
-      return parsed;
-    }
-  } catch {
-    // Not JSON or parse error - try to fix truncated JSON by finding the last valid closing brace
   }
 
-  // Try brace-counting recovery: find a valid JSON substring by counting braces
-  // First pass: look for a complete object (braceCount === 0)
-  try {
-    let braceCount = 0;
-    let lastCompleteIndex = -1;
-    let lastClosingIndex = -1;
-
-    for (let i = 0; i < jsonToParse.length; i++) {
-      if (jsonToParse[i] === "{") braceCount++;
-      if (jsonToParse[i] === "}") {
-        braceCount--;
-        lastClosingIndex = i; // Track the last closing brace we see
-        if (braceCount === 0) {
-          lastCompleteIndex = i;
-          break; // Found the matching closing brace for the outermost object
-        }
-      }
+  // The outermost object closed: everything after it is trailing noise.
+  if (lastCompleteIndex > 0) {
+    try {
+      return JSON.parse(jsonToParse.slice(0, lastCompleteIndex + 1));
+    } catch {
+      return undefined;
     }
+  }
 
-    // First, try the complete object if found
-    if (lastCompleteIndex > 0) {
-      const validJson = jsonToParse.slice(0, lastCompleteIndex + 1);
-      const parsed = JSON.parse(validJson);
-      if (parsed && typeof parsed === "object") {
-        return formatParsedObject(parsed as Record<string, unknown>);
-      }
+  // The outermost object never closed. A nested one might still stand alone.
+  if (lastClosingIndex > 0) {
+    try {
+      return JSON.parse(jsonToParse.slice(0, lastClosingIndex + 1));
+    } catch {
+      return undefined;
     }
-
-    // If no complete object found, try using the last closing brace we saw
-    // This handles cases where JSON is truncated mid-object
-    if (lastClosingIndex > 0 && lastCompleteIndex === -1) {
-      const validJson = jsonToParse.slice(0, lastClosingIndex + 1);
-      try {
-        const parsed = JSON.parse(validJson);
-        if (parsed && typeof parsed === "object") {
-          return formatParsedObject(parsed as Record<string, unknown>);
-        }
-      } catch {
-        // Still can't parse this fragment
-      }
-    }
-  } catch {
-    // Still can't parse
   }
 
   return undefined;
+}
+
+/**
+ * The user-facing text a tool declared for itself, via the authoritative
+ * `__pi_render` envelope. A bare JSON string is already display text and is
+ * returned as-is.
+ *
+ * Returns `undefined` for anything else, including a JSON object with no
+ * envelope — formatting a particular tool vendor's payload is a presentation's
+ * job, not this utility's.
+ */
+export function getFormattedToolOutput(output: string): string | undefined {
+  const parsed = parseLooseJson(output);
+  if (typeof parsed === "string") return parsed;
+  if (parsed === null || typeof parsed !== "object") return undefined;
+  const envelope = (parsed as { __pi_render?: { text?: unknown } }).__pi_render;
+  if (envelope?.text === undefined || envelope.text === null) return undefined;
+  return String(envelope.text);
 }


### PR DESCRIPTION
## Why

`ToolCard` dispatched on tool output inline: an `outputHtml` branch, an edit/write diff
branch, a `__pi_render` branch, and a `<pre>` fallback, all in one component. Adding a
renderer meant editing that chain — and the chain had grown a vendor-specific formatter
nobody had specified: `getFormattedToolOutput` formatted openlore's `orient()` payload for
*any* tool whose JSON happened to carry a `title` or `summary` key.

## What changes

An ordered table of presentations, matched first-wins and total by construction (the last
entry matches unconditionally). Selection is stable while streaming: a presentation chosen
at `tool_start` is never revoked when output lands, so a card cannot swap renderer under the
reader. One exception, and it is deliberate — an extension's own rendering may replace a
built-in guess, because it is a claim rather than a heuristic.

Two presentations are new:

- **git diff** — `bash` with a command anchored on `git diff` / `git show`, parsed into
  per-file blocks with `+n`/`−n` counts and an `open` / `history` action per file.
- **code search** — the `grep` tool, hits grouped by file, each path opening the file.

Presentations name an action from a **closed enumeration** mapped onto existing `useAgent`
actions. They cannot construct a wire message, invoke a tool, or submit a prompt. That
closes the escalation path by construction, which matters here because there is no
per-tool-call approval boundary anywhere in this codebase.

Also in scope:

- `getFormattedToolOutput` is narrowed to the `__pi_render` envelope and exports its
  truncation recovery; the openlore field formatting moves to its own registry row, where
  its coupling is visible.
- `item.outputHtmlCollapsed` is finally consumed for the folded state — the server has been
  producing it and the client throwing it away.

## Verification

Full UI suite green, coverage gate green, `openspec validate --strict` passes.
`ToolCard.test.tsx` passes **unmodified**, which was the point: this is an extraction.

Manually exercised in the running app: raw fallback, git-diff (real hunks *and* the
`--stat` case that falls back inside the presentation), file-write, file-edit, the
`open`/`history` actions, the raw-output reveal, and a `<script>` in tool output rendering
as inert text with `window.__pwned` never defined.

Spec: `openspec/changes/add-tool-result-presentations/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)