### PR TITLE
fix(embed): draw the widget's borders, keep overlays inside the app root

### DIFF
--- a/e2e/embed.spec.ts
+++ b/e2e/embed.spec.ts
@@ -105,6 +105,43 @@ test("setTheme switches the widget without touching the host", async ({ page }) 
   expect((await readTheme()).hostBackground).toBe(light.hostBackground);
 });
 
+/**
+ * Borders, which Tailwind v4 draws through a registered custom property.
+ *
+ * `@property` registers on the document or not at all: inside a shadow tree, and
+ * inside an adopted stylesheet in particular, the rule is parsed and ignored.
+ * `.border` is `border-style: var(--tw-border-style); border-width: 1px`, so with
+ * the property unregistered that `var()` resolves to nothing, `border-style` is
+ * invalid at computed-value time, and every border in the widget silently
+ * vanishes — cards, menus, composer, tables alike. Width and colour still arrive,
+ * which is why it reads as a flat design rather than as a bug.
+ */
+test("the widget's borders are drawn, not silently dropped", async ({ page }) => {
+  await expect(page.getByTitle("connected")).toBeVisible();
+
+  const drawn = await page.evaluate(() => {
+    const shadow = document.querySelector("#widget")!.shadowRoot!;
+    const bordered = shadow.querySelector('[title="Settings"]')!;
+    const style = getComputedStyle(bordered);
+    return {
+      borderStyle: style.borderStyle,
+      borderWidth: style.borderWidth,
+      // The registration lives on the document, the one thing that must cross
+      // the shadow boundary — and it is Tailwind's own namespace, not the host's.
+      registered: document.getElementById("pi-outpost-custom-properties") !== null,
+      registrationsAreTailwindsOwn: (document.getElementById("pi-outpost-custom-properties")?.textContent ?? "")
+        .split("@property")
+        .slice(1)
+        .every((rule) => rule.trimStart().startsWith("--tw-")),
+    };
+  });
+
+  expect(drawn.borderStyle).toBe("solid");
+  expect(drawn.borderWidth).not.toBe("0px");
+  expect(drawn.registered).toBe(true);
+  expect(drawn.registrationsAreTailwindsOwn).toBe(true);
+});
+
 test("unmount empties the shadow root and leaves the container", async ({ page }) => {
   await expect(page.getByRole("textbox", { name: /message pi/i })).toBeVisible();
 
@@ -312,6 +349,8 @@ test.describe("diagrams in the widget", () => {
 
     await page.keyboard.press("Escape");
     await expect(page.getByRole("dialog")).toHaveCount(0);
+  });
+
   });
 });
 

--- a/e2e/embed.spec.ts
+++ b/e2e/embed.spec.ts
@@ -392,6 +392,79 @@ test.describe("diagrams in the widget", () => {
     expect(painted.cellText).toContain("REQ-001");
   });
 
