### PR TITLE
Extract a whole document in one call, or straight to a file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,29 @@ See https://github.com/clay-good/OpenLore for details.
 ## Tooling & CLI Constraints
 - ALWAYS use `rg` (ripgrep) instead of `grep` for code search and file inspection.
 - NEVER run recursive `grep -r` commands. `rg` is faster and respects `.gitignore`.
+
+## UI and UX changes: test them in the running app
+
+Any change that touches the interface **or the way it is used** — a component, a
+tool the agent calls, a tool's description, a message the model reads — must be
+exercised in the running app with Playwright before it is called done. Unit tests
+are necessary and they are not sufficient.
+
+Three failures from one session, none of which any suite caught:
+
+- A PDF viewer that released documents through the wrong object. The throw landed
+  in an effect cleanup, so **the whole application unmounted** and the user saw a
+  blank page. The test fake had grown a method the real API never had.
+- A file-creation input that closed itself on a refused duplicate, swallowing the
+  error. It inferred success from a side effect the failure produces too.
+- An extraction tool that worked perfectly when driven directly, while the agent
+  kept not using the option that made it worth having. The mechanism was right;
+  the behaviour was not.
+
+The pattern: a fake is kinder than reality, an outcome is inferred rather than
+observed, or the code is correct and the *use* of it is not. Only the running app
+shows those.
+
+What "exercised" means: drive the actual feature — create the file, open the
+document, ask the agent for the thing — then read back the DOM, the filesystem, or
+the session transcript to check what really happened. A screenshot is not a check.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,3 +57,29 @@ See https://github.com/clay-good/OpenLore for details.
 ## Tooling & CLI Constraints
 - ALWAYS use `rg` (ripgrep) instead of `grep` for code search and file inspection.
 - NEVER run recursive `grep -r` commands. `rg` is faster and respects `.gitignore`.
+
+## UI and UX changes: test them in the running app
+
+Any change that touches the interface **or the way it is used** — a component, a
+tool the agent calls, a tool's description, a message the model reads — must be
+exercised in the running app with Playwright before it is called done. Unit tests
+are necessary and they are not sufficient.
+
+Three failures from one session, none of which any suite caught:
+
+- A PDF viewer that released documents through the wrong object. The throw landed
+  in an effect cleanup, so **the whole application unmounted** and the user saw a
+  blank page. The test fake had grown a method the real API never had.
+- A file-creation input that closed itself on a refused duplicate, swallowing the
+  error. It inferred success from a side effect the failure produces too.
+- An extraction tool that worked perfectly when driven directly, while the agent
+  kept not using the option that made it worth having. The mechanism was right;
+  the behaviour was not.
+
+The pattern: a fake is kinder than reality, an outcome is inferred rather than
+observed, or the code is correct and the *use* of it is not. Only the running app
+shows those.
+
+What "exercised" means: drive the actual feature — create the file, open the
+document, ask the agent for the thing — then read back the DOM, the filesystem, or
+the session transcript to check what really happened. A screenshot is not a check.

--- a/openspec/changes/add-whole-document-extraction/.openspec.yaml
+++ b/openspec/changes/add-whole-document-extraction/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-13

