### PR TITLE
ci: artifact actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: node scripts/coverage-summary.mjs server=server/coverage/lcov.info ui=ui/coverage/lcov.info
       - name: Keep the coverage for the badge job
         if: matrix.os == 'ubuntu-latest' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage
           path: |
@@ -89,7 +89,7 @@ jobs:
       - run: npm run test:e2e
         env:
           CI: true
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: playwright-report
@@ -111,7 +111,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: coverage
           path: coverage-artifact


### PR DESCRIPTION
Every run was warning:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: actions/upload-artifact@v4, actions/download-artifact@v4
```

Bumped to the latest majors rather than the first one that runs on Node 24: upload `v4 → v7`, download `v4 → v8`. The runtime actually moves in upload v6 / download v7; the majors above add direct upload/download and an ESM migration that is transparent to callers, and the two pair (v8's direct downloads exist for v7's direct uploads).

Our usage is unchanged since v4 — archived multi-file upload, download by name into a path.

**One gap to know about:** the `badge` job that consumes the artifact only runs on the default branch, so this PR's CI exercises the upload side but not the download. That path is proved on the first push to main.