+  /**
+   * Column sizing, which only a browser can answer: jsdom has no layout, so the
+   * width a column actually ends up with is not a thing a unit test can see.
+   */
+  test("a reader can size a column, and the rules run both ways", async ({ page }) => {
+    await openHost(page, { ...withDiagrams(), theme: "light" });
+    await expect(page.getByTitle("connected")).toBeVisible();
+
+    const rules = await page.evaluate(() => {
+      const shadow = document.querySelector("#widget")!.shadowRoot!;
+      const cell = [...shadow.querySelectorAll("td")].find((element) => element.textContent?.includes("REQ-001"))!;
+      const style = getComputedStyle(cell);
+      return { left: style.borderLeftWidth, bottom: style.borderBottomWidth };
+    });
+    // A row rule alone leaves seven columns of prose running together
+    expect(rules.left).not.toBe("0px");
+    expect(rules.bottom).not.toBe("0px");
+
+    // Grabbed deep in the table, not at the header: a column boundary is a line
+    // the whole height of it, and that is where a reader reading row ten reaches.
+    const grip = await page.evaluate(() => {
+      const shadow = document.querySelector("#widget")!.shadowRoot!;
+      const table = [...shadow.querySelectorAll("table")].find((element) => element.textContent?.includes("REQ-001"))!;
+      const row = [...table.querySelectorAll("tbody tr")].at(-1)!;
+      row.scrollIntoView({ block: "center" });
+      const handle = row.querySelectorAll("td")[1]!.querySelector('[aria-hidden="true"]')!;
+      const box = handle.getBoundingClientRect();
+      return {
+        x: box.x + box.width / 2,
+        y: box.y + box.height / 2,
+        before: Math.round(table.querySelectorAll("th")[1]!.getBoundingClientRect().width),
+      };
+    });
+
+    await page.mouse.move(grip.x, grip.y);
+    await page.mouse.down();
+    await page.mouse.move(grip.x + 150, grip.y, { steps: 10 });
+    await page.mouse.up();
+
+    const after = await page.evaluate(() => {
+      const shadow = document.querySelector("#widget")!.shadowRoot!;
+      const table = [...shadow.querySelectorAll("table")].find((element) => element.textContent?.includes("REQ-001"))!;
+      return Math.round(table.querySelectorAll("th")[1]!.getBoundingClientRect().width);
+    });
+
+    // The whole drag, not the first few pixels of it: pointer capture on the
+    // divider died on the first re-render and a 150-pixel gesture arrived as 30.
+    expect(after - grip.before).toBeGreaterThanOrEqual(140);
+  });
+
+  test("a table reaches the widget at all, rows and cell kinds intact", async ({ page }) => {
+    await openHost(page, { ...withDiagrams(), theme: "light" });
+    await expect(page.getByTitle("connected")).toBeVisible();
+
+    const table = await page.evaluate(() => {
+      const shadow = document.querySelector("#widget")!.shadowRoot!;
+      const tables = [...shadow.querySelectorAll("table")];
+      const requirements = tables.find((element) => element.textContent?.includes("REQ-001"));
+      if (!requirements) return null;
+      const lastRow = [...requirements.querySelectorAll("tbody tr")].at(-1)!;
+      return {
+        columns: [...requirements.querySelectorAll("thead th")].map((cell) => cell.textContent),
+        rows: requirements.querySelectorAll("tbody tr").length,
+        // string, number, boolean and null all reach a cell; none may be dropped
+        lastRow: [...lastRow.querySelectorAll("td")].map((cell) => cell.textContent),
+      };
+    });
+
+    expect(table).not.toBeNull();
+    expect(table!.columns).toEqual(["ID", "Requirement", "Status", "Safety"]);
+    expect(table!.rows).toBe(4);
+    expect(table!.lastRow[0]).toBe("REQ-004");
+    expect(table!.lastRow[3]).toBe("\u2014"); // null reads as an em dash, not as "null"
   });
 });
 

