### PR TITLE
fix(build): npm pack --json changed shape, and it broke the release

### DIFF
--- a/scripts/check-embed-package.mjs
+++ b/scripts/check-embed-package.mjs
@@ -105,7 +105,17 @@ function packedFiles() {
     stdio: ["ignore", "pipe", "ignore"],
     shell: useShell && process.platform === "win32",
   });
-  return JSON.parse(output)[0].files;
+  // Two shapes, because npm changed one. It used to answer with an array of
+  // packed packages; npm 11 answers with an object keyed by package name. Reading
+  // `[0]` on the object yields undefined, and the failure — "Cannot read
+  // properties of undefined (reading 'files')" — names neither npm nor the shape,
+  // so it looks like a broken check rather than a moved field. Accept both.
+  const parsed = JSON.parse(output);
+  const packed = Array.isArray(parsed) ? parsed[0] : Object.values(parsed)[0];
+  if (!Array.isArray(packed?.files)) {
+    throw new Error(`"npm pack --json" reported no file list (got ${Array.isArray(parsed) ? "an empty array" : `keys: ${Object.keys(parsed).join(", ") || "none"}`})`);
+  }
+  return packed.files;
 }
 
 const unpublished = declared.filter(([, relative]) => !packed.has(relative.replace(/^\.\//, "")));


### PR DESCRIPTION
The v0.8.0 publish job never reached `npm publish` — it died in `check:embed`:

```
[check-embed-package] could not inspect the package tarball: Cannot read properties of undefined (reading 'files')
```

`npm pack --dry-run --json` used to return an array of packed packages; npm 11 returns an object keyed by package name, so `[0]` is undefined. Reproduces locally on npm 12.

Both shapes are accepted now. Verified the check still fails for the reason it exists: removing `dist` from `files` in embed/package.json still reports every entry point resolving to nothing.

**The registry still serves 0.7.0** for both `pi-outpost` and `@pi-outpost/embed` — v0.8.0 needs re-running the release job once this lands.