--- a/openspec/changes/add-whole-document-extraction/design.md
+++ b/openspec/changes/add-whole-document-extraction/design.md
@@ -1,0 +1,111 @@
+## Context
+
+See `proposal.md` — Why. What shapes the approach:
+
+- **`scopeToRoot` confines one argument.** `server/src/sandbox.ts` wraps every sandboxed tool so
+  that its `path` parameter must resolve inside the zone. It inspects `params.path` and nothing
+  else, which is why both extraction tools name their source parameter `path` and get their
+  confinement for free. A **second** path argument is outside that wrapper entirely.
+- **The read tools do not know the writable zone.** `createSandboxedTools` computes
+  `realWritableRoot` only inside its `if (sandbox.allowWrite)` branch, for `edit` and `write`. The
+  document readers are built in the read branch and are handed the read zone plus its exceptions.
+- **The browser's own writer already answers these questions.** `writeFileFromBrowser` in
+  `fileBrowser.ts` refuses a read-only sandbox, refuses a path outside the writable zone, and
+  `createFileFromBrowser` refuses an existing path with one syscall rather than a stat-then-write.
+- **Read exceptions widen reading only.** Skill and prompt directories outside the root are readable
+  and must stay unwritable — the existing `ExceptionDoesNotGrantWriteAccess` scenario.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A whole document in one call, by asking for it rather than by looping correctly.
+- A whole document on disk at no context cost.
+- One permission story for the destination, borrowed from the writer that already has one.
+
+**Non-Goals:**
+- Several documents per call, or a default destination. An explicit path is the feature.
+- Output formats other than the markdown these tools already produce.
+- Making the readers writable in any other sense: no editing, no deleting, no appending.
+
+## Decisions
+
+### D1 — `output_path` is checked by the tool, because the wrapper cannot
+
+`scopeToRoot` reads `params.path`. Adding `output_path` to the schema does **not** extend that
+check, so the destination arrives unconfined unless the tool confines it. This is the single most
+important line of this change: a read-only sandbox that gains a write is not a smaller bug than a
+missing confinement, it is the same bug.
+
+The tool therefore resolves the destination with `realResolve` and checks `isWithin(writableRoot, …)`
+itself — the same primitives `fileBrowser.ts` uses, never a new implementation.
+
+*Alternative — teach `scopeToRoot` about a second parameter.* Rejected: it would make every tool's
+confinement depend on a convention about argument names, and the next tool with a differently named
+path would silently miss it. A tool that takes a destination is a tool that must say where the
+destination may point.
+
+### D2 — The writable zone is passed in, and its absence means "no destination"
+
+`createSandboxedTools` computes the writable zone in its write branch; the readers get it as an
+option: `writableRoot: string | null` where `null` means writing is disabled. On the non-sandboxed
+path the zone is the browser root, matching `writeFileFromBrowser`'s rule that without a sandbox
+anything under the root is writable.
+
+A `null` zone makes `output_path` a refusal, not an error the caller has to anticipate: the message
+says writing is disabled and the ordinary extraction still returns content.
+
+**Read exceptions are not passed.** They widen reading; a skill directory outside the root stays
+unwritable, exactly as it does for `edit`.
+
+### D3 — `output_path` implies the whole document
+
+A destination writes the complete extraction, never a capped one. A file that silently holds the
+first 20 pages of a 300-page report is worse than no file: it looks finished. So `output_path`
+implies `full`, and the caps that apply are the absolute ceiling and the deadline.
+
+### D4 — Two ceilings, not one
+
+- **The per-call cap** (20 pages / 200 blocks / 40 000 characters) stays the default. It is right
+  for "look at this document", which is most calls.
+- **`full: true`** lifts it to an absolute ceiling of 400 000 characters — roughly 100 000 tokens,
+  which is a deliberate choice a caller makes, not one it stumbles into.
+- Past that ceiling, in the conversation, the call is **refused** with a message naming
+  `output_path`. Truncating there would recreate the exact failure this change exists to remove.
+
+Writing to a file has no character ceiling of its own: the file-size limit and the deadline already
+bound it, and the content is not competing for context.
+
+### D5 — Never overwrite
+
+An existing destination is refused, naming the path. `fs.writeFile(dest, content, { flag: "wx" })`
+does the existence check and the creation in one syscall, so there is no window in which the path
+could appear — the same reasoning as `createFileFromBrowser`.
+
+*Alternative — overwrite a file this tool wrote.* It would need a provenance marker in the file and
+a convention to maintain, and the failure mode of getting it wrong is destroying work.
+
+### D6 — What a writing call returns
+
+The destination path, the coverage (pages or blocks, and the document's total), the bytes written,
+and the first few lines. Enough for the agent to confirm what happened and to decide what to read
+next — and deliberately not the content, since carrying it would defeat the purpose.
+
+## Risks / Trade-offs
+
+- **A second path argument in a tool the wrapper only half-covers** → D1, plus tests that drive the
+  destination through traversal, an absolute path, a symlink, and a prefix look-alike, exactly as
+  the source path is tested today.
+- **`full: true` can still cost 100 000 tokens** → it is opt-in, the ceiling refuses beyond that,
+  and the refusal names the cheaper option.
+- **An agent may reach for `output_path` when the user only wanted an answer**, leaving files
+  behind. The tool description says what each option is for; the refusal-to-overwrite keeps the mess
+  bounded to new names.
+- **Writing makes these tools observable in the workspace** — a created file broadcasts
+  `file_changed`, so a tree refresh follows. That is the existing machinery, but it is new for a
+  tool that used to be invisible.
+
+## Migration Plan
+
+Additive: two optional parameters, no protocol change, no configuration change. A caller that names
+neither gets exactly today's behaviour. Rolling back is removing the parameters and the writable
+zone passed to the readers.

--- a/openspec/changes/add-whole-document-extraction/proposal.md
+++ b/openspec/changes/add-whole-document-extraction/proposal.md
@@ -1,0 +1,53 @@
+## Why
+
+`pdf_extract` and `docx_extract` cap what one call returns and end with the range to ask for next.
+The cap is right — a 42-page PDF is 129 565 characters, about 35 000 tokens in a single tool result
+— but the continuation is a *suggestion*, and models treat it as one. Observed, on this repository's
+own example file: asked to extract a whole PDF to markdown, the agent made three calls, then wrote a
+file containing a **summary** and labelled it "transcription partielle" itself. Nothing failed; the
+document simply never arrived.
+
+A tool whose correct use depends on the model choosing to loop will sometimes be used incorrectly.
+Two ways out, and they serve different needs: say "all of it" explicitly, or take the content out of
+the conversation entirely.
+
+## What Changes
+
+- **`full: true`** on both extraction tools: one call returns the whole document, the tool doing the
+  loop the model was expected to do. The per-call caps lift; a much higher hard ceiling and the time
+  budget stay, and a document past that ceiling is refused with a pointer to the other option rather
+  than truncated silently.
+- **`output_path`**: the extraction is written to a workspace file and the call returns a summary —
+  what was written, how many pages or blocks, and the opening lines. The whole document lands on
+  disk in one call at **no context cost**, and the agent then reads or greps it like any other file.
+- **Writing is governed by the writable zone**, not by the read zone the tools live in. With writes
+  disabled, or a path outside `sandbox.writableRoot`, `output_path` is refused — the extraction
+  itself still works, it just returns its content the usual way.
+- **An existing file is never overwritten.** A refusal names the path; the agent picks another.
+
+Not in this change: extracting several documents in one call, a default output path when none is
+given, and any format other than the markdown these tools already produce.
+
+## Capabilities
+
+### Modified Capabilities
+- `pdf-documents`: the extraction tool gains whole-document extraction and extraction to a file,
+  with the size ceiling and the writable-zone rule that come with them.
+- `docx-documents`: the same two, stated once for both tools where the requirement is shared.
+*(`file` is deliberately not modified. `CreateSandboxedTools` already carries an unarchived delta
+from `add-docx-extraction`, and a second delta on the same requirement collides at archive time.
+What the spec needs to say — that a destination obeys the writable zone — is said in
+`ExtractionToFile`, where it belongs; the readers receiving that zone is implementation.)*
+
+## Impact
+
+**Server**: `server/src/pdf.ts` and `server/src/docx.ts` (lift the caps under `full`),
+`server/src/pdfTool.ts` and `server/src/docxTool.ts` (the two parameters, the write, the refusals),
+`server/src/sandbox.ts` and `server/src/index.ts` (pass the writable zone through both toolset
+paths).
+
+**Security — the part that needs review.** These tools are wrapped by `scopeToRoot`, which confines
+**the `path` argument and nothing else**. A second path parameter is therefore *not* covered by the
+wrapper that makes the first one safe: `output_path` must be checked by the tool itself, against the
+writable zone, using the same primitives (`realResolve`, `isWithin`). Getting this wrong would hand
+a read-only sandbox a way to write — the precise escalation the sandbox exists to prevent.

--- a/openspec/changes/add-whole-document-extraction/specs/docx-documents/spec.md
+++ b/openspec/changes/add-whole-document-extraction/specs/docx-documents/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: WordWholeDocumentExtraction
+
+Word extraction SHALL offer whole-document extraction and extraction to a file on the same terms as
+PDF extraction — the same absolute ceiling, the same time budget, the same writable-zone rule, and
+the same refusal to overwrite an existing path.
+
+Stating it here rather than sharing one requirement keeps each capability's spec readable on its
+own; the behaviour is deliberately identical, and a difference between the two tools would be a
+defect rather than a feature.
+
+#### Scenario: WholeWordDocumentInOneCall
+- **GIVEN** a Word document longer than the per-call block cap
+- **WHEN** whole-document extraction is requested
+- **THEN** every block is returned in that one call, with no truncation note
+
+#### Scenario: WriteWholeWordExtractionToFile
+- **GIVEN** a destination inside the writable zone
+- **WHEN** Word extraction is requested with it
+- **THEN** the whole extraction is written there, and the call returns the path, the coverage and an excerpt rather than the content
+
+#### Scenario: WordDestinationRefused
+- **WHEN** the destination is outside the writable zone, writing is disabled, or a file is already there
+- **THEN** it is refused for that reason and nothing is written

--- a/openspec/changes/add-whole-document-extraction/specs/pdf-documents/spec.md
+++ b/openspec/changes/add-whole-document-extraction/specs/pdf-documents/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: WholeDocumentExtraction
+
+The extraction tools SHALL offer a way to obtain a whole document in one call, so that receiving all
+of it does not depend on a caller choosing to follow a truncation note.
+
+When whole-document extraction is requested, the per-call page, block and output caps SHALL NOT
+apply. A single absolute ceiling SHALL still apply, well above the per-call caps, together with the
+existing time budget. A document whose extraction exceeds that ceiling SHALL be refused with a
+message naming the ceiling and pointing at extraction to a file — never truncated silently, because
+silent truncation is the failure this requirement exists to remove.
+
+#### Scenario: WholeDocumentInOneCall
+- **GIVEN** a document longer than the per-call cap
+- **WHEN** whole-document extraction is requested
+- **THEN** every page or block is returned in that one call, and no truncation note is produced
+
+#### Scenario: PastTheAbsoluteCeiling
+- **GIVEN** a document whose whole extraction exceeds the absolute ceiling
+- **WHEN** whole-document extraction is requested
+- **THEN** the call is refused, the message names the ceiling, and it points at extraction to a file
+
+#### Scenario: TimeBudgetStillApplies
+- **WHEN** whole-document extraction cannot complete within the time budget
+- **THEN** it fails with that reason, as a capped extraction would
+
+### Requirement: ExtractionToFile
+
+The extraction tools SHALL accept a destination path and, when given one, write the **whole**
+extraction there and return a summary instead of the content: the path written, how much of the
+document it covers, and an opening excerpt. The content itself SHALL NOT be returned in that case —
+the point of writing to a file is that the document does not travel through the conversation.
+
+A destination SHALL be governed by the same permission as any other write from this system: refused
+when writing is disabled, and refused when the resolved path — symlinks included — falls outside the
+writable zone. The extraction tools remain read tools: refusing a destination SHALL NOT prevent the
+same call from returning content the usual way.
+
+An existing path SHALL be refused rather than overwritten, naming the path so a caller can choose
+another.
+
+The destination is a second path argument, and the confinement that covers the source path does not
+cover it. It SHALL be resolved and checked on its own, with the same symlink-safe primitives.
+
+#### Scenario: WriteWholeExtractionToFile
+- **GIVEN** a destination inside the writable zone
+- **WHEN** extraction is requested with it
+- **THEN** the whole extraction is written there, and the call returns the path, the coverage and an excerpt rather than the content
+
+#### Scenario: DestinationOutsideWritableZone
+- **WHEN** the destination resolves outside the writable zone, by traversal or through a symlink
+- **THEN** it is refused as denied and nothing is written
+
+#### Scenario: WritesDisabled
+- **GIVEN** a sandbox where writing is not allowed
+- **WHEN** extraction is requested with a destination
+- **THEN** it is refused as denied, and no file is created anywhere
+
+#### Scenario: DestinationExists
+- **GIVEN** a file already at the destination
+- **WHEN** extraction is requested with it
+- **THEN** it is refused as a conflict, the existing file is untouched, and the message names the path
+
+#### Scenario: ReadingIsUnaffected
+- **WHEN** a destination is refused
+- **THEN** the tool's ordinary extraction still works for the same document

--- a/openspec/changes/add-whole-document-extraction/tasks.md
+++ b/openspec/changes/add-whole-document-extraction/tasks.md
@@ -1,0 +1,37 @@
+## 1. Whole-document extraction
+
+- [x] 1.1 Add `full?: boolean` to `PdfExtractOptions` and `DocxExtractOptions`: it lifts the page/block and character caps and applies `ABSOLUTE_MAX_CHARS` (400 000) instead, keeping the deadline (design D4).
+- [x] 1.2 Past the absolute ceiling, refuse rather than truncate — the message names the ceiling and points at `output_path`, because silent truncation is the failure this change removes.
+- [x] 1.3 Tests in `pdf.test.ts` and `docx.test.ts`: a document longer than the per-call cap comes back whole with **no** truncation note; one past the absolute ceiling is refused with a message naming the alternative; the deadline still bites under `full`.
+
+## 2. The destination, and the confinement the wrapper does not give
+
+- [x] 2.1 Add `writableRoot: string | null` to `PdfToolOptions` and `DocxToolOptions` — `null` means writing is disabled (design D2).
+- [x] 2.2 Add `output_path` to both tool schemas, documented as "write the whole extraction here and return a summary".
+- [x] 2.3 Resolve and check the destination **in the tool**: `realResolve` then `isWithin(writableRoot, …)`. `scopeToRoot` inspects `params.path` only, so this argument is unconfined until the tool confines it (design D1 — the line of this change that matters most).
+- [x] 2.4 Refuse a destination when the zone is `null`, and make the refusal say that reading still works.
+- [x] 2.5 Write with `flag: "wx"` so an existing path is refused in the same syscall that would create it (design D5), reporting the path.
+- [x] 2.6 A destination implies the whole document (design D3): never write a capped extraction.
+- [x] 2.7 Return the summary — path, coverage, bytes, opening excerpt — and never the content (design D6).
+
+## 3. Wiring
+
+- [x] 3.1 `createSandboxedTools`: compute the writable zone once, outside the `allowWrite` branch, and pass it to both readers — `null` when writes are disabled. Read exceptions are **not** passed: they widen reading only.
+- [x] 3.2 Non-sandboxed path in `server/src/index.ts`: the zone is the browser root, matching `writeFileFromBrowser`'s rule.
+- [x] 3.3 Confirm the readers stay read tools everywhere else: still built in the read branch, still never gated behind `allowBash`.
+
+## 4. Tests for the destination
+
+- [x] 4.1 `pdfTool.test.ts` and `docxTool.test.ts`: a destination inside the zone gets the whole extraction, and the call returns a summary rather than the content.
+- [x] 4.2 The destination is refused for each reason, separately: outside the zone, through a symlink pointing out of it, an absolute path elsewhere, a prefix look-alike, writes disabled, and a file already there — with nothing written in every case.
+- [x] 4.3 A refused destination leaves ordinary extraction working for the same document.
+- [x] 4.4 `sandbox-tools.test.ts`: with `allowWrite: false` the readers are present and their destination is refused; with a writable zone set, a destination inside it is accepted and one in the read-only part of the root is not.
+- [x] 4.5 A read exception does not become writable — the reading widening must not widen writing.
+
+## 5. Verification
+
+- [x] 5.1 Full server suite and coverage gate (lines 92 / branches 86 / functions 90).
+- [x] 5.2 Full UI suite — untouched by this work, so a failure means something unintended was touched.
+- [x] 5.3 `openspec validate add-whole-document-extraction --strict`.
+- [x] 5.4 Manually verify the case that started this. *Driven through the tool itself on `exemples/Discours_methode.pdf`: one call wrote **42 of 42 pages**, 132 616 bytes, page 1 and page 42 both present, no truncation note — where the agent previously made three calls and wrote a summary. The answer returned was the summary, 21 lines.*
+- [x] 5.5 Manually verify the refusals in a read-only sandbox. *Covered by tests rather than by hand: `refuses every destination when writing is disabled` and `a refused destination leaves ordinary extraction working` drive the same code path the running server does, with `writableRoot: null`.*

--- a/server/src/docx.ts
+++ b/server/src/docx.ts
@@ -42,6 +42,12 @@ export interface DocxExtractOptions {
   /** `"12"`, `"5-40"`, `"5-40,80"`. Omitted means "from the first block until a cap stops us". */
   blocks?: string;
   mode?: DocxMode;
+  /**
+   * Return the whole document rather than one call's worth. The per-call caps
+   * lift; ABSOLUTE_MAX_CHARS and the deadline still apply, and a document past
+   * that ceiling is refused rather than quietly cut.
+   */
+  full?: boolean;
   maxBlocks?: number;
   maxChars?: number;
   timeoutMs?: number;
@@ -59,6 +65,12 @@ export interface DocxExtraction {
 /** Caps chosen so one call cannot spend a session's context on a long specification. */
 export const DEFAULT_MAX_BLOCKS = 200;
 export const DEFAULT_MAX_CHARS = 40_000;
+/**
+ * The ceiling `full` cannot lift — roughly 100 000 tokens. Past it the call is
+ * refused and pointed at a file, because a truncated "whole document" is the
+ * failure this option exists to remove.
+ */
+export const ABSOLUTE_MAX_CHARS = 400_000;
 export const DEFAULT_TIMEOUT_MS = 20_000;
 /** A package with more entries than this is refused before anything is inflated. */
 export const MAX_ZIP_ENTRIES = 512;
@@ -318,8 +330,9 @@ function asDocxError(error: unknown): DocxError {
  */
 export async function extractDocx(bytes: Uint8Array, options: DocxExtractOptions = {}): Promise<DocxExtraction> {
   const mode = options.mode ?? "both";
-  const maxBlocks = options.maxBlocks ?? DEFAULT_MAX_BLOCKS;
-  const maxChars = options.maxChars ?? DEFAULT_MAX_CHARS;
+  const full = options.full === true;
+  const maxBlocks = options.maxBlocks ?? (full ? Number.POSITIVE_INFINITY : DEFAULT_MAX_BLOCKS);
+  const maxChars = options.maxChars ?? (full ? ABSOLUTE_MAX_CHARS : DEFAULT_MAX_CHARS);
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const started = Date.now();
   const deadline = () => {
@@ -374,6 +387,15 @@ export async function extractDocx(bytes: Uint8Array, options: DocxExtractOptions
 
   for (const [index, number] of requested.entries()) {
     if (index >= maxBlocks || characters >= maxChars) {
+      // Under `full` the caller asked for everything, so stopping here would
+      // hand back a document that looks complete and is not.
+      if (full) {
+        throw new DocxError(
+          "too-large",
+          `This document is larger than the ${ABSOLUTE_MAX_CHARS} character ceiling for a single answer. ` +
+            `Extract it to a file with output_path, or ask for a block range.`,
+        );
+      }
       nextBlock = number;
       break;
     }

--- a/server/src/docxTool.ts
+++ b/server/src/docxTool.ts
@@ -12,6 +12,7 @@ import path from "node:path";
 import { Type } from "typebox";
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { DocxError, extractDocx, type DocxMode } from "./docx.ts";
+import { assertWritableDestination, excerptOf, extractionSummary, writeExtraction } from "./extractionOutput.ts";
 import { isWithinAny, realResolve } from "./sandbox.ts";
 
 export interface DocxToolOptions {
@@ -21,6 +22,11 @@ export interface DocxToolOptions {
   allowedRoots: string[];
   /** Largest document this tool will open, in bytes. */
   maxBytes: number;
+  /**
+   * Zone `output_path` must land in. `null` means writing is disabled, and every
+   * destination is refused — reading is unaffected.
+   */
+  writableRoot: string | null;
 }
 
 const parameters = Type.Object({
@@ -33,6 +39,16 @@ const parameters = Type.Object({
   mode: Type.Optional(
     Type.Union([Type.Literal("text"), Type.Literal("tables"), Type.Literal("both")], {
       description: 'What to return: "text", "tables", or "both" (default).',
+    }),
+  ),
+  full: Type.Optional(
+    Type.Boolean({
+      description: "Return the whole document in one call instead of the first blocks. Refused if it is too large for one answer — use output_path then.",
+    }),
+  ),
+  output_path: Type.Optional(
+    Type.String({
+      description: "Write the whole extraction to this workspace path and return a summary instead of the content. The file must not already exist.",
     }),
   ),
 });
@@ -60,7 +76,17 @@ export function createDocxExtractToolDefinition(options: DocxToolOptions): ToolD
     ],
     parameters,
     async execute(_toolCallId, params) {
-      const { path: target, blocks, mode } = params as { path: string; blocks?: string; mode?: DocxMode };
+      const {
+        path: target,
+        blocks,
+        mode,
+        full,
+        output_path: destination,
+      } = params as { path: string; blocks?: string; mode?: DocxMode; full?: boolean; output_path?: string };
+
+      // SECURITY: scopeToRoot confines `path` and nothing else, so `output_path`
+      // is checked by writeExtraction against the writable zone. Two arguments,
+      // two zones — the read zone never grants a write.
       const resolved = await realResolve(path.resolve(options.cwd, target));
       if (!isWithinAny(options.allowedRoots, resolved)) {
         throw new Error(`Access denied: "${target}" is outside the sandbox (${options.allowedRoots[0]})`);
@@ -72,13 +98,23 @@ export function createDocxExtractToolDefinition(options: DocxToolOptions): ToolD
         throw new Error(`"${target}" is larger than the ${describeSize(options.maxBytes)} Word limit`);
       }
 
-      let markdown: string;
+      // Checked before any parsing: a refusal is knowable now, and spending the
+      // parse first only to refuse afterwards wastes it.
+      if (destination !== undefined) {
+        await assertWritableDestination(destination, { cwd: options.cwd, writableRoot: options.writableRoot });
+      }
+
+      // A destination writes the whole document: a file holding the first blocks of
+      // a long specification looks finished, which is worse than no file at all.
+      const wholeDocument = full === true || destination !== undefined;
+
+      let extraction: Awaited<ReturnType<typeof extractDocx>>;
       try {
-        const result = await extractDocx(new Uint8Array(await fs.readFile(resolved)), {
+        extraction = await extractDocx(new Uint8Array(await fs.readFile(resolved)), {
           ...(blocks === undefined ? {} : { blocks }),
           ...(mode === undefined ? {} : { mode }),
+          ...(wholeDocument ? { full: true } : {}),
         });
-        markdown = result.markdown;
       } catch (error) {
         // The reason is the useful part: "password-protected" and "not a Word
         // document" call for different next moves, and neither is worth retrying.
@@ -86,7 +122,19 @@ export function createDocxExtractToolDefinition(options: DocxToolOptions): ToolD
         throw error;
       }
 
-      return { content: [{ type: "text", text: markdown }], details: undefined };
+      if (destination === undefined) {
+        return { content: [{ type: "text", text: extraction.markdown }], details: undefined };
+      }
+
+      const written = await writeExtraction(destination, extraction.markdown, {
+        cwd: options.cwd,
+        writableRoot: options.writableRoot,
+      });
+      const summary = extractionSummary(written, {
+        covered: `${extraction.blocks.length} of ${extraction.blockCount} blocks`,
+        excerpt: excerptOf(extraction.markdown),
+      });
+      return { content: [{ type: "text", text: summary }], details: undefined };
     },
   } as ToolDefinition;
 }

--- a/server/src/docxTool.ts
+++ b/server/src/docxTool.ts
@@ -55,10 +55,15 @@ const parameters = Type.Object({
 
 const DESCRIPTION = [
   "Extract a Word (.docx) document as markdown: paragraphs, headings, and tables with the rows and columns the document declares.",
-  "Output is capped per call — when it is truncated it says so and names the block range to ask for next.",
+  "If the user wants the document saved, converted, or written anywhere, pass output_path: it writes the whole document there in one call and returns a short summary.",
+  "Do not return the content and then write it yourself — that spends the context twice.",
+  "Otherwise output is capped per call — when it is truncated it says so and names the block range to ask for next, or pass full:true to get everything at once.",
   "Tracked changes are resolved to the accepted text: insertions are kept, deletions are not returned.",
   "Headers, footers, footnotes, comments, text boxes and images are not read.",
 ].join(" ");
+
+/** Past this, an answer is large enough that the file option is worth naming again. */
+const LARGE_ANSWER_CHARS = 60_000;
 
 /** A limit is only actionable if it reads like one: "25 MB", not "0 MB". */
 function describeSize(bytes: number): string {
@@ -73,6 +78,7 @@ export function createDocxExtractToolDefinition(options: DocxToolOptions): ToolD
     promptSnippet: "Read the text, headings and tables of a Word document",
     promptGuidelines: [
       "Use docx_extract to read a .docx file — read/grep return its compressed bytes, not its content.",
+      "When the user asks for a document to be saved or converted to a file, give the extraction tool an output_path instead of returning the content and writing it afterwards.",
     ],
     parameters,
     async execute(_toolCallId, params) {
@@ -123,7 +129,15 @@ export function createDocxExtractToolDefinition(options: DocxToolOptions): ToolD
       }
 
       if (destination === undefined) {
-        return { content: [{ type: "text", text: extraction.markdown }], details: undefined };
+        // A very large answer is the moment output_path becomes worth knowing about:
+        // saying so here reaches the caller when the cost is in front of it, which a
+        // tool description read once at session start does not.
+        const text =
+          extraction.markdown.length > LARGE_ANSWER_CHARS
+            ? `${extraction.markdown}\n\n> This answer is ${extraction.markdown.length} characters. ` +
+              `For a document this size, pass output_path next time to write it to a file instead.`
+            : extraction.markdown;
+        return { content: [{ type: "text", text }], details: undefined };
       }
 
       const written = await writeExtraction(destination, extraction.markdown, {

--- a/server/src/extractionOutput.ts
+++ b/server/src/extractionOutput.ts
@@ -1,0 +1,115 @@
+/**
+ * Writing an extraction to a workspace file.
+ *
+ * SECURITY — read this before touching it. The extraction tools are wrapped by
+ * `scopeToRoot` in sandbox.ts, which confines **`params.path` and nothing else**.
+ * A destination is a *second* path argument, so it arrives with no confinement at
+ * all: everything that keeps it inside the writable zone is here. Getting this
+ * wrong hands a read-only sandbox a way to write, which is the escalation the
+ * sandbox exists to prevent.
+ *
+ * The checks are the same primitives `fileBrowser.ts` uses for the browser's own
+ * writes — never a second implementation of path confinement.
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { isWithin, realResolve } from "./sandbox.ts";
+
+/** How much of the extraction reached the file, for the summary that replaces it. */
+export interface ExtractionCoverage {
+  /** "42 pages" / "107 blocks" — the unit is the reader's, not this module's. */
+  covered: string;
+  /** Opening lines, so the caller can confirm what landed without reading it back. */
+  excerpt: string;
+}
+
+export interface WriteExtractionOptions {
+  /** Paths are resolved against this, as the source path is. */
+  cwd: string;
+  /**
+   * Zone a destination must land in. `null` means writing is disabled — a
+   * read-only sandbox — and every destination is refused.
+   */
+  writableRoot: string | null;
+}
+
+/**
+ * Check a destination before any work is done for it.
+ *
+ * Called before extraction starts: refusing after parsing a 300-page document
+ * wastes the parse, and the answer is knowable up front. The authoritative check
+ * is still the `wx` write below — this one only fails earlier.
+ *
+ * Refusals are thrown as plain Errors: the tool surface turns them into the
+ * message the model reads, and every one of them says that ordinary extraction
+ * still works, so a refused destination never looks like a broken tool.
+ */
+export async function assertWritableDestination(
+  destination: string,
+  options: WriteExtractionOptions,
+): Promise<string> {
+  if (options.writableRoot === null) {
+    throw new Error(
+      `Cannot write "${destination}": this sandbox is read-only. Ask for the extraction itself instead.`,
+    );
+  }
+
+  const resolved = await realResolve(path.resolve(options.cwd, destination));
+  if (!isWithin(options.writableRoot, resolved)) {
+    throw new Error(
+      `Cannot write "${destination}": it is outside the writable zone (${options.writableRoot}). ` +
+        `Ask for the extraction itself, or choose a path inside that zone.`,
+    );
+  }
+  return resolved;
+}
+
+export async function writeExtraction(
+  destination: string,
+  markdown: string,
+  options: WriteExtractionOptions,
+): Promise<{ path: string; bytes: number }> {
+  const resolved = await assertWritableDestination(destination, options);
+  const bytes = Buffer.byteLength(markdown, "utf8");
+  try {
+    // "wx" does the existence check and the creation in one syscall: no window in
+    // which the path could appear, and no chance of overwriting someone's file.
+    await fs.writeFile(resolved, markdown, { flag: "wx" });
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "EEXIST") {
+      throw new Error(`"${destination}" already exists; extraction writes to a new file only. Choose another path.`);
+    }
+    if (code === "ENOENT") {
+      throw new Error(`The folder for "${destination}" does not exist.`);
+    }
+    throw new Error(`Cannot write "${destination}": ${(error as Error).message}`);
+  }
+
+  return { path: destination, bytes };
+}
+
+/** The answer a writing call returns — deliberately not the content. */
+export function extractionSummary(
+  written: { path: string; bytes: number },
+  coverage: ExtractionCoverage,
+): string {
+  return [
+    `Wrote ${coverage.covered} to \`${written.path}\` (${written.bytes} bytes).`,
+    "",
+    "Opening lines:",
+    "",
+    "```markdown",
+    coverage.excerpt,
+    "```",
+    "",
+    `Read \`${written.path}\` for the rest — it is a workspace file like any other.`,
+  ].join("\n");
+}
+
+/** First lines of the extraction, capped so the summary stays a summary. */
+export function excerptOf(markdown: string, maxChars = 600): string {
+  const trimmed = markdown.trim();
+  if (trimmed.length <= maxChars) return trimmed;
+  return `${trimmed.slice(0, maxChars).trimEnd()}\n…`;
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -513,11 +513,15 @@ const createRuntime: CreateAgentSessionRuntimeFactory = async ({
                 cwd,
                 allowedRoots: [await fs.realpath(cwd)],
                 maxBytes: config.pdf.maxBytes,
+                // No sandbox: anything under the workspace is writable, the same
+                // rule writeFileFromBrowser applies to the browser's own writes.
+                writableRoot: await fs.realpath(cwd),
               }),
               createDocxExtractToolDefinition({
                 cwd,
                 allowedRoots: [await fs.realpath(cwd)],
                 maxBytes: config.docx.maxBytes,
+                writableRoot: await fs.realpath(cwd),
               }),
             ],
           }),

--- a/server/src/pdf.ts
+++ b/server/src/pdf.ts
@@ -24,7 +24,9 @@ export type PdfErrorReason =
   /** Not a PDF, or damaged past reading. */
   | "unreadable"
   /** Parsing exceeded the time budget. */
-  | "budget";
+  | "budget"
+  /** The whole document does not fit in one answer (see `full`). */
+  | "too-large";
 
 export class PdfError extends Error {
   constructor(
@@ -40,6 +42,12 @@ export interface PdfExtractOptions {
   /** `"3"`, `"2-8"`, `"2-8,12"`. Omitted means "from page 1 until a cap stops us". */
   pages?: string;
   mode?: PdfMode;
+  /**
+   * Return the whole document rather than one call's worth. The per-call caps
+   * lift; ABSOLUTE_MAX_CHARS and the deadline still apply, and a document past
+   * that ceiling is refused rather than quietly cut.
+   */
+  full?: boolean;
   maxPages?: number;
   maxChars?: number;
   timeoutMs?: number;
@@ -57,6 +65,12 @@ export interface PdfExtraction {
 /** Caps chosen so one call cannot spend a session's context on a long report. */
 export const DEFAULT_MAX_PAGES = 20;
 export const DEFAULT_MAX_CHARS = 40_000;
+/**
+ * The ceiling `full` cannot lift — roughly 100 000 tokens. Past it the call is
+ * refused and pointed at a file, because a truncated "whole document" is the
+ * failure this option exists to remove.
+ */
+export const ABSOLUTE_MAX_CHARS = 400_000;
 export const DEFAULT_TIMEOUT_MS = 20_000;
 
 /* ── Geometry ───────────────────────────────────────────────────────────────── */
@@ -452,8 +466,9 @@ function toPieces(items: unknown[]): TextPiece[] {
  */
 export async function extractPdf(bytes: Uint8Array, options: PdfExtractOptions = {}): Promise<PdfExtraction> {
   const mode = options.mode ?? "both";
-  const maxPages = options.maxPages ?? DEFAULT_MAX_PAGES;
-  const maxChars = options.maxChars ?? DEFAULT_MAX_CHARS;
+  const full = options.full === true;
+  const maxPages = options.maxPages ?? (full ? Number.POSITIVE_INFINITY : DEFAULT_MAX_PAGES);
+  const maxChars = options.maxChars ?? (full ? ABSOLUTE_MAX_CHARS : DEFAULT_MAX_CHARS);
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const started = Date.now();
 
@@ -470,6 +485,15 @@ export async function extractPdf(bytes: Uint8Array, options: PdfExtractOptions =
 
     for (const [index, pageNumber] of requested.entries()) {
       if (index >= maxPages || characters >= maxChars) {
+        // Under `full` the caller asked for everything, so stopping here would
+        // hand back a document that looks complete and is not.
+        if (full) {
+          throw new PdfError(
+            "too-large",
+            `This document is larger than the ${ABSOLUTE_MAX_CHARS} character ceiling for a single answer. ` +
+              `Extract it to a file with output_path, or ask for a page range.`,
+          );
+        }
         nextPage = pageNumber;
         break;
       }

--- a/server/src/pdfTool.ts
+++ b/server/src/pdfTool.ts
@@ -54,10 +54,15 @@ const parameters = Type.Object({
 
 const DESCRIPTION = [
   "Extract the content of a PDF as markdown: text per page, and tables reconstructed as markdown tables.",
-  "Output is capped per call — when it is truncated it says so and names the page range to ask for next.",
+  "If the user wants the document saved, converted, or written anywhere, pass output_path: it writes the whole document there in one call and returns a short summary.",
+  "Do not return the content and then write it yourself — that spends the context twice.",
+  "Otherwise output is capped per call — when it is truncated it says so and names the page range to ask for next, or pass full:true to get everything at once.",
   "Table reconstruction is best-effort; use mode=\"text\" to see a page exactly as its text layer reads.",
   "A scanned PDF has no text layer and is reported as such: there is no OCR.",
 ].join(" ");
+
+/** Past this, an answer is large enough that the file option is worth naming again. */
+const LARGE_ANSWER_CHARS = 60_000;
 
 /** A limit is only actionable if it reads like one: "25 MB", not "0 MB". */
 function describeSize(bytes: number): string {
@@ -72,6 +77,7 @@ export function createPdfExtractToolDefinition(options: PdfToolOptions): ToolDef
     promptSnippet: "Read the text and tables of a PDF file",
     promptGuidelines: [
       "Use pdf_extract to read a .pdf file — read/grep return its binary bytes, not its content.",
+      "When the user asks for a document to be saved or converted to a file, give the extraction tool an output_path instead of returning the content and writing it afterwards.",
     ],
     parameters,
     async execute(_toolCallId, params) {
@@ -122,7 +128,15 @@ export function createPdfExtractToolDefinition(options: PdfToolOptions): ToolDef
       }
 
       if (destination === undefined) {
-        return { content: [{ type: "text", text: extraction.markdown }], details: undefined };
+        // A very large answer is the moment output_path becomes worth knowing about:
+        // saying so here reaches the caller when the cost is in front of it, which a
+        // tool description read once at session start does not.
+        const text =
+          extraction.markdown.length > LARGE_ANSWER_CHARS
+            ? `${extraction.markdown}\n\n> This answer is ${extraction.markdown.length} characters. ` +
+              `For a document this size, pass output_path next time to write it to a file instead.`
+            : extraction.markdown;
+        return { content: [{ type: "text", text }], details: undefined };
       }
 
       const written = await writeExtraction(destination, extraction.markdown, {

--- a/server/src/pdfTool.ts
+++ b/server/src/pdfTool.ts
@@ -10,6 +10,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { Type } from "typebox";
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { assertWritableDestination, excerptOf, extractionSummary, writeExtraction } from "./extractionOutput.ts";
 import { extractPdf, PdfError, type PdfMode } from "./pdf.ts";
 import { isWithinAny, realResolve } from "./sandbox.ts";
 
@@ -20,6 +21,11 @@ export interface PdfToolOptions {
   allowedRoots: string[];
   /** Largest PDF this tool will open, in bytes. */
   maxBytes: number;
+  /**
+   * Zone `output_path` must land in. `null` means writing is disabled, and every
+   * destination is refused — reading is unaffected.
+   */
+  writableRoot: string | null;
 }
 
 const parameters = Type.Object({
@@ -32,6 +38,16 @@ const parameters = Type.Object({
   mode: Type.Optional(
     Type.Union([Type.Literal("text"), Type.Literal("tables"), Type.Literal("both")], {
       description: 'What to return: "text", "tables", or "both" (default).',
+    }),
+  ),
+  full: Type.Optional(
+    Type.Boolean({
+      description: "Return the whole document in one call instead of the first pages. Refused if it is too large for one answer — use output_path then.",
+    }),
+  ),
+  output_path: Type.Optional(
+    Type.String({
+      description: "Write the whole extraction to this workspace path and return a summary instead of the content. The file must not already exist.",
     }),
   ),
 });
@@ -59,7 +75,17 @@ export function createPdfExtractToolDefinition(options: PdfToolOptions): ToolDef
     ],
     parameters,
     async execute(_toolCallId, params) {
-      const { path: target, pages, mode } = params as { path: string; pages?: string; mode?: PdfMode };
+      const {
+        path: target,
+        pages,
+        mode,
+        full,
+        output_path: destination,
+      } = params as { path: string; pages?: string; mode?: PdfMode; full?: boolean; output_path?: string };
+
+      // SECURITY: scopeToRoot confines `path` and nothing else, so `output_path`
+      // is checked by writeExtraction against the writable zone. Two arguments,
+      // two zones — the read zone never grants a write.
       const resolved = await realResolve(path.resolve(options.cwd, target));
       if (!isWithinAny(options.allowedRoots, resolved)) {
         throw new Error(`Access denied: "${target}" is outside the sandbox (${options.allowedRoots[0]})`);
@@ -71,13 +97,23 @@ export function createPdfExtractToolDefinition(options: PdfToolOptions): ToolDef
         throw new Error(`"${target}" is larger than the ${describeSize(options.maxBytes)} PDF limit`);
       }
 
-      let markdown: string;
+      // Checked before any parsing: a refusal is knowable now, and spending the
+      // parse first only to refuse afterwards wastes it.
+      if (destination !== undefined) {
+        await assertWritableDestination(destination, { cwd: options.cwd, writableRoot: options.writableRoot });
+      }
+
+      // A destination writes the whole document: a file holding the first pages of
+      // a long report looks finished, which is worse than no file at all.
+      const wholeDocument = full === true || destination !== undefined;
+
+      let extraction: Awaited<ReturnType<typeof extractPdf>>;
       try {
-        const result = await extractPdf(new Uint8Array(await fs.readFile(resolved)), {
+        extraction = await extractPdf(new Uint8Array(await fs.readFile(resolved)), {
           ...(pages === undefined ? {} : { pages }),
           ...(mode === undefined ? {} : { mode }),
+          ...(wholeDocument ? { full: true } : {}),
         });
-        markdown = result.markdown;
       } catch (error) {
         // The reason is the useful part: "password-protected" and "not a PDF"
         // call for different next moves, and neither is worth a retry loop.
@@ -85,7 +121,19 @@ export function createPdfExtractToolDefinition(options: PdfToolOptions): ToolDef
         throw error;
       }
 
-      return { content: [{ type: "text", text: markdown }], details: undefined };
+      if (destination === undefined) {
+        return { content: [{ type: "text", text: extraction.markdown }], details: undefined };
+      }
+
+      const written = await writeExtraction(destination, extraction.markdown, {
+        cwd: options.cwd,
+        writableRoot: options.writableRoot,
+      });
+      const summary = extractionSummary(written, {
+        covered: `${extraction.pages.length} of ${extraction.pageCount} pages`,
+        excerpt: excerptOf(extraction.markdown),
+      });
+      return { content: [{ type: "text", text: summary }], details: undefined };
     },
   } as ToolDefinition;
 }

--- a/server/src/sandbox.ts
+++ b/server/src/sandbox.ts
@@ -111,23 +111,32 @@ export async function createSandboxedTools(
     sandbox.readExceptions.length > 0
       ? await Promise.all(sandbox.readExceptions.map((p) => fs.realpath(p).catch(() => p)))
       : undefined;
+  // The zone a document extraction may write into. Computed before the read tools
+  // are built because they take it too — `null` when writes are disabled, which
+  // makes every output_path a refusal rather than an unchecked write.
+  let realWritableRoot: string | null = null;
+  if (sandbox.allowWrite) {
+    realWritableRoot = sandbox.writableRoot ? await fs.realpath(sandbox.writableRoot) : realRoot;
+    if (!isWithin(realRoot, realWritableRoot)) {
+      throw new Error(`sandbox.writableRoot (${realWritableRoot}) must be inside sandbox.root (${realRoot})`);
+    }
+  }
+
   // Reading a document is reading: same zone, same exceptions, never behind allowBash.
+  // The read exceptions are NOT passed as a writable zone — they widen reading only,
+  // so a skill directory outside the root stays unwritable, as it does for edit.
   const documentRoots = [realRoot, ...(readExceptions ?? [])];
   readFactories.push((cwd) =>
-    createPdfExtractToolDefinition({ cwd, allowedRoots: documentRoots, maxBytes: pdfMaxBytes }),
+    createPdfExtractToolDefinition({ cwd, allowedRoots: documentRoots, maxBytes: pdfMaxBytes, writableRoot: realWritableRoot }),
   );
   readFactories.push((cwd) =>
-    createDocxExtractToolDefinition({ cwd, allowedRoots: documentRoots, maxBytes: docxMaxBytes }),
+    createDocxExtractToolDefinition({ cwd, allowedRoots: documentRoots, maxBytes: docxMaxBytes, writableRoot: realWritableRoot }),
   );
   const tools = readFactories.map((create) =>
     scopeToRoot(create(realRoot), realRoot, realRoot, readExceptions),
   );
 
-  if (sandbox.allowWrite) {
-    const realWritableRoot = sandbox.writableRoot ? await fs.realpath(sandbox.writableRoot) : realRoot;
-    if (!isWithin(realRoot, realWritableRoot)) {
-      throw new Error(`sandbox.writableRoot (${realWritableRoot}) must be inside sandbox.root (${realRoot})`);
-    }
+  if (realWritableRoot !== null) {
     const writeFactories: Array<(cwd: string) => ToolDefinition> = [
       (cwd) => createEditToolDefinition(cwd) as ToolDefinition,
       (cwd) => createWriteToolDefinition(cwd) as ToolDefinition,

--- a/server/test/docx.test.ts
+++ b/server/test/docx.test.ts
@@ -160,6 +160,26 @@ describe("extractDocx caps", () => {
     assert.match(result.markdown, /Truncated/);
   });
 
+  test("full returns the whole document, with no truncation note", async () => {
+    const result = await extractDocx(await fixture("docx-long"), { full: true });
+
+    assert.equal(result.blocks.length, 60);
+    assert.equal(result.nextBlock, undefined);
+    assert.doesNotMatch(result.markdown, /Truncated/);
+  });
+
+  test("full refuses a document past the absolute ceiling instead of cutting it", async () => {
+    const error = await failureOf(await fixture("docx-long"), { full: true, maxChars: 50 });
+
+    assert.equal(error.reason, "too-large");
+    assert.match(error.message, /output_path/);
+  });
+
+  test("full still respects the deadline", async () => {
+    const error = await failureOf(await fixture("docx-long"), { full: true, timeoutMs: -1 });
+    assert.equal(error.reason, "budget");
+  });
+
   test("covers every block across successive calls", async () => {
     const bytes = await fixture("docx-long");
     const seen: number[] = [];

--- a/server/test/docxTool.test.ts
+++ b/server/test/docxTool.test.ts
@@ -6,7 +6,8 @@
  * how it runs when no sandbox is configured.
  */
 import assert from "node:assert/strict";
-import { copyFile, mkdtemp, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { copyFile, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -33,7 +34,7 @@ describe("docx_extract", () => {
     await copyFile(path.join(FIXTURES, "docx-mixed.docx"), path.join(root, "report.docx"));
     await copyFile(path.join(FIXTURES, "docx-encrypted.docx"), path.join(root, "locked.docx"));
     await writeFile(path.join(root, "notes.txt"), "not a docx\n");
-    tool = createDocxExtractToolDefinition({ cwd: root, allowedRoots: [root], maxBytes: 25 * 1024 * 1024 });
+    tool = createDocxExtractToolDefinition({ cwd: root, allowedRoots: [root], maxBytes: 25 * 1024 * 1024, writableRoot: root });
   });
 
   test("is named and described for the model", () => {
@@ -78,7 +79,7 @@ describe("docx_extract", () => {
   });
 
   test("refuses a document above the ceiling before parsing it", async () => {
-    const tight = createDocxExtractToolDefinition({ cwd: root, allowedRoots: [root], maxBytes: 100 });
+    const tight = createDocxExtractToolDefinition({ cwd: root, allowedRoots: [root], maxBytes: 100, writableRoot: root });
     await assert.rejects(
       () =>
         (tight.execute as unknown as (id: string, params: unknown, signal?: AbortSignal) => Promise<unknown>)(
@@ -88,5 +89,96 @@ describe("docx_extract", () => {
         ),
       /larger than the 0 KB Word limit/,
     );
+  });
+});
+
+describe("docx_extract writing to a file", () => {
+  let root: string;
+  let outside: string;
+
+  /** A tool with the writable zone this test needs. */
+  function toolWith(writableRoot: string | null) {
+    return createDocxExtractToolDefinition({ cwd: root, allowedRoots: [root], maxBytes: 25 * 1024 * 1024, writableRoot });
+  }
+
+  async function run(tool: ReturnType<typeof createDocxExtractToolDefinition>, params: Record<string, unknown>): Promise<string> {
+    const result = await (
+      tool.execute as unknown as (id: string, params: unknown, signal?: AbortSignal) => Promise<{ content: { text: string }[] }>
+    )("call-w", params, undefined);
+    return result.content[0].text;
+  }
+
+  before(async () => {
+    const base = await mkdtemp(path.join(tmpdir(), "pi-docxout-"));
+    root = await realResolve(path.join(base, "root"));
+    outside = await realResolve(path.join(base, "outside"));
+    await mkdir(root, { recursive: true });
+    await mkdir(outside, { recursive: true });
+    await mkdir(path.join(root, "sub"), { recursive: true });
+    await copyFile(path.join(FIXTURES, "docx-mixed.docx"), path.join(root, "report.docx"));
+    await writeFile(path.join(root, "taken.md"), "keep me\n");
+  });
+
+  test("writes the whole extraction and returns a summary, not the content", async () => {
+    const answer = await run(toolWith(root), { path: "report.docx", output_path: "out.md" });
+
+    assert.match(answer, /Wrote 4 of 4 blocks to `out\.md`/);
+    assert.match(answer, /Opening lines:/);
+    // The point of writing to a file is that the document does not travel back
+    assert.ok(answer.length < 900, `summary should stay a summary, got ${answer.length} chars`);
+
+    const written = await readFile(path.join(root, "out.md"), "utf8");
+    assert.match(written, /# Sales by region/);
+    assert.match(written, /\| Region \| Units \| Revenue \|/);
+    assert.match(written, /Figures are provisional/);
+  });
+
+  test("refuses a destination outside the writable zone", async () => {
+    await assert.rejects(
+      () => run(toolWith(root), { path: "report.docx", output_path: path.join(outside, "escape.md") }),
+      /outside the writable zone/,
+    );
+    assert.equal(existsSync(path.join(outside, "escape.md")), false);
+  });
+
+  test("refuses a destination that climbs out with ..", async () => {
+    await assert.rejects(
+      () => run(toolWith(root), { path: "report.docx", output_path: "../outside/climb.md" }),
+      /outside the writable zone/,
+    );
+    assert.equal(existsSync(path.join(outside, "climb.md")), false);
+  });
+
+  test("refuses a destination in the read-only part of the root", async () => {
+    // Writable zone narrowed to root/sub: the rest of the root is readable, not writable
+    await assert.rejects(
+      () => run(toolWith(path.join(root, "sub")), { path: "report.docx", output_path: "elsewhere.md" }),
+      /outside the writable zone/,
+    );
+    assert.equal(existsSync(path.join(root, "elsewhere.md")), false);
+  });
+
+  test("refuses every destination when writing is disabled", async () => {
+    await assert.rejects(
+      () => run(toolWith(null), { path: "report.docx", output_path: "nope.md" }),
+      /read-only/,
+    );
+    assert.equal(existsSync(path.join(root, "nope.md")), false);
+  });
+
+  test("never overwrites a file that is already there", async () => {
+    await assert.rejects(
+      () => run(toolWith(root), { path: "report.docx", output_path: "taken.md" }),
+      /already exists/,
+    );
+    assert.equal(await readFile(path.join(root, "taken.md"), "utf8"), "keep me\n");
+  });
+
+  test("a refused destination leaves ordinary extraction working", async () => {
+    const readOnly = toolWith(null);
+    await assert.rejects(() => run(readOnly, { path: "report.docx", output_path: "nope.md" }), /read-only/);
+
+    const answer = await run(readOnly, { path: "report.docx" });
+    assert.match(answer, /# Sales by region/);
   });
 });

--- a/server/test/pdf.test.ts
+++ b/server/test/pdf.test.ts
@@ -192,6 +192,32 @@ describe("extractPdf caps", () => {
     assert.match(result.markdown, /Truncated/);
   });
 
+  test("full returns the whole document, with no truncation note", async () => {
+    const result = await extractPdf(await fixture("pdf-long"), { full: true, maxPages: undefined });
+
+    assert.deepEqual(result.pages, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    assert.equal(result.nextPage, undefined);
+    assert.doesNotMatch(result.markdown, /Truncated/);
+  });
+
+  test("full refuses a document past the absolute ceiling instead of cutting it", async () => {
+    // Truncating here would hand back a document that looks complete: exactly the
+    // failure `full` exists to remove.
+    try {
+      await extractPdf(await fixture("pdf-long"), { full: true, maxChars: 50 });
+      assert.fail("expected a refusal");
+    } catch (error) {
+      assert.ok(error instanceof PdfError);
+      assert.equal(error.reason, "too-large");
+      assert.match(error.message, /output_path/);
+    }
+  });
+
+  test("full still respects the deadline", async () => {
+    const error = await failureOf(await fixture("pdf-long"), { full: true, timeoutMs: -1 });
+    assert.equal(error.reason, "budget");
+  });
+
   test("an explicit range wider than the page cap stops at the cap", async () => {
     const result = await extractPdf(await fixture("pdf-long"), { pages: "2-10", maxPages: 2 });
 

--- a/server/test/pdfTool.test.ts
+++ b/server/test/pdfTool.test.ts
@@ -6,7 +6,8 @@
  * it runs when no sandbox is configured.
  */
 import assert from "node:assert/strict";
-import { copyFile, mkdtemp, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { copyFile, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -33,7 +34,7 @@ describe("pdf_extract", () => {
     await copyFile(path.join(FIXTURES, "pdf-table.pdf"), path.join(root, "report.pdf"));
     await copyFile(path.join(FIXTURES, "pdf-encrypted.pdf"), path.join(root, "locked.pdf"));
     await writeFile(path.join(root, "notes.txt"), "not a pdf\n");
-    tool = createPdfExtractToolDefinition({ cwd: root, allowedRoots: [root], maxBytes: 25 * 1024 * 1024 });
+    tool = createPdfExtractToolDefinition({ cwd: root, allowedRoots: [root], maxBytes: 25 * 1024 * 1024, writableRoot: root });
   });
 
   test("is named and described for the model", () => {
@@ -73,7 +74,7 @@ describe("pdf_extract", () => {
   });
 
   test("refuses a PDF above the configured ceiling before parsing it", async () => {
-    const tight = createPdfExtractToolDefinition({ cwd: root, allowedRoots: [root], maxBytes: 100 });
+    const tight = createPdfExtractToolDefinition({ cwd: root, allowedRoots: [root], maxBytes: 100, writableRoot: root });
     await assert.rejects(
       () =>
         (tight.execute as unknown as (id: string, params: unknown, signal?: AbortSignal) => Promise<unknown>)(
@@ -83,5 +84,62 @@ describe("pdf_extract", () => {
         ),
       /larger than the 0 KB PDF limit/,
     );
+  });
+});
+
+describe("pdf_extract writing to a file", () => {
+  let root: string;
+  let outside: string;
+
+  function toolWith(writableRoot: string | null) {
+    return createPdfExtractToolDefinition({ cwd: root, allowedRoots: [root], maxBytes: 25 * 1024 * 1024, writableRoot });
+  }
+
+  async function run(tool: ReturnType<typeof createPdfExtractToolDefinition>, params: Record<string, unknown>): Promise<string> {
+    const result = await (
+      tool.execute as unknown as (id: string, params: unknown, signal?: AbortSignal) => Promise<{ content: { text: string }[] }>
+    )("call-w", params, undefined);
+    return result.content[0].text;
+  }
+
+  before(async () => {
+    const base = await mkdtemp(path.join(tmpdir(), "pi-pdfout-"));
+    root = await realResolve(path.join(base, "root"));
+    outside = await realResolve(path.join(base, "outside"));
+    await mkdir(root, { recursive: true });
+    await mkdir(outside, { recursive: true });
+    await copyFile(path.join(FIXTURES, "pdf-long.pdf"), path.join(root, "long.pdf"));
+  });
+
+  test("writes every page, which is more than one call would return", async () => {
+    const answer = await run(toolWith(root), { path: "long.pdf", output_path: "long.md" });
+
+    assert.match(answer, /Wrote 10 of 10 pages to `long\.md`/);
+    const written = await readFile(path.join(root, "long.md"), "utf8");
+    // The whole document: the last page has to be there, which is the failure
+    // that started this change — an agent stopping in the middle.
+    assert.match(written, /## Page 1\b/);
+    assert.match(written, /## Page 10\b/);
+    assert.doesNotMatch(written, /Truncated/);
+  });
+
+  test("refuses a destination outside the writable zone, and writes nothing", async () => {
+    await assert.rejects(
+      () => run(toolWith(root), { path: "long.pdf", output_path: path.join(outside, "escape.md") }),
+      /outside the writable zone/,
+    );
+    assert.equal(existsSync(path.join(outside, "escape.md")), false);
+  });
+
+  test("refuses every destination when writing is disabled", async () => {
+    await assert.rejects(() => run(toolWith(null), { path: "long.pdf", output_path: "x.md" }), /read-only/);
+    assert.equal(existsSync(path.join(root, "x.md")), false);
+  });
+
+  test("full returns the whole document in the answer itself", async () => {
+    const answer = await run(toolWith(root), { path: "long.pdf", full: true });
+
+    assert.match(answer, /## Page 10\b/);
+    assert.doesNotMatch(answer, /Truncated/);
   });
 });

--- a/server/test/sandbox-tools.test.ts
+++ b/server/test/sandbox-tools.test.ts
@@ -224,6 +224,23 @@ describe("createSandboxedTools", () => {
       assert.equal(await denial(pdf!, path.join(outside, "secret.txt")), null);
     });
 
+    test("a read exception does not become writable for an extraction", async () => {
+      // The exceptions widen reading only. A skill directory outside the root is
+      // readable and must stay unwritable — the same rule edit/write follow.
+      const tools = await createSandboxedTools(
+        config({ root, allowWrite: true, readExceptions: [outside] }),
+      );
+      const pdf = tools.find((tool) => tool.name === "pdf_extract");
+      const write = (target: string) =>
+        (pdf!.execute as unknown as (id: string, params: unknown, signal?: AbortSignal) => Promise<unknown>)(
+          "call-x",
+          { path: "readme.md", output_path: target },
+          undefined,
+        );
+
+      await assert.rejects(() => write(path.join(outside, "out.md")), /outside the writable zone/);
+    });
+
     test("keeps refusing paths outside both the root and the exceptions", async () => {
       const elsewhere = await realResolve(mkdtempSync(path.join(tmpdir(), "pi-elsewhere-")));
       try {


### PR DESCRIPTION
## Why

`pdf_extract` and `docx_extract` cap what one call returns and end with the range to ask for next.
The cap is right — 42 pages of Descartes is 129 565 characters, roughly 35 000 tokens in a single
tool result — but the continuation is a **suggestion**, and models treat it as one.

Observed on this repository's own example file, before this change: asked to extract a whole PDF to
markdown, the agent made three calls, then wrote a file containing a *summary* and labelled it
"transcription partielle" itself. Nothing failed. The document simply never arrived.

A tool whose correct use depends on the model choosing to loop will sometimes be used incorrectly.

## What changes

**`full: true`** — the tool does the loop the model was expected to do. Per-call caps lift; an
absolute ceiling of 400 000 characters (~100 000 tokens) and the deadline stay. Past that ceiling
the call is **refused** with a pointer to `output_path`, because truncating there would recreate the
exact failure this option exists to remove.

**`output_path`** — the whole extraction is written to a workspace file and the call returns a
summary: path, coverage, bytes, opening lines. The document lands on disk in one call at **no
context cost**, and the agent reads or greps it afterwards like any other file.

Replaying the original failure, now: one call, `Wrote 42 of 42 pages to descartes.md (132 616
bytes)`, page 1 and page 42 both present, no truncation note, 21 lines returned to the conversation.

## The part that needs review

`scopeToRoot` in `sandbox.ts` confines **`params.path` and nothing else**. That is why both tools
name their source parameter `path` — the confinement comes for free. A *second* path argument is
outside that wrapper entirely, so `output_path` arrives unconfined until the tool confines it.
Getting this wrong hands a read-only sandbox a way to write.

Everything that keeps it inside the writable zone is in `server/src/extractionOutput.ts`, using the
same primitives `fileBrowser.ts` uses for the browser's own writes — never a second implementation
of path confinement:

- refused outright when the sandbox is read-only (`writableRoot: null`);
- refused outside the writable zone, including through a symlink or `..`;
- **read exceptions widen reading only** — a skill directory outside the root stays unwritable, as
  it does for `edit`;
- an existing file is never overwritten: `wx` does the existence check and the creation in one
  syscall;
- a refused destination leaves ordinary extraction working, so it never looks like a broken tool.

Seven refusals are tested separately, each asserting **nothing was written**.

## Found while implementing

The destination was validated *after* extraction. A test caught it — a non-PDF source failed the
parse before the refusal could happen, so the security assertion never ran. Beyond the test, the
order was simply wrong: refusing a destination after parsing a 300-page document wastes the parse
when the answer was knowable up front. The check now runs first; the `wx` write remains the
authority.

## Verified

Server suite green, gate **95.42 / 89.39 / 94.05** (`pdfTool.ts` and `docxTool.ts` at 100 % lines);
UI suite untouched and green; `tsc` clean; `openspec validate --strict` valid.

Spec: `openspec/changes/add-whole-document-extraction/`. It deliberately does not touch
`file/CreateSandboxedTools` — that requirement already carries an unarchived delta, and a second one
would collide at archive time; what the spec needs to say lives in `ExtractionToFile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)