### PR TITLE
chore(release): v0.10.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-outpost",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "type": "module",
   "description": "A web interface for the pi coding agent: a browser chat UI you run with npx — no clone, no build.",
   "license": "MIT",

--- a/embed/package.json
+++ b/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-outpost/embed",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "type": "module",
   "description": "Mount pi-outpost as a Shadow-DOM-isolated widget inside another web app.",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
     },
     "cli": {
       "name": "pi-outpost",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "^0.84.1",
@@ -44,7 +44,7 @@
     },
     "embed": {
       "name": "@pi-outpost/embed",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "devDependencies": {
         "@microsoft/api-extractor": "^7.58.9",


### PR DESCRIPTION
Version bump only — `cli` and `embed` 0.9.1 → 0.10.0, plus the lock. Everything it releases is already on `main` (#78, #79, #80, #81).

Minor rather than patch: the widget gains a contract addition (a table row may declare a change role) and two exports, and loses a rendering bug that made every border in it disappear.

## What v0.10.0 ships

- **The widget had no borders at all.** Tailwind v4 draws them through a registered custom property, and `@property` registers on the document or not at all — inside a Shadow tree the rule is parsed and ignored, so `border-style` was invalid at computed-value time and resolved to `none`. Cards, menus, composer, tables. It read as a flat design rather than as a bug. *(#78)*
- **An enlarged overlay was painted by the host page**, because it portalled past the app's own root and inherited from the host element instead. SVG hid it; a table's HTML text did not. *(#78)*
- **Table columns the reader can size.** *(#78)*
- **A table's rows may report a change** — `added`, `changed`, `context`, `removed` — drawn in the colours a graph uses for the same words, with the key doubling as a filter. A table still cannot be proposed. *(#79)*
- **Take a table away as CSV or XLSX**, roles included as a `change` column, narrowed views exporting only what they show. *(#79)*
- **CI runs its browser suite in the Playwright image**: 16 minutes of installing Chromium became a 26-second image pull. *(#80)*

## Before tagging

The tag is the trigger and the version claim: `release.yml` publishes both packages to npm from it over OIDC, and a published version cannot be withdrawn. Merge this first, then `git tag v0.10.0 && git push origin v0.10.0` from `main`.

Release notes are drafted and ready to paste into the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)