### PR TITLE
docs: name the bench in the UI rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,3 +151,13 @@ shows those.
 What "exercised" means: drive the actual feature — create the file, open the
 document, ask the agent for the thing — then read back the DOM, the filesystem, or
 the session transcript to check what really happened. A screenshot is not a check.
+
+How: `npm run bench` (`scripts/embed-bench.mts`) leaves a real widget running —
+host page on its own origin with hostile CSS, two servers behind it, a seeded
+transcript with diagrams and tables. Fixed ports: host **4321**, plain server
+**4322**, seeded transcript **4323**; use `127.0.0.1`, not `localhost`, because
+that is the origin the server allows.
+
+**Rebuild first**: `web`, then `@pi-outpost/embed`, then `build:e2e-host`. The
+bench serves `dist/`, so an unbuilt fix is invisible and you will debug a fix that
+is already correct.


### PR DESCRIPTION
The UI section already said a change has to be exercised in the running app. It did not say *how* — so the one thing that makes that check cheap, `npm run bench`, was discoverable only by reading `scripts/`.

Adds the command, the fixed ports (4321 / 4322 / 4323), why the host must be reached as `127.0.0.1` and not `localhost` (that is the origin the server allows), and the rebuild order — the bench serves `dist/`, so an unbuilt fix is invisible and you end up debugging one that is already correct.

Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)