--- a/e2e/embed.spec.ts
+++ b/e2e/embed.spec.ts
@@ -299,7 +299,7 @@ test.describe("diagrams in the widget", () => {
 
     const overlay = await readOverlay(page, "structured-enlarged");
     expect(overlay).toEqual({
-      // Portalled into the shadow root: the outermost point that is still styled
+      // Portalled inside the shadow tree, where the widget's own styling reaches
       tree: "shadow",
       position: "fixed",
       zIndex: "100",
@@ -349,6 +349,47 @@ test.describe("diagrams in the widget", () => {
 
     await page.keyboard.press("Escape");
     await expect(page.getByRole("dialog")).toHaveCount(0);
+  });
+
+  /**
+   * A table is the one kind made of HTML text, and text inherits.
+   *
+   * Inherited properties are not blocked by a shadow boundary — they are
+   * overridden by whatever the tree declares for itself, and the app declares
+   * its own on its root element. An overlay portalled past that root is a
+   * sibling of it, so it inherited from the host element instead, and this host
+   * paints `* { color: red }`. Every cell of an enlarged table came out red.
+   * Diagrams never showed it: SVG text carries an explicit `fill`.
+   */
+  test("an enlarged table is painted by the widget, not by the host page", async ({ page }) => {
+    await openHost(page, { ...withDiagrams(), theme: "light" });
+    await expect(page.getByTitle("connected")).toBeVisible();
+
+    await page.getByRole("button", { name: /Show table view at full size/ }).first().click();
+    await expect(page.getByRole("dialog", { name: /table view, full size/i })).toBeVisible();
+
+    const painted = await page.evaluate(() => {
+      const shadow = document.querySelector("#widget")!.shadowRoot!;
+      const overlay = shadow.querySelector('[data-testid="structured-enlarged"]')!;
+      const appRoot = shadow.querySelector("#root")!;
+      const cell = overlay.querySelector("td")!;
+      return {
+        insideTheAppRoot: appRoot.contains(overlay),
+        siblingOfTheAppRoot: overlay.parentNode === shadow,
+        overlayColour: getComputedStyle(overlay).color,
+        cellColour: getComputedStyle(cell).color,
+        hostColour: getComputedStyle(document.querySelector("#widget")!).color,
+        cellText: cell.textContent,
+      };
+    });
+
+    // The host really is painting red, or this test proves nothing
+    expect(painted.hostColour).toBe("rgb(255, 0, 0)");
+    expect(painted.insideTheAppRoot).toBe(true);
+    expect(painted.siblingOfTheAppRoot).toBe(false);
+    expect(painted.overlayColour).not.toBe("rgb(255, 0, 0)");
+    expect(painted.cellColour).not.toBe("rgb(255, 0, 0)");
+    expect(painted.cellText).toContain("REQ-001");
   });
 
   });

--- a/e2e/fixtures/seeded-transcript.ts
+++ b/e2e/fixtures/seeded-transcript.ts
@@ -114,6 +114,28 @@ const SEQUENCE_WITH_CONTAINERS = {
   },
 };
 
+/**
+ * A table, and the one kind that is HTML text rather than a picture.
+ *
+ * SVG text carries an explicit `fill` and inherits nothing, so a diagram cannot
+ * show what the overlay inherits from. A requirement in prose can, which is how
+ * an overlay portalled past the app's own root — and inheriting the host page's
+ * `* { color: red }` — stayed invisible until someone enlarged a table.
+ */
+const REQUIREMENTS_TABLE = {
+  schema: "urn:structured-exchange:1",
+  kind: "table",
+  data: {
+    columns: ["ID", "Requirement", "Status", "Safety"],
+    rows: [
+      ["REQ-001", "The braking system shall bring the vehicle to a full stop within 40 m on dry asphalt.", "approved", true],
+      ["REQ-002", "The dashboard shall signal a fault within 200 ms of detection.", "in review", true],
+      ["REQ-003", "The system shall log every actuation with a monotonic timestamp.", "approved", false],
+      ["REQ-004", "The ECU shall read battery voltage at 10 Hz.", "draft", null],
+    ],
+  },
+};
+
 export const SEEDED_MESSAGES = [
   { role: "user", content: "Draw me the architecture." },
   { role: "assistant", content: [{ type: "text", text: SEEDED_MERMAID }] },
@@ -150,5 +172,16 @@ export const SEEDED_MESSAGES = [
     toolName: "structured_exchange",
     content: "sequence whose containers interleave as declared",
     details: SEQUENCE_WITH_CONTAINERS,
+  },
+  {
+    role: "assistant",
+    content: [{ type: "toolCall", id: "call-4", name: "structured_exchange", arguments: { kind: "table" } }],
+  },
+  {
+    role: "toolResult",
+    toolCallId: "call-4",
+    toolName: "structured_exchange",
+    content: "requirements table with 4 rows",
+    details: REQUIREMENTS_TABLE,
   },
 ];

--- a/embed/src/mount.tsx
+++ b/embed/src/mount.tsx
@@ -37,9 +37,41 @@ export interface MountHandle {
  * host page's CSS in both directions (Tailwind's reset never touches the host page,
  * and the host page's styles never bleed into the widget).
  */
+/** Marks the one registration, so a second widget on the page does not add another. */
+const PROPERTY_REGISTRATION_ID = "pi-outpost-custom-properties";
+
+/**
+ * Registers the stylesheet's typed custom properties on the document.
+ *
+ * `@property` registers on the document or not at all: inside a shadow tree —
+ * and inside an adopted stylesheet in particular — the rule is parsed and
+ * ignored. Tailwind v4 leans on it. `.border` is `border-style:
+ * var(--tw-border-style); border-width: 1px`, and with the property
+ * unregistered that `var()` resolves to nothing, which makes `border-style`
+ * invalid at computed-value time and leaves it `none`. The width and the colour
+ * arrive, the line does not: every border in the widget was silently missing,
+ * cards, menus, composer and tables alike. It reads as a flat design rather than
+ * as a bug, which is why it survived this long.
+ *
+ * A registration declares the type and initial value of a custom property; it
+ * paints nothing by itself. `--tw-*` is Tailwind's own namespace, so this stays
+ * out of the host page's way — the one thing that must cross the boundary here,
+ * because the boundary is exactly what breaks it.
+ */
+function registerCustomProperties(cssText: string): void {
+  if (typeof document === "undefined" || document.getElementById(PROPERTY_REGISTRATION_ID)) return;
+  const registrations = cssText.match(/@property\s+--[\w-]+\s*\{[^}]*\}/g);
+  if (registrations === null) return;
+  const style = document.createElement("style");
+  style.id = PROPERTY_REGISTRATION_ID;
+  style.textContent = registrations.join("\n");
+  document.head.appendChild(style);
+}
+
 export function mount(container: HTMLElement, options: MountOptions = {}): MountHandle {
   const shadow = container.shadowRoot ?? container.attachShadow({ mode: "open" });
   shadow.replaceChildren();
+  registerCustomProperties(css);
 
   // Chrome 97 silently drops <style> elements >~512 KB inside Shadow DOM;
   // Tailwind v4 is ~1.5 MB, so we use the constructable stylesheet API instead.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "check:css": "node scripts/check-web-css.mjs",
     "check:embed": "node scripts/check-embed-package.mjs",
     "build:e2e-host": "vite build --config e2e/vite.config.ts",
-    "test:e2e": "npm run build:e2e-host && playwright test --config e2e/playwright.config.ts"
+    "test:e2e": "npm run build:e2e-host && playwright test --config e2e/playwright.config.ts",
+    "bench": "tsx scripts/embed-bench.mts"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1",

--- a/scripts/embed-bench.mts
+++ b/scripts/embed-bench.mts
@@ -1,0 +1,131 @@
+/**
+ * A live embed, for pressing the buttons by hand.
+ *
+ * The browser suite boots this same shape and tears it down in the same second;
+ * what a person needs is the shape left running. So: the built host page on its
+ * own origin, and two servers behind it — a plain one (sandbox configured, so
+ * Settings has something to show) and one whose session already holds the
+ * seeded transcript (diagrams and the table).
+ *
+ *   npm run bench
+ *
+ * Serves `dist/`, so build first: web, then @pi-outpost/embed, then
+ * `npm run build:e2e-host` — an unbuilt fix is invisible here.
+ */
+import { createServer } from "node:http";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { SEEDED_MESSAGES } from "../e2e/fixtures/seeded-transcript";
+// @ts-expect-error -- .mjs harness, no types
+import { makeWorkspace, startServer } from "../server/test/harness.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(HERE, "..");
+const HOST_DIST = path.join(REPO, "e2e/dist-host");
+const HOST_PORT = Number(process.env.BENCH_PORT ?? 4321);
+
+const TYPES: Record<string, string> = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".map": "application/json",
+};
+
+function serveHostPage(port: number): Promise<{ url: string; close: () => Promise<void> }> {
+  const server = createServer((request, response) => {
+    const requested = new URL(request.url ?? "/", "http://localhost").pathname;
+    const relative = requested === "/" ? "index.html" : requested.replace(/^\/+/, "");
+    const file = path.join(HOST_DIST, relative);
+    if (!file.startsWith(HOST_DIST + path.sep) && file !== path.join(HOST_DIST, "index.html")) {
+      response.writeHead(403).end();
+      return;
+    }
+    readFile(file).then(
+      (bytes) => {
+        response.writeHead(200, { "content-type": TYPES[path.extname(file)] ?? "application/octet-stream" });
+        response.end(bytes);
+      },
+      () => response.writeHead(404).end(),
+    );
+  });
+  return new Promise((resolve) => {
+    server.listen(port, "127.0.0.1", () => {
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        close: () =>
+          new Promise((done) => {
+            server.closeAllConnections();
+            server.close(() => done());
+          }),
+      });
+    });
+  });
+}
+
+/** No real provider key: nothing here talks to a model, and PI_OFFLINE keeps it that way. */
+function onlyOneFakeProvider(): Record<string, string | undefined> {
+  const env: Record<string, string | undefined> = {};
+  for (const name of Object.keys(process.env)) {
+    if (/API_KEY|AUTH_TOKEN|_TOKEN$/.test(name)) env[name] = undefined;
+  }
+  env.ANTHROPIC_API_KEY = "sk-ant-not-a-real-key";
+  return env;
+}
+
+const host = await serveHostPage(HOST_PORT);
+
+const root = await makeWorkspace({
+  "readme.md": "# workspace\n\nA file the browser is allowed to see.\n",
+  "docs/notes.md": "# notes\n\nAnother file, so the tree has a folder in it.\n",
+  ".pi/prompts/greet.md": "---\ndescription: say hello\n---\n\nSay hello.\n",
+});
+const plain = await startServer(
+  root,
+  {
+    // Fixed ports, unlike the browser suite's: a bench whose URL changes every
+    // run is a bench nobody keeps open in a tab.
+    server: { allowedOrigins: [host.url], port: HOST_PORT + 1 },
+    branding: { title: "bench" },
+    noPromptTemplates: false,
+  },
+  { env: onlyOneFakeProvider() },
+);
+
+const diagramRoot = await makeWorkspace({ "readme.md": "# diagrams\n" });
+const fakeConfig = path.join(diagramRoot, "fake-rpc.json");
+await writeFile(fakeConfig, JSON.stringify({ messages: SEEDED_MESSAGES, state: { sessionId: "diagrams-1" } }));
+const diagrams = await startServer(
+  diagramRoot,
+  {
+    server: { allowedOrigins: [host.url], port: HOST_PORT + 2 },
+    branding: { title: "bench diagrams", defaultTheme: "light" },
+    agentRuntime: {
+      mode: "rpc",
+      executable: process.execPath,
+      args: [path.join(REPO, "server/test/fixtures/fake-pi-rpc.mjs")],
+      startupTimeoutMs: 20_000,
+    },
+    // RPC refuses a sandbox it cannot enforce on a child that builds its own tools.
+    sandbox: undefined,
+  },
+  { env: { ...onlyOneFakeProvider(), FAKE_PI_RPC_CONFIG: fakeConfig } },
+);
+
+const link = (server: string) => `${host.url}/?server=${encodeURIComponent(server)}&theme=light`;
+console.log("\n  embed bench — the widget inside a host page that fights it\n");
+console.log(`  settings, files, sessions   ${link(plain.base)}`);
+console.log(`  seeded transcript           ${link(diagrams.base)}   (diagrams + table)`);
+console.log("\n  ctrl-c to stop\n");
+
+let stopping = false;
+const stop = async () => {
+  if (stopping) return;
+  stopping = true;
+  await diagrams.stop();
+  await plain.stop();
+  await host.close();
+  process.exit(0);
+};
+process.on("SIGINT", stop);
+process.on("SIGTERM", stop);

