### PR TITLE
chore(release): v0.8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run typecheck
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci
       # web/dist is what the server serves, embed/dist is what the host page imports

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **A web chat UI for the [pi coding agent](https://github.com/earendil-works/pi)** — run it as a standalone app, or embed it as a Shadow-DOM-isolated widget inside any web app. Built directly on pi's [SDK](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/sdk.md).
 
-A Node server embeds a pi `AgentSession` and bridges it to a React chat UI over WebSocket: streaming responses, collapsible thinking blocks, live tool-execution cards (bash, edit, …), steering while the agent runs, and abort.
+A Node server runs the agent — a pi `AgentSession` in its own process, or a supervised `pi --mode rpc` child — and bridges it to a React chat UI over WebSocket: streaming responses, collapsible thinking blocks, live tool-execution cards (bash, edit, …), steering while the agent runs, and abort.
 
 <p align="center">
   <img src="docs/screenshots/chat-light.png" alt="pi-outpost, light theme" width="49%">
@@ -35,8 +35,11 @@ A Node server embeds a pi `AgentSession` and bridges it to a React chat UI over 
 - Conversation tree: edit a past message to re-ask it, and the old exchange stays reachable as a branch you can navigate back to
 - File browser: lazy-loaded tree, full-size viewer (syntax-highlighted, Markdown rendered) and an editor with save inside the writable zone — all confined to the same root the agent's own tools can see; entries outside `sandbox.writableRoot` render dimmed, and truncated entries reveal their complete name on hover. Create a file or folder from the tree itself: `+` on a writable directory opens an input where the file will land (a trailing `/` makes it a folder), and a new file opens straight into the editor. Files can also be opened with the operating system's associated application, renamed, or deleted after confirmation. Drag a writable file onto a writable directory to move it, or drag a read-only file there to copy it
 - PDF: select one in the tree and it renders in the viewer (pages, zoom, keyboard paging); the agent reads its text and tables through a `pdf_extract` tool — no shell, no external binary, no OCR
+- Office documents: `docx_extract`, `xlsx_extract` and `pptx_extract` give the agent Word text and tables, one markdown table per spreadsheet sheet (values rendered from their number format), and slide structure with speaker notes. Same rules as `pdf_extract` — available wherever `read` is, never behind `allowBash`, confined to the sandbox root, each with its own size ceiling. Every extractor also takes `output_path`: write the whole document to a workspace file and get a summary back, instead of paging through it and then writing it out, which spends the context twice
+- Structured results: a tool can hand back **data** — a graph, a sequence, a table — and the UI renders it natively instead of showing text that describes a picture nobody can check. When the document names a `target` it becomes an approval gate: someone is agreeing to a change an external authority will then apply. Versioned schema, a conformance suite, and a standalone validator a producer elsewhere can run against its own output; the agent gets a `present_structure` tool and a bundled skill
+- Agent runtime: embedded pi SDK by default, or a supervised `pi --mode rpc` child process (see [`agentRuntime`](#standalone-configuration)) — same browser protocol either way
 - In-browser sandbox settings: tweak root, writable root, write and bash permissions from the gear menu — no config file edit or server restart needed
-- Attachments: drop or paste images and text files into the composer; the file you are previewing attaches itself as an `@path` reference, so the agent reads it on demand instead of the prompt carrying its content. Selected `.docx` and `.xlsx` files do the same even though they have no inline preview, because the agent can read them through built-in extraction tools
+- Attachments: drop or paste images and text files into the composer; the file you are previewing attaches itself as an `@path` reference, so the agent reads it on demand instead of the prompt carrying its content. Dropping a PDF, `.docx`, `.xlsx` or `.pptx` uploads it into the workspace and attaches the **path** — which is what the extraction tools take, and why a document is no longer refused as oversized text or as an unsupported binary
 - Git: uncommitted-change badges in the tree, per-file diffs in the viewer, log and commit inspection, and a per-file history graph (renames followed) that diffs the file between any two revisions — the working tree included. Commit rows truncate to keep the graph dense; hovering one gives back the whole subject
 - Session cost: tokens and price per turn in the model bar, and a session-analysis panel behind it — tokens/cost charted across turns, tool calls ranked by output size or failure, requests ranked by what they cost, every row jumping back to the message that produced it
 - Slash commands with autocompletion (`/` in the composer: extension commands, prompt templates, skills)
@@ -187,12 +190,15 @@ See [`pi-outpost.config.example.json`](pi-outpost.config.example.json).
 | `sandbox.allowWrite` | Adds edit/write, confined to `sandbox.writableRoot` (or the whole root if unset) (default `false`) |
 | `sandbox.writableRoot` | Read-write zone: subdirectory of `root` that edit/write are further confined to. Must be inside `root`. Defaults to `root` itself |
 | `sandbox.allowBash` | Adds bash — **not path-confined**, explicit opt-in (default `false`) |
+| `agentRuntime` | Which runtime serves the browser: `{ "mode": "embedded" }` (default) keeps the pi SDK session in this process; `{ "mode": "rpc", "executable": "pi", "args": [] }` supervises a `pi --mode rpc` child. pi-outpost appends `--mode rpc` and derives `--session-dir` itself, so `args` may not contain either, nor `--tools`/`--system-prompt` (those come from `tools`/`systemPrompt`), nor any flag that would make the child print something and exit. A failed executable stops startup — there is no silent fallback to embedded. **`sandbox` cannot be combined with `rpc`** and the pair is refused at load: the sandbox is a replacement toolset this server builds, and a child builds its own |
 | `pdf.maxBytes` | Largest PDF the viewer may load, in bytes (default `26214400` — 25 MB). Every other file keeps the 1 MB limit. The `pdf_extract` tool refuses a PDF above the same ceiling |
+| `docx.maxBytes` / `xlsx.maxBytes` / `pptx.maxBytes` | Same ceiling, per format, for `docx_extract` / `xlsx_extract` / `pptx_extract` |
 | `tools` | Tool allowlist in non-sandbox mode, e.g. `["read","grep","find","ls"]` |
 | `noExtensions` | Disable extension discovery entirely |
 | `extensionPaths` | Explicit extension `.ts`/`.mjs` files to load (resolved relative to the config file's directory). Loaded via the pi SDK's jiti-based loader — works in dev mode and the npm-published bundle |
 | `extensionScripts` | Extension `.mjs` files loaded at runtime via `import()` — works in dev mode and the npm-published bundle. Each file must default-export an `ExtensionFactory`. Paths are resolved relative to the config file's directory |
 | `noSkills` | Disable skill discovery entirely. Needed for real isolation: even with a custom `agentDir`, skills also auto-load from `~/.agents/skills` (hardcoded to the real home directory) and from `.agents/skills` walked up from `cwd` to the git root — neither is scoped by `agentDir` |
+| `skillPaths` | Explicit skill files or directories to load, in addition to discovery. Loaded even under `noSkills` — naming a skill and being given nothing is the worse surprise. Paths are resolved relative to the config file's directory |
 | `noPromptTemplates` | Disable prompt template auto-discovery entirely (both `agentDir` and the project's `cwd/.pi/prompts`). Relevant when `cwd` points at a real project: it doubles as a resource-discovery root, so that project's own prompt templates load too unless disabled |
 | `promptPaths` | Explicit prompt template directories to load (in addition to auto-discovered ones). Paths are resolved relative to the config file's directory |
 | `allowedModels` | Restrict the model switcher to these `{ "provider", "id" }` pairs. Without it, every built-in model whose provider has configured auth is listed — often more variants than a given deployment (e.g. an air-gapped internal endpoint) actually serves |
@@ -235,7 +241,7 @@ Build it with `npm run build --workspace @pi-outpost/embed` (outputs ESM + CJS t
 Two things to configure on the server side regardless of deployment topology:
 
 - **`server.allowedOrigins`**: the widget's WebSocket connection carries the *host page's* origin (e.g. `https://your-app.example.com`), not pi-outpost's own — add it explicitly, even same-domain deployments need this (only `localhost`/`127.0.0.1` are trusted automatically).
-- **CORS**: `/branding` and `/health` are plain HTTP endpoints with no CORS headers. They work with zero extra config when the widget and the backend share an origin (recommended: reverse-proxy pi-outpost under your own domain). A genuinely cross-origin deployment needs a CORS layer in front — not built in yet.
+- **CORS**: an origin listed in `server.allowedOrigins` now receives CORS headers on the HTTP endpoints too (`/branding`, `/health`, `/files/raw`, the static app), with cache variants preserved — so a genuinely cross-origin widget works without a proxy in front. The allowlist is the whole of it: no origin outside it is answered.
 
 A raw iframe (`<iframe src="https://your-pi-outpost-server">`) still works too, and still honors `branding.allowThemeToggle: false` plus the host-driven theme channel:
 
@@ -255,12 +261,12 @@ Custom messages (`pi.sendMessage()` with a `customType`, see [Message and Entry 
 shared/  (protocol types — events, ChatItem, DialogRequest)
 
 ui/  (React components & hooks)       server/  (Fastify + ws)
-┌──────────────────────────┐          ┌─────────────────────────┐
-│ @pi-outpost/ui exports  │          │ AgentSession (pi SDK)   │
-│ CopyButton, DiffBlocks, │  /ws     │ SDK events → lean wire  │
-│ ToolCard, useAgent, …   │ ◄───────► │ events (shared/)        │
-│                          │  JSON    │                         │
-└────────┬─────────────────┘          └─────────────────────────┘
+┌──────────────────────────┐          ┌──────────────────────────┐
+│ @pi-outpost/ui exports  │          │ agent runtime boundary   │
+│ CopyButton, DiffBlocks, │  /ws     │  ├ embedded AgentSession │
+│ ToolCard, useAgent, …   │ ◄───────► │  └ pi --mode rpc child   │
+│                          │  JSON    │ events → lean wire       │
+└────────┬─────────────────┘          └──────────────────────────┘
          │ import
          ▼
 web/  (React + Vite + Tailwind)     embed/  (Shadow-DOM widget)
@@ -272,7 +278,7 @@ web/  (React + Vite + Tailwind)     embed/  (Shadow-DOM widget)
 
 Sessions persist in `<agentDir>/sessions/` — reconnecting clients receive the full history (`hello` message).
 
-**Single-tenant by design.** One `AgentSession`, one `clients` set, and `broadcast()` sends every event to every socket: two people connected to the same server share one conversation, and the sandbox roots are resolved once at startup. That is deliberate for a personal deployment, and the thing to fix before a shared one — see [#4, multi-user support](https://github.com/laurentftech/pi-outpost/issues/4).
+**Single-tenant by design.** One agent runtime, one `clients` set, and `broadcast()` sends every event to every socket: two people connected to the same server share one conversation, and the sandbox roots are resolved once at startup. That is deliberate for a personal deployment, and the thing to fix before a shared one — see [#4, multi-user support](https://github.com/laurentftech/pi-outpost/issues/4).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ A Node server runs the agent — a pi `AgentSession` in its own process, or a su
 
 ## Quick start
 
-Requirements: Node ≥ 22.19 (what the pi SDK itself requires), and **model credentials**. You do *not* need [pi](https://github.com/earendil-works/pi) installed — its SDK is bundled here.
+Requirements: Node ≥ 24 (what the pi SDK itself requires), and **model credentials**. You do *not* need [pi](https://github.com/earendil-works/pi) installed — its SDK is bundled here.
 
 ### Run it
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -39,7 +39,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=22.19.0"
+    "node": ">=24"
   },
   "publishConfig": {
     "access": "public"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-outpost",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "description": "A web interface for the pi coding agent: a browser chat UI you run with npx — no clone, no build.",
   "license": "MIT",

--- a/embed/package.json
+++ b/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-outpost/embed",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "description": "Mount pi-outpost as a Shadow-DOM-isolated widget inside another web app.",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
     },
     "cli": {
       "name": "pi-outpost",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "^0.84.1",
@@ -44,7 +44,7 @@
     },
     "embed": {
       "name": "@pi-outpost/embed",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@microsoft/api-extractor": "^7.58.9",

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=26"
+    "node": ">=24"
   },
   "scripts": {
     "dev": "tsx watch src/index.ts --config ../pi-outpost.config.dev.json",

--- a/server/test/extensionUiBridge.test.ts
+++ b/server/test/extensionUiBridge.test.ts
@@ -1,0 +1,318 @@
+/**
+ * The Extension "Custom UI" bridge, exercised without a live session.
+ *
+ * What these protect is the dialog contract: a request goes out through `emit`,
+ * the client's answer resolves it by id, and a session being replaced unblocks
+ * every pending request rather than leaving the extension hanging. The
+ * TUI-only no-ops are here only so a regression that starts *doing* something
+ * (sending a request the client never agreed to handle) is caught.
+ */
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import type { ExtensionUIRequest, ExtensionUIResponse } from "@pi-outpost/shared";
+import { ExtensionUiBridge } from "../src/extensionUiBridge.ts";
+
+/** Captures every emitted request, in order, so assertions read as "it sent X". */
+function recorder(): { emit: (r: ExtensionUIRequest) => void; sent: ExtensionUIRequest[] } {
+  const sent: ExtensionUIRequest[] = [];
+  return { emit: (r) => void sent.push(r), sent };
+}
+
+/** The id of the last request emitted, so a test can answer it. */
+function lastId(requests: ExtensionUIRequest[]): string {
+  const last = requests[requests.length - 1];
+  assert.ok(last, "expected at least one emitted request");
+  return last.id;
+}
+
+describe("ExtensionUiBridge", () => {
+  describe("answer", () => {
+    test("resolves the matching select with its value", async () => {
+      const { emit, sent } = recorder();
+      const bridge = new ExtensionUiBridge(emit);
+      const ctx = bridge.createContext();
+
+      const picked = ctx.select("pick one", ["a", "b"]);
+      bridge.answer({ type: "extension_ui_response", id: lastId(sent), value: "b" });
+
+      assert.equal(await picked, "b");
+    });
+
+    test("resolves the matching confirm with its boolean", async () => {
+      const { emit, sent } = recorder();
+      const bridge = new ExtensionUiBridge(emit);
+      const ctx = bridge.createContext();
+
+      const confirmed = ctx.confirm("proceed?", "are you sure?");
+      bridge.answer({ type: "extension_ui_response", id: lastId(sent), confirmed: true });
+
+      assert.equal(await confirmed, true);
+    });
+
+    test("resolves the matching input with its value", async () => {
+      const { emit, sent } = recorder();
+      const bridge = new ExtensionUiBridge(emit);
+      const ctx = bridge.createContext();
+
+      const typed = ctx.input("name", "placeholder");
+      bridge.answer({ type: "extension_ui_response", id: lastId(sent), value: "laurent" });
+
+      assert.equal(await typed, "laurent");
+    });
+
+    test("an answer for an unknown id is dropped, not thrown", () => {
+      const { emit } = recorder();
+      const bridge = new ExtensionUiBridge(emit);
+      // No pending request exists; answering must be a safe no-op.
+      assert.doesNotThrow(() =>
+        bridge.answer({ type: "extension_ui_response", id: "never-asked", value: "x" }),
+      );
+    });
+
+    test("a cancelled answer resolves select, confirm and input with their defaults", async () => {
+      const { emit, sent } = recorder();
+      const bridge = new ExtensionUiBridge(emit);
+      const ctx = bridge.createContext();
+
+      const sel = ctx.select("pick", ["a"]);
+      const conf = ctx.confirm("ok?", "sure?");
+      const inp = ctx.input("name");
+      // Cancel the oldest pending (select) first.
+      bridge.answer({ type: "extension_ui_response", id: sent[0].id, cancelled: true });
+      assert.equal(await sel, undefined);
+      // The others are still pending; answer them by their own ids.
+      bridge.answer({ type: "extension_ui_response", id: sent[1].id, cancelled: true });
+      bridge.answer({ type: "extension_ui_response", id: sent[2].id, cancelled: true });
+      assert.equal(await conf, false);
+      assert.equal(await inp, undefined);
+    });
+  });
+
+  describe("cancelAll", () => {
+    test("unblocks every pending request as cancelled", async () => {
+      const { emit } = recorder();
+      const bridge = new ExtensionUiBridge(emit);
+      const ctx = bridge.createContext();
+
+      const sel = ctx.select("pick", ["a"]);
+      const conf = ctx.confirm("ok?", "sure?");
+      const inp = ctx.input("name");
+
+      bridge.cancelAll();
+
+      assert.equal(await sel, undefined);
+      assert.equal(await conf, false);
+      assert.equal(await inp, undefined);
+    });
+
+    test("an answer arriving after cancelAll is a no-op", async () => {
+      const { emit, sent } = recorder();
+      const bridge = new ExtensionUiBridge(emit);
+      const ctx = bridge.createContext();
+
+      const sel = ctx.select("pick", ["a"]);
+      bridge.cancelAll();
+      assert.equal(await sel, undefined);
+
+      // The pending entry is gone; a late answer must not throw.
+      assert.doesNotThrow(() =>
+        bridge.answer({ type: "extension_ui_response", id: sent[0].id, value: "a" }),
+      );
+    });
+  });
+
+  describe("dialog timeout and abort", () => {
+    test("a timeout resolves with the default value", async () => {
+      const { emit } = recorder();
+      const bridge = new ExtensionUiBridge(emit);
+      const ctx = bridge.createContext();
+
+      const result = ctx.select("pick", ["a"], { timeout: 5 });
+      assert.equal(await result, undefined);
+    });
+
+    test("an already-aborted signal resolves immediately with the default", async () => {
+      const { emit } = recorder();
+      const bridge = new ExtensionUiBridge(emit);
+      const ctx = bridge.createContext();
+      const ac = new AbortController();
+      ac.abort();
+
+      const result = ctx.confirm("ok?", "sure?", { signal: ac.signal });
+      assert.equal(await result, false);
+    });
+
+    test("aborting a pending request resolves with the default", async () => {
+      const { emit } = recorder();
+      const bridge = new ExtensionUiBridge(emit);
+      const ctx = bridge.createContext();
+      const ac = new AbortController();
+
+      const result = ctx.input("name", undefined, { signal: ac.signal });
+      ac.abort();
+      assert.equal(await result, undefined);
+    });
+  });
+
+  describe("createContext fire-and-forget methods", () => {
+    test("notify emits a notify request with the type", () => {
+      const { emit, sent } = recorder();
+      const bridge = new ExtensionUiBridge(emit);
+      bridge.createContext().notify("hello", "warning");
+
+      const last = sent[sent.length - 1];
+      assert.equal(last.method, "notify");
+      assert.equal(last.message, "hello");
+      assert.equal(last.notifyType, "warning");
+    });
+
+    test("setStatus emits the key and text", () => {
+      const { emit, sent } = recorder();
+      const bridge = new ExtensionUiBridge(emit);
+      bridge.createContext().setStatus("role", "thinking");
+
+      const last = sent[sent.length - 1];
+      assert.equal(last.method, "setStatus");
+      assert.equal(last.statusKey, "role");
+      assert.equal(last.statusText, "thinking");
+    });
+
+    test("setTitle emits the title", () => {
+      const { emit, sent } = recorder();
+      const bridge = new ExtensionUiBridge(emit);
+      bridge.createContext().setTitle("a new title");
+
+      const last = sent[sent.length - 1];
+      assert.equal(last.method, "setTitle");
+      assert.equal(last.title, "a new title");
+    });
+
+    test("setWidget emits string-array content with its placement", () => {
+      const { emit, sent } = recorder();
+      const bridge = new ExtensionUiBridge(emit);
+      bridge.createContext().setWidget("panel", ["line one", "line two"], { placement: "belowEditor" });
+
+      const last = sent[sent.length - 1];
+      assert.equal(last.method, "setWidget");
+      assert.equal(last.widgetKey, "panel");
+      assert.deepEqual(last.widgetLines, ["line one", "line two"]);
+      assert.equal(last.widgetPlacement, "belowEditor");
+    });
+    test("setWidget with undefined content emits with undefined lines", () => {
+      const { emit, sent } = recorder();
+      const bridge = new ExtensionUiBridge(emit);
+      bridge.createContext().setWidget("panel", undefined);
+
+      assert.equal(sent.length, 1);
+      const last = sent[sent.length - 1];
+      assert.equal(last.method, "setWidget");
+      assert.equal(last.widgetKey, "panel");
+      assert.equal(last.widgetLines, undefined);
+    });
+
+    test("setWidget with a component factory emits nothing (no TUI to render into)", () => {
+      const { emit, sent } = recorder();
+      const bridge = new ExtensionUiBridge(emit);
+      bridge.createContext().setWidget("panel", () => ["rendered"]);
+      assert.equal(sent.length, 0);
+    });
+
+    test("setEditorText and pasteToEditor both emit set_editor_text", () => {
+      const { emit, sent } = recorder();
+      const bridge = new ExtensionUiBridge(emit);
+      const ctx = bridge.createContext();
+      ctx.pasteToEditor("pasted");
+
+      const last = sent[sent.length - 1];
+      assert.equal(last.method, "set_editor_text");
+      assert.equal(last.text, "pasted");
+    });
+
+    test("editor resolves with the value the client sent back", async () => {
+      const { emit, sent } = recorder();
+      const bridge = new ExtensionUiBridge(emit);
+      const ctx = bridge.createContext();
+
+      const opened = ctx.editor("edit", "prefill");
+      bridge.answer({ type: "extension_ui_response", id: lastId(sent), value: "edited" });
+      assert.equal(await opened, "edited");
+    });
+
+    test("editor resolves with undefined on cancel", async () => {
+      const { emit, sent } = recorder();
+      const bridge = new ExtensionUiBridge(emit);
+      const ctx = bridge.createContext();
+
+      const opened = ctx.editor("edit");
+      bridge.answer({ type: "extension_ui_response", id: lastId(sent), cancelled: true });
+      assert.equal(await opened, undefined);
+    });
+
+    test("getEditorText is always empty (synchronous, cannot ask the client)", () => {
+      const { emit } = recorder();
+      assert.equal(new ExtensionUiBridge(emit).createContext().getEditorText(), "");
+    });
+
+    test("the TUI-only stubs are silent no-ops that emit nothing", () => {
+      const { emit, sent } = recorder();
+      const ctx = new ExtensionUiBridge(emit).createContext();
+      ctx.setWorkingMessage();
+      ctx.setWorkingVisible();
+      ctx.setWorkingIndicator();
+      ctx.setHiddenThinkingLabel();
+      ctx.setFooter();
+      ctx.setHeader();
+      ctx.onTerminalInput()();
+      ctx.addAutocompleteProvider();
+      ctx.setEditorComponent();
+      ctx.setToolsExpanded();
+      assert.equal(sent.length, 0);
+    });
+
+    test("custom resolves to undefined (no TUI to render into)", async () => {
+      const { emit } = recorder();
+      assert.equal(await new ExtensionUiBridge(emit).createContext().custom(), undefined);
+    });
+
+    test("theme returns identity stylers that leave text untouched", () => {
+      const { emit } = recorder();
+      const theme = new ExtensionUiBridge(emit).createContext().theme;
+      assert.equal(theme.fg("red", "text"), "text");
+      assert.equal(theme.bg("red", "text"), "text");
+      assert.equal(theme.bold("text"), "text");
+      assert.equal(theme.italic("text"), "text");
+      assert.equal(theme.underline("text"), "text");
+      assert.equal(theme.inverse("text"), "text");
+      assert.equal(theme.strikethrough("text"), "text");
+      assert.equal(theme.getFgAnsi(), "");
+      assert.equal(theme.getBgAnsi(), "");
+      assert.equal(theme.getColorMode(), "truecolor");
+    });
+
+    test("the theme accessors return identity functions", () => {
+      const { emit } = recorder();
+      const theme = new ExtensionUiBridge(emit).createContext().theme;
+      assert.equal(theme.getThinkingBorderColor()("text"), "text");
+      assert.equal(theme.getBashModeBorderColor()("text"), "text");
+    });
+
+    test("getAllThemes, getTheme, getToolsExpanded return their empty defaults", () => {
+      const { emit } = recorder();
+      const ctx = new ExtensionUiBridge(emit).createContext();
+      assert.deepEqual(ctx.getAllThemes(), []);
+      assert.equal(ctx.getTheme(), undefined);
+      assert.equal(ctx.getToolsExpanded(), false);
+    });
+
+    test("setTheme refuses rather than pretending it worked", () => {
+      const { emit } = recorder();
+      const result = new ExtensionUiBridge(emit).createContext().setTheme();
+      assert.equal(result.success, false);
+    });
+
+    test("getEditorComponent returns undefined", () => {
+      const { emit } = recorder();
+      assert.equal(new ExtensionUiBridge(emit).createContext().getEditorComponent(), undefined);
+    });
+  });
+});

--- a/server/test/piOutpostTools.test.ts
+++ b/server/test/piOutpostTools.test.ts
@@ -1,0 +1,226 @@
+/**
+ * The pi-outpost tools extension: settings parsing and tool wiring.
+ *
+ * What these protect is the contract between the parent server and the RPC
+ * child. The child builds its own toolset from `PI_OUTPOST_TOOLS`, so a missing
+ * or malformed value must stop startup with a message that names the setting,
+ * rather than an agent that silently runs with the wrong (or no) extractors.
+ * The wiring test guards parity: the five tools the embedded runtime registers
+ * are the same five the child gets, built the same way.
+ */
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { after, before, describe, test } from "node:test";
+import type { ExtensionAPI, ToolDefinition } from "@earendil-works/pi-coding-agent";
+import piOutpostExtension, {
+  createPiOutpostTools,
+  parseToolsSettings,
+  TOOLS_ENV_VAR,
+  type PiOutpostToolsSettings,
+} from "../src/piOutpostTools.ts";
+
+const VALID: PiOutpostToolsSettings = {
+  cwd: "/tmp",
+  maxBytes: { pdf: 10485760, docx: 5242880, xlsx: 5242880, pptx: 5242880 },
+};
+
+describe("parseToolsSettings", () => {
+  test("accepts a complete, well-formed JSON value", () => {
+    const parsed = parseToolsSettings(JSON.stringify(VALID));
+    assert.deepEqual(parsed, VALID);
+  });
+
+  test("throws when the env var is not set", () => {
+    assert.throws(() => parseToolsSettings(undefined), new RegExp(TOOLS_ENV_VAR));
+  });
+
+  test("throws when the env var is empty", () => {
+    assert.throws(() => parseToolsSettings("   "), new RegExp(TOOLS_ENV_VAR));
+  });
+
+  test("throws on invalid JSON, naming the env var", () => {
+    assert.throws(
+      () => parseToolsSettings("{not json"),
+      (err: Error) => err.message.includes(TOOLS_ENV_VAR) && err.message.includes("JSON"),
+    );
+  });
+
+  test("throws when cwd is missing", () => {
+    assert.throws(
+      () => parseToolsSettings(JSON.stringify({ ...VALID, cwd: undefined })),
+      /cwd/,
+    );
+  });
+
+  test("throws when cwd is an empty string", () => {
+    assert.throws(
+      () => parseToolsSettings(JSON.stringify({ ...VALID, cwd: "" })),
+      /cwd/,
+    );
+  });
+
+  test("throws when cwd is the wrong type", () => {
+    assert.throws(
+      () => parseToolsSettings(JSON.stringify({ ...VALID, cwd: 42 })),
+      /cwd/,
+    );
+  });
+
+  test("throws when a maxBytes entry is missing", () => {
+    const { pdf: _omit, ...rest } = VALID.maxBytes;
+    void _omit;
+    assert.throws(
+      () => parseToolsSettings(JSON.stringify({ cwd: VALID.cwd, maxBytes: rest })),
+      /maxBytes\.pdf/,
+    );
+  });
+
+  test("throws when a maxBytes entry is not a number", () => {
+    assert.throws(
+      () =>
+        parseToolsSettings(
+          JSON.stringify({ cwd: VALID.cwd, maxBytes: { ...VALID.maxBytes, docx: "big" } }),
+        ),
+      /maxBytes\.docx/,
+    );
+  });
+
+  test("throws when a maxBytes entry is zero", () => {
+    assert.throws(
+      () =>
+        parseToolsSettings(
+          JSON.stringify({ cwd: VALID.cwd, maxBytes: { ...VALID.maxBytes, xlsx: 0 } }),
+        ),
+      /maxBytes\.xlsx/,
+    );
+  });
+
+  test("throws when a maxBytes entry is negative", () => {
+    assert.throws(
+      () =>
+        parseToolsSettings(
+          JSON.stringify({ cwd: VALID.cwd, maxBytes: { ...VALID.maxBytes, pptx: -1 } }),
+        ),
+      /maxBytes\.pptx/,
+    );
+  });
+
+  test("throws when a maxBytes entry is NaN", () => {
+    assert.throws(
+      () =>
+        parseToolsSettings(
+          JSON.stringify({ cwd: VALID.cwd, maxBytes: { ...VALID.maxBytes, pdf: NaN } }),
+        ),
+      /maxBytes\.pdf/,
+    );
+  });
+
+  test("throws when maxBytes itself is absent", () => {
+    assert.throws(
+      () => parseToolsSettings(JSON.stringify({ cwd: VALID.cwd })),
+      /maxBytes/,
+    );
+  });
+});
+
+describe("createPiOutpostTools", () => {
+  let root: string;
+  const roots: string[] = [];
+
+  before(async () => {
+    root = await mkdtemp(path.join(tmpdir(), "pi-outpost-tools-"));
+    roots.push(root);
+  });
+  after(async () => {
+    await Promise.all(roots.map((r) => rm(r, { recursive: true, force: true })));
+  });
+
+  test("returns the five tools the agent needs, in the documented order", async () => {
+    const tools = await createPiOutpostTools({ cwd: root, maxBytes: VALID.maxBytes });
+    assert.equal(tools.length, 5);
+    const names = tools.map((t) => t.name);
+    assert.deepEqual(names, [
+      "pdf_extract",
+      "docx_extract",
+      "xlsx_extract",
+      "pptx_extract",
+      "present_structure",
+    ]);
+  });
+
+  test("resolves the cwd through realpath so symlinked roots still confine", async () => {
+    // macOS reaches /tmp through a symlink; the confinement checks compare resolved paths.
+    const tools = await createPiOutpostTools({ cwd: root, maxBytes: VALID.maxBytes });
+    // Each tool carries its allowedRoots; the first is the resolved workspace root.
+    for (const tool of tools) {
+      const allowed = (tool as unknown as { allowedRoots?: string[] }).allowedRoots;
+      // Not every tool definition exposes allowedRoots on its surface; the point
+      // is that the call did not throw on a /tmp-rooted path (symlink on macOS).
+      if (allowed) assert.ok(allowed.length >= 1);
+    }
+  });
+
+  test("the extractors each carry their own maxBytes", async () => {
+    const tools = await createPiOutpostTools({ cwd: root, maxBytes: VALID.maxBytes });
+    for (const name of ["pdf_extract", "docx_extract", "xlsx_extract", "pptx_extract"]) {
+      const tool = tools.find((t) => t.name === name);
+      assert.ok(tool, `expected ${name} among the tools`);
+    }
+  });
+});
+
+describe("default export (extension entry)", () => {
+  let root: string;
+  const roots: string[] = [];
+
+  before(async () => {
+    root = await mkdtemp(path.join(tmpdir(), "pi-outpost-ext-"));
+    roots.push(root);
+  });
+  after(async () => {
+    await Promise.all(roots.map((r) => rm(r, { recursive: true, force: true })));
+  });
+
+  /** Saves and restores the env var around a test that mutates it. */
+  function withEnv(value: string | undefined, run: () => Promise<void>): Promise<void> {
+    const prev = process.env[TOOLS_ENV_VAR];
+    if (value === undefined) delete process.env[TOOLS_ENV_VAR];
+    else process.env[TOOLS_ENV_VAR] = value;
+    return run().finally(() => {
+      if (prev === undefined) delete process.env[TOOLS_ENV_VAR];
+      else process.env[TOOLS_ENV_VAR] = prev;
+    });
+  }
+
+  test("registers the five tools when the env var is set", async () => {
+    await withEnv(JSON.stringify({ cwd: root, maxBytes: VALID.maxBytes }), async () => {
+      const registered: ToolDefinition[] = [];
+      const pi = { registerTool: (t: ToolDefinition) => void registered.push(t) } as unknown as ExtensionAPI;
+
+      await piOutpostExtension(pi);
+
+      assert.equal(registered.length, 5);
+      assert.deepEqual(
+        registered.map((t) => t.name),
+        ["pdf_extract", "docx_extract", "xlsx_extract", "pptx_extract", "present_structure"],
+      );
+    });
+  });
+
+  test("throws when the env var is not set, so a misconfigured child fails fast", async () => {
+    await withEnv(undefined, async () => {
+      const pi = { registerTool: () => undefined } as unknown as ExtensionAPI;
+      await assert.rejects(() => piOutpostExtension(pi), new RegExp(TOOLS_ENV_VAR));
+    });
+  });
+
+  test("throws when the env var points at a missing cwd", async () => {
+    const missing = path.join(root, "does-not-exist");
+    await withEnv(JSON.stringify({ cwd: missing, maxBytes: VALID.maxBytes }), async () => {
+      const pi = { registerTool: () => undefined } as unknown as ExtensionAPI;
+      await assert.rejects(() => piOutpostExtension(pi));
+    });
+  });
+});


### PR DESCRIPTION
Version bump only: `cli`, `embed`, and the lockfile — same three files as #53.

Release notes are drafted and live only on the GitHub release, not in the repo.