### PR TITLE
fix(embed): the widget's overlays landed outside the tree that styles them

### DIFF
--- a/e2e/embed.spec.ts
+++ b/e2e/embed.spec.ts
@@ -10,14 +10,22 @@
 import { expect, test, type Page } from "@playwright/test";
 
 /** The host page with the backend it should talk to. */
-async function openHost(page: Page): Promise<void> {
+async function openHost(page: Page, options: { server?: string; theme?: string } = {}): Promise<void> {
   const url = new URL(process.env.PI_E2E_HOST_URL!);
-  url.searchParams.set("server", process.env.PI_E2E_SERVER_URL!);
+  url.searchParams.set("server", options.server ?? process.env.PI_E2E_SERVER_URL!);
+  if (options.theme !== undefined) url.searchParams.set("theme", options.theme);
   await page.goto(url.toString());
 }
 
+/** The backend whose session already holds a Mermaid diagram and a structured exchange. */
+function withDiagrams(): { server: string } {
+  return { server: process.env.PI_E2E_DIAGRAMS_URL! };
+}
+
 test.beforeEach(async ({ page }) => {
-  await openHost(page);
+  // A named theme, so these tests do not read differently on a runner whose OS
+  // prefers dark. The tests that are *about* where the theme comes from say so.
+  await openHost(page, { theme: "light" });
 });
 
 test("mounts inside a shadow root and connects across origins", async ({ page }) => {
@@ -118,7 +126,7 @@ test("mounting reports no console error", async ({ page }) => {
   page.on("console", (message) => {
     if (message.type() === "error") errors.push(message.text());
   });
-  await openHost(page);
+  await openHost(page, { theme: "light" });
   await expect(page.getByTitle("connected")).toBeVisible();
 
   expect(errors).toEqual([]);
@@ -160,7 +168,7 @@ test.describe("BrandingArrivesBeforeTheSession", () => {
       requestAnimationFrame(sample);
     });
 
-    await openHost(page);
+    await openHost(page, { theme: "light" });
     await expect(page.getByRole("banner").getByText("embed smoke")).toBeVisible();
     await page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())));
 
@@ -210,4 +218,146 @@ test("a workspace file is readable from the host page's origin", async ({ page }
 
   expect(status.ok).toBe(true);
   expect(status.text).toContain("guarded workspace");
+});
+
+/**
+ * Diagrams inside the widget.
+ *
+ * The suite could only ever assert the empty state before this: no transcript,
+ * so no diagram, so no overlay, so nothing ever opened one inside a Shadow DOM.
+ * The enlarge overlay portalled itself to `document.body`, which is the wrong
+ * side of the shadow boundary — the widget's stylesheet is adopted by the shadow
+ * root, and a node outside it is styled by nothing at all. Measured in the
+ * browser, that overlay came out `position: static`, `z-index: auto`,
+ * transparent, and stacked below the widget with half of it off-screen.
+ */
+test.describe("diagrams in the widget", () => {
+  /** Reads the overlay wherever it ended up, and says which tree that was. */
+  const readOverlay = (page: Page, testId: string) =>
+    page.evaluate((id) => {
+      const shadow = document.querySelector("#widget")!.shadowRoot!;
+      const inShadow = shadow.querySelector(`[data-testid="${id}"]`);
+      const overlay = inShadow ?? document.querySelector(`[data-testid="${id}"]`);
+      if (!overlay) return null;
+      const style = getComputedStyle(overlay);
+      const box = overlay.getBoundingClientRect();
+      const widget = document.querySelector("#widget")!.getBoundingClientRect();
+      return {
+        tree: inShadow ? "shadow" : "document",
+        position: style.position,
+        zIndex: style.zIndex,
+        transparent: style.backgroundColor === "rgba(0, 0, 0, 0)",
+        // Covering the viewport is the whole job; below the widget is the bug.
+        coversViewport: box.top <= widget.top && box.height >= innerHeight - 1,
+      };
+    }, testId);
+
+  test("the structured exchange enlarges over the widget, not under it", async ({ page }) => {
+    await openHost(page, { ...withDiagrams(), theme: "light" });
+    await expect(page.getByTitle("connected")).toBeVisible();
+
+    // The card opens expanded, so the enlarge control is already there. Named by
+    // its aria-label: the Mermaid diagram above it is captioned "⤢ enlarge" too.
+    await page.getByRole("button", { name: /Show graph view at full size/ }).click();
+
+    const overlay = await readOverlay(page, "structured-enlarged");
+    expect(overlay).toEqual({
+      // Portalled into the shadow root: the outermost point that is still styled
+      tree: "shadow",
+      position: "fixed",
+      zIndex: "100",
+      transparent: false,
+      coversViewport: true,
+    });
+  });
+
+  test("a Mermaid diagram can be enlarged too", async ({ page }) => {
+    await openHost(page, { ...withDiagrams(), theme: "light" });
+    await expect(page.getByTitle("connected")).toBeVisible();
+
+    // Rendering is debounced, and the control only exists once there is an SVG
+    const diagram = page.locator("#widget").locator("svg[id^='mermaid-']").first();
+    await expect(diagram).toBeVisible();
+
+    const inlineWidth = (await diagram.boundingBox())!.width;
+
+    await page.getByRole("button", { name: /Show diagram at full size/ }).click();
+
+    await expect(page.getByRole("dialog", { name: /diagram, full size/i })).toBeVisible();
+    expect(await readOverlay(page, "mermaid-enlarged")).toEqual({
+      tree: "shadow",
+      position: "fixed",
+      zIndex: "100",
+      transparent: false,
+      coversViewport: true,
+    });
+
+    // Bigger, which is the entire point. Mermaid writes width="100%" and no
+    // intrinsic size, so an overlay that shrink-wraps its content renders the
+    // diagram *smaller* than the chat column it was supposed to escape.
+    const enlargedWidth = await page.evaluate(() => {
+      const shadow = document.querySelector("#widget")!.shadowRoot!;
+      const overlay = shadow.querySelector('[data-testid="mermaid-enlarged"]')!;
+      return overlay.querySelector("svg")!.getBoundingClientRect().width;
+    });
+    expect(enlargedWidth).toBeGreaterThanOrEqual(inlineWidth);
+  });
+
+  test("Escape closes an overlay opened inside the widget", async ({ page }) => {
+    await openHost(page, { ...withDiagrams(), theme: "light" });
+    await expect(page.getByTitle("connected")).toBeVisible();
+
+    await page.getByRole("button", { name: /Show graph view at full size/ }).click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+  });
+});
+
+/**
+ * Where the theme comes from when the host does not set it on every mount.
+ *
+ * Both cases below were unreachable while the host page named a theme in its
+ * own source: `branding.defaultTheme` was never consulted, and a stored pick
+ * could quietly outrank the host's option with nothing to catch it.
+ */
+test.describe("the theme a deployment configured", () => {
+  test("a host that names no theme gets the server's branding.defaultTheme", async ({ page }) => {
+    await openHost(page, withDiagrams());
+    await expect(page.getByTitle("connected")).toBeVisible();
+
+    await expect
+      .poll(() => page.evaluate(() => (document.querySelector("#widget") as HTMLElement).dataset.theme))
+      .toBe("light");
+  });
+
+  test("the theme the host asked for at mount beats one this browser remembered", async ({ page }) => {
+    // A visitor who once clicked ☾ on this origin. Before, that single click
+    // outranked `mount(el, { theme: "light" })` for good: the host could not
+    // give its widget the theme its own page was designed around.
+    await openHost(page, withDiagrams());
+    await page.evaluate(() => localStorage.setItem("pi-outpost:theme", "dark"));
+
+    await openHost(page, { ...withDiagrams(), theme: "light" });
+    await expect(page.getByTitle("connected")).toBeVisible();
+
+    await expect
+      .poll(() => page.evaluate(() => (document.querySelector("#widget") as HTMLElement).dataset.theme))
+      .toBe("light");
+    // Still remembered, so the reader's own pick survives a host that says nothing
+    expect(await page.evaluate(() => localStorage.getItem("pi-outpost:theme"))).toBe("dark");
+  });
+
+  test("a stored pick still wins over branding when the host names nothing", async ({ page }) => {
+    await openHost(page, withDiagrams());
+    await page.evaluate(() => localStorage.setItem("pi-outpost:theme", "dark"));
+
+    await openHost(page, withDiagrams());
+    await expect(page.getByTitle("connected")).toBeVisible();
+
+    await expect
+      .poll(() => page.evaluate(() => (document.querySelector("#widget") as HTMLElement).dataset.theme))
+      .toBe("dark");
+  });
 });

--- a/e2e/fixtures/seeded-transcript.ts
+++ b/e2e/fixtures/seeded-transcript.ts
@@ -1,0 +1,78 @@
+/**
+ * A transcript with diagrams in it, served by the scripted RPC agent.
+ *
+ * The browser specs need a session that already contains what they are about —
+ * a Mermaid fence and a structured exchange — and no model is going to produce
+ * one on demand in an offline test run. `fake-pi-rpc.mjs` answers `get_messages`
+ * from a file, so the transcript is written here and simply read back.
+ *
+ * Everything a widget shows for these lives behind that content: the enlarge
+ * overlay, its portal, and the theme the diagrams are drawn in. Without a
+ * transcript the suite could only ever assert the empty state, which is how an
+ * overlay that lands unstyled and off-screen inside a Shadow DOM went unnoticed.
+ */
+
+/** Wide enough that the chat column has to scroll it — which is what enlarge is for. */
+export const SEEDED_MERMAID = [
+  "Here is how the pieces fit together.",
+  "",
+  "```mermaid",
+  "graph LR",
+  "  browser[Browser] --> widget[Embedded widget]",
+  "  widget --> ws[WebSocket]",
+  "  widget --> http[HTTP branding]",
+  "  ws --> server[pi-outpost server]",
+  "  http --> server",
+  "  server --> agent[Agent runtime]",
+  "  agent --> tools[Tools]",
+  "  tools --> workspace[(Workspace)]",
+  "  server --> sessions[(Sessions)]",
+  "```",
+].join("\n");
+
+/** A graph envelope. Edges carry `kind`: the schema requires it of anything without a `ref`. */
+const ENVELOPE = {
+  schema: "urn:structured-exchange:1",
+  kind: "graph",
+  data: {
+    nodes: [
+      { id: "browser", label: "Browser" },
+      { id: "widget", label: "Embedded widget" },
+      { id: "ws", label: "WebSocket transport" },
+      { id: "http", label: "HTTP branding request" },
+      { id: "server", label: "pi-outpost server" },
+      { id: "agent", label: "Agent runtime" },
+      { id: "tools", label: "Tool surface" },
+      { id: "workspace", label: "Workspace files" },
+      { id: "sessions", label: "Session store" },
+    ],
+    edges: [
+      { from: "browser", to: "widget", kind: "flow" },
+      { from: "widget", to: "ws", kind: "flow" },
+      { from: "widget", to: "http", kind: "flow" },
+      { from: "ws", to: "server", kind: "flow" },
+      { from: "http", to: "server", kind: "flow" },
+      { from: "server", to: "agent", kind: "flow" },
+      { from: "agent", to: "tools", kind: "flow" },
+      { from: "tools", to: "workspace", kind: "flow" },
+      { from: "server", to: "sessions", kind: "flow" },
+    ],
+  },
+};
+
+export const SEEDED_MESSAGES = [
+  { role: "user", content: "Draw me the architecture." },
+  { role: "assistant", content: [{ type: "text", text: SEEDED_MERMAID }] },
+  {
+    role: "assistant",
+    content: [{ type: "toolCall", id: "call-1", name: "structured_exchange", arguments: { kind: "graph" } }],
+  },
+  {
+    role: "toolResult",
+    toolCallId: "call-1",
+    toolName: "structured_exchange",
+    content: "graph with 9 nodes",
+    // The only channel the server forwards a structured exchange from.
+    details: ENVELOPE,
+  },
+];

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,7 +1,8 @@
 import { createServer } from "node:http";
-import { access, readFile } from "node:fs/promises";
+import { access, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { SEEDED_MESSAGES } from "./fixtures/seeded-transcript";
 // The same harness the server's own integration tests use: a real server, in its
 // own process group, against a throwaway workspace, with PI_OFFLINE set so the
 // SDK's model runtime never reaches the network.
@@ -9,6 +10,7 @@ import { fileURLToPath } from "node:url";
 import { makeWorkspace, startServer } from "../server/test/harness.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(HERE, "..");
 const HOST_DIST = path.join(HERE, "dist-host");
 
 const TYPES: Record<string, string> = {
@@ -85,6 +87,58 @@ function onlyOneFakeProvider(): Record<string, string | undefined> {
 }
 
 /**
+ * Newest mtime under `dir` among the files a build actually consumes.
+ *
+ * Extensions, not everything: notes and fixtures sit next to source, and a
+ * gate that rebuilds the world because a README was edited is a gate people
+ * learn to work around.
+ */
+async function newestChange(dir: string): Promise<number> {
+  const skip = new Set(["node_modules", "dist", "dist-host", "coverage", ".turbo"]);
+  const built = /\.(ts|tsx|js|jsx|mjs|cjs|css|html|json)$/;
+  let newest = 0;
+  const walk = async (at: string): Promise<void> => {
+    const entries = await readdir(at, { withFileTypes: true }).catch(() => []);
+    for (const entry of entries) {
+      if (entry.name.startsWith(".") || skip.has(entry.name)) continue;
+      const full = path.join(at, entry.name);
+      if (entry.isDirectory()) await walk(full);
+      else if (built.test(entry.name)) newest = Math.max(newest, (await stat(full)).mtimeMs);
+    }
+  };
+  await walk(dir);
+  return newest;
+}
+
+/**
+ * Refuses to run a browser suite against a build older than its own source.
+ *
+ * Existence was the only check, and existence is not the question: a stale
+ * bundle serves yesterday's behaviour perfectly happily. A fix can then be
+ * written, the suite run, and every assertion pass or fail against code that is
+ * not the code under test — which is exactly what happened while an overlay fix
+ * sat unbuilt and the widget kept showing the bug it had already lost.
+ *
+ * Reads mtimes, so it assumes the build ran in the same checkout as the sources
+ * it is compared against — true of this repo's CI, which builds and runs the
+ * browser job together. Restoring `web/dist`, `embed/dist` or `dist-host` from a
+ * cache across jobs would hand this function timestamps older than a fresh
+ * checkout's, and it would refuse a build that is in fact current.
+ */
+async function assertFresh(artifact: string, sources: readonly string[], command: string): Promise<void> {
+  const built = (await stat(artifact)).mtimeMs;
+  for (const source of sources) {
+    const changed = await newestChange(path.join(REPO, source));
+    if (changed > built) {
+      throw new Error(
+        `${path.relative(REPO, artifact)} is older than ${source} — run \`${command}\` first ` +
+          `(built ${new Date(built).toISOString()}, ${source} changed ${new Date(changed).toISOString()})`,
+      );
+    }
+  }
+}
+
+/**
  * Boots what both specs need and hands the URLs to the workers through the
  * environment. Returning a function registers it as the teardown.
  */
@@ -92,14 +146,19 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
   // Both specs read a built artifact rather than source. Saying which one is
   // missing beats the cascade of 404s and blank pages that follows otherwise.
   const required = [
-    [path.join(HERE, "..", "web/dist/index.html"), "npm run build --workspace web"],
-    [path.join(HERE, "..", "embed/dist/pi-outpost-embed.js"), "npm run build --workspace @pi-outpost/embed"],
-    [path.join(HOST_DIST, "index.html"), "npm run build:e2e-host"],
+    [path.join(REPO, "web/dist/index.html"), "npm run build --workspace web", ["web/src", "ui/src", "shared/src"]],
+    [
+      path.join(REPO, "embed/dist/pi-outpost-embed.js"),
+      "npm run build --workspace @pi-outpost/embed",
+      ["embed/src", "ui/src", "web/src", "shared/src"],
+    ],
+    [path.join(HOST_DIST, "index.html"), "npm run build:e2e-host", ["e2e/host", "embed/dist"]],
   ] as const;
-  for (const [file, command] of required) {
+  for (const [file, command, sources] of required) {
     await access(file).catch(() => {
-      throw new Error(`missing ${path.relative(path.join(HERE, ".."), file)} — run \`${command}\` first`);
+      throw new Error(`missing ${path.relative(REPO, file)} — run \`${command}\` first`);
     });
+    await assertFresh(file, sources, command);
   }
 
   const host = await serveHostPage();
@@ -130,12 +189,43 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
     { env: onlyOneFakeProvider() },
   );
 
+  // A third server, whose session already holds the diagrams. Its own server
+  // because the transcript comes from a scripted RPC child rather than the
+  // embedded runtime, and because it is the one configured to open light —
+  // `branding.defaultTheme` is untestable on a server whose host page names a
+  // theme of its own.
+  const diagramRoot = await makeWorkspace({ "readme.md": "# diagrams\n" });
+  const fakeConfig = path.join(diagramRoot, "fake-rpc.json");
+  await writeFile(
+    fakeConfig,
+    JSON.stringify({ messages: SEEDED_MESSAGES, state: { sessionId: "diagrams-1" } }),
+  );
+  const diagrams = await startServer(
+    diagramRoot,
+    {
+      server: { allowedOrigins: [host.url] },
+      branding: { title: "diagram smoke", defaultTheme: "light" },
+      agentRuntime: {
+        mode: "rpc",
+        executable: process.execPath,
+        args: [path.join(REPO, "server/test/fixtures/fake-pi-rpc.mjs")],
+        startupTimeoutMs: 20_000,
+      },
+      // RPC refuses to pair with a sandbox it cannot enforce on a child that
+      // builds its own tools; the harness sandboxes by default.
+      sandbox: undefined,
+    },
+    { env: { ...onlyOneFakeProvider(), FAKE_PI_RPC_CONFIG: fakeConfig } },
+  );
+
   process.env.PI_E2E_HOST_URL = host.url;
   process.env.PI_E2E_SERVER_URL = server.base;
   process.env.PI_E2E_GUARDED_URL = guarded.base;
+  process.env.PI_E2E_DIAGRAMS_URL = diagrams.base;
   process.env.PI_E2E_TOKEN = E2E_TOKEN;
 
   return async () => {
+    await diagrams.stop();
     await guarded.stop();
     await server.stop();
     await host.close();

--- a/e2e/host/main.ts
+++ b/e2e/host/main.ts
@@ -32,11 +32,16 @@ const serverUrl = params.get("server") ?? undefined;
 // A host that already authenticates its user supplies the token itself, which
 // is what makes the browser preflight every request the widget sends.
 const token = params.get("token") ?? undefined;
+// Optional on purpose. A host that names a theme overrides the server's
+// branding.defaultTheme, so leaving it out is the only way to exercise the
+// branding path — and that path is a real one: it is how a deployment sets the
+// theme for hosts that do not care to.
+const theme = (params.get("theme") ?? undefined) as Theme | undefined;
 
 const handle: MountHandle = mount(container, {
   ...(serverUrl === undefined ? {} : { serverUrl }),
   ...(token === undefined ? {} : { token }),
-  theme: "light",
+  ...(theme === undefined ? {} : { theme }),
 });
 
 window.__embed = {

--- a/embed/README.md
+++ b/embed/README.md
@@ -38,6 +38,17 @@ widget.unmount(); // tear down the React tree
 
 `mount(container, options?)` returns `{ unmount(), setTheme(theme) }`. The container itself stays in the DOM after `unmount()`, with an empty shadow root.
 
+### Which theme wins
+
+Strongest first:
+
+1. `setTheme()`, a `{ type: "pi-outpost:set-theme", theme }` message, or the reader using the widget's own toggle — whatever was chosen while it was on screen;
+2. the `theme` you pass to `mount()`. Naming it means you get it: a reader who once used the toggle on this origin does not overrule the page that embeds the widget;
+3. a theme this browser remembered from an earlier visit;
+4. the server's `branding.defaultTheme`, itself falling back to `"system"`.
+
+So pass `theme` when your page has a look the widget has to match, and leave it out when the deployment's own `branding.defaultTheme` should decide.
+
 ## Server-rendered apps
 
 Importing the package is safe anywhere, but `mount()` needs a real DOM: it attaches a shadow root to the element you give it. In Next.js, Remix or Astro, call it from an effect (client-side only):

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -297,9 +297,10 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
     if (e.dataTransfer.files.length > 0) void attachFiles(Array.from(e.dataTransfer.files));
   }
   const { theme, toggle: toggleTheme, setTheme } = useTheme(
-    initialTheme ?? state.branding.defaultTheme ?? "system",
+    state.branding.defaultTheme ?? "system",
     state.branding.allowThemeToggle !== false,
     accentTarget,
+    initialTheme,
   );
   useImperativeHandle(ref, () => ({ setTheme }), [setTheme]);
   const mainRef = useRef<HTMLElement>(null);

--- a/ui/src/components/EnlargedView.tsx
+++ b/ui/src/components/EnlargedView.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useRef, type ReactNode, type RefObject } from "react";
+import { createPortal } from "react-dom";
+
+/**
+ * Where an overlay is rendered.
+ *
+ * `position: fixed` and a z-index are only as absolute as the nearest ancestor
+ * that made a stacking context, and a diagram lives deep inside the transcript.
+ * The composer and the toolbar are in other branches with contexts of their own,
+ * so they painted over an overlay that was nominally above them — leaving
+ * controls visible and clickable through a dialog that had claimed the screen.
+ * Hence a portal, out to the top of the tree.
+ *
+ * Which top depends on where the app is mounted. Embedded, it lives in a Shadow
+ * DOM whose stylesheet is adopted by the shadow root (embed/src/mount.tsx), and
+ * the document body is on the wrong side of that boundary: a node portalled
+ * there gets no styling at all. Measured in the widget, the overlay came out
+ * `position: static`, `z-index: auto`, transparent, and stacked *below* the
+ * widget — half of it off-screen. The shadow root is the outermost point that is
+ * still styled, so that is as far out as the portal goes.
+ *
+ * `anchor` is any element inside the app; the tree it belongs to decides.
+ * Answering `undefined` for an anchor that is not mounted matters: the caller
+ * remembers the last real answer rather than falling back to the document, and
+ * falling back is the bug.
+ */
+export function overlayHost(anchor: Element | null | undefined): Element | DocumentFragment | undefined {
+  const root = anchor?.getRootNode();
+  if (root === undefined) return undefined;
+  return root instanceof ShadowRoot ? root : globalThis.document.body;
+}
+
+/**
+ * Something at its own size, out of the chat column.
+ *
+ * Its natural size, not the window's: enlarging exists to undo a narrow column,
+ * not to magnify a four-box diagram. Escape and the backdrop both close it — an
+ * overlay you cannot dismiss without hunting for a control is worse than none.
+ */
+export function EnlargedView({
+  label,
+  open,
+  onClose,
+  children,
+  actions,
+  containerRef,
+  anchorRef,
+  testId = "structured-enlarged",
+}: {
+  label: string;
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  /** Export controls, so a diagram adjusted at full size can be taken away from here. */
+  actions?: ReactNode;
+  containerRef?: RefObject<HTMLDivElement | null>;
+  /**
+   * An element of the caller's, still mounted while the overlay is open. It is
+   * read only to find which tree — document or shadow root — this app lives in.
+   */
+  anchorRef?: RefObject<HTMLElement | null>;
+  testId?: string;
+}) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  /**
+   * The last tree the anchor was actually in.
+   *
+   * Resolved on every render it can be, and kept when it cannot. The anchor is a
+   * node of the caller's, and a caller is free to unmount it for a render while
+   * this stays open — reading `null` then would silently send the overlay back to
+   * the document body, which is the whole bug, only intermittently.
+   */
+  const host = useRef<Element | DocumentFragment>(undefined);
+  host.current = overlayHost(anchorRef?.current) ?? host.current;
+
+  if (!open) return null;
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={`${label}, full size`}
+      data-testid={testId}
+      onClick={onClose}
+      className="fixed inset-0 z-[100] flex items-center justify-center overflow-auto bg-black/60 p-6"
+    >
+      <div
+        onClick={(event) => event.stopPropagation()}
+        className="max-h-full w-auto max-w-[95vw] overflow-auto rounded-lg bg-white p-4 shadow-xl dark:bg-zinc-900"
+      >
+        <div className="mb-2 flex items-center justify-between gap-4">
+          <span className="text-xs text-zinc-500">{label}</span>
+          <div className="flex items-center gap-3">
+            {actions}
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              className="rounded px-2 py-0.5 text-xs text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-800"
+            >
+              ✕
+            </button>
+          </div>
+        </div>
+        <div ref={containerRef} className="[&_svg]:!max-w-none">
+          {children}
+        </div>
+      </div>
+    </div>,
+    host.current ?? globalThis.document.body,
+  );
+}

--- a/ui/src/components/Mermaid.test.tsx
+++ b/ui/src/components/Mermaid.test.tsx
@@ -10,7 +10,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
-import { Mermaid } from "./Mermaid";
+import { Mermaid, naturalWidth } from "./Mermaid";
 
 const renderDiagram = vi.hoisted(() => vi.fn());
 const initialize = vi.hoisted(() => vi.fn());
@@ -112,5 +112,27 @@ describe("Mermaid", () => {
     await settle();
     // The debounce timer was cleared with the component: nothing was ever asked for
     expect(renderDiagram).not.toHaveBeenCalled();
+  });
+});
+
+describe("naturalWidth", () => {
+  // Real mermaid output, both shapes: it writes a viewBox with a negative
+  // origin, and `width="100%"` with no intrinsic size of its own.
+  it("reads the width past a negative, fractional origin", () => {
+    expect(naturalWidth('<svg viewBox="-8 -8 96 36" width="100%">')).toBe(96);
+    expect(naturalWidth('<svg viewBox="-50 -10 450 176" width="100%">')).toBe(450);
+    expect(naturalWidth('<svg viewBox="-0.5 -12.25 1304.8 135">')).toBe(1304.8);
+  });
+
+  it("takes the outer diagram's box, not a marker's", () => {
+    // Markers carry viewBoxes of their own, and they live inside <defs>, which
+    // can only follow the opening tag — so the first match is the diagram's.
+    const svg = '<svg viewBox="0 0 800 200"><defs><marker viewBox="0 0 10 10"/></defs></svg>';
+    expect(naturalWidth(svg)).toBe(800);
+  });
+
+  it("says nothing rather than guessing when there is no usable box", () => {
+    expect(naturalWidth("<svg>")).toBeUndefined();
+    expect(naturalWidth('<svg viewBox="0 0 0 0">')).toBeUndefined();
   });
 });

