### PR TITLE
Smoke-test both integrations in a real browser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,37 @@ jobs:
       - run: npm run build
       # A stylesheet can build cleanly and style nothing (#38) — check the artifact.
       - run: npm run check:css
+      # An embed package can build cleanly and be unusable: a missing entry point,
+      # or a second React bundled in. Both are invisible until someone installs it.
+      - run: npm run check:embed
+
+  # The two ways this project is consumed, in a real browser: the app the server
+  # serves, and the widget a host page mounts. Shadow DOM, cross-origin wiring and
+  # an actually-applied stylesheet are all invisible to jsdom, which is where the
+  # 847 UI tests run. Its own job: it needs a browser the other legs do not, and
+  # running in parallel keeps it off the critical path.
+  browser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      # web/dist is what the server serves, embed/dist is what the host page imports
+      - run: npm run build
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+      - run: npm run test:e2e
+        env:
+          CI: true
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: e2e/test-results/
+          retention-days: 7
 
   # The badge, drawn and pushed here rather than by a marketplace action: this is
   # the only job that may write to the repository, and nothing outside it runs.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,19 @@ jobs:
       - run: npm run build
       # 0.6.6 shipped unstyled; never publish that again.
       - run: npm run check:css
+      # Never publish a package whose entry points resolve to nothing, or that
+      # carries its own React into a host page that already has one.
+      - run: npm run check:embed
+
+      # The browser smoke test runs on every PR too. Repeated here because this is
+      # the last gate before the artifact becomes someone else's dependency, and
+      # the widget's integration surface — Shadow DOM, cross-origin — is exactly
+      # what a consumer meets first.
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+      - run: npm run test:e2e
+        env:
+          CI: true
 
       # BASCULE vers Node 26 pour le build du blob SEA (--build-sea + mainFormat:module)
       - name: Setup Node 26 for SEA build

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ dist/
 # Test coverage artifacts (vitest --coverage)
 coverage/
 
+# Browser smoke test: the built host page, and what a failing run leaves behind
+e2e/dist-host/
+e2e/test-results/
+
 # Local test config (personal): the agent's workspace, its own agentDir, its writable zone
 /pi-outpost.config.json
 .pi-outpost-test-agent/

--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * The standalone app, served by a real server, loaded in a real browser.
+ *
+ * 847 UI tests render these components in jsdom, where a stylesheet that was
+ * never emitted is invisible, an effect that throws during cleanup is caught by
+ * the test renderer, and a WebSocket is a fake that is kinder than the real one.
+ * This spec asserts the three things only a browser can see: the bundle loads,
+ * the socket connects, and the interface is styled.
+ *
+ * It does not talk to a model — the server runs with PI_OFFLINE, so there is no
+ * turn to have. What is under test is the wiring, which is what breaks silently.
+ */
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(process.env.PI_E2E_SERVER_URL!);
+});
+
+test("loads and connects to the server that served it", async ({ page }) => {
+  // The connection badge only reaches this state through an open WebSocket
+  await expect(page.getByTitle("connected")).toBeVisible();
+  await expect(page.getByRole("textbox", { name: /message pi/i })).toBeVisible();
+});
+
+test("renders with its stylesheet applied", async ({ page }) => {
+  // #38 shipped an interface that built cleanly and styled nothing. The composer
+  // is laid out by Tailwind utilities, so an unstyled build leaves it at the
+  // browser's default `display: block` with no padding.
+  const composer = page.getByRole("textbox", { name: /message pi/i });
+  await expect(composer).toBeVisible();
+
+  const padding = await composer.evaluate((element) => getComputedStyle(element).paddingLeft);
+  expect(padding).not.toBe("0px");
+});
+
+test("reaches the workspace the server was given", async ({ page }) => {
+  await page.getByTitle("Show files").click();
+  await expect(page.getByText("readme.md")).toBeVisible();
+});
+
+test("reports no console error while loading", async ({ page }) => {
+  // A blank page with a clean network tab is the shape the PdfViewer regression
+  // took: the app unmounted itself and only the console said so.
+  const errors: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(message.text());
+  });
+  await page.reload();
+  await expect(page.getByTitle("connected")).toBeVisible();
+
+  expect(errors).toEqual([]);
+});

