### PR TITLE
chore(release): v0.7.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-outpost",
-  "version": "0.6.7",
+  "version": "0.7.0",
   "type": "module",
   "description": "A web interface for the pi coding agent: a browser chat UI you run with npx — no clone, no build.",
   "license": "MIT",

--- a/embed/package.json
+++ b/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-outpost/embed",
-  "version": "0.6.7",
+  "version": "0.7.0",
   "type": "module",
   "description": "Mount pi-outpost as a Shadow-DOM-isolated widget inside another web app.",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
     },
     "cli": {
       "name": "pi-outpost",
-      "version": "0.6.7",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "^0.84.1",
@@ -43,7 +43,7 @@
     },
     "embed": {
       "name": "@pi-outpost/embed",
-      "version": "0.6.7",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@microsoft/api-extractor": "^7.58.9",


### PR DESCRIPTION
Moves `pi-outpost` and `@pi-outpost/embed` from 0.6.7 to 0.7.0, plus the lockfile.

The release workflow treats the tag as the version claim and refuses to publish if no package is
actually at it, so this lands before `v0.7.0` is tagged.

Contents of the release: PDF viewer and `pdf_extract` (#50), presentation-based tool results (#47),
file and folder creation from the tree (#49), the file-history graph (#44) and its commit-subject
tooltip (#51), per-turn session cost and the analysis panel (#41), plus the fixes in #52, #43 and
#40 and the coverage gates from #42 and #45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)