--- a/ui/src/components/EnlargedView.test.tsx
+++ b/ui/src/components/EnlargedView.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { overlayHost } from "./EnlargedView";
+
+/**
+ * Where the overlay is portalled, which decides what it inherits.
+ *
+ * jsdom has no cascade, so these tests pin the target rather than the colour;
+ * the colour itself is asserted in the browser, against a host page that paints
+ * everything red. Both matter: the rule here is what the code decides, and the
+ * browser test is whether that decision was the right one.
+ */
+describe("overlayHost", () => {
+  it("stays inside the app's own root when the app lives in a shadow tree", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const shadow = container.attachShadow({ mode: "open" });
+    const appRoot = document.createElement("div");
+    const transcript = document.createElement("div");
+    const diagram = document.createElement("svg");
+    transcript.appendChild(diagram);
+    appRoot.appendChild(transcript);
+    shadow.appendChild(appRoot);
+
+    // Not the shadow root: that is a sibling position, outside everything the
+    // app declares for itself, so the overlay would inherit from the host page.
+    expect(overlayHost(diagram)).toBe(appRoot);
+    expect(overlayHost(diagram)).not.toBe(shadow);
+    container.remove();
+  });
+
+  it("takes the root element even when the anchor is that element", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const shadow = container.attachShadow({ mode: "open" });
+    const appRoot = document.createElement("div");
+    shadow.appendChild(appRoot);
+
+    expect(overlayHost(appRoot)).toBe(appRoot);
+    container.remove();
+  });
+
+  it("uses the document body in the standalone app", () => {
+    const anchor = document.createElement("div");
+    document.body.appendChild(anchor);
+
+    expect(overlayHost(anchor)).toBe(document.body);
+    anchor.remove();
+  });
+
+  it("answers undefined for an anchor that is not mounted, rather than guessing", () => {
+    // The caller keeps its last real answer. Falling back to the document here
+    // is how the overlay silently left the shadow tree between renders.
+    expect(overlayHost(null)).toBeUndefined();
+    expect(overlayHost(undefined)).toBeUndefined();
+  });
+});

