### PR TITLE
Wait for a render to be in flight before cancelling it

### DIFF
--- a/ui/src/components/PdfViewer.test.tsx
+++ b/ui/src/components/PdfViewer.test.tsx
@@ -149,13 +149,23 @@ describe("PdfViewer", () => {
     serverReturnsPdf(1);
     const cancel = vi.fn();
     let resolveRender: (() => void) | undefined;
+    const startRender = vi.fn(() => ({
+      promise: new Promise<void>((resolve) => (resolveRender = resolve)),
+      cancel,
+    }));
     getPage.mockImplementation(async () => ({
       getViewport: () => ({ width: 10, height: 10 }),
-      render: () => ({ promise: new Promise<void>((resolve) => (resolveRender = resolve)), cancel }),
+      render: startRender,
     }));
 
     render(<PdfViewer path="report.pdf" />);
     await screen.findByText("Page 1 / 1");
+    // The counter says the document loaded; it does not say a render started.
+    // The component only holds a task to cancel once it is past `await getPage`,
+    // so zooming before that finds nothing in flight and the test fails without
+    // the component having done anything wrong — which is how it flaked, on the
+    // slowest runner and nowhere else.
+    await waitFor(() => expect(startRender).toHaveBeenCalled());
 
     // pdf.js refuses a second render on a canvas already rendering, so zooming
     // mid-render must cancel the first one rather than start beside it.


### PR DESCRIPTION
Fixes the flake that turned the Windows leg red on #59, in a test that PR had not touched.

```
AssertionError: expected "vi.fn()" to be called at least once
  PdfViewer > cancels a page's render in flight before redrawing it
```

## The race

The test awaited the page counter and then zoomed. The counter says the *document* loaded; it does not say a *render* started. The component only holds a task to cancel once it is past `await doc.getPage(...)`:

```ts
const page = await doc.getPage(pageNumber);   // ← the zoom can land here
…
const task = page.render({ canvas, viewport, annotationMode: 0 });
renderRef.current = task;                      // ← only now is there something to cancel
```

On a slow enough runner the click arrives before that line, finds nothing in flight, and cancels nothing. The component behaved correctly; the test failed anyway. It only runs on Windows — `npm test --workspace ui` is gated on `matrix.os != 'ubuntu-latest'` — which is why it went unnoticed.

The fix waits for the render to actually start before zooming, which is the state the test's own name describes.

## Verified rather than assumed

- **The race is the cause.** Delaying `getPage` by 120 ms reproduces the CI assertion exactly on the old test, and passes on the new one.
- **It still catches its regression.** Removing the cancellation makes it fail again.
- **It does not isolate which cancel path fires.** Cutting `cancelRender(previous)` alone keeps it green, because the effect cleanup React runs before re-running the effect cancels the task anyway. That is the behaviour the test names, and it survives losing either half — a fact about the component, not a gap in the test. Recorded here rather than "fixed" by asserting on internals.

Full UI suite green (847), and the PdfViewer file run three times over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)