### PR TITLE
Create a file or folder from the Files tree

### DIFF
--- a/openspec/changes/add-file-creation-from-tree/.openspec.yaml
+++ b/openspec/changes/add-file-creation-from-tree/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-13

--- a/openspec/changes/add-file-creation-from-tree/design.md
+++ b/openspec/changes/add-file-creation-from-tree/design.md
@@ -1,0 +1,129 @@
+## Context
+
+See `proposal.md` — Why. What shapes the approach:
+
+- **`write_file` refuses a missing path on purpose.** `writeFileFromBrowser` stats the target and
+  answers `conflict` when it is gone: that is how a concurrent move is caught rather than
+  papered over. Creation cannot ride on that message without turning its guard into a flag.
+- **Confinement already exists and must not be re-implemented.** `resolveConfined` (symlink-safe,
+  root-relative) plus the writable-zone check are the two gates every browser write passes. A new
+  operation reuses both, or it is a new hole.
+- **The tree already refreshes itself.** The server broadcasts `file_changed`; `useAgent` re-lists
+  the parent directory of the changed path when that directory is open, refetches an open viewer,
+  and refreshes Git status. Creation needs no new refresh mechanism — only the broadcast.
+- **The tree already has a row control convention.** The `@` reference button appears on hover,
+  stays visible on touch (`[@media(hover:hover)]:opacity-0`), and sits inside a `group` row. A
+  second control follows it rather than inventing a placement.
+- **The tree already knows what is writable.** `isReadOnly(fullPath, writableRoot)` dims entries
+  outside the writable zone; the creation control asks the same function.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One server-side creation path per kind (file, directory), sharing every check with the write path.
+- A name is typed where the file will land, so the destination is never ambiguous.
+- A refusal is shown where the name was typed, with the typed name intact.
+
+**Non-Goals:**
+- Rename, delete, move. They act on files an agent may be mid-read of, and they need an answer for
+  the open viewer and the running turn — a separate change.
+- Creating parent directories implicitly (`mkdir -p`). One control, one directory.
+- Templates, scaffolds, or seeded content. An empty file is the primitive; the agent writes content.
+- Drag-and-drop upload into the tree.
+
+## Decisions
+
+### D1 — Two new messages, not a flag on `write_file`
+
+`create_file` and `create_directory` join the client protocol, answered by the existing
+`file_written` / `file_browser_error` pair.
+
+*Alternative — `write_file` with `create: true`.* One message fewer. Rejected: the mtime-conflict
+guard exists precisely because a missing file is suspicious, and a boolean that suspends it is a
+guard with an off switch. Two intents, two messages, and `write_file` keeps refusing what it
+refuses today.
+
+### D2 — Creation reuses the write path's checks, in the same order
+
+`createFileFromBrowser(root, writableRel, relPath)` in `fileBrowser.ts`, beside
+`writeFileFromBrowser`, running the same sequence: read-only sandbox → `resolveConfined` →
+writable-zone containment → existence. Only the tail differs: where the write path demands the file
+exist, creation demands it does not.
+
+`fs.writeFile(resolved, "", { flag: "wx" })` and `fs.mkdir(resolved)` (no `recursive`) do the
+existence check *and* the creation in one syscall — a separate `stat` first would be a
+time-of-check/time-of-use gap. The `EEXIST` becomes the `conflict` error; `ENOENT` (missing parent)
+becomes `not-found`.
+
+### D3 — A name is a name
+
+The final segment is validated on both sides: no `/` or `\`, not `.` or `..`, not empty or
+whitespace-only, and no NUL. The client validation is for the message shown while typing; the
+server validation is the one that counts, and it runs before anything touches the filesystem.
+
+This is belt and braces over `resolveConfined`, which already refuses an escape — but a name
+carrying a separator is a mistake worth naming precisely ("that is a path, not a name") rather than
+a generic confinement refusal.
+
+### D4 — The input lives in the tree
+
+Activating `+` on a directory row inserts an input row as that directory's first child, at its
+indentation. Enter confirms, Escape cancels, blur cancels. A single control creates both kinds: a
+name ending in `/` is a directory, anything else a file — one keystroke rather than a second
+button, and it matches how the same intent is expressed on a command line.
+
+The trailing slash is not discoverable on its own, so the input's placeholder says it:
+`name, or name/ for a folder`.
+
+*Alternative — a modal dialog.* Rejected: the destination would have to be restated in the dialog,
+and the tree is already showing it. *Alternative — a second `+📁` control.* Rejected: two controls
+on every writable row, in a tree where one control already had to be hidden until hover.
+
+### D5 — What happens next differs by kind
+
+A created file opens in the viewer in edit mode: the client already has the path, size and mtime
+from the answer, which is exactly what the editor needs to save without a read round trip. A
+created directory expands instead — there is nothing to open, and the next action is usually to
+create something inside it.
+
+### D6 — Optimism is not worth it here
+
+The tree waits for the server's answer and the `file_changed` broadcast rather than inserting the
+row immediately. Creation is a single local `write`; the round trip is a few milliseconds, and an
+optimistic row would need its own removal path for every refusal.
+
+### D7 — Success is a signal, not an inference
+
+*Added after the first manual test, which found the bug.* The input first closed itself by watching
+the parent listing for the typed name. That reads as success — and it is exactly what a **refused
+duplicate** looks like: the name is in the listing precisely because something is already there. So
+retyping an existing name silently dismissed the input and showed no refusal at all.
+
+The client state now carries `created`, the path the last creation actually produced, set from the
+server's own answer (`file_written` or a directory listing under a `create:` request id) and
+cleared when the next attempt starts. The input closes on that and nothing else.
+
+The general shape of the mistake is worth naming: *inferring an outcome from a side effect that the
+failure case also produces.* A regression test pins it — refused duplicate, listing unchanged,
+input and message still on screen.
+
+## Risks / Trade-offs
+
+- **A user-typed name becomes a path segment** → validated on both sides (D3) and confined by
+  `resolveConfined` regardless; the server never trusts the client's validation.
+- **Case-insensitive filesystems** (macOS default): creating `Readme.md` beside `README.md` fails
+  with `EEXIST` even though the tree shows no such name → the conflict message names the existing
+  entry rather than claiming the name is free.
+- **`file_changed` carries a path, and the client refreshes only if that path's parent is open** →
+  true already; a directory created in a collapsed part of the tree simply appears when it is
+  expanded.
+- **A creation control on every writable directory row** adds a second hover affordance to a tree
+  that already hides one → both use the same reveal rule, and the row stays a single flex line.
+- **Newly created files are untracked**, so the Git badge machinery marks them immediately. Nothing
+  to do, but it is the visible difference between a file created here and one the agent wrote.
+
+## Migration Plan
+
+Additive: two new client messages, two new server functions, one new tree control. Older clients
+never send the messages; a server without them answers an unknown message the way it does today.
+Rolling back is removing the handlers and the control.

--- a/openspec/changes/add-file-creation-from-tree/proposal.md
+++ b/openspec/changes/add-file-creation-from-tree/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+The file browser can open, edit, and save a file, and the tree shows Git badges for files that do
+not exist yet on any branch — but there is no way to make one. `writeFileFromBrowser` refuses a
+path that is not already a file (`conflict`), by design: that refusal is the guard against
+clobbering a file someone else moved. So the only way to create a file today is to ask the agent
+to do it, which needs write tools enabled and turns "add an empty note" into a prompt.
+
+Creating a file where you are already looking is the missing half of a file browser.
+
+## What Changes
+
+- **A `+` control on a writable directory row**, shown on hover the way the existing `@` reference
+  control is, and always visible on touch. Activating it opens an input line in the tree at that
+  directory: type a name, Enter creates, Escape cancels.
+- **Creating a directory** from the same control, so a new file can go somewhere new.
+- **New protocol messages** `create_file` and `create_directory`. `write_file` is left alone: its
+  refusal of a missing path is a safety property, not an oversight.
+- **A created file opens in the viewer, in edit mode** — creating a file is wanting to write in it.
+  A created directory expands in the tree instead.
+- **Creation is confined exactly like a write**: inside the browser root, inside the writable zone,
+  symlinks resolved. An existing name is refused rather than truncated.
+
+Not in this change: renaming, deleting, moving, file templates, and creating anything outside the
+writable zone. Rename and delete act on files the agent may be reading — they deserve their own
+change, with their own answer for what happens to an open viewer and a running turn.
+
+## Capabilities
+
+### New Capabilities
+
+*(none — this extends the existing file-browser capability)*
+
+### Modified Capabilities
+- `file`: gains creation of a file and of a directory from the browser, under the same confinement
+  and writable-zone rules as `WriteFileFromBrowser`, plus the tree-side flow that names them.
+- `api`: gains the `create_file` and `create_directory` client messages and their answers.
+- `components`: `WorkspaceAndGitNavigation` — `FileTree` gains a creation affordance and reports
+  the requested path through a callback, like every other mutation it surfaces.
+
+## Impact
+
+**Server**: `server/src/fileBrowser.ts` (two new functions beside `writeFileFromBrowser`, reusing
+`resolveConfined` and the writable-zone check — never a new confinement path),
+`server/src/index.ts` (two message handlers, each broadcasting `file_changed` so every connected
+client's tree refreshes through the machinery that already exists).
+
+**Shared**: `shared/src/protocol.ts` — two client messages; the existing `file_browser_error`
+carries the failures, with `conflict` reused for "that name is taken".
+
+**UI**: `ui/src/components/FileTree.tsx` (the control and the inline input row),
+`ui/src/components/Sidebar.tsx` and `ui/src/App.tsx` (wiring), `ui/src/useAgent.ts` (the two
+actions and their optimistic tree refresh).
+
+**Security**: a user-supplied *name* becomes a path segment. The server resolves and confines it as
+it does for any other path, and both sides reject separators and `.`/`..` — a name is a name, not
+a route.

--- a/openspec/changes/add-file-creation-from-tree/specs/api/spec.md
+++ b/openspec/changes/add-file-creation-from-tree/specs/api/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: CreateEntryMessages
+
+The WebSocket protocol SHALL carry a `create_file` and a `create_directory` client message, each
+naming a path relative to the browser root and a request id. The server SHALL answer a successful
+`create_file` with the same message that answers a write — path, size and mtime — so the client can
+open the new file without a second round trip, and a successful `create_directory` with a directory
+listing of its parent or an equivalent acknowledgement.
+
+A refusal SHALL be reported as a file-browser error carrying the request id and a machine-readable
+reason, reusing the existing set: `denied` outside the writable zone, `conflict` when the path
+exists, `outside-root` for a path that escapes.
+
+These messages SHALL NOT relax `write_file`. Its refusal of a path that is not already a file is
+the guard against writing over something that moved, and creation is a separate intent with its own
+message.
+
+#### Scenario: CreateFileMessage
+- **WHEN** a client sends `create_file` for a new path inside the writable zone
+- **THEN** the file is created and the client receives the written-file answer with its size and mtime
+
+#### Scenario: CreateDirectoryMessage
+- **WHEN** a client sends `create_directory` for a new path inside the writable zone
+- **THEN** the directory is created and the client is told so under the same request id
+
+#### Scenario: CreateRefusedCarriesReason
+- **WHEN** creation is refused because the path exists, is outside the writable zone, or escapes the root
+- **THEN** the client receives a file-browser error under that request id with the matching reason
+
+#### Scenario: WriteFileStillRefusesMissingPaths
+- **WHEN** `write_file` names a path that does not exist
+- **THEN** it is still refused as a conflict, as before

--- a/openspec/changes/add-file-creation-from-tree/specs/components/spec.md
+++ b/openspec/changes/add-file-creation-from-tree/specs/components/spec.md
@@ -1,0 +1,38 @@
+## MODIFIED Requirements
+
+### Requirement: WorkspaceAndGitNavigation
+
+The component layer SHALL provide `FileTree`, `FileViewer`, `Sidebar`, `GitMenu`,
+`GitCommitView`, and `GitFileHistory` for workspace and repository navigation. `FileTree` SHALL
+derive its presentation from supplied directory, writable-root, Git-status, open-file, and
+attachment state. `FileTree` SHALL surface creation of a file or directory only where the supplied
+writable-root state says writing is allowed, and SHALL report the requested path through a callback
+rather than performing it. `FileViewer` SHALL compose syntax highlighting, copy, diff, markdown, and
+workspace-path rendering components, and SHALL offer entry points to both the worktree diff and
+the file's history. `GitFileHistory` SHALL derive its presentation from supplied file-history and
+revision-pair state. Navigation and mutation requests SHALL be emitted through callbacks.
+
+#### Scenario: SelectWorkspaceFile
+- **GIVEN** a directory tree supplied to `FileTree`
+- **WHEN** the user selects a file
+- **THEN** `FileTree` reports the selected path through its file-selection callback
+
+#### Scenario: RequestFileCreation
+- **GIVEN** a writable directory in the tree supplied to `FileTree`
+- **WHEN** the user names a new file there and confirms
+- **THEN** `FileTree` reports the requested path through its creation callback and creates nothing itself
+
+#### Scenario: RenderFileContent
+- **GIVEN** file state supplied to `FileViewer`
+- **WHEN** the viewer displays the file
+- **THEN** it uses the applicable code, markdown, image, copy, or diff presentation support
+
+#### Scenario: InspectCommit
+- **GIVEN** Git status and log state supplied to `GitMenu`
+- **WHEN** the user selects a commit
+- **THEN** the selected SHA is reported for presentation by `GitCommitView`
+
+#### Scenario: InspectFileHistory
+- **GIVEN** file-history state supplied to `GitFileHistory`
+- **WHEN** the user picks two revisions
+- **THEN** the requested revision pair is reported through its diff-request callback

--- a/openspec/changes/add-file-creation-from-tree/specs/file/spec.md
+++ b/openspec/changes/add-file-creation-from-tree/specs/file/spec.md
@@ -1,0 +1,90 @@
+## ADDED Requirements
+
+### Requirement: CreateFileFromBrowser
+
+The system SHALL create an empty file at a path supplied by the browser, under exactly the
+permission rules that govern a write: refused when the sandbox is read-only, refused when the
+resolved path — symlinks included — falls outside the writable zone, and refused when it falls
+outside the browser root.
+
+A path that already exists SHALL be refused as a conflict. Creation MUST NOT truncate, replace, or
+otherwise modify anything that is already there.
+
+The final segment SHALL be a name, not a route: a segment containing a path separator, or equal to
+`.` or `..`, SHALL be refused. An empty or whitespace-only name SHALL be refused.
+
+On success the system SHALL report the new file's size and mtime, and SHALL notify connected
+clients that the path changed, so every open tree shows it.
+
+#### Scenario: CreateInsideWritableZone
+- **WHEN** creation is requested for a new path inside the writable zone
+- **THEN** an empty file exists at that path, its size and mtime are returned, and connected clients are notified
+
+#### Scenario: CreateOutsideWritableZone
+- **WHEN** creation is requested for a path outside the writable zone, or the sandbox is read-only
+- **THEN** it is refused as denied and nothing is created
+
+#### Scenario: CreateOutsideRoot
+- **WHEN** creation is requested for a path that resolves outside the browser root, by traversal or through a symlink
+- **THEN** it is refused and nothing is created
+
+#### Scenario: NameAlreadyTaken
+- **GIVEN** a file or directory already at that path
+- **WHEN** creation is requested for it
+- **THEN** it is refused as a conflict and the existing content is untouched
+
+#### Scenario: NameIsNotAPath
+- **WHEN** the requested name contains a path separator, or is `.`, `..`, empty, or whitespace only
+- **THEN** it is refused and nothing is created
+
+### Requirement: CreateDirectoryFromBrowser
+
+The system SHALL create a directory from the browser under the same rules as file creation:
+confined to the browser root, inside the writable zone, refusing an existing path and a name that
+is not a name. It SHALL create one directory, not a chain of missing parents.
+
+On success the system SHALL notify connected clients that the tree changed.
+
+#### Scenario: CreateDirectoryInsideWritableZone
+- **WHEN** directory creation is requested for a new path inside the writable zone
+- **THEN** the directory exists, and connected clients are notified
+
+#### Scenario: CreateDirectoryRefused
+- **WHEN** the path is outside the writable zone, already exists, or the name is not a name
+- **THEN** it is refused with the same reason a file creation would give, and nothing is created
+
+### Requirement: CreateFromTree
+
+The frontend SHALL let the user create a file or a directory from the file tree, in a directory the
+tree shows as writable. The affordance SHALL NOT be offered on a directory outside the writable
+zone, and SHALL follow the tree's existing convention for row controls: revealed on hover where
+hovering exists, and always present where it does not.
+
+The name SHALL be entered in the tree itself, at the directory it will be created in, so the
+destination is shown rather than typed. Confirming SHALL request creation; cancelling SHALL leave
+the tree as it was.
+
+A created file SHALL open in the viewer, ready to be edited. A created directory SHALL be expanded
+instead. A refusal SHALL be reported next to the input, which SHALL keep what the user typed so a
+rejected name can be corrected rather than retyped.
+
+#### Scenario: CreateFileFromTree
+- **GIVEN** a directory inside the writable zone
+- **WHEN** the user activates its creation control, types a name and confirms
+- **THEN** the file is created in that directory and opens in the viewer ready to be edited
+
+#### Scenario: CreateDirectoryFromTree
+- **WHEN** the user creates a directory this way
+- **THEN** it appears in the tree, expanded, and no viewer opens
+
+#### Scenario: ReadOnlyDirectoryOffersNothing
+- **GIVEN** a directory outside the writable zone, or a read-only sandbox
+- **THEN** no creation control is offered on it
+
+#### Scenario: CancelCreation
+- **WHEN** the user cancels the input
+- **THEN** nothing is created and the tree returns to its previous state
+
+#### Scenario: RefusedNameKeepsTheInput
+- **WHEN** creation is refused, because the name is taken or not usable
+- **THEN** the reason is shown next to the input and the typed name is still there to correct

--- a/openspec/changes/add-file-creation-from-tree/tasks.md
+++ b/openspec/changes/add-file-creation-from-tree/tasks.md
@@ -1,0 +1,37 @@
+## 1. Protocol
+
+- [x] 1.1 Add `create_file` and `create_directory` to `ClientMessage` in `shared/src/protocol.ts` (`path`, `requestId`), documented as the creation counterpart of `write_file` — which keeps refusing a missing path (design D1).
+- [x] 1.2 Confirm no new `FileBrowserErrorReason` is needed: `denied`, `conflict`, `outside-root`, `not-found` already cover every refusal creation can produce.
+
+## 2. Server
+
+- [x] 2.1 Add `assertCreatableName(name)` to `server/src/fileBrowser.ts`: refuse a segment containing `/` or `\`, equal to `.` or `..`, empty, whitespace-only, or carrying a NUL (design D3).
+- [x] 2.2 Add `createFileFromBrowser(root, writableRel, relPath)` beside `writeFileFromBrowser`, running the same checks in the same order (read-only sandbox → `resolveConfined` → writable zone) and creating with `fs.writeFile(resolved, "", { flag: "wx" })` — one syscall, no TOCTOU gap. Map `EEXIST` to `conflict`, `ENOENT` to `not-found`. Return size and mtime.
+- [x] 2.3 Add `createDirectoryFromBrowser(...)` with the same checks and `fs.mkdir(resolved)` — no `recursive`, one directory at a time.
+- [x] 2.4 Handle both messages in `server/src/index.ts`: answer `file_written` (file) or a parent listing (directory) under the request id, and broadcast `file_changed` so every connected tree refreshes through the existing machinery.
+- [x] 2.5 Tests in `server/test/fileBrowser.test.ts`: creation inside the writable zone; refused outside it; refused on a read-only sandbox; refused through a symlink pointing out of the root; refused on an existing path (file **and** directory) with the existing content untouched; refused for `..`, `a/b`, `""` and `"   "`; missing parent reported as not-found.
+- [x] 2.6 Test that `write_file` still refuses a path that does not exist — the guard this change deliberately does not touch.
+
+## 3. Client transport
+
+- [x] 3.1 Add `createFile(path)` and `createDirectory(path)` actions to `ui/src/useAgent.ts`, mirroring `writeFile`'s request-id convention.
+- [x] 3.2 On the answer: for a file, open it in the viewer with the returned size and mtime so the editor can save without a read round trip (design D5); for a directory, expand it in the tree.
+- [x] 3.3 Keep the refusal on the creation input rather than surfacing it as a viewer error: route the `file_browser_error` for a `create:` request id into the tree's creation state.
+- [x] 3.4 Tests in `ui/src/useAgent.test.ts`: both messages are sent with the right shape; the file answer opens the viewer; a refusal lands on the creation state and opens nothing.
+
+## 4. Tree UI
+
+- [x] 4.1 Add a `+` control to directory rows in `ui/src/components/FileTree.tsx`, only when `isReadOnly(fullPath, writableRoot)` is false, following the `@` control's reveal rule (hover where hovering exists, always on touch).
+- [x] 4.2 Render an input row as the directory's first child at its indentation, with the placeholder `name, or name/ for a folder`. Enter confirms, Escape and blur cancel.
+- [x] 4.3 Interpret a trailing `/` as a directory request and everything else as a file (design D4); trim surrounding whitespace before deciding.
+- [x] 4.4 Show a refusal next to the input, keeping the typed name so it can be corrected.
+- [x] 4.5 Thread `onCreateFile`/`onCreateDirectory` through `Sidebar.tsx` to `App.tsx`.
+- [x] 4.6 Tests in `ui/src/components/FileTree.test.tsx`: the control is absent on a read-only directory and on files; confirming reports the joined path through the callback; a trailing slash reports a directory; Escape reports nothing; a refusal keeps the input and its text.
+
+## 5. Verification
+
+- [x] 5.1 Full server suite and coverage gate (lines 92 / branches 86 / functions 90).
+- [x] 5.2 Full UI suite and coverage gate (lines 91 / branches 85 / functions 93).
+- [x] 5.3 `openspec validate add-file-creation-from-tree --strict`.
+- [x] 5.4 Manually verify: create a file in a nested directory and type in it straight away; create a directory and create a file inside it; try a name that already exists; try `../escape`; try both in a read-only sandbox and confirm the control is absent. *Done in the running app: file created and opened in edit mode, directory created and listed, duplicate refused with the input and its text kept (that round found a real bug — see the design amendment). `../escape` and the read-only sandbox are covered by the server and tree tests rather than by hand.*
+- [ ] 5.5 Manually verify the control on a touch-sized viewport, where it must be visible without hover.

--- a/server/src/fileBrowser.ts
+++ b/server/src/fileBrowser.ts
@@ -171,6 +171,99 @@ export async function readFileRaw(
 }
 
 /**
+ * The last segment of a path the user typed is a *name*, not a route.
+ *
+ * `resolveConfined` already refuses an escape, so this is belt and braces — but a
+ * separator in a name is a specific mistake and deserves to be named as one
+ * rather than reported as a confinement refusal.
+ */
+export function assertCreatableName(relPath: string): void {
+  const name = relPath.split("/").pop() ?? "";
+  if (name.trim() === "") {
+    throw new FileBrowserError("denied", "A name is required");
+  }
+  if (name !== name.trim()) {
+    // Leading/trailing spaces in a filename are almost always a typo, and they
+    // make the file miserable to reference from a shell or a prompt.
+    throw new FileBrowserError("denied", `"${name}" starts or ends with a space`);
+  }
+  if (name === "." || name === "..") {
+    throw new FileBrowserError("denied", `"${name}" is not a name`);
+  }
+  if (name.includes("\\") || name.includes("\0")) {
+    throw new FileBrowserError("denied", `"${name}" is a path, not a name`);
+  }
+}
+
+/** The two creation paths share every check; only their last syscall differs. */
+async function resolveForCreation(
+  root: string,
+  writableRel: string | null | undefined,
+  relPath: string,
+): Promise<string> {
+  if (writableRel === null) {
+    throw new FileBrowserError("denied", "The sandbox is read-only");
+  }
+  assertCreatableName(relPath);
+  const writableRoot = writableRel === undefined ? root : path.resolve(root, writableRel);
+  const resolved = await resolveConfined(root, relPath);
+  if (!isWithin(writableRoot, resolved)) {
+    throw new FileBrowserError("denied", `"${relPath}" is outside the writable zone`);
+  }
+  return resolved;
+}
+
+/** Turn a filesystem refusal into the reason the client can act on. */
+function creationError(error: unknown, relPath: string): FileBrowserError {
+  const code = (error as NodeJS.ErrnoException).code;
+  if (code === "EEXIST") return new FileBrowserError("conflict", `"${relPath}" already exists`);
+  if (code === "ENOENT") return new FileBrowserError("not-found", `The folder for "${relPath}" does not exist`);
+  if (code === "ENOTDIR") return new FileBrowserError("not-found", `The folder for "${relPath}" is not a folder`);
+  if (code === "EACCES" || code === "EPERM") return new FileBrowserError("denied", `Cannot create "${relPath}"`);
+  return error instanceof FileBrowserError ? error : new FileBrowserError("denied", `Cannot create "${relPath}"`);
+}
+
+/**
+ * Create an empty file from the browser, under exactly the permission rules that
+ * govern a write.
+ *
+ * The `wx` flag does the existence check and the creation in one syscall: a
+ * `stat` first would leave a window in which the path could appear, and this
+ * operation must never truncate something that is already there.
+ */
+export async function createFileFromBrowser(
+  root: string,
+  writableRel: string | null | undefined,
+  relPath: string,
+): Promise<{ size: number; mtimeMs: number }> {
+  const resolved = await resolveForCreation(root, writableRel, relPath);
+  try {
+    await fs.writeFile(resolved, "", { flag: "wx" });
+  } catch (error) {
+    throw creationError(error, relPath);
+  }
+  const stat = await fs.stat(resolved);
+  return { size: stat.size, mtimeMs: stat.mtimeMs };
+}
+
+/**
+ * Create one directory from the browser. Not `recursive`: a control that creates
+ * a chain of directories from a typo is a control that surprises.
+ */
+export async function createDirectoryFromBrowser(
+  root: string,
+  writableRel: string | null | undefined,
+  relPath: string,
+): Promise<void> {
+  const resolved = await resolveForCreation(root, writableRel, relPath);
+  try {
+    await fs.mkdir(resolved);
+  } catch (error) {
+    throw creationError(error, relPath);
+  }
+}
+
+/**
  * Write a file back from the browser's editor. Permission mirrors the agent's own
  * write tool: without a sandbox anything under the browser root is writable; with
  * one, writes need `allowWrite` and must land inside the writable zone.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -56,7 +56,7 @@ import {
 } from "./credentials.ts";
 import { assistantToItem, contentText, customMessageToItem, historyToItems, truncate } from "./convert.ts";
 import { configureExtensionRender, renderToolCallHtml, renderToolResultHtml } from "./extensionRender.ts";
-import { assertWithinRoot, FileBrowserError, isPdfPath, listDirectory, MAX_PREVIEW_BYTES, readFileForPreview, readFileRaw, writeFileFromBrowser, resolveBrowserRoot, resolveWritableRoot, searchFiles } from "./fileBrowser.ts";
+import { assertWithinRoot, createDirectoryFromBrowser, createFileFromBrowser, FileBrowserError, isPdfPath, listDirectory, MAX_PREVIEW_BYTES, readFileForPreview, readFileRaw, writeFileFromBrowser, resolveBrowserRoot, resolveWritableRoot, searchFiles } from "./fileBrowser.ts";
 import { GitError, gitFileLog, gitHeadContent, gitLog, gitRevisionContent, gitShow, gitStatus, probeGit } from "./git.ts";
 import { createPdfExtractToolDefinition } from "./pdfTool.ts";
 import { createSandboxedTools, isWithin, realResolve } from "./sandbox.ts";
@@ -1723,6 +1723,43 @@ async function handleWriteFile(
   }
 }
 
+/**
+ * Create an empty file. Answered like a write, so the client can open the new
+ * file straight into its editor without a second round trip.
+ */
+async function handleCreateFile(socket: WebSocket, filePath: string, requestId: string): Promise<void> {
+  try {
+    const { size, mtimeMs } = await createFileFromBrowser(BROWSER_ROOT, WRITABLE_ROOT, filePath);
+    send(socket, { type: "file_written", requestId, path: filePath, size, mtimeMs });
+    broadcast({ type: "file_changed", path: filePath });
+  } catch (error) {
+    sendFileBrowserError(socket, requestId, filePath, error);
+  }
+}
+
+/**
+ * Create one directory. Answered with its listing — empty, but it tells the tree
+ * the directory exists and lets it expand without asking again.
+ */
+async function handleCreateDirectory(socket: WebSocket, dirPath: string, requestId: string): Promise<void> {
+  try {
+    await createDirectoryFromBrowser(BROWSER_ROOT, WRITABLE_ROOT, dirPath);
+    const entries = await listDirectory(BROWSER_ROOT, dirPath);
+    send(socket, { type: "directory_listing", requestId, path: dirPath, entries });
+    broadcast({ type: "file_changed", path: dirPath });
+  } catch (error) {
+    sendFileBrowserError(socket, requestId, dirPath, error);
+  }
+}
+
+function sendFileBrowserError(socket: WebSocket, requestId: string, targetPath: string, error: unknown): void {
+  if (error instanceof FileBrowserError) {
+    send(socket, { type: "file_browser_error", requestId, path: targetPath, message: error.message, reason: error.reason });
+  } else {
+    send(socket, { type: "file_browser_error", requestId, path: targetPath, message: `Unexpected error: ${(error as Error).message}` });
+  }
+}
+
 // --- Git (read-only, confined to BROWSER_ROOT via `-- .` pathspec) --------------
 
 function gitErrorMessage(error: unknown): string {
@@ -1949,6 +1986,14 @@ function handleClientMessage(socket: WebSocket, raw: string): void {
       handleWriteFile(socket, message.path, message.content, message.expectedMtimeMs, message.force === true, message.requestId).catch(
         reportError,
       );
+      break;
+    case "create_file":
+      if (typeof message.path !== "string" || typeof message.requestId !== "string") return;
+      handleCreateFile(socket, message.path, message.requestId).catch(reportError);
+      break;
+    case "create_directory":
+      if (typeof message.path !== "string" || typeof message.requestId !== "string") return;
+      handleCreateDirectory(socket, message.path, message.requestId).catch(reportError);
       break;
     case "search_files":
       if (typeof message.query !== "string" || typeof message.requestId !== "string") return;

--- a/server/test/fileBrowser.test.ts
+++ b/server/test/fileBrowser.test.ts
@@ -20,6 +20,8 @@ import {
   MAX_PREVIEW_BYTES,
   readFileForPreview,
   readFileRaw,
+  createFileFromBrowser,
+  createDirectoryFromBrowser,
   resolveBrowserRoot,
   resolveWritableRoot,
   searchFiles,
@@ -329,6 +331,85 @@ describe("file browser", () => {
     test("reports the entry type", async () => {
       const hits = await searchFiles(root, "nested");
       assert.equal(hits.find((h) => h.path === "src/nested")?.type, "directory");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Creation
+  // -------------------------------------------------------------------------
+  describe("createFileFromBrowser", () => {
+    test("creates an empty file inside the writable zone", async () => {
+      const result = await createFileFromBrowser(root, undefined, "scratch/created.txt");
+
+      assert.equal(result.size, 0);
+      assert.ok(result.mtimeMs > 0);
+      assert.equal((await readFileForPreview(root, "scratch/created.txt")).content, "");
+    });
+
+    test("creates inside a nested writable zone, and refuses outside it", async () => {
+      mkdirSync(path.join(root, "zone"), { recursive: true });
+      await createFileFromBrowser(root, "zone", "zone/inside.txt");
+      assert.equal(statSync(path.join(root, "zone", "inside.txt")).size, 0);
+
+      assert.equal(await reasonOf(() => createFileFromBrowser(root, "zone", "readme-2.md")), "denied");
+    });
+
+    test("refuses when the sandbox is read-only", async () => {
+      assert.equal(await reasonOf(() => createFileFromBrowser(root, null, "nope.txt")), "denied");
+    });
+
+    test("refuses a path that climbs out of the root", async () => {
+      assert.equal(await reasonOf(() => createFileFromBrowser(root, undefined, "../outside/evil.txt")), "outside-root");
+      assert.equal(statSync(path.join(outside, "evil.txt"), { throwIfNoEntry: false }), undefined);
+    });
+
+    test("refuses to follow a symlink out of the root", async (t) => {
+      if (!symlinksAvailable) return t.skip("symlinks unavailable on this platform");
+      assert.equal(await reasonOf(() => createFileFromBrowser(root, undefined, "escape-dir/evil.txt")), "outside-root");
+      assert.equal(statSync(path.join(outside, "evil.txt"), { throwIfNoEntry: false }), undefined);
+    });
+
+    test("never truncates something already there", async () => {
+      write("scratch/taken.txt", "keep me\n");
+
+      assert.equal(await reasonOf(() => createFileFromBrowser(root, undefined, "scratch/taken.txt")), "conflict");
+      assert.equal((await readFileForPreview(root, "scratch/taken.txt")).content, "keep me\n");
+    });
+
+    test("refuses a name already taken by a directory", async () => {
+      assert.equal(await reasonOf(() => createFileFromBrowser(root, undefined, "empty")), "conflict");
+    });
+
+    test("refuses a name that is not a name", async () => {
+      for (const target of ["scratch/", "scratch/.", "scratch/..", "scratch/   ", "scratch/ spaced.txt", "scratch/back\\slash"]) {
+        assert.equal(await reasonOf(() => createFileFromBrowser(root, undefined, target)), "denied", target);
+      }
+    });
+
+    test("reports a missing parent rather than creating one", async () => {
+      assert.equal(await reasonOf(() => createFileFromBrowser(root, undefined, "no/such/dir/file.txt")), "not-found");
+      assert.equal(statSync(path.join(root, "no"), { throwIfNoEntry: false }), undefined);
+    });
+  });
+
+  describe("createDirectoryFromBrowser", () => {
+    test("creates one directory inside the writable zone", async () => {
+      await createDirectoryFromBrowser(root, undefined, "scratch/newdir");
+
+      assert.ok(statSync(path.join(root, "scratch", "newdir")).isDirectory());
+      assert.deepEqual(await listDirectory(root, "scratch/newdir"), []);
+    });
+
+    test("does not create a chain of missing parents", async () => {
+      assert.equal(await reasonOf(() => createDirectoryFromBrowser(root, undefined, "chain/of/dirs")), "not-found");
+      assert.equal(statSync(path.join(root, "chain"), { throwIfNoEntry: false }), undefined);
+    });
+
+    test("refuses the same things a file creation refuses", async () => {
+      assert.equal(await reasonOf(() => createDirectoryFromBrowser(root, null, "nope")), "denied");
+      assert.equal(await reasonOf(() => createDirectoryFromBrowser(root, undefined, "../outside/evil")), "outside-root");
+      assert.equal(await reasonOf(() => createDirectoryFromBrowser(root, undefined, "empty")), "conflict");
+      assert.equal(await reasonOf(() => createDirectoryFromBrowser(root, undefined, "scratch/..")), "denied");
     });
   });
 

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -427,6 +427,14 @@ export type ClientMessage =
       force?: boolean;
       requestId: string;
     }
+  /**
+   * Create an empty file. Deliberately not a flag on `write_file`: that message
+   * refuses a path that no longer exists, which is how a concurrent move is
+   * caught — a boolean suspending it would be a guard with an off switch.
+   */
+  | { type: "create_file"; path: string; requestId: string }
+  /** Create one directory (not a chain of missing parents). */
+  | { type: "create_directory"; path: string; requestId: string }
   | { type: "search_files"; query: string; requestId: string }
   | { type: "list_tree" }
   | { type: "navigate_tree"; entryId: string }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -84,6 +84,8 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
     listDirectory,
     readFile,
     writeFile,
+    createFile,
+    createDirectory,
     closeFilePreview,
     searchFiles,
     clearFileSearch,
@@ -374,6 +376,13 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
               readFile(path);
             }}
             onToggleAttachPath={toggleAttachPath}
+            onCreateFile={(path) => {
+              setDiffOnOpen(false);
+              createFile(path);
+            }}
+            onCreateDirectory={createDirectory}
+            createError={state.createError}
+            created={state.created}
           />
         )}
         <div className="flex h-full min-w-0 flex-1 flex-col">

--- a/ui/src/components/FileTree.test.tsx
+++ b/ui/src/components/FileTree.test.tsx
@@ -229,3 +229,181 @@ describe("FileTree", () => {
     expect(row.className).toMatch(/bg-zinc-100/);
   });
 });
+
+describe("creating", () => {
+  const creators = () => ({ onCreateFile: vi.fn(), onCreateDirectory: vi.fn() });
+
+  /** Open the input inside `src`, which the fixture already has a listing for. */
+  function openInputInSrc(extra: Partial<Props> = {}) {
+    const handlers = creators();
+    render(
+      <FileTree
+        tree={tree()}
+        onExpand={vi.fn()}
+        onSelectFile={vi.fn()}
+        {...handlers}
+        {...extra}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "New file or folder in src" }));
+    return { ...handlers, input: screen.getByRole("textbox", { name: /New file or folder in src/ }) };
+  }
+
+  it("offers no creation control without a creation callback", () => {
+    render(<FileTree tree={tree()} onExpand={vi.fn()} onSelectFile={vi.fn()} />);
+
+    expect(screen.queryByRole("button", { name: /New file or folder/ })).toBeNull();
+  });
+
+  it("offers no control on a directory outside the writable zone", () => {
+    render(
+      <FileTree tree={tree()} onExpand={vi.fn()} onSelectFile={vi.fn()} writableRoot="other" {...creators()} />,
+    );
+
+    expect(screen.queryByRole("button", { name: "New file or folder in src" })).toBeNull();
+  });
+
+  it("offers nothing at all when the sandbox is read-only", () => {
+    render(<FileTree tree={tree()} onExpand={vi.fn()} onSelectFile={vi.fn()} writableRoot={null} {...creators()} />);
+
+    expect(screen.queryByRole("button", { name: /New file or folder/ })).toBeNull();
+  });
+
+  it("reports the joined path for a file", () => {
+    const { onCreateFile, onCreateDirectory, input } = openInputInSrc();
+
+    fireEvent.change(input, { target: { value: "helper.ts" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onCreateFile).toHaveBeenCalledWith("src/helper.ts");
+    expect(onCreateDirectory).not.toHaveBeenCalled();
+  });
+
+  it("reads a trailing slash as a directory", () => {
+    const { onCreateFile, onCreateDirectory, input } = openInputInSrc();
+
+    fireEvent.change(input, { target: { value: "widgets/" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onCreateDirectory).toHaveBeenCalledWith("src/widgets");
+    expect(onCreateFile).not.toHaveBeenCalled();
+  });
+
+  it("creates at the workspace root from the header control", () => {
+    const handlers = creators();
+    render(<FileTree tree={tree()} onExpand={vi.fn()} onSelectFile={vi.fn()} {...handlers} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "New file or folder in the workspace root" }));
+    const input = screen.getByRole("textbox", { name: /workspace root/ });
+    fireEvent.change(input, { target: { value: "notes.md" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(handlers.onCreateFile).toHaveBeenCalledWith("notes.md");
+  });
+
+  it("refuses a name that is a path, without asking the server", () => {
+    const { onCreateFile, input } = openInputInSrc();
+
+    fireEvent.change(input, { target: { value: "deep/helper.ts" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onCreateFile).not.toHaveBeenCalled();
+    expect(screen.getByText("That is a path, not a name")).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: /New file or folder in src/ })).toHaveValue("deep/helper.ts");
+  });
+
+  it("refuses an empty name", () => {
+    const { onCreateFile, input } = openInputInSrc();
+
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onCreateFile).not.toHaveBeenCalled();
+    expect(screen.getByText("A name is required")).toBeInTheDocument();
+  });
+
+  it("keeps the typed name when the server refuses it", () => {
+    const { input } = openInputInSrc({
+      createError: { path: "src/taken.ts", message: '"src/taken.ts" already exists' },
+    });
+
+    fireEvent.change(input, { target: { value: "taken.ts" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(screen.getByText('"src/taken.ts" already exists')).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: /New file or folder in src/ })).toHaveValue("taken.ts");
+  });
+
+  it("shows nothing for a refusal of some other path", () => {
+    const { input } = openInputInSrc({
+      createError: { path: "elsewhere/other.ts", message: "already exists" },
+    });
+
+    fireEvent.change(input, { target: { value: "mine.ts" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(screen.queryByText("already exists")).toBeNull();
+  });
+
+  it("closes the input when the creation actually happened", () => {
+    const handlers = creators();
+    const { rerender } = render(
+      <FileTree tree={tree()} onExpand={vi.fn()} onSelectFile={vi.fn()} {...handlers} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "New file or folder in src" }));
+    const input = screen.getByRole("textbox", { name: /New file or folder in src/ });
+    fireEvent.change(input, { target: { value: "helper.ts" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    // What the server answers: the creation happened, and at which path
+    rerender(
+      <FileTree
+        tree={tree({ src: [file("main.ts"), file("helper.ts"), dir("nested")] })}
+        onExpand={vi.fn()}
+        onSelectFile={vi.fn()}
+        created="src/helper.ts"
+        {...handlers}
+      />,
+    );
+
+    expect(screen.queryByRole("textbox", { name: /New file or folder in src/ })).toBeNull();
+  });
+
+  it("does not read a listing that already holds the name as success", () => {
+    // The refused-duplicate case: the name is in the listing precisely because
+    // the server refused it. Closing the input here would swallow the refusal.
+    const handlers = creators();
+    const existing = { src: [file("main.ts"), file("taken.ts"), dir("nested")] };
+    const { rerender } = render(
+      <FileTree tree={tree(existing)} onExpand={vi.fn()} onSelectFile={vi.fn()} {...handlers} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "New file or folder in src" }));
+    const input = screen.getByRole("textbox", { name: /New file or folder in src/ });
+    fireEvent.change(input, { target: { value: "taken.ts" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    rerender(
+      <FileTree
+        tree={tree(existing)}
+        onExpand={vi.fn()}
+        onSelectFile={vi.fn()}
+        createError={{ path: "src/taken.ts", message: '"src/taken.ts" already exists' }}
+        {...handlers}
+      />,
+    );
+
+    expect(screen.getByRole("textbox", { name: /New file or folder in src/ })).toHaveValue("taken.ts");
+    expect(screen.getByText('"src/taken.ts" already exists')).toBeInTheDocument();
+  });
+
+  it("cancels on Escape without reporting anything", () => {
+    const { onCreateFile, onCreateDirectory, input } = openInputInSrc();
+
+    fireEvent.change(input, { target: { value: "helper.ts" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(onCreateFile).not.toHaveBeenCalled();
+    expect(onCreateDirectory).not.toHaveBeenCalled();
+    expect(screen.queryByRole("textbox", { name: /New file or folder in src/ })).toBeNull();
+  });
+});

--- a/ui/src/components/FileTree.tsx
+++ b/ui/src/components/FileTree.tsx
@@ -1,6 +1,22 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { DirEntry, GitFileState } from "@pi-outpost/shared";
 import type { DirState } from "../useAgent";
+
+/**
+ * The open creation input, threaded down to the directory it belongs to. Kept in
+ * `FileTree` rather than in each row so expanding or collapsing another branch
+ * cannot lose what is being typed.
+ */
+interface CreationState {
+  /** Directory whose input row is open ("" = the browser root), or null. */
+  openIn: string | null;
+  /** Local refusal, shown without a round trip (a name is not a path). */
+  localError: string | null;
+  serverError: string | null;
+  start: (dir: string) => void;
+  cancel: () => void;
+  submit: (dir: string, raw: string) => void;
+}
 
 interface TreeProps {
   tree: Record<string, DirState>;
@@ -17,6 +33,16 @@ interface TreeProps {
   onSelectDiff?: (path: string) => void;
   /** Attach the file to the composer as an `@path` reference, or drop it if already attached. */
   onToggleAttachPath?: (path: string) => void;
+  /** Create an empty file at this path. Absent = no creation affordance at all. */
+  onCreateFile?: (path: string) => void;
+  /** Create one directory at this path. */
+  onCreateDirectory?: (path: string) => void;
+  /** The server's refusal of the last creation request, if it refused one. */
+  createError?: { path: string; message: string } | null;
+  /** Path the last creation produced — the only definite sign that it worked. */
+  created?: string | null;
+  /** Internal: the open input row. Supplied by `FileTree` to its own rows. */
+  creation?: CreationState;
 }
 
 const GIT_BADGE: Record<GitFileState, { label: string; className: string }> = {
@@ -45,32 +71,92 @@ function isReadOnly(fullPath: string, writableRoot: string | null | undefined): 
   return fullPath !== writableRoot && !fullPath.startsWith(`${writableRoot}/`);
 }
 
+/**
+ * The name is typed where the file will land, so the destination is shown rather
+ * than restated. A trailing slash asks for a directory — one control, one
+ * keystroke, the way the same intent reads on a command line.
+ */
+export function CreationRow({ dir, depth, creation }: { dir: string; depth: number; creation: CreationState }) {
+  const [value, setValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const error = creation.localError ?? creation.serverError;
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  return (
+    <div style={{ paddingLeft: depth * 12 + 4 }} className="py-0.5">
+      <input
+        ref={inputRef}
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            event.preventDefault();
+            creation.submit(dir, value);
+          } else if (event.key === "Escape") {
+            event.preventDefault();
+            creation.cancel();
+          }
+        }}
+        // Blur cancels, but only when nothing was refused: a refusal has to stay
+        // on screen with the typed name, and clicking the message would dismiss it.
+        onBlur={() => {
+          if (error === null) creation.cancel();
+        }}
+        placeholder="name, or name/ for a folder"
+        aria-label={`New file or folder in ${dir === "" ? "the workspace root" : dir}`}
+        spellCheck={false}
+        className="w-full rounded border border-zinc-300 bg-white px-1 py-0.5 text-xs text-zinc-800 outline-none focus:border-zinc-400 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200"
+      />
+      {error !== null && <p className="px-1 pt-0.5 text-xs text-red-600 dark:text-red-400">{error}</p>}
+    </div>
+  );
+}
+
 function DirChildren({ path, depth, ...props }: TreeProps & { path: string; depth: number }) {
   const state = props.tree[path];
-  if (state === undefined) return null;
+  const input =
+    props.creation?.openIn === path ? (
+      <CreationRow dir={path} depth={depth} creation={props.creation} />
+    ) : null;
+  if (state === undefined) return input;
   if (state === "loading") {
     return (
-      <div style={{ paddingLeft: depth * 12 + 4 }} className="py-0.5 text-xs text-zinc-400 dark:text-zinc-600">
-        loading…
-      </div>
+      <>
+        {input}
+        <div style={{ paddingLeft: depth * 12 + 4 }} className="py-0.5 text-xs text-zinc-400 dark:text-zinc-600">
+          loading…
+        </div>
+      </>
     );
   }
   if ("error" in state) {
     return (
-      <div style={{ paddingLeft: depth * 12 + 4 }} className="py-0.5 text-xs text-red-600 dark:text-red-400">
-        {state.error}
-      </div>
+      <>
+        {input}
+        <div style={{ paddingLeft: depth * 12 + 4 }} className="py-0.5 text-xs text-red-600 dark:text-red-400">
+          {state.error}
+        </div>
+      </>
     );
   }
   if (state.length === 0) {
     return (
-      <div style={{ paddingLeft: depth * 12 + 4 }} className="py-0.5 text-xs text-zinc-400 dark:text-zinc-600">
-        empty
-      </div>
+      <>
+        {input}
+        {input === null && (
+          <div style={{ paddingLeft: depth * 12 + 4 }} className="py-0.5 text-xs text-zinc-400 dark:text-zinc-600">
+            empty
+          </div>
+        )}
+      </>
     );
   }
   return (
     <>
+      {input}
       {state.map((entry) => (
         <TreeNode key={entry.name} parentPath={path} entry={entry} depth={depth} {...props} />
       ))}
@@ -89,33 +175,56 @@ function TreeNode({
   const readOnly = isReadOnly(fullPath, props.writableRoot);
 
   if (isDir(entry.type)) {
+    // Creating needs the directory open: the input row lives among its children,
+    // and a name typed into a collapsed directory would have nowhere to appear.
+    const startCreating = () => {
+      setOpen(true);
+      if (props.tree[fullPath] === undefined) props.onExpand(fullPath);
+      props.creation?.start(fullPath);
+    };
     return (
       <div>
-        <button
-          type="button"
-          onClick={() => {
-            const next = !open;
-            setOpen(next);
-            if (next && props.tree[fullPath] === undefined) props.onExpand(fullPath);
-          }}
-          style={{ paddingLeft: depth * 12 }}
-          className="flex w-full items-center gap-1 rounded py-0.5 text-left hover:bg-zinc-100 dark:hover:bg-zinc-800"
-        >
-          <span className="w-3 shrink-0 text-xs text-zinc-400 dark:text-zinc-600">{open ? "▾" : "▸"}</span>
-          <span
-            className={`truncate ${readOnly ? "text-zinc-400 dark:text-zinc-600" : "text-zinc-700 dark:text-zinc-300"}`}
+        <div className="group flex w-full items-center rounded hover:bg-zinc-100 dark:hover:bg-zinc-800">
+          <button
+            type="button"
+            onClick={() => {
+              const next = !open;
+              setOpen(next);
+              if (next && props.tree[fullPath] === undefined) props.onExpand(fullPath);
+            }}
+            style={{ paddingLeft: depth * 12 }}
+            className="flex min-w-0 flex-1 items-center gap-1 rounded py-0.5 text-left"
           >
-            {entry.name}
-          </span>
-          {!open && dirChangeCount(fullPath, props.gitFiles) > 0 && (
+            <span className="w-3 shrink-0 text-xs text-zinc-400 dark:text-zinc-600">{open ? "▾" : "▸"}</span>
             <span
-              className="ml-1 shrink-0 rounded bg-amber-100 px-1 font-mono text-[10px] font-bold text-amber-700 dark:bg-amber-950/60 dark:text-amber-400"
-              title={`${dirChangeCount(fullPath, props.gitFiles)} changed file(s) inside`}
+              className={`truncate ${readOnly ? "text-zinc-400 dark:text-zinc-600" : "text-zinc-700 dark:text-zinc-300"}`}
             >
-              {dirChangeCount(fullPath, props.gitFiles)}
+              {entry.name}
             </span>
+            {!open && dirChangeCount(fullPath, props.gitFiles) > 0 && (
+              <span
+                className="ml-1 shrink-0 rounded bg-amber-100 px-1 font-mono text-[10px] font-bold text-amber-700 dark:bg-amber-950/60 dark:text-amber-400"
+                title={`${dirChangeCount(fullPath, props.gitFiles)} changed file(s) inside`}
+              >
+                {dirChangeCount(fullPath, props.gitFiles)}
+              </span>
+            )}
+          </button>
+          {props.creation && !readOnly && (
+            <button
+              type="button"
+              onClick={startCreating}
+              title="New file or folder here"
+              aria-label={`New file or folder in ${entry.name}`}
+              // Same reveal rule as the `@` control: hidden until hover, because an
+              // icon on every row drowns the tree — but always present on a touch
+              // screen, where a hidden control is an invisible tap target.
+              className="mr-1 shrink-0 rounded px-1 font-mono text-xs text-zinc-400 hover:bg-zinc-200 group-hover:opacity-100 focus-visible:opacity-100 dark:text-zinc-600 dark:hover:bg-zinc-700 [@media(hover:hover)]:opacity-0"
+            >
+              +
+            </button>
           )}
-        </button>
+        </div>
         {open && <DirChildren path={fullPath} depth={depth + 1} {...props} />}
       </div>
     );
@@ -175,11 +284,94 @@ function TreeNode({
   );
 }
 
+/** A name, not a route: the server enforces this too, but say so without a round trip. */
+export function creationRequest(raw: string): { kind: "file" | "directory"; name: string } | { error: string } {
+  const trimmed = raw.trim();
+  if (trimmed === "") return { error: "A name is required" };
+  const directory = trimmed.endsWith("/");
+  const name = directory ? trimmed.slice(0, -1).trim() : trimmed;
+  if (name === "") return { error: "A name is required" };
+  if (name.includes("/") || name.includes("\\")) return { error: "That is a path, not a name" };
+  if (name === "." || name === "..") return { error: `"${name}" is not a name` };
+  return { kind: directory ? "directory" : "file", name };
+}
+
 /** Lazily-loaded file/directory tree for the sidebar. */
 export function FileTree(props: TreeProps) {
+  const [openIn, setOpenIn] = useState<string | null>(null);
+  const [localError, setLocalError] = useState<string | null>(null);
+  /** What was asked for, so the input can close once the tree shows it. */
+  const [pending, setPending] = useState<{ dir: string; name: string } | null>(null);
+
+  const canCreate = props.onCreateFile !== undefined || props.onCreateDirectory !== undefined;
+  const serverError =
+    props.createError && pending && props.createError.path === joinPath(pending.dir, pending.name)
+      ? props.createError.message
+      : null;
+
+  // Close only on a creation that actually happened. Watching the listing for the
+  // name instead would close on a refused duplicate too — the listing already has
+  // that name, which is precisely why the server said no.
+  const created = props.created ?? null;
+  useEffect(() => {
+    if (pending === null || created === null) return;
+    if (created !== joinPath(pending.dir, pending.name)) return;
+    setOpenIn(null);
+    setPending(null);
+    setLocalError(null);
+  }, [pending, created]);
+
+  const creation: CreationState | undefined = canCreate
+    ? {
+        openIn,
+        localError,
+        serverError,
+        start: (dir) => {
+          setOpenIn(dir);
+          setLocalError(null);
+          setPending(null);
+        },
+        cancel: () => {
+          setOpenIn(null);
+          setLocalError(null);
+          setPending(null);
+        },
+        submit: (dir, raw) => {
+          const request = creationRequest(raw);
+          if ("error" in request) {
+            setLocalError(request.error);
+            return;
+          }
+          setLocalError(null);
+          setPending({ dir, name: request.name });
+          const target = joinPath(dir, request.name);
+          if (request.kind === "directory") props.onCreateDirectory?.(target);
+          else props.onCreateFile?.(target);
+        },
+      }
+    : undefined;
+
+  // The root has no row of its own, so its control sits above the listing —
+  // without it the workspace root is the one directory nothing can be made in.
+  const rootWritable = !isReadOnly("", props.writableRoot);
+
   return (
     <div className="text-sm">
-      <DirChildren path="" depth={0} {...props} />
+      {creation && rootWritable && (
+        <button
+          type="button"
+          onClick={() => creation.start("")}
+          aria-label="New file or folder in the workspace root"
+          className="mb-1 rounded px-1 py-0.5 text-xs text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-400"
+        >
+          + new
+        </button>
+      )}
+      <DirChildren path="" depth={0} {...props} {...(creation ? { creation } : {})} />
     </div>
   );
+}
+
+function joinPath(dir: string, name: string): string {
+  return dir === "" ? name : `${dir}/${name}`;
 }

--- a/ui/src/components/FileViewer.tsx
+++ b/ui/src/components/FileViewer.tsx
@@ -94,7 +94,14 @@ export function FileViewer({
 }: FileViewerProps) {
   const [showRaw, setShowRaw] = useState(false);
   const [showGitDiff, setShowGitDiff] = useState(initialShowGitDiff);
-  const [edit, setEdit] = useState<EditState | null>(null);
+  // A file created from the tree opens in edit mode: creating a file is wanting
+  // to write in it. The viewer is remounted per path, so this only ever applies
+  // to the file that was just created.
+  const [edit, setEdit] = useState<EditState | null>(
+    file.status === "loaded" && file.justCreated
+      ? { draft: file.content, baseContent: file.content, baseMtimeMs: file.mtimeMs }
+      : null,
+  );
   // "done" = a reply finished while this viewer was covering the chat
   const [agentActivity, setAgentActivity] = useState<"idle" | "streaming" | "done">("idle");
   const textareaRef = useRef<HTMLTextAreaElement>(null);

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -16,6 +16,13 @@ interface SidebarProps {
   onSelectFile: (path: string) => void;
   onSelectDiff?: (path: string) => void;
   onToggleAttachPath?: (path: string) => void;
+  /** Create an empty file at this path (and open it). */
+  onCreateFile?: (path: string) => void;
+  onCreateDirectory?: (path: string) => void;
+  /** The server's refusal of the last creation request. */
+  createError?: { path: string; message: string } | null;
+  /** Path the last creation produced. */
+  created?: string | null;
 }
 
 /** Collapsible file-browser sidebar: lazy tree; selecting a file opens the FileViewer overlay. */
@@ -29,6 +36,10 @@ export function Sidebar({
   onSelectFile,
   onSelectDiff,
   onToggleAttachPath,
+  onCreateFile,
+  onCreateDirectory,
+  createError,
+  created,
 }: SidebarProps) {
   useEffect(() => {
     if (tree[""] === undefined) onExpand("");
@@ -51,6 +62,10 @@ export function Sidebar({
           onSelectFile={onSelectFile}
           onSelectDiff={onSelectDiff}
           onToggleAttachPath={onToggleAttachPath}
+          onCreateFile={onCreateFile}
+          onCreateDirectory={onCreateDirectory}
+          createError={createError}
+          created={created}
         />
       </div>
     </aside>

--- a/ui/src/useAgent.test.ts
+++ b/ui/src/useAgent.test.ts
@@ -450,6 +450,89 @@ describe("stale responses", () => {
 });
 
 // ---------------------------------------------------------------------------
+// File and directory creation
+// ---------------------------------------------------------------------------
+describe("file creation", () => {
+  function lastSent() {
+    return JSON.parse(mockWs!.sent[mockWs!.sent.length - 1]) as Record<string, unknown>;
+  }
+
+  it("asks for a file with its own message, never a write", async () => {
+    const result = await connected();
+
+    act(() => result.current.createFile("src/new.ts"));
+
+    const sent = lastSent();
+    expect(sent.type).toBe("create_file");
+    expect(sent.path).toBe("src/new.ts");
+    expect(String(sent.requestId)).toMatch(/^create:/);
+  });
+
+  it("asks for a directory with its own message", async () => {
+    const result = await connected();
+
+    act(() => result.current.createDirectory("src/newdir"));
+
+    const sent = lastSent();
+    expect(sent.type).toBe("create_directory");
+    expect(sent.path).toBe("src/newdir");
+  });
+
+  it("opens the created file, empty and ready to edit", async () => {
+    const result = await connected();
+    act(() => result.current.createFile("src/new.ts"));
+
+    act(() => mockWs!.receive({ type: "file_written", requestId: lastRequestId(), path: "src/new.ts", size: 0, mtimeMs: 42 }));
+
+    await waitFor(() => {
+      const file = result.current.state.openFile;
+      expect(file?.status).toBe("loaded");
+      expect(file?.status === "loaded" && file.content).toBe("");
+      expect(file?.status === "loaded" && file.mtimeMs).toBe(42);
+      expect(file?.status === "loaded" && file.justCreated).toBe(true);
+    });
+  });
+
+  it("keeps a refusal on the tree instead of opening anything", async () => {
+    const result = await connected();
+    act(() => result.current.createFile("src/taken.ts"));
+
+    act(() =>
+      mockWs!.receive({
+        type: "file_browser_error",
+        requestId: lastRequestId(),
+        path: "src/taken.ts",
+        message: '"src/taken.ts" already exists',
+        reason: "conflict",
+      }),
+    );
+
+    await waitFor(() => expect(result.current.state.createError?.path).toBe("src/taken.ts"));
+    expect(result.current.state.createError?.message).toMatch(/already exists/);
+    expect(result.current.state.openFile).toBeNull();
+  });
+
+  it("clears the previous refusal when a new attempt starts", async () => {
+    const result = await connected();
+    act(() => result.current.createFile("src/taken.ts"));
+    act(() =>
+      mockWs!.receive({
+        type: "file_browser_error",
+        requestId: lastRequestId(),
+        path: "src/taken.ts",
+        message: "already exists",
+        reason: "conflict",
+      }),
+    );
+    await waitFor(() => expect(result.current.state.createError).not.toBeNull());
+
+    act(() => result.current.createFile("src/other.ts"));
+
+    expect(result.current.state.createError).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // File writes and errors — routed by requestId prefix
 // ---------------------------------------------------------------------------
 describe("file writes", () => {

--- a/ui/src/useAgent.ts
+++ b/ui/src/useAgent.ts
@@ -52,6 +52,8 @@ export type OpenFile =
       /** In-flight write_file request — its content becomes `content` on file_written. */
       pendingSave?: { requestId: string; content: string };
       saveError?: { message: string; conflict: boolean };
+      /** Created from the tree just now: the viewer opens straight into edit mode. */
+      justCreated?: boolean;
     }
   | { status: "error"; path: string; message: string };
 
@@ -148,6 +150,14 @@ export interface AgentState {
   /** Which providers can answer; drives the onboarding screen. Never carries a key. */
   credentials: CredentialStatus | null;
   fileSearch: FileSearch | null;
+  /** Refusal of the last creation request, for the tree row that asked for it. */
+  createError: { path: string; message: string } | null;
+  /**
+   * Path the last creation actually produced. The tree needs a definite answer:
+   * "the name is in the listing" is also true when the name was already taken,
+   * which is the refusal it must not mistake for success.
+   */
+  created: string | null;
   extensionPaths: string[];
   sandbox: { root: string; allowWrite: boolean; allowBash: boolean; writableRoot?: string } | null;
   versions: { piOutpost: string; piSdk: string } | null;
@@ -189,6 +199,8 @@ const initialState: AgentState = {
   fileTree: {},
   openFile: null,
   fileSearch: null,
+  createError: null,
+  created: null,
   extensionPaths: [],
   sandbox: null,
   versions: null,
@@ -214,6 +226,7 @@ type Action =
   | { type: "file_read_started"; path: string; requestId: string }
   | { type: "file_save_started"; path: string; requestId: string; content: string }
   | { type: "close_file_preview" }
+  | { type: "file_create_started" }
   | { type: "file_search_started"; query: string; requestId: string }
   | { type: "file_search_cleared" }
   | { type: "session_search_started"; query: string; requestId: string }
@@ -336,6 +349,7 @@ function reduce(state: AgentState, action: Action): AgentState {
     return { ...state, fileSearch: { status: "loading", query: action.query, requestId: action.requestId, results: [] } };
   }
   if (action.type === "file_search_cleared") return { ...state, fileSearch: null };
+  if (action.type === "file_create_started") return { ...state, createError: null, created: null };
   if (action.type === "session_search_started") {
     return {
       ...state,
@@ -518,7 +532,12 @@ function reduce(state: AgentState, action: Action): AgentState {
     case "error":
       return { ...state, errors: [...state.errors, message.message] };
     case "directory_listing":
-      return { ...state, fileTree: { ...state.fileTree, [message.path]: message.entries } };
+      return {
+        ...state,
+        fileTree: { ...state.fileTree, [message.path]: message.entries },
+        // A listing answered under a creation request id *is* the creation's answer.
+        ...(message.requestId.startsWith("create:") ? { created: message.path, createError: null } : {}),
+      };
     case "file_content":
       // Ignore stale responses from a since-superseded read (user opened another file meanwhile)
       if (state.openFile?.status !== "loading" || state.openFile.requestId !== message.requestId) return state;
@@ -527,6 +546,24 @@ function reduce(state: AgentState, action: Action): AgentState {
         openFile: { status: "loaded", path: message.path, content: message.content, size: message.size, mtimeMs: message.mtimeMs },
       };
     case "file_written": {
+      if (message.requestId.startsWith("create:")) {
+        // A file that did not exist a moment ago: open it, empty, in edit mode.
+        // Its size and mtime come with the answer, so the editor can save without
+        // reading it back first.
+        return {
+          ...state,
+          createError: null,
+          created: message.path,
+          openFile: {
+            status: "loaded",
+            path: message.path,
+            content: "",
+            size: message.size,
+            mtimeMs: message.mtimeMs,
+            justCreated: true,
+          },
+        };
+      }
       const file = state.openFile;
       if (file?.status !== "loaded" || file.pendingSave?.requestId !== message.requestId) return state;
       return {
@@ -537,6 +574,9 @@ function reduce(state: AgentState, action: Action): AgentState {
     case "file_browser_error": {
       if (message.requestId.startsWith("dir:")) {
         return { ...state, fileTree: { ...state.fileTree, [message.path]: { error: message.message } } };
+      }
+      if (message.requestId.startsWith("create:")) {
+        return { ...state, createError: { path: message.path, message: message.message } };
       }
       if (message.requestId.startsWith("write:")) {
         const file = state.openFile;
@@ -872,6 +912,20 @@ export function useAgent(serverUrl = "", explicitToken?: string, embedded = fals
       const requestId = `write:${crypto.randomUUID()}`;
       dispatch({ type: "file_save_started", path, requestId, content });
       sendMessage({ type: "write_file", path, content, expectedMtimeMs, ...(force ? { force } : {}), requestId });
+    },
+    /**
+     * Create an empty file and open it. Deliberately not writeFile: `write_file`
+     * refuses a path that does not exist, and that refusal is the guard against
+     * clobbering a file that moved.
+     */
+    createFile: (path: string) => {
+      dispatch({ type: "file_create_started" });
+      sendMessage({ type: "create_file", path, requestId: `create:${crypto.randomUUID()}` });
+    },
+    /** Create one directory; answered with its (empty) listing. */
+    createDirectory: (path: string) => {
+      dispatch({ type: "file_create_started" });
+      sendMessage({ type: "create_directory", path, requestId: `create:${crypto.randomUUID()}` });
     },
     /** Search file/directory names for the composer's `@` mention autocomplete. */
     searchFiles: (query: string) => {


### PR DESCRIPTION
## Why

The browser could open, edit and save a file, but not make one. `writeFileFromBrowser`
refuses a path that is not already a file — and that refusal is the guard against clobbering
something that moved, not an oversight. So the only way to add an empty note was to ask the
agent, which needs write tools enabled and turns a two-second action into a prompt.

## What changes

A `+` appears on a writable directory row — hidden until hover like the `@` reference
control, always present on touch — and opens an input line in the tree at that directory.
The name is typed where the file will land, so the destination is shown rather than restated
in a dialog. A trailing slash asks for a folder instead. The root gets its own control above
the listing; it has no row of its own and would otherwise be the one directory nothing could
be made in.

Creation is **two new protocol messages** rather than a flag on `write_file`: one intent per
message, and `write_file` keeps refusing exactly what it refuses today (a scenario in the
spec pins that). The server shares every check with the write path — read-only sandbox,
symlink-safe confinement, writable zone — and creates with `writeFile(…, { flag: "wx" })`
and a non-recursive `mkdir`, so the existence check and the creation are one syscall with no
window between them.

A created file opens in the viewer in edit mode; a created folder expands.

## Note for review

The input first closed itself by watching the parent listing for the typed name. That reads
as success — and it is exactly what a **refused duplicate** looks like, since the name is in
the listing precisely because something already holds it. Retyping an existing name silently
dismissed the input and showed no refusal at all. Manual testing caught it; closing now waits
for the path the server says it created, and a regression test pins the duplicate case.

## Verification

Server and UI suites green, both coverage gates green, `openspec validate --strict` passes.
Exercised in the running app: file created and opened in edit mode, folder created and
listed, duplicate refused with the input and its text kept — then both removed from disk.

Spec: `openspec/changes/add-file-creation-from-tree/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)