--- a/ui/src/components/EnlargedView.tsx
+++ b/ui/src/components/EnlargedView.tsx
@@ -16,8 +16,21 @@ import { createPortal } from "react-dom";
  * the document body is on the wrong side of that boundary: a node portalled
  * there gets no styling at all. Measured in the widget, the overlay came out
  * `position: static`, `z-index: auto`, transparent, and stacked *below* the
- * widget — half of it off-screen. The shadow root is the outermost point that is
- * still styled, so that is as far out as the portal goes.
+ * widget — half of it off-screen.
+ *
+ * Far enough out, then, but no further: the app's own root element, not the
+ * shadow root above it. Inherited properties cross a shadow boundary — they are
+ * not blocked, only overridden by whatever the tree declares for itself — and
+ * what the app declares, it declares on that root. An overlay portalled past it
+ * is a sibling, so it inherits from the *host element* instead, and a host page
+ * that paints `* { color: red }` paints the widget's dialog red. Diagrams hid
+ * this for a while: SVG text carries an explicit `fill` and inherits nothing. A
+ * table is HTML text, and came out red on every cell.
+ *
+ * The root element is found by climbing rather than by id, so it is whatever the
+ * app was actually mounted into. It creates no containing block, so `fixed`
+ * still resolves against the viewport, and it is still above every stacking
+ * context inside the app — which is what the portal was for.
  *
  * `anchor` is any element inside the app; the tree it belongs to decides.
  * Answering `undefined` for an anchor that is not mounted matters: the caller