--- a/ui/src/components/Mermaid.tsx
+++ b/ui/src/components/Mermaid.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useRef, useState } from "react";
 import { useThemeContext } from "../theme/ThemeContext";
 import { CopyButton } from "./CopyButton";
+import { EnlargedView } from "./EnlargedView";
 
 type MermaidTheme = "dark" | "default";
 
@@ -24,6 +25,21 @@ async function loadMermaid(theme: MermaidTheme) {
   return module;
 }
 
+/**
+ * The diagram's own width, read from its viewBox.
+ *
+ * Needed because mermaid writes `width="100%"` and a `max-width` on the SVG: it
+ * has no intrinsic size, it fills whatever it is put in. Dropped into the
+ * overlay's shrink-to-fit box that comes out *smaller* than the chat column —
+ * enlarge that shrinks. Giving the box the diagram's real width makes the SVG
+ * fill exactly that, and the modal scrolls when it does not fit.
+ */
+export function naturalWidth(svg: string): number | undefined {
+  const viewBox = /viewBox="\s*[\d.-]+[\s,]+[\d.-]+[\s,]+([\d.]+)[\s,]+([\d.]+)/.exec(svg);
+  const width = viewBox ? Number(viewBox[1]) : Number.NaN;
+  return Number.isFinite(width) && width > 0 ? width : undefined;
+}
+
 export function Mermaid({ code }: { code: string }) {
   const id = useId().replace(/[^a-zA-Z0-9]/g, "");
   const theme = useThemeContext();
@@ -31,6 +47,10 @@ export function Mermaid({ code }: { code: string }) {
   const [svg, setSvg] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [showCode, setShowCode] = useState(false);
+  const [enlarged, setEnlarged] = useState(false);
+  // The block, not the diagram: it stays mounted whichever face is showing, so
+  // the overlay can always tell which tree it belongs to.
+  const blockRef = useRef<HTMLDivElement>(null);
   const codeRef = useRef(code);
   codeRef.current = code;
 
@@ -58,7 +78,10 @@ export function Mermaid({ code }: { code: string }) {
 
   if (svg) {
     return (
-      <div className="group relative my-2 rounded-lg border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-800 dark:bg-zinc-900">
+      <div
+        ref={blockRef}
+        className="group relative my-2 rounded-lg border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-800 dark:bg-zinc-900"
+      >
         <div className="absolute left-2 top-2 z-10 opacity-0 transition-opacity group-hover:opacity-100">
           <button
             type="button"
@@ -69,7 +92,23 @@ export function Mermaid({ code }: { code: string }) {
             {showCode ? "⚏ diagram" : "⌗ code"}
           </button>
         </div>
-        <div className="absolute right-2 top-2 z-10 opacity-0 transition-opacity group-hover:opacity-100">
+        <div className="absolute right-2 top-2 z-10 flex items-center gap-2 opacity-0 transition-opacity group-hover:opacity-100">
+          {/* Same reason the structured-exchange view has one: a wide diagram in a
+              narrow column arrives as a sliver, and scrolling it sideways is not
+              reading it. */}
+          {!showCode && (
+            <button
+              type="button"
+              onClick={() => setEnlarged(true)}
+              // Named, not just captioned: the structured-exchange view has an
+              // enlarge control of its own, and a page carrying both would
+              // otherwise offer two buttons called the same thing.
+              aria-label="Show diagram at full size"
+              className="rounded px-1.5 py-0.5 text-xs text-zinc-400 hover:bg-zinc-100 hover:text-zinc-700 dark:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+            >
+              ⤢ enlarge
+            </button>
+          )}
           <CopyButton text={code} />
         </div>
         {showCode ? (
@@ -81,6 +120,20 @@ export function Mermaid({ code }: { code: string }) {
             dangerouslySetInnerHTML={{ __html: svg }}
           />
         )}
+        <EnlargedView
+          label="diagram"
+          testId="mermaid-enlarged"
+          open={enlarged}
+          onClose={() => setEnlarged(false)}
+          anchorRef={blockRef}
+        >
+          <div
+            style={{ width: naturalWidth(svg) }}
+            className="[&_svg]:!h-auto [&_svg]:!max-w-none [&_svg]:!w-full"
+            // eslint-disable-next-line react/no-danger — the same SVG, at its own size
+            dangerouslySetInnerHTML={{ __html: svg }}
+          />
+        </EnlargedView>
       </div>
     );
   }

--- a/ui/src/presentations/StructuredExchangeView.test.tsx
+++ b/ui/src/presentations/StructuredExchangeView.test.tsx
@@ -167,6 +167,21 @@ describe("what stays reachable", () => {
     expect(screen.getByTestId("structured-raw-output")).toHaveTextContent("the original output");
   });
 
+  it("shows the envelope the view is drawn from, which the raw output is not", () => {
+    // The card showed the rendering, the derived syntax, the text equivalent and
+    // the tool's own output — everything except the document all of those come
+    // from. Asked why a node reads as added rather than context, that is the one
+    // artifact that answers, and it never reaches the model to be asked about.
+    renderBody(withStructured(proposal));
+    fireEvent.click(screen.getByText(/show envelope/));
+
+    const shown = screen.getByTestId("structured-envelope").textContent ?? "";
+    expect(JSON.parse(shown)).toEqual(proposal);
+    // Indented rather than as it arrived on one line: this is for reading
+    expect(shown).toContain("\n  ");
+    expect(screen.queryByTestId("structured-raw-output")).not.toBeInTheDocument();
+  });
+
   it("offers a textual equivalent of what the view displays", () => {
     renderBody(withStructured(proposal));
     fireEvent.click(screen.getByText(/show text equivalent/));

--- a/ui/src/presentations/StructuredExchangeView.tsx
+++ b/ui/src/presentations/StructuredExchangeView.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import { createPortal } from "react-dom";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { EnlargedView } from "../components/EnlargedView";
 import type {
   StructuredElement,
   StructuredMessage,
@@ -1674,85 +1674,22 @@ function TableView({ data }: { data: StructuredTableData }) {
   );
 }
 
-/* ── Enlarged view ──────────────────────────────────────────────────────────── */
-
 /**
- * The diagram at its own size, out of the chat column.
+ * The envelope as text, indented so it can be read.
  *
- * Its natural size, not the window's: enlarging exists to undo a narrow column,
- * not to magnify a four-box diagram. Escape and the backdrop both close it — an
- * overlay you cannot dismiss without hunting for a control is worse than none.
+ * Taken from the string that arrived rather than from the validated object: what
+ * a reader is checking here is what the producer actually sent. Indentation is
+ * the only thing changed — `JSON.stringify` keeps key order, so nothing moves.
  */
-function EnlargedView({
-  label,
-  open,
-  onClose,
-  children,
-  actions,
-  containerRef,
-}: {
-  label: string;
-  open: boolean;
-  onClose: () => void;
-  children: ReactNode;
-  /** Export controls, so a diagram adjusted at full size can be taken away from here. */
-  actions?: ReactNode;
-  containerRef?: React.RefObject<HTMLDivElement | null>;
-}) {
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [open, onClose]);
-
-  if (!open) return null;
-
-  /**
-   * Rendered into the document body rather than where it sits in the tree.
-   *
-   * `position: fixed` and a z-index are only as absolute as the nearest ancestor
-   * that made a stacking context, and this modal lives deep inside the transcript.
-   * The composer and the toolbar are in other branches with contexts of their own, so
-   * they painted over an overlay that was nominally above them — leaving controls
-   * visible and clickable through a dialog that had claimed the screen.
-   */
-  return createPortal(
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-label={`${label}, full size`}
-      data-testid="structured-enlarged"
-      onClick={onClose}
-      className="fixed inset-0 z-[100] flex items-center justify-center overflow-auto bg-black/60 p-6"
-    >
-      <div
-        onClick={(event) => event.stopPropagation()}
-        className="max-h-full w-auto max-w-[95vw] overflow-auto rounded-lg bg-white p-4 shadow-xl dark:bg-zinc-900"
-      >
-        <div className="mb-2 flex items-center justify-between gap-4">
-          <span className="text-xs text-zinc-500">{label}</span>
-          <div className="flex items-center gap-3">
-            {actions}
-            <button
-              type="button"
-              onClick={onClose}
-              aria-label="Close"
-              className="rounded px-2 py-0.5 text-xs text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-800"
-            >
-              ✕
-            </button>
-          </div>
-        </div>
-        <div ref={containerRef} className="[&_svg]:!max-w-none">
-          {children}
-        </div>
-      </div>
-    </div>,
-    globalThis.document.body,
-  );
+function envelopeSource(structured: string | undefined, envelope: ValidatedStructuredExchange): string {
+  if (structured === undefined) return JSON.stringify(envelope, null, 2);
+  try {
+    return JSON.stringify(JSON.parse(structured), null, 2);
+  } catch {
+    // Unreachable by way of the validator, which parsed it first. Shown as it
+    // came rather than swallowed, on the chance the two ever disagree.
+    return structured;
+  }
 }
 
 /* ── Textual equivalent ─────────────────────────────────────────────────────── */
@@ -1877,6 +1814,7 @@ function StructuredExchangeBody({ item }: PresentationProps) {
   const [showText, setShowText] = useState(false);
   const [showExport, setShowExport] = useState(false);
   const [showRaw, setShowRaw] = useState(false);
+  const [showEnvelope, setShowEnvelope] = useState(false);
   const [copied, setCopied] = useState<string | null>(null);
   const diagramRef = useRef<HTMLDivElement>(null);
   const enlargedRef = useRef<HTMLDivElement>(null);
@@ -2017,6 +1955,9 @@ function StructuredExchangeBody({ item }: PresentationProps) {
         open={enlarged}
         onClose={() => setEnlarged(false)}
         containerRef={enlargedRef}
+        // The inline diagram stays mounted while the overlay is open, so it is
+        // what tells the overlay which tree it has to be rendered into.
+        anchorRef={diagramRef}
         actions={
           envelope.kind !== "table" && (
             <>
@@ -2094,6 +2035,9 @@ function StructuredExchangeBody({ item }: PresentationProps) {
             {showExport ? "hide" : "show"} derived diagram syntax
           </button>
         )}
+        <button type="button" className="text-zinc-500 underline" onClick={() => setShowEnvelope((open) => !open)}>
+          {showEnvelope ? "hide" : "show"} envelope
+        </button>
         <button type="button" className="text-zinc-500 underline" onClick={() => setShowRaw((open) => !open)}>
           {showRaw ? "hide" : "show"} original output
         </button>
@@ -2116,6 +2060,23 @@ function StructuredExchangeBody({ item }: PresentationProps) {
           </p>
           <pre data-testid="structured-derived-export" className="overflow-x-auto rounded bg-zinc-100 p-2 text-xs dark:bg-zinc-800">
             {mermaid}
+          </pre>
+        </div>
+      )}
+      {showEnvelope && (
+        <div>
+          {/* Everything else on this card is downstream of this document: the
+              rendering, the derived syntax, the text equivalent. When a producer
+              is wrong — a node marked added that should read as context — the
+              envelope is the only artifact that says why, and it was the one
+              thing the card did not show. Not the raw output either: that is
+              what the tool wrote for the model, and the envelope never reaches
+              the model at all. */}
+          <p className="mb-1 text-[11px] text-zinc-500">
+            The validated document this view is drawn from. It is not sent to the model.
+          </p>
+          <pre data-testid="structured-envelope" className="max-h-80 overflow-auto rounded bg-zinc-100 p-2 text-xs dark:bg-zinc-800">
+            {envelopeSource(item.structured, envelope)}
           </pre>
         </div>
       )}

--- a/ui/src/theme/useTheme.test.ts
+++ b/ui/src/theme/useTheme.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Which theme wins, and why it matters who is asking.
+ *
+ * The rank that this file is really about: a host application names a theme on
+ * every `mount()`, and a value this browser remembered from some earlier visit
+ * was silently beating it. In a page that asked for light, a single past click
+ * on ☾ left the widget dark for good, with nothing the host could do about it.
+ */
+import { renderHook, act } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { useTheme } from "./useTheme";
+
+const STORAGE_KEY = "pi-outpost:theme";
+
+beforeAll(() => {
+  // jsdom ships no matchMedia, and the hook asks it what the OS prefers. "Not
+  // dark" keeps every case below about precedence rather than about the OS.
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  })) as unknown as typeof window.matchMedia;
+});
+
+afterEach(() => {
+  localStorage.clear();
+  document.documentElement.removeAttribute("data-theme");
+});
+
+function mount(configured: "light" | "dark" | "system", hostTheme?: "light" | "dark" | "system") {
+  const root = document.createElement("div");
+  return renderHook(() => useTheme(configured, true, root, hostTheme)).result;
+}
+
+describe("useTheme precedence", () => {
+  it("takes the server's configured default when nothing else has an opinion", () => {
+    expect(mount("light").current.theme).toBe("light");
+  });
+
+  it("lets a stored pick from an earlier visit override the configured default", () => {
+    localStorage.setItem(STORAGE_KEY, "dark");
+
+    expect(mount("light").current.theme).toBe("dark");
+  });
+
+  it("gives the host the theme it asked for, over anything this browser remembered", () => {
+    localStorage.setItem(STORAGE_KEY, "dark");
+
+    // mount(container, { theme: "light" }) — an instruction repeated every mount
+    expect(mount("dark", "light").current.theme).toBe("light");
+  });
+
+  it("keeps the host's theme when branding arrives with a different default", () => {
+    // Branding lands after the first render; without an override marked, the
+    // effect that adopts it would undo what the host asked for.
+    const root = document.createElement("div");
+    const { result, rerender } = renderHook(
+      ({ configured }: { configured: "light" | "dark" }) => useTheme(configured, true, root, "light"),
+      { initialProps: { configured: "system" as "light" | "dark" } },
+    );
+
+    rerender({ configured: "dark" });
+
+    expect(result.current.theme).toBe("light");
+    expect(root.dataset.theme).toBe("light");
+  });
+
+  it("still lets the reader change it afterwards, and remembers that", () => {
+    const result = mount("dark", "light");
+
+    act(() => result.current.setTheme("dark"));
+
+    expect(result.current.theme).toBe("dark");
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("dark");
+  });
+
+  it("ignores a stored pick when the deployment turned the toggle off", () => {
+    localStorage.setItem(STORAGE_KEY, "dark");
+
+    const root = document.createElement("div");
+    const { result } = renderHook(() => useTheme("light", false, root));
+
+    expect(result.current.theme).toBe("light");
+  });
+});

--- a/ui/src/theme/useTheme.ts
+++ b/ui/src/theme/useTheme.ts
@@ -5,20 +5,35 @@ import { loadStoredTheme, resolveSystemTheme, storeTheme } from "./theme";
 /**
  * Resolves and applies the effective light/dark theme.
  *
- * Precedence: an explicit local pick (toggle button, persisted) or a message
- * from a host page (`{ type: "pi-outpost:set-theme", theme }` — for
- * embedding, independent of whether the toggle is enabled) wins over
- * `defaultTheme` from server config, which itself falls back to "system".
+ * Precedence, strongest first:
+ *
+ * 1. a message from a host page (`{ type: "pi-outpost:set-theme", theme }`) or
+ *    the host calling `setTheme()`, and the toggle button — whatever was chosen
+ *    while this widget was on screen;
+ * 2. `hostTheme` — the theme the embedding application named when it mounted
+ *    (`mount(el, { theme })`). An instruction the host repeats on every mount
+ *    outranks anything this browser happens to have remembered: a widget that
+ *    came up dark because someone once clicked ☾, in a page that asked for
+ *    light, is a widget the host cannot control at all;
+ * 3. a stored local pick from a previous visit;
+ * 4. `defaultTheme` from server config, itself falling back to "system".
  *
  * `rootElement` is where `data-theme` is applied — `document.documentElement`
  * for the standalone app, or the widget's own container element when mounted
  * inside a Shadow DOM (see `embed/src/mount.tsx`), so `dark:` styling stays
  * scoped to the widget instead of leaking onto the host page's `<html>`.
  */
-export function useTheme(defaultTheme: Theme, allowToggle: boolean, rootElement: HTMLElement = document.documentElement) {
+export function useTheme(
+  defaultTheme: Theme,
+  allowToggle: boolean,
+  rootElement: HTMLElement = document.documentElement,
+  hostTheme?: Theme,
+) {
   const stored = allowToggle ? loadStoredTheme() : null;
-  const [preference, setPreference] = useState<Theme>(stored ?? defaultTheme);
-  const hasOverride = useRef(stored !== null);
+  const [preference, setPreference] = useState<Theme>(hostTheme ?? stored ?? defaultTheme);
+  // Both a host's theme and a stored pick settle the question, so neither is
+  // displaced when branding arrives.
+  const hasOverride = useRef(hostTheme !== undefined || stored !== null);
 
   // Once branding loads (or changes) with no local/host override yet, adopt it.
   useEffect(() => {


### PR DESCRIPTION
Found by driving the real embedded widget in a browser, not by reading it. Four defects, one root cause shared by the first and the last.

## The overlay was outside the tree that styles it

`EnlargedView` portalled to `document.body`. Embedded, the app lives in a Shadow DOM whose stylesheet is adopted by the shadow root, so a node in the document is styled by nothing at all. Measured in the widget:

```
tree        document.body      →  shadow root
position    static             →  fixed
z-index     auto               →  100
background  transparent        →  oklab(0 0 0 / .6)
box         y=754, h=184       →  covers the viewport
```

Stacked below the widget, half of it off-screen. The portal now targets the shadow root when there is one — the outermost point that is still styled. `EnlargedView` moves to its own module for it.

## A host's theme lost to localStorage

One past click on ☾ on that origin, and `mount(el, { theme: "light" })` was ignored for good: the host could not give its widget the theme its own page was built around. An instruction the host repeats on every mount now outranks a remembered pick. A stored pick still beats `branding.defaultTheme` (the documented order), and the reader's own toggle still wins over everything. Precedence is now written down in the embed README.

## Mermaid had no enlarge, and the first one shrank the diagram

Mermaid writes `width="100%"` with no intrinsic size, so a shrink-to-fit overlay rendered the diagram *narrower* than the column it was escaping. The box now takes its width from the diagram's viewBox:

```
inline 712 px → enlarged 712 px   (before)
inline 712 px → enlarged 1356 px  (after)
```

## Why the suite saw none of it

`embed.spec.ts` never rendered a diagram — no transcript, so no overlay, so nothing ever opened one inside a Shadow DOM. There is now a third test server whose session is seeded through the scripted RPC agent (a Mermaid fence and a structured exchange), and tests that open both overlays and read back where they landed, how they are stacked, and whether enlarging enlarges.

Reverting either fix and rebuilding turns the two diagram tests red — checked, not assumed.

## Two things the browser taught along the way

- The suite was running against a `dist/` older than its own source: a fix was written, the suite run, and the assertions answered about code that was not under test. Global setup now refuses a stale artifact and names it (`web/dist/index.html is older than ui/src — run … first`). It counts only files a build consumes, so editing a note next to source does not trip it.
- Adding an enlarge control to Mermaid left two buttons on the page with the same accessible name. Each is named now.

## Also here

`show envelope` on the structured-exchange card. The rendering, the derived syntax, the text equivalent and the tool's raw output were all reachable; the validated document they all derive from was not — and it is the only artifact that answers "why is this node marked added?".

## Checks

`npm run typecheck` clean · UI 1127 · server 1166 · Playwright 21/21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)