--- a/e2e/embed.spec.ts
+++ b/e2e/embed.spec.ts
@@ -1,0 +1,160 @@
+/**
+ * The widget, mounted into a page that is not ours.
+ *
+ * Everything here is invisible to the unit suites by construction: jsdom has no
+ * Shadow DOM worth the name, no cascade to isolate, and no separate origin. The
+ * host page fights the widget on purpose — `* { color: red }`, `all: unset` on
+ * every control, a `box-sizing` the reset disagrees with — because that is what
+ * a design system does to anything it embeds.
+ */
+import { expect, test, type Page } from "@playwright/test";
+
+/** The host page with the backend it should talk to. */
+async function openHost(page: Page): Promise<void> {
+  const url = new URL(process.env.PI_E2E_HOST_URL!);
+  url.searchParams.set("server", process.env.PI_E2E_SERVER_URL!);
+  await page.goto(url.toString());
+}
+
+test.beforeEach(async ({ page }) => {
+  await openHost(page);
+});
+
+test("mounts inside a shadow root and connects across origins", async ({ page }) => {
+  // Playwright pierces shadow roots, so the widget's own controls are reachable
+  await expect(page.getByRole("textbox", { name: /message pi/i })).toBeVisible();
+  await expect(page.getByTitle("connected")).toBeVisible();
+
+  const shape = await page.evaluate(() => {
+    const shadow = document.querySelector("#widget")!.shadowRoot;
+    return {
+      open: shadow !== null,
+      // The app is mounted under #root inside the shadow tree, not in the document
+      rootInside: shadow?.querySelector("#root") !== null,
+      rootInDocument: document.querySelector("#widget > #root") !== null,
+    };
+  });
+  expect(shape).toEqual({ open: true, rootInside: true, rootInDocument: false });
+});
+
+test("carries its stylesheet as an adopted sheet, not a <style> element", async ({ page }) => {
+  // Chrome drops <style> over ~512 KB inside a shadow root and Tailwind v4 is
+  // ~1.5 MB, so the widget uses constructable sheets. Falling back silently
+  // would leave it unstyled in exactly the browsers it targets.
+  const sheets = await page.evaluate(() => {
+    const shadow = document.querySelector("#widget")!.shadowRoot!;
+    return {
+      adopted: shadow.adoptedStyleSheets.length,
+      rules: shadow.adoptedStyleSheets[0]?.cssRules.length ?? 0,
+    };
+  });
+  expect(sheets.adopted).toBe(1);
+  expect(sheets.rules).toBeGreaterThan(100);
+});
+
+test("the host page's styles do not reach into the widget", async ({ page }) => {
+  const composer = page.getByRole("textbox", { name: /message pi/i });
+  await expect(composer).toBeVisible();
+
+  const colour = await composer.evaluate((element) => getComputedStyle(element).color);
+  // The host paints every element red; the widget's text must not be
+  expect(colour).not.toBe("rgb(255, 0, 0)");
+
+  // `all: unset` on the host's controls would flatten the widget's buttons too
+  const button = page.getByTitle("Show files");
+  const background = await button.evaluate((element) => getComputedStyle(element).backgroundColor);
+  expect(background).not.toBe("rgb(255, 0, 255)");
+});
+
+test("the widget's reset does not reach out into the host page", async ({ page }) => {
+  // Tailwind's preflight sets margin: 0 on every element. Leaking out of the
+  // shadow tree would silently restyle the page that embedded us.
+  const host = await page.locator("#host-text").evaluate((element) => ({
+    margin: getComputedStyle(element).marginTop,
+    family: getComputedStyle(element).fontFamily,
+  }));
+  expect(host.margin).not.toBe("0px");
+  expect(host.family).toContain("Comic Sans MS");
+});
+
+test("setTheme switches the widget without touching the host", async ({ page }) => {
+  // The theme lands as data-theme on the container the host handed us — the
+  // widget needs a cascade root, and it takes the one it was given rather than
+  // document.documentElement, which would be the host page's.
+  const readTheme = () =>
+    page.evaluate(() => ({
+      widget: (document.querySelector("#widget") as HTMLElement).dataset.theme ?? "",
+      hostBackground: getComputedStyle(document.body).backgroundColor,
+    }));
+
+  const light = await readTheme();
+  expect(light.widget).toBe("light");
+
+  await page.evaluate(() => window.__embed.setTheme("dark"));
+  await expect.poll(async () => (await readTheme()).widget).toBe("dark");
+
+  // The host's own background is the host's business
+  expect((await readTheme()).hostBackground).toBe(light.hostBackground);
+});
+
+test("unmount empties the shadow root and leaves the container", async ({ page }) => {
+  await expect(page.getByRole("textbox", { name: /message pi/i })).toBeVisible();
+
+  const after = await page.evaluate(() => {
+    window.__embed.unmount();
+    const container = document.querySelector("#widget");
+    return {
+      containerStillThere: container !== null,
+      shadowChildren: container?.shadowRoot?.querySelector("#root")?.childElementCount ?? -1,
+    };
+  });
+  expect(after.containerStillThere).toBe(true);
+  expect(after.shadowChildren).toBe(0);
+});
+
+test("mounting reports no console error", async ({ page }) => {
+  const errors: string[] = [];
+  page.on("console", (message) => {
+    // The known /branding CORS failure has a test of its own below; counting it
+    // here too would make one defect fail two tests and hide the next one.
+    if (message.type() === "error" && !/branding|ERR_FAILED/.test(message.text())) {
+      errors.push(message.text());
+    }
+  });
+  await openHost(page);
+  await expect(page.getByTitle("connected")).toBeVisible();
+
+  expect(errors).toEqual([]);
+});
+
+test.fail(
+  "the branding request survives the origin the widget was mounted from",
+  async ({ page }) => {
+    /*
+     * KNOWN GAP — this test is expected to fail, and says why.
+     *
+     * The server never emits an Access-Control-Allow-Origin header. `allowedOrigins`
+     * gates the WebSocket handshake and the Host check, and nothing else, so
+     * GET /branding answers 200 to a cross-origin fetch and the browser then
+     * discards the response.
+     *
+     * The widget still works: useAgent swallows the failure, and the branding
+     * arrives moments later on the WebSocket's "hello". What is lost is the
+     * reason the route exists — server/src/index.ts starts the HTTP server before
+     * the agent runtime specifically so branding does not wait behind a setup
+     * that "can take a few seconds", because that wait showed up as a flash of
+     * default branding. Cross-origin, that flash is back, and only for embedded
+     * hosts.
+     *
+     * Fixing it means answering with the CORS headers for origins that are
+     * already allowed — a change to what the server exposes, so it belongs in its
+     * own change rather than in the commit that added this harness. When it is
+     * fixed, this test starts passing and Playwright reports it as an unexpected
+     * pass: remove the .fail() then.
+     */
+    const response = await page.request.get(`${process.env.PI_E2E_SERVER_URL}/branding`, {
+      headers: { Origin: process.env.PI_E2E_HOST_URL! },
+    });
+    expect(response.headers()["access-control-allow-origin"]).toBe(process.env.PI_E2E_HOST_URL);
+  },
+);

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -61,6 +61,30 @@ function serveHostPage(): Promise<{ url: string; close: () => Promise<void> }> {
 }
 
 /**
+ * The environment the test server gets: no provider key except one that is not
+ * real.
+ *
+ * Both halves matter. Without the removals the run inherits whatever the
+ * developer has configured, and the suite passes on their machine and fails on a
+ * runner that has nothing — which is exactly what happened the first time this
+ * job ran in CI: with no key at all the app renders the onboarding screen ("No
+ * model provider is set up yet") and there is no composer to find. Without the
+ * fake key it would now fail everywhere instead.
+ *
+ * The key is never used: PI_OFFLINE keeps the runtime off the network and no
+ * test sends a message. It exists so the interface under test is the interface,
+ * not the setup wizard.
+ */
+function onlyOneFakeProvider(): Record<string, string | undefined> {
+  const env: Record<string, string | undefined> = {};
+  for (const name of Object.keys(process.env)) {
+    if (/API_KEY|AUTH_TOKEN|_TOKEN$/.test(name)) env[name] = undefined;
+  }
+  env.ANTHROPIC_API_KEY = "sk-ant-not-a-real-key";
+  return env;
+}
+
+/**
  * Boots what both specs need and hands the URLs to the workers through the
  * environment. Returning a function registers it as the teardown.
  */