@@ -25,9 +38,11 @@ import { createPortal } from "react-dom";
  * falling back is the bug.
  */
 export function overlayHost(anchor: Element | null | undefined): Element | DocumentFragment | undefined {
-  const root = anchor?.getRootNode();
-  if (root === undefined) return undefined;
-  return root instanceof ShadowRoot ? root : globalThis.document.body;
+  if (anchor === null || anchor === undefined) return undefined;
+  if (!(anchor.getRootNode() instanceof ShadowRoot)) return globalThis.document.body;
+  let element: Element = anchor;
+  while (element.parentElement !== null) element = element.parentElement;
+  return element;
 }
 
 /**

--- a/ui/src/presentations/StructuredExchangeView.test.tsx
+++ b/ui/src/presentations/StructuredExchangeView.test.tsx
@@ -266,6 +266,60 @@ describe("declared order and declared kinds survive", () => {
     expect(container.querySelector('[data-message-index="0"] line')).toBeNull();
   });
 
+  it("gives every column a divider the reader can take hold of", () => {
+    const table = { schema: S, kind: "table", data: { columns: ["ID", "Requirement"], rows: [["REQ-1", "text"]] } };
+    const { container } = renderBody(withStructured(table));
+
+    // Named, so the divider is reachable without a mouse and says which column
+    // it belongs to. A requirements table is where an unnamed handle is useless:
+    // there are seven of them and they look alike.
+    expect(screen.getByLabelText("Resize column ID")).toBeInTheDocument();
+    expect(screen.getByLabelText("Resize column Requirement")).toBeInTheDocument();
+
+    // Untouched, the browser's own layout decides: no width is imposed
+    const cols = [...container.querySelectorAll("col")];
+    expect(cols).toHaveLength(2);
+    expect(cols.every((col) => col.style.width === "")).toBe(true);
+    expect(container.querySelector("table")!.style.tableLayout).toBe("");
+  });
+
+  it("widens and narrows a column from the keyboard, and stops at a column still being one", () => {
+    const table = { schema: S, kind: "table", data: { columns: ["ID", "Requirement"], rows: [["REQ-1", "text"]] } };
+    const { container } = renderBody(withStructured(table));
+    const divider = screen.getByLabelText("Resize column ID");
+    const widthOf = (index: number) => container.querySelectorAll("col")[index]!.style.width;
+
+    fireEvent.keyDown(divider, { key: "ArrowRight" });
+    const widened = parseFloat(widthOf(0));
+    expect(widened).toBeGreaterThan(0);
+    // Sizing the first column must not resize the second one out from under it
+    const neighbour = widthOf(1);
+
+    fireEvent.keyDown(divider, { key: "ArrowRight" });
+    expect(parseFloat(widthOf(0))).toBeGreaterThan(widened);
+    expect(widthOf(1)).toBe(neighbour);
+
+    // Down to the floor and no further: a column dragged to nothing cannot be
+    // grabbed again, and the reader has no way back.
+    for (let press = 0; press < 20; press += 1) fireEvent.keyDown(divider, { key: "ArrowLeft" });
+    expect(parseFloat(widthOf(0))).toBe(48);
+
+    // Once sized, the widths are what lays the table out
+    expect(container.querySelector("table")!.style.tableLayout).toBe("fixed");
+  });
+
+  it("keeps a reader's column sizing out of the document", () => {
+    const table = { schema: S, kind: "table", data: { columns: ["ID"], rows: [["REQ-1"]] } };
+    const item = withStructured(table);
+    const before = item.structured;
+    renderBody(item);
+
+    fireEvent.keyDown(screen.getByLabelText("Resize column ID"), { key: "ArrowRight" });
+
+    // Presentation only, per ReaderMayAdjustAndNarrowTheView
+    expect(item.structured).toBe(before);
+  });
+
   it("renders table columns and rows in their declared order", () => {
     const table = {
       schema: S,

--- a/ui/src/presentations/StructuredExchangeView.tsx
+++ b/ui/src/presentations/StructuredExchangeView.tsx
@@ -1787,15 +1787,128 @@ function SequenceView({ data, isProposal }: { data: StructuredSequenceData; isPr
 
 /* ── Table ──────────────────────────────────────────────────────────────────── */
 
