### PR TITLE
fix: escape backslashes before pipes in extracted table cells

### DIFF
--- a/server/src/pdf.ts
+++ b/server/src/pdf.ts
@@ -203,8 +203,16 @@ function columnsOf(lines: Line[], cellsPerLine: Cell[][], start: number, end: nu
   return columns.length >= 2 ? { start, end, columns } : null;
 }
 
+/**
+ * A cell's text comes from the PDF, so it is attacker-controlled: it must not be
+ * able to add columns or rows to the table it lands in.
+ *
+ * Backslashes are escaped first. Escaping only the pipe leaves `\|` as `\\|` —
+ * an escaped backslash followed by a *live* pipe, which splits the cell exactly
+ * as the crafted text intended.
+ */
 function escapeCell(text: string): string {
-  return text.replace(/\|/g, "\\|").replace(/\s+/g, " ").trim();
+  return text.replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/\s+/g, " ").trim();
 }
 
 /**

--- a/server/test/pdf.test.ts
+++ b/server/test/pdf.test.ts
@@ -16,6 +16,7 @@ import {
   detectTableBlocks,
   extractPdf,
   lineCells,
+  linesToMarkdownTable,
   parsePageRange,
   pdfjsAssetDirs,
   PdfError,
@@ -258,6 +259,25 @@ describe("line and table geometry", () => {
     ]);
 
     assert.deepEqual(detectTableBlocks(lines), []);
+  });
+
+  test("a cell cannot break out of its column", () => {
+    // The text is the PDF's, so it is attacker-controlled. Escaping only the pipe
+    // would turn a trailing backslash into an escaped backslash followed by a live
+    // separator — the cell would swallow the boundary and shift every column after it.
+    const rows = [700, 680, 660].flatMap((y, r) => [
+      piece(r === 0 ? "name\\" : `n${r}`, 72, y),
+      piece(`v${r}`, 300, y),
+    ]);
+    const lines = buildLines(rows);
+    const block = detectTableBlocks(lines)[0];
+
+    const markdown = linesToMarkdownTable(lines, block);
+    const header = markdown.split("\n")[0];
+    assert.equal(header, String.raw`| name\\ | v0 |`);
+    for (const row of markdown.split("\n")) {
+      assert.equal(row.split(" | ").length, 2, `every row keeps two columns: ${row}`);
+    }
   });
 
   test("three aligned rows are a table", () => {


### PR DESCRIPTION
CodeQL alert #10 (`js/incomplete-sanitization`, high) on `escapeCell`.

A table cell's text comes from the PDF, so it is attacker-controlled. `escapeCell` escaped the
pipe but not the backslash, so `\|` became `\\|` — an escaped backslash followed by a **live**
separator. A crafted cell could therefore close its own column and shift every column after it in
the markdown the agent reads.

Escaping the backslash first fixes it. The regression test builds a table whose first cell ends in
a backslash and asserts every row still has exactly two columns.

Not a code-execution issue — the output is markdown in a tool result — but it is untrusted input
shaping the structure the model reads, which is the thing this extractor exists to keep honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)