@@ -83,11 +107,15 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
   const root = await makeWorkspace({
     "readme.md": "# workspace\n\nA file the browser is allowed to see.\n",
   });
-  const server = await startServer(root, {
-    // The host page is a different origin, which is the whole point of the widget.
-    server: { allowedOrigins: [host.url] },
-    branding: { title: "embed smoke" },
-  });
+  const server = await startServer(
+    root,
+    {
+      // The host page is a different origin, which is the whole point of the widget.
+      server: { allowedOrigins: [host.url] },
+      branding: { title: "embed smoke" },
+    },
+    { env: onlyOneFakeProvider() },
+  );
 
   process.env.PI_E2E_HOST_URL = host.url;
   process.env.PI_E2E_SERVER_URL = server.base;

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,99 @@
+import { createServer } from "node:http";
+import { access, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+// The same harness the server's own integration tests use: a real server, in its
+// own process group, against a throwaway workspace, with PI_OFFLINE set so the
+// SDK's model runtime never reaches the network.
+// @ts-expect-error -- .mjs harness, no types; the shape is asserted below
+import { makeWorkspace, startServer } from "../server/test/harness.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const HOST_DIST = path.join(HERE, "dist-host");
+
+const TYPES: Record<string, string> = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".map": "application/json",
+};
+
+/**
+ * Serves the built host page on its own origin.
+ *
+ * Its own origin matters: a widget loaded same-origin with the backend would
+ * never exercise the cross-origin path that every real host application takes.
+ */
+function serveHostPage(): Promise<{ url: string; close: () => Promise<void> }> {
+  const server = createServer((request, response) => {
+    const requested = new URL(request.url ?? "/", "http://localhost").pathname;
+    const relative = requested === "/" ? "index.html" : requested.replace(/^\/+/, "");
+    // Name arithmetic, then a containment check: this serves a build directory
+    // to a browser we control, and it still does not get to read outside it.
+    const file = path.join(HOST_DIST, relative);
+    if (!file.startsWith(HOST_DIST + path.sep) && file !== path.join(HOST_DIST, "index.html")) {
+      response.writeHead(403).end();
+      return;
+    }
+    readFile(file).then(
+      (bytes) => {
+        response.writeHead(200, { "content-type": TYPES[path.extname(file)] ?? "application/octet-stream" });
+        response.end(bytes);
+      },
+      () => response.writeHead(404).end(),
+    );
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address !== null ? address.port : 0;
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        close: () =>
+          new Promise((done) => {
+            server.closeAllConnections();
+            server.close(() => done());
+          }),
+      });
+    });
+  });
+}
+
+/**
+ * Boots what both specs need and hands the URLs to the workers through the
+ * environment. Returning a function registers it as the teardown.
+ */
+export default async function globalSetup(): Promise<() => Promise<void>> {
+  // Both specs read a built artifact rather than source. Saying which one is
+  // missing beats the cascade of 404s and blank pages that follows otherwise.
+  const required = [
+    [path.join(HERE, "..", "web/dist/index.html"), "npm run build --workspace web"],
+    [path.join(HERE, "..", "embed/dist/pi-outpost-embed.js"), "npm run build --workspace @pi-outpost/embed"],
+    [path.join(HOST_DIST, "index.html"), "npm run build:e2e-host"],
+  ] as const;
+  for (const [file, command] of required) {
+    await access(file).catch(() => {
+      throw new Error(`missing ${path.relative(path.join(HERE, ".."), file)} — run \`${command}\` first`);
+    });
+  }
+
+  const host = await serveHostPage();
+
+  const root = await makeWorkspace({
+    "readme.md": "# workspace\n\nA file the browser is allowed to see.\n",
+  });
+  const server = await startServer(root, {
+    // The host page is a different origin, which is the whole point of the widget.
+    server: { allowedOrigins: [host.url] },
+    branding: { title: "embed smoke" },
+  });
+
+  process.env.PI_E2E_HOST_URL = host.url;
+  process.env.PI_E2E_SERVER_URL = server.base;
+
+  return async () => {
+    await server.stop();
+    await host.close();
+  };
+}