+/** Narrow enough to be a column still, wide enough to grab again. */
+const MIN_COLUMN_WIDTH = 48;
+
+/** One nudge of a divider held by the keyboard rather than the mouse. */
+const COLUMN_STEP = 16;
+
+/**
+ * A table, with rules on both axes and columns the reader can size.
+ *
+ * A requirements table is the case that made this necessary: an identifier
+ * column squeezed until `REQ-001` broke across two lines, beside a column of
+ * prose given a third of the width. Nothing about the document says how wide
+ * anything should be, and no heuristic here would know either — the reader can
+ * see what they are reading, so the reader gets the handles.
+ *
+ * Sizing is presentation only (see `ReaderMayAdjustAndNarrowTheView`): it is
+ * held in this component, never written back into the envelope, and a fresh
+ * rendering starts from the browser's own layout again.
+ *
+ * Which is also why widths start unset. `auto` layout reads content better than
+ * any measurement taken before the content is there, so the first drag freezes
+ * what the browser worked out and only then switches to `fixed` — from that
+ * point the columns hold their size and the wrapper scrolls.
+ */
 function TableView({ data }: { data: StructuredTableData }) {
+  const [widths, setWidths] = useState<number[] | null>(null);
+  const headRef = useRef<HTMLTableRowElement>(null);
+
+  /** What the browser is currently giving each column, before we take over. */
+  const measured = useCallback((): number[] => {
+    const cells = [...(headRef.current?.querySelectorAll("th") ?? [])];
+    return cells.map((cell) => Math.max(MIN_COLUMN_WIDTH, Math.round(cell.getBoundingClientRect().width)));
+  }, []);
+
+  const resize = useCallback(
+    (index: number, to: (current: number) => number) =>
+      setWidths((previous) => {
+        const base = previous ?? measured();
+        const next = [...base];
+        next[index] = Math.max(MIN_COLUMN_WIDTH, Math.round(to(base[index] ?? MIN_COLUMN_WIDTH)));
+        return next;
+      }),
+    [measured],
+  );
+
+  function startDrag(event: React.PointerEvent<HTMLDivElement>, index: number) {
+    event.preventDefault();
+    const startX = event.clientX;
+    const startWidths = widths ?? measured();
+    setWidths(startWidths);
+
+    /**
+     * The gesture is followed on the window, not on the divider.
+     *
+     * Pointer capture is the obvious answer and it does not survive this: the
+     * first movement sets state, the header re-renders, and a capture whose
+     * element React has replaced is simply gone — a 150-pixel drag arrived as
+     * thirty. The window is still there whatever the header does, and it is also
+     * what lets the pointer leave the table mid-drag without dropping it.
+     */
+    const onMove = (move: PointerEvent) => {
+      const from = startWidths[index] ?? MIN_COLUMN_WIDTH;
+      resize(index, () => from + (move.clientX - startX));
+    };
+    const onUp = () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointercancel", onUp);
+    };
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+    window.addEventListener("pointercancel", onUp);
+  }
+
+  const total = widths?.reduce((sum, width) => sum + width, 0);
+
+  /**
+   * The grabbable edge of a column, repeated down every row of it.
+   *
+   * A column boundary is a line the whole height of the table, and that is where
+   * a reader reaches for it — at the row they are reading, not by travelling
+   * back up to the header. Only the header's is focusable: one keyboard target
+   * per column is a control, ninety-eight of them is a tab trap.
+   */
+  const divider = (index: number, column: string, keyboard: boolean) => (
+    <div
+      role={keyboard ? "separator" : "presentation"}
+      aria-orientation={keyboard ? "vertical" : undefined}
+      aria-label={keyboard ? `Resize column ${column}` : undefined}
+      aria-hidden={keyboard ? undefined : true}
+      tabIndex={keyboard ? 0 : undefined}
+      onPointerDown={(event) => startDrag(event, index)}
+      onKeyDown={(event) => {
+        if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+        event.preventDefault();
+        const step = event.key === "ArrowRight" ? COLUMN_STEP : -COLUMN_STEP;
+        resize(index, (current) => current + step);
+      }}
+      className="absolute -right-px top-0 h-full w-1.5 cursor-col-resize touch-none hover:bg-zinc-400 focus:bg-zinc-400 focus:outline-none dark:hover:bg-zinc-500 dark:focus:bg-zinc-500"
+    />
+  );
+
   return (
     <div className="overflow-x-auto">
-      <table className="w-full border-collapse text-xs">
+      <table
+        className={`border-collapse text-xs ${widths ? "" : "w-full"}`}
+        style={total === undefined ? undefined : { tableLayout: "fixed", width: total }}
+      >
+        <colgroup>
+          {data.columns.map((_, index) => (
+            <col key={index} style={widths ? { width: widths[index] } : undefined} />
+          ))}
+        </colgroup>
         <thead>
-          <tr>
+          <tr ref={headRef}>
             {data.columns.map((column, index) => (
-              <th key={index} className="border-b border-zinc-300 px-2 py-1 text-left font-medium dark:border-zinc-700">
-                {column}
+              <th
+                key={index}
+                className="relative border border-zinc-300 px-2 py-1 text-left font-medium dark:border-zinc-700"
+              >
+                <span className="block truncate">{column}</span>
+                {divider(index, column, true)}
               </th>
             ))}
           </tr>
@@ -1804,8 +1917,12 @@ function TableView({ data }: { data: StructuredTableData }) {
           {data.rows.map((row, rowIndex) => (
             <tr key={rowIndex}>
               {row.map((cell, cellIndex) => (
-                <td key={cellIndex} className="border-b border-zinc-200 px-2 py-1 dark:border-zinc-800">
+                <td
+                  key={cellIndex}
+                  className="relative border border-zinc-200 px-2 py-1 align-top break-words dark:border-zinc-800"
+                >
                   {cell === null ? <span className="opacity-40">—</span> : String(cell)}
+                  {divider(cellIndex, data.columns[cellIndex] ?? "", false)}
                 </td>
               ))}
             </tr>


### PR DESCRIPTION
Three things the browser suite could see and the unit suites could not, plus the bench that made them visible.

## The widget had no borders at all

`@property` registers on the document or not at all: inside a shadow tree — and inside an adopted stylesheet in particular — the rule is parsed and ignored. Tailwind v4 leans on it. `.border` is `border-style: var(--tw-border-style); border-width: 1px`, so with the property unregistered that `var()` resolves to nothing, `border-style` is invalid at computed-value time, and every border in the widget silently vanished: cards, menus, composer, tables alike. Width and colour still arrived, which is why it read as a flat design rather than as a bug.

`mount()` now copies the stylesheet's `@property` rules onto the document. They declare type and initial value and paint nothing by themselves, and `--tw-*` is Tailwind's own namespace, so this stays out of the host page's way — the one thing that must cross the boundary, because the boundary is what breaks it.

Shipped `0.9.1` does not have this.

## An enlarged overlay inherited from the host page

Inherited properties cross a shadow boundary — they are not blocked, only overridden by whatever the tree declares for itself — and what the app declares, it declares on its own root. An overlay portalled to the shadow root is a *sibling* of that root, so it inherited from the host element, and a host that paints `* { color: red }` painted the widget's dialog red.

Diagrams hid it: SVG text carries an explicit `fill` and inherits nothing. A table is HTML text and came out red on every cell — hence the requirements table now in the seeded transcript.

## A reader can size a table's columns

An identifier column squeezed until `REQ-001` broke across two lines, beside a column of prose given a third of the width. Nothing in the document says how wide anything should be, so the reader gets the handles. Widths start unset (`auto` reads content better than any measurement taken before the content is there); the first drag freezes the browser's own layout and switches to `fixed`. Sizing is presentation only — never written back into the envelope.

The gesture is followed on the window rather than through pointer capture: the first move sets state, the header re-renders, and a capture whose element React replaced is gone — a 150-pixel drag arrived as thirty.

## `npm run bench`

The browser suite boots this exact shape and tears it down in the same second. `npm run bench` leaves it running: the built host page on its own origin, hostile CSS and all, with a plain server (Settings has a sandbox to show) and one holding the seeded transcript. Fixed ports, so the tab stays valid across restarts.

## Checks

- `npm run typecheck`, `npm run lint` — clean
- ui unit suites — 1154 passed
- `npm run test:e2e` — 34 passed, including the new borders assertion (there was none: exactly the kind of fix that regresses in silence) and the table's paint/rules/resize tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)