### PR TITLE
Show a commit's full subject on hover

### DIFF
--- a/ui/src/components/GitFileHistory.test.tsx
+++ b/ui/src/components/GitFileHistory.test.tsx
@@ -37,6 +37,13 @@ describe("GitFileHistory", () => {
     expect(rows[1]).toHaveAttribute("aria-label", expect.stringContaining("latest change"));
   });
 
+  it("keeps the whole subject reachable on hover, since the row truncates it", () => {
+    const long = "a subject far too long for the row, whose end says why the commit exists";
+    setup({ history: loaded({ entries: [entry("aaaaaaa1", [], long)] }) });
+
+    expect(screen.getByText(long)).toHaveAttribute("title", long);
+  });
+
   it("spells out the line counts for a screen reader", () => {
     setup();
     expect(screen.getAllByLabelText("3 lines added, 1 removed").length).toBe(ENTRIES.length);

--- a/ui/src/components/GitFileHistory.tsx
+++ b/ui/src/components/GitFileHistory.tsx
@@ -323,7 +323,11 @@ function HistoryRow({ row, laneCount, role, isFocused, onSelect, onFocus, ref }:
       {entry ? (
         <>
           <span className="shrink-0 font-mono text-xs text-amber-600 dark:text-amber-500">{entry.sha.slice(0, 7)}</span>
-          <span className="min-w-0 flex-1 truncate text-sm text-zinc-700 dark:text-zinc-300">{entry.subject}</span>
+          {/* The row truncates to keep the graph dense; hovering restores what
+              was cut, which is usually the half of the subject that says why. */}
+          <span className="min-w-0 flex-1 truncate text-sm text-zinc-700 dark:text-zinc-300" title={entry.subject}>
+            {entry.subject}
+          </span>
           <span className="shrink-0 text-[10px] text-zinc-400 dark:text-zinc-600">
             {entry.author} · {relativeDate(entry.date)}
           </span>

--- a/ui/src/components/GitMenu.test.tsx
+++ b/ui/src/components/GitMenu.test.tsx
@@ -114,4 +114,11 @@ describe("GitMenu", () => {
     fireEvent.mouseDown(within(screen.getByText("most recent")).getByText("most recent"));
     expect(screen.getByText("most recent")).toBeInTheDocument();
   });
+
+  it("keeps the whole subject reachable on hover, since the row truncates it", () => {
+    setup();
+    fireEvent.click(chip());
+
+    expect(screen.getByText("most recent")).toHaveAttribute("title", "most recent");
+  });
 });

--- a/ui/src/components/GitMenu.tsx
+++ b/ui/src/components/GitMenu.tsx
@@ -67,7 +67,11 @@ export function GitMenu({ status, log, onFetchLog, onShowCommit }: GitMenuProps)
               className="flex w-full items-baseline gap-2 px-3 py-1.5 text-left text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800"
             >
               <span className="shrink-0 font-mono text-xs text-amber-600 dark:text-amber-500">{entry.sha.slice(0, 7)}</span>
-              <span className="min-w-0 flex-1 truncate text-zinc-700 dark:text-zinc-300">{entry.subject}</span>
+              {/* Same reason as the history graph: the list truncates, the tooltip
+                  gives back the end of the subject without opening the commit. */}
+              <span className="min-w-0 flex-1 truncate text-zinc-700 dark:text-zinc-300" title={entry.subject}>
+                {entry.subject}
+              </span>
               <span className="shrink-0 text-xs text-zinc-400 dark:text-zinc-600">
                 {entry.author} · {relativeDate(entry.date)}
               </span>


### PR DESCRIPTION
Both commit lists truncate. The history graph keeps its rows dense so the lanes stay readable;
the branch menu is a narrow dropdown. What gets cut is the end of the subject — usually the half
that says *why* the commit exists — and reading it meant opening the commit.

A `title` on the subject gives it back where it was cut, in both lists.

The message **body** is deliberately not fetched. The protocol already carries the subject, so
this costs no round trip and no new message; pulling bodies would mean a new `git_commit_message`
call and a per-sha cache for something a hover should not have to wait for.

Tests: one per list, asserting the full subject is reachable from the truncated row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)