### PR TITLE
fix(server): the startup hint naming a rejected flag could never fire

### DIFF
--- a/server/src/rpcRuntime.ts
+++ b/server/src/rpcRuntime.ts
@@ -134,7 +134,12 @@ class RpcRuntime implements AgentRuntime {
       // Never leave a half-started child behind: the operator gets an actionable
       // startup error and no orphaned process holding their session file open.
       await this.process.stop().catch(() => {});
-      const detail = this.failed ?? (error instanceof Error ? error.message : String(error));
+      // The child's own output, not just the cause: this error goes to the console
+      // and stops startup, so nothing is leaked to a browser by including it — and
+      // the flag a fork rejected is only ever named in there. Reading `this.failed`
+      // instead meant scanning a string that cannot contain a flag name, so the hint
+      // below could never fire.
+      const detail = this.process.failureWithOutput ?? this.failed ?? (error instanceof Error ? error.message : String(error));
       // A child that rejects a flag names the flag; the operator wrote a setting.
       const hint = explainRejectedFlags(detail);
       throw new Error(`[pi] the Pi RPC runtime failed to start: ${detail}${hint ? ` ${hint}` : ""}`);

--- a/server/test/pi-rpc.test.ts
+++ b/server/test/pi-rpc.test.ts
@@ -236,6 +236,21 @@ describe("RpcRuntimeStarts", () => {
     );
   });
 
+  /**
+   * A fork that lacks a flag names the flag; the operator wrote a setting. The
+   * bridge between the two lives in the startup error, and it silently stopped
+   * working when the child's output was split out of the client-facing cause —
+   * the string being scanned could no longer contain a flag name. Only a test
+   * that goes through the real startup path catches that; the unit test for
+   * `explainRejectedFlags` kept passing on a string nobody was passing it.
+   */
+  test("names the setting behind a flag the executable rejected", async () => {
+    await assert.rejects(
+      startFake({ startupFailure: "Error: unknown flag: --skill\nRun `omp --help` for available flags.", startupExitCode: 2 }),
+      /--skill \(from "skillPaths/,
+    );
+  });
+
   test("accepts a runtime without the optional command catalog", async () => {
     const { runtime } = await startFake({
       failures: {


### PR DESCRIPTION
Found by running `omp` against the dev config: it refuses `--skill`, and the error named the flag but not the setting that produced it — the whole point of the hint.

Two fixes from #66 collided. Stripping the child's stderr from what clients see also stripped it from what the startup path scans, so `explainRejectedFlags` searched a string that could not contain a flag name. The unit test kept passing on input nobody was passing it; the new test goes through the real startup path.