### PR TITLE
chore(release): v0.9.1

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-outpost",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "description": "A web interface for the pi coding agent: a browser chat UI you run with npx — no clone, no build.",
   "license": "MIT",

--- a/embed/package.json
+++ b/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-outpost/embed",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "description": "Mount pi-outpost as a Shadow-DOM-isolated widget inside another web app.",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
     },
     "cli": {
       "name": "pi-outpost",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "^0.84.1",
@@ -39,12 +39,12 @@
         "esbuild": "^0.28.1"
       },
       "engines": {
-        "node": ">=22.19.0"
+        "node": ">=24"
       }
     },
     "embed": {
       "name": "@pi-outpost/embed",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@microsoft/api-extractor": "^7.58.9",
@@ -407,7 +407,6 @@
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.1.tgz",
       "integrity": "sha512-ncAqFrG+iybuPGOhMiZoEHkEzTpJgz3guYD32pD+M7ucc0WeHmauP6wa7qwP8V/KWvsZDVNa5XGsdZ7fkC7w7A==",
-      "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-agent-core": "^0.84.1",
@@ -10656,7 +10655,7 @@
         "typescript": "^5.8.0"
       },
       "engines": {
-        "node": ">=26"
+        "node": ">=24"
       }
     },
     "shared": {


### PR DESCRIPTION
Patch release. One fix since v0.9.0.

## Embed widget: a click inside the widget is not a click outside a menu

Every dismissable menu closes on a pointer press outside itself, asked the ordinary way — a `mousedown` listener on `document`, then `ref.contains(event.target)`. Inside a Shadow root that question has one answer: the event is retargeted at the boundary, so the listener is handed the widget's host element and never the button that was pressed. "Outside" meant everywhere.

`mousedown` runs before `click`, so the press that chose a suggestion closed the list instead of taking it. `/` and `@` autocomplete could not be used with a mouse at all, and clicking back into the composer dismissed the list you were typing towards. Five other menus were closing on their own contents too.

Fixed in #76 by reading `event.composedPath()`, behind one shared `useClickOutside` replacing four identical copies.

## This PR

- `cli` and `embed` bumped to 0.9.1
- `package-lock.json` engines resynced with what `cli` (`>=24`) and `server` (`>=24`) already declare — the lock had gone stale

Publishing is the tag, not the merge: `git tag v0.9.1 && git push origin v0.9.1` once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)