--- a/e2e/host/index.html
+++ b/e2e/host/index.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>embed host page</title>
+    <style>
+      /*
+       * Deliberately hostile host styles. A widget that survives these survives a
+       * real application: every one of them is something a design system does, and
+       * every one would reach the widget if the Shadow DOM were not doing its job.
+       */
+      * {
+        color: rgb(255, 0, 0);
+        font-family: "Comic Sans MS", cursive;
+        box-sizing: content-box;
+      }
+      button,
+      input,
+      textarea {
+        all: unset;
+        background: rgb(255, 0, 255);
+      }
+      body {
+        margin: 0;
+        background: rgb(240, 240, 240);
+      }
+      #widget {
+        width: 900px;
+        height: 700px;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Witness element: the widget's own reset must not reach it. -->
+    <p id="host-text">host paragraph</p>
+    <div id="widget"></div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/e2e/host/main.ts
+++ b/e2e/host/main.ts
@@ -1,0 +1,40 @@
+/**
+ * The host application, reduced to what a host application actually does: import
+ * the published entry point, call mount(), keep the handle.
+ *
+ * The import is `@pi-outpost/embed` rather than a relative path into src, so it
+ * resolves through package.json's `exports` map — the same resolution a consumer
+ * gets, against the same built bundle. Importing the source would test code we
+ * do not ship.
+ *
+ * React is left to the bundler here, exactly as in a host app: the widget
+ * declares it as a peer dependency, so this page is where the single copy comes
+ * from. (That there is only one copy is asserted against the artifact, in
+ * scripts/check-embed-package.mjs — a bundled second React runs fine in its own
+ * tree and would not fail here.)
+ */
+import { mount, type MountHandle, type Theme } from "@pi-outpost/embed";
+
+declare global {
+  interface Window {
+    /** Handed to the test so it drives the public API rather than internals. */
+    __embed: {
+      setTheme(theme: Theme): void;
+      unmount(): void;
+    };
+  }
+}
+
+const container = document.querySelector<HTMLElement>("#widget")!;
+// The server the widget talks to; the test's global setup puts a real one here.
+const serverUrl = new URLSearchParams(location.search).get("server") ?? undefined;
+
+const handle: MountHandle = mount(container, {
+  ...(serverUrl === undefined ? {} : { serverUrl }),
+  theme: "light",
+});
+
+window.__embed = {
+  setTheme: (theme) => handle.setTheme(theme),
+  unmount: () => handle.unmount(),
+};

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,5 @@
+{
+  "private": true,
+  "type": "module",
+  "//": "Not a workspace — this exists so Playwright loads the files here as ES modules. The global setup imports server/test/harness.mjs, which a CommonJS transpile could not require()."
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,37 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig, devices } from "@playwright/test";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Browser smoke tests for the two ways this project is consumed: the standalone
+ * app the server serves, and the widget a host application mounts.
+ *
+ * Chromium only, and deliberately: this is a wiring check, not a compatibility
+ * matrix. Three browsers would triple the runtime to re-assert the same facts.
+ *
+ * The server and the host page are started once in global-setup.ts and their
+ * URLs arrive through the environment.
+ */
+export default defineConfig({
+  testDir: HERE,
+  // Failure artifacts belong beside the tests, not in the repository root, which
+  // is where Playwright puts them by default (relative to the working directory).
+  outputDir: path.join(HERE, "test-results"),
+  globalSetup: "./global-setup.ts",
+  // Both specs share one server; parallel workers would race on its session store
+  workers: 1,
+  fullyParallel: false,
+  // A green run is the only acceptable result; a retry that passes hides a race
+  retries: 0,
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  reporter: process.env.CI ? [["github"], ["list"]] : [["list"]],
+  use: {
+    ...devices["Desktop Chrome"],
+    // Kept only for a failure: enough to see what the page looked like
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+});

--- a/e2e/vite.config.ts
+++ b/e2e/vite.config.ts
@@ -1,5 +1,11 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
+
+// fileURLToPath, not URL.pathname: on Windows the latter yields "/D:/..." with a
+// leading slash, which is not a path any filesystem call accepts.
+const HERE = path.dirname(fileURLToPath(import.meta.url));
 
 /**
  * Builds the host page the embed smoke test loads.
@@ -10,10 +16,10 @@ import { defineConfig } from "vite";
  * whether or not the Shadow DOM did anything.
  */
 export default defineConfig({
-  root: new URL("./host", import.meta.url).pathname,
+  root: path.join(HERE, "host"),
   plugins: [react()],
   build: {
-    outDir: new URL("./dist-host", import.meta.url).pathname,
+    outDir: path.join(HERE, "dist-host"),
     emptyOutDir: true,
   },
 });

--- a/e2e/vite.config.ts
+++ b/e2e/vite.config.ts
@@ -1,0 +1,19 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+/**
+ * Builds the host page the embed smoke test loads.
+ *
+ * No Tailwind plugin here on purpose: the widget carries its own stylesheet
+ * inlined in the bundle, and a host page that happened to build the same
+ * utilities would make the isolation assertions meaningless — they would pass
+ * whether or not the Shadow DOM did anything.
+ */
+export default defineConfig({
+  root: new URL("./host", import.meta.url).pathname,
+  plugins: [react()],
+  build: {
+    outDir: new URL("./dist-host", import.meta.url).pathname,
+    emptyOutDir: true,
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "pi-outpost": "^0.6.4"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "concurrently": "^10.0.4"
       }
     },

--- a/package.json
+++ b/package.json
@@ -17,9 +17,13 @@
     "build": "npm run build --workspaces --if-present",
     "typecheck": "npm run typecheck --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",
-    "check:css": "node scripts/check-web-css.mjs"
+    "check:css": "node scripts/check-web-css.mjs",
+    "check:embed": "node scripts/check-embed-package.mjs",
+    "build:e2e-host": "vite build --config e2e/vite.config.ts",
+    "test:e2e": "npm run build:e2e-host && playwright test --config e2e/playwright.config.ts"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "concurrently": "^10.0.4"
   },
   "dependencies": {

--- a/scripts/check-embed-package.mjs
+++ b/scripts/check-embed-package.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+/**
+ * Guard against an embed package that builds cleanly and cannot be consumed.
+ *
+ * `npm run build --workspace @pi-outpost/embed` proves the code compiles. It
+ * proves nothing about the thing we publish, and the two fail apart:
+ *
+ * - **Entry points.** package.json promises `main`, `module`, `types` and an
+ *   `exports` map. A renamed output or a `files` array that stops covering one
+ *   of them leaves a tarball whose `import { mount } from "@pi-outpost/embed"`
+ *   resolves to nothing. Every gate we have stays green, because every gate
+ *   reads the source tree rather than the tarball.
+ * - **A second React.** react/react-dom are peer dependencies, externalised in
+ *   embed/vite.config.ts. If that externalisation regresses, the widget carries
+ *   its own React into a host page that already has one — two copies, hooks
+ *   throwing "invalid hook call", and a bundle that built without a warning.
+ *
+ * Both are cheap to assert against the artifact, which is why they are here and
+ * not in the browser smoke test: a test that needs Chromium to notice a missing
+ * file is a slow way to learn it. The CSS side of the same worry lives in
+ * check-web-css.mjs.
+ *
+ * Run after `npm run build --workspace @pi-outpost/embed`.
+ */
+import { execFileSync } from "node:child_process";
+import { access, readFile } from "node:fs/promises";
+import path from "node:path";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+const EMBED = path.join(ROOT, "embed");
+
+const fail = (message, detail) => {
+  console.error(`[check-embed-package] ${message}`);
+  if (detail) console.error(`\n${detail}`);
+  process.exit(1);
+};
+
+const manifest = JSON.parse(await readFile(path.join(EMBED, "package.json"), "utf8"));
+
+/* ── 1. Every entry point the manifest promises exists ───────────────────────── */
+
+/** Paths the manifest points at, by the field that points at them. */
+const declared = [
+  ["main", manifest.main],
+  ["module", manifest.module],
+  ["types", manifest.types],
+  ['exports["."].import', manifest.exports?.["."]?.import],
+  ['exports["."].require', manifest.exports?.["."]?.require],
+  ['exports["."].types', manifest.exports?.["."]?.types],
+].filter(([, value]) => typeof value === "string");
+
+if (declared.length === 0) fail("embed/package.json declares no entry point at all");
+
+const absent = [];
+for (const [field, relative] of declared) {
+  const target = path.join(EMBED, relative);
+  await access(target).catch(() => absent.push([field, relative]));
+}
+if (absent.length > 0) {
+  fail(
+    "embed/package.json points at files the build did not produce:",
+    absent.map(([field, relative]) => `  ${field} → ${relative}`).join("\n") +
+      `\n\nRun "npm run build --workspace @pi-outpost/embed" first. If an output was` +
+      ` renamed, the manifest has to follow it — a consumer's import resolves through` +
+      ` these fields and nothing else.`,
+  );
+}
+
+/* ── 2. Those entry points are inside the published tarball ──────────────────── */
+
+// `files` decides what ships. A path can exist locally and still be absent from
+// the tarball, which is the failure that only shows up after publishing.
+// --ignore-scripts: prepack would rebuild, and we are inspecting what is there.
+let packed;
+try {
+  const output = execFileSync("npm", ["pack", "--dry-run", "--json", "--ignore-scripts"], {
+    cwd: EMBED,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  packed = new Set(JSON.parse(output)[0].files.map((entry) => entry.path));
+} catch (error) {
+  fail(`could not inspect the package tarball: ${error.message}`);
+}
+
+const unpublished = declared.filter(([, relative]) => !packed.has(relative.replace(/^\.\//, "")));
+if (unpublished.length > 0) {
+  fail(
+    "entry points that exist locally but are not in the published tarball:",
+    unpublished.map(([field, relative]) => `  ${field} → ${relative}`).join("\n") +
+      `\n\nThe "files" array in embed/package.json decides what ships. A consumer` +
+      ` installing this version would get a package whose entry points resolve to nothing.`,
+  );
+}
+
+/* ── 3. The ESM entry really exports mount ──────────────────────────────────── */
+
+// Imported rather than pattern-matched: an export the bundler renamed, or a
+// module that throws while initialising, both fail here and neither shows in a
+// substring search. mount() itself is not called — it needs a DOM.
+const entry = path.join(EMBED, manifest.module ?? manifest.main);
+let exported;
+try {
+  exported = await import(entry);
+} catch (error) {
+  fail(
+    `importing the ESM entry threw: ${error.message}`,
+    `  ${path.relative(ROOT, entry)}\n\nThe published module fails at load time, before a` +
+      ` consumer calls anything.`,
+  );
+}
+if (typeof exported.mount !== "function") {
+  fail(
+    `the ESM entry exports no mount() function`,
+    `  exports: ${Object.keys(exported).join(", ") || "(none)"}\n\n` +
+      `mount() is the package's whole public surface.`,
+  );
+}
+
+/* ── 4. React is peer-provided, not bundled ─────────────────────────────────── */
+
+const bundle = await readFile(entry, "utf8");
+// The internals object is React's own and appears in no consumer bundle that
+// merely imports React. Its presence means a copy was inlined.
+const REACT_INTERNALS = /__CLIENT_INTERNALS_DO_NOT_USE|__SECRET_INTERNALS_DO_NOT_USE/;
+if (REACT_INTERNALS.test(bundle)) {
+  fail(
+    "the bundle carries its own copy of React",
+    `React and react-dom are peer dependencies and must stay external (see the` +
+      ` "external" list in embed/vite.config.ts). Bundled, the widget runs a second` +
+      ` React inside a host page that already has one: hooks throw "invalid hook call"` +
+      ` and context crosses nothing.`,
+  );
+}
+// The other half of the same claim: it must still *import* React from outside.
+if (!/from\s*["']react["']|["']react-dom\/client["']/.test(bundle)) {
+  fail(
+    "the bundle imports neither react nor react-dom/client",
+    `Externalised correctly, the bundle keeps those imports for the host to resolve.` +
+      ` Neither bundled nor imported means the widget has no React at all.`,
+  );
+}
+
+console.log(
+  `[check-embed-package] ${declared.length} entry points present and published,` +
+    ` mount() exported, React external (${(bundle.length / 1024 / 1024).toFixed(1)} MB bundle)`,
+);

--- a/scripts/check-embed-package.mjs
+++ b/scripts/check-embed-package.mjs
@@ -73,18 +73,38 @@ if (absent.length > 0) {
 // --ignore-scripts: prepack would rebuild, and we are inspecting what is there.
 let packed;
 try {
-  // npm.cmd on Windows: execFileSync does not go through a shell, so the bare
-  // name resolves to nothing there (spawnSync npm ENOENT). Naming the file
-  // keeps the call shell-free, which is what we want around an argument list.
-  const npm = process.platform === "win32" ? "npm.cmd" : "npm";
-  const output = execFileSync(npm, ["pack", "--dry-run", "--json", "--ignore-scripts"], {
+  packed = new Set(packedFiles().map((entry) => entry.path));
+} catch (error) {
+  fail(`could not inspect the package tarball: ${error.message}`);
+}
+
+/**
+ * `npm pack --dry-run --json`, run without a shell on every platform.
+ *
+ * Windows makes this awkward twice over: the executable is `npm.cmd`, so the
+ * bare name resolves to nothing (ENOENT), and since the CVE-2024-27980 fix Node
+ * refuses to spawn a `.cmd` at all unless `shell: true` (EINVAL). Passing
+ * `shell: true` would work — the arguments here are literals — but it hands an
+ * argument list to a command interpreter for no reason.
+ *
+ * So npm is invoked the way npm invokes itself: node running npm's own CLI
+ * entry point, whose path npm exports as `npm_execpath` to the scripts it runs.
+ * Outside `npm run` that variable is absent, and the platform name is the
+ * fallback — with the shell Windows requires for a `.cmd`.
+ */
+function packedFiles() {
+  const cli = process.env.npm_execpath;
+  const [command, argv, useShell] = cli
+    ? [process.execPath, [cli], false]
+    : [process.platform === "win32" ? "npm.cmd" : "npm", [], true];
+
+  const output = execFileSync(command, [...argv, "pack", "--dry-run", "--json", "--ignore-scripts"], {
     cwd: EMBED,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "ignore"],
+    shell: useShell && process.platform === "win32",
   });
-  packed = new Set(JSON.parse(output)[0].files.map((entry) => entry.path));
-} catch (error) {
-  fail(`could not inspect the package tarball: ${error.message}`);
+  return JSON.parse(output)[0].files;
 }
 
 const unpublished = declared.filter(([, relative]) => !packed.has(relative.replace(/^\.\//, "")));

--- a/scripts/check-embed-package.mjs
+++ b/scripts/check-embed-package.mjs
@@ -25,6 +25,7 @@
 import { execFileSync } from "node:child_process";
 import { access, readFile } from "node:fs/promises";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 const ROOT = path.resolve(import.meta.dirname, "..");
 const EMBED = path.join(ROOT, "embed");
@@ -122,10 +123,13 @@ if (unpublished.length > 0) {
 // Imported rather than pattern-matched: an export the bundler renamed, or a
 // module that throws while initialising, both fail here and neither shows in a
 // substring search. mount() itself is not called — it needs a DOM.
+//
+// As a file:// URL: on Windows an absolute path starts with a drive letter,
+// which the ESM loader reads as an unsupported "d:" scheme.
 const entry = path.join(EMBED, manifest.module ?? manifest.main);
 let exported;
 try {
-  exported = await import(entry);
+  exported = await import(pathToFileURL(entry).href);
 } catch (error) {
   fail(
     `importing the ESM entry threw: ${error.message}`,

--- a/scripts/check-embed-package.mjs
+++ b/scripts/check-embed-package.mjs
@@ -73,7 +73,11 @@ if (absent.length > 0) {
 // --ignore-scripts: prepack would rebuild, and we are inspecting what is there.
 let packed;
 try {
-  const output = execFileSync("npm", ["pack", "--dry-run", "--json", "--ignore-scripts"], {
+  // npm.cmd on Windows: execFileSync does not go through a shell, so the bare
+  // name resolves to nothing there (spawnSync npm ENOENT). Naming the file
+  // keeps the call shell-free, which is what we want around an argument list.
+  const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+  const output = execFileSync(npm, ["pack", "--dry-run", "--json", "--ignore-scripts"], {
     cwd: EMBED,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "ignore"],


### PR DESCRIPTION
Answers a question that turned out to have a real answer: **is a browser-level integration test for embed worth it, or superfluous?** Not superfluous — it found something on the first run.

## What was missing

The unit suites render in jsdom. That is where 847 UI tests pass, and also where an unemitted stylesheet is invisible, a Shadow DOM barely exists, a second origin is nobody's problem, and a fake is kinder than the real API. #38 shipped an unstyled interface straight through that gap. `check-web-css.mjs` closed it for the stylesheet; this closes it for the wiring.

## Two targets

| | asserted |
|---|---|
| **Standalone app** (`app.spec.ts`) | loads, WebSocket connects, composer actually styled, workspace reachable, no console error |
| **Widget** (`embed.spec.ts`) | mounts in a Shadow DOM across origins, stylesheet adopted (not a `<style>` element — Chrome drops those over ~512 KB and Tailwind v4 is ~1.5 MB), host styles don't get in, the reset doesn't get out, `setTheme`, `unmount` |

The host page fights the widget on purpose — `* { color: red }`, `all: unset` on every control — because that is what a design system does to anything it embeds.

The server is `server/test/harness.mjs`, the same one the integration suites use: real server, own process group, throwaway workspace, `PI_OFFLINE` so nothing reaches the network. No model is called; the wiring is what breaks silently.

## Plus a cheap artifact check

`scripts/check-embed-package.mjs` covers what a browser cannot see: every entry point `package.json` promises exists **and** ships in the tarball (`npm pack --dry-run`), the ESM entry really exports `mount()`, and React stayed external. A bundled second React runs fine in its own tree — it would pass every browser test — and breaks hooks in a host app that already has one. ~2 s, no browser.

## What it found

The server emits **no CORS headers at all**. `allowedOrigins` gates the WebSocket handshake and the `Host` check, nothing else — so a cross-origin widget's `GET /branding` answers 200 and the browser discards it.

It degrades quietly: `useAgent` swallows the failure and the branding arrives on the WebSocket `hello` moments later. But that route exists precisely to avoid waiting: the server starts its HTTP listener before the agent runtime *because* that wait "was showing up as a flash of default branding on every page load". Cross-origin, the flash is back, and only for embedded hosts.

Recorded as a `test.fail()` with the full reasoning rather than fixed here — it changes what the server exposes, so it deserves its own change. When it is fixed, Playwright reports an unexpected pass and the marker comes off.

## Where it runs

Own parallel job on every PR — it needs a browser the other legs don't, and in parallel it stays off the critical path behind a job that already runs 642 server tests, 847 UI tests and builds on two OSes. Repeated before publishing, where the artifact becomes someone else's dependency.

`@playwright/test` was already a devDependency of `web`, unused; the lockfile moves by one line.

## Verification

12/12 green locally in ~17 s. `npm run typecheck`, `npm run lint` and `npm ci --dry-run` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)