### PR TITLE
chore(release): v0.9.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ interactive-test/workspace/
 interactive-test/.pi-agent/
 interactive-test/*.log
 .omo/run-continuation/
+RELEASE_NOTES.md

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-outpost",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "description": "A web interface for the pi coding agent: a browser chat UI you run with npx — no clone, no build.",
   "license": "MIT",

--- a/embed/package.json
+++ b/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-outpost/embed",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "description": "Mount pi-outpost as a Shadow-DOM-isolated widget inside another web app.",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
     },
     "cli": {
       "name": "pi-outpost",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "^0.84.1",
@@ -44,7 +44,7 @@
     },
     "embed": {
       "name": "@pi-outpost/embed",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "devDependencies": {
         "@microsoft/api-extractor": "^7.58.9",


### PR DESCRIPTION
Bump `embed` and `cli` packages to `0.9.0`.

Covers everything merged since v0.8.0:
- structured-exchange containers (#74)
- PDF Type3 font extraction fix (#72)
- embed widget overlays/theme/mermaid (#73)
- CI artifact actions Node 24 (#70)

Merge → tag `v0.9.0` → publish.