### PR TITLE
feat: standalone executables, and an interface that opens itself

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,20 @@ name: Release
 on:
   push:
     tags: ["v*"]
+  # The executables are the half of this pipeline that cannot be judged from a
+  # laptop: they are per-platform by nature, and a runtime whose single-executable
+  # support is broken builds them happily and crashes on the first invocation. This
+  # runs the matrix from any branch, without publishing anything.
+  workflow_dispatch:
+    inputs:
+      executables_only:
+        description: "Build the executables and stop (no npm publish)"
+        type: boolean
+        default: true
 
 permissions:
-  contents: read
+  # The executables are uploaded to the release this tag created.
+  contents: write
   # The OIDC token GitHub mints for this workflow. npm's trusted publisher for both
   # packages names this repo and this file, so the token *is* the credential: no
   # NPM_TOKEN, nothing to steal from the repo's secrets, and provenance is attested
@@ -16,7 +27,69 @@ permissions:
   id-token: write
 
 jobs:
+  # One executable per platform, built on that platform: a single-file executable
+  # carries a runtime, and a runtime is not cross-buildable. They gate the publish
+  # rather than following it — a version on npm whose release page has nothing to
+  # download is worse than a release that stopped.
+  executables:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-latest
+            arch: arm64
+          - runner: macos-13
+            arch: x64
+          - runner: ubuntu-latest
+            arch: x64
+          - runner: windows-latest
+            arch: x64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          # 26 and not the version the rest of the pipeline uses: --build-sea is
+          # what produces an executable, and it landed in 26.
+          node-version: 26
+          cache: npm
+      - run: npm ci
+      # The executable inlines the built web UI, so the UI has to exist first
+      - run: npm run build
+
+      - name: Build the executable
+        shell: bash
+        run: |
+          version=$(node -p "require('./cli/package.json').version")
+          os=$(node -p "process.platform === 'win32' ? 'windows' : process.platform === 'darwin' ? 'macos' : 'linux'")
+          name="pi-outpost-$version-$os-${{ matrix.arch }}"
+          [ "$os" = "windows" ] && name="$name.exe"
+          node --import tsx/esm server/src/index.ts build-exe --out "$name" --force
+          echo "ARTIFACT=$name" >> "$GITHUB_ENV"
+
+      # build-exe already refuses to report success for an executable that does not
+      # run — it invokes the result before printing a path. This asserts the other
+      # half: that what runs is *this* version, not a stale bundle picked up by
+      # accident.
+      - name: It reports the version being released
+        shell: bash
+        run: |
+          printed=$("./$ARTIFACT" --version)
+          expected=$(node -p "require('./cli/package.json').version")
+          if [ "$printed" != "$expected" ]; then
+            echo "::error::the executable reports $printed, the tag says $expected"
+            exit 1
+          fi
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.ARTIFACT }}
+          path: ${{ env.ARTIFACT }}
+          if-no-files-found: error
+
   publish:
+    needs: executables
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -100,3 +173,19 @@ jobs:
             npm publish --workspace "$pkg"
           done
 
+  # Attached after publish, from the artifacts the matrix already proved runnable.
+  attach:
+    needs: [executables, publish]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          path: executables
+          merge-multiple: true
+      - name: Attach the executables to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "$GITHUB_REF_NAME" executables/* --clobber --repo "$GITHUB_REPOSITORY"

--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ npx pi-outpost init   # writes a starter pi-outpost.config.json here
 npx pi-outpost        # serves the UI on http://127.0.0.1:3141/
 ```
 
+The server opens the interface in your browser once it is listening. `--no-open`, or
+`"openBrowser": false`, if you would rather it did not.
+
+**Or download a single file with nothing installed at all** — no Node, no npm.
+Each release carries an executable per platform under
+[Releases](https://github.com/laurentftech/pi-outpost/releases): the server and the
+web UI are inside it. Unsigned, so macOS and Windows warn on first launch; see
+[docs/sea-packaging.md](docs/sea-packaging.md), which also covers building one
+yourself with `npx pi-outpost build-exe`.
+
 Open the UI with no credentials and it asks for them: pick a provider and paste an API key, or declare an OpenAI-compatible endpoint of your own (see [Model credentials](#model-credentials)). Nothing to restart — the chat is usable as soon as you save.
 
 pi-outpost never starts without a configuration file: the agent's working directory, its tools and its sandbox are decided there, and guessing them from whatever directory you happen to be standing in is not a decision anyone wants made for them. `init` writes the safe version of that file (read-only, no bash) for you to open up as needed.
@@ -113,6 +123,8 @@ pi-outpost init [options]     write a starter configuration file
 pi-outpost config [options]   print the configuration that would be used, and where it came from
 pi-outpost login --provider <name>
                               store an API key in <agentDir>/auth.json
+pi-outpost build-exe [options]
+                              build a standalone executable from this installation
 ```
 
 > **Upgrading from a pre-`0.1.0` clone?** Three behaviours changed. The server now **refuses to start without a configuration file** (it used to fall back to a plain local pi: your launch directory as workspace, full toolset, bash enabled) — run `pi-outpost init`. `PI_OUTPOST_PORT`/`PORT` now **override** `server.port` instead of being overridden by it, in line with `PI_OUTPOST_TOKEN`, which always won. And `PI_CWD` is now `PI_OUTPOST_CWD`.
@@ -128,6 +140,9 @@ pi-outpost login --provider <name>
 | `-h, --help` / `-v, --version` | |
 | `init --global` | Write to the user config directory instead of `./` |
 | `init --force` | Overwrite an existing file |
+| `--open` / `--no-open` | Open the interface in your browser once listening (default: wherever a desktop session exists) |
+| `build-exe --out <path>` | Where to write the executable (default `./pi-outpost`, `.exe` on Windows) |
+| `build-exe --force` | Replace an existing file at that path |
 
 There is deliberately **no `--token` flag**: a secret on the command line is readable by anyone who can list processes. Use `PI_OUTPOST_TOKEN` or the file's `server.token`.
 

--- a/cli/scripts/build.mjs
+++ b/cli/scripts/build.mjs
@@ -99,39 +99,51 @@ await esbuild.build({
   },
 });
 
-// ── Patch getAliases() for SEA mode ──────────────────────────────────────────
-// In SEA mode (or when running the bundled file outside node_modules), the
-// SDK's getAliases() calls require.resolve("typebox") relative to the bundle's
-// location on disk. Since the SEA bundle is fully inlined, there is no
-// node_modules/ at that path and require.resolve() throws MODULE_NOT_FOUND.
-// We wrap getAliases() so resolution failures produce empty aliases instead —
-// enough for extensions that use only type imports (stripped by jiti).
+// ── Let extensions reach the bundled packages ────────────────────────────────
+// The same patch server/scripts/build-sea.mjs applies, and for the same reason:
+// this bundle is what `--build-sea` turns into an executable, so an extension
+// loaded from disk beside it has no node_modules to resolve the agent's own
+// packages from. jiti's `virtualModules` serves them as already-loaded objects,
+// the SDK already builds that map, and it selects it on `isBunBinary` — false in
+// a Node SEA. One condition, not a new mechanism.
+//
+// Two bundles carry this because two paths produce an executable: this one for
+// `node --build-sea`, and server/dist/bundle.mjs for the blob. Patching only one
+// leaves extensions working on whichever path the machine happened to take.
 {
-  console.log("[build] patching getAliases() for SEA bundle …");
+  console.log("[build] routing extension imports through jiti's virtual modules …");
   let src = await readFile(SEA_BUNDLE, "utf-8");
-  // esbuild bundles with 2-space indentation — match it exactly
-  const openBefore =
-    "function getAliases() {\n" +
-    "  if (_aliases)\n" +
-    "    return _aliases;";
-  const openAfter =
-    "function getAliases() {\n" +
-    "  if (_aliases)\n" +
-    "    return _aliases;\n" +
-    "  try {";
-  const tailBefore =
-    "};\n" +
-    "  return _aliases;\n" +
-    "}";
-  const tailAfter =
-    "};\n" +
-    "  return _aliases;\n" +
+
+  const helper =
+    "\nfunction __piOutpostIsSea() {\n" +
+    "  try {\n" +
+    "    return require(\"node:sea\").isSea();\n" +
     "  } catch {\n" +
-    "    _aliases = {};\n" +
-    "    return _aliases;\n" +
+    "    return false;\n" +
     "  }\n" +
-    "}";
+    "}\n";
+  const requireShim = "const require = ___createRequire(import.meta.url);";
+  if (!src.includes(requireShim)) {
+    throw new Error("[build] the bundle's createRequire shim moved — the SEA extension patch needs it");
+  }
+  src = src.replace(requireShim, requireShim + helper);
+
+  const branchBefore = "...isBunBinary ? { virtualModules: VIRTUAL_MODULES, tryNative: false }";
+  if (!src.includes(branchBefore)) {
+    throw new Error("[build] the SDK's jiti branch moved — extensions would lose their bundled packages");
+  }
+  src = src.replace(branchBefore, "...isBunBinary || __piOutpostIsSea() ? { virtualModules: VIRTUAL_MODULES, tryNative: false }");
+
+  // Kept as a seatbelt rather than as the mechanism: if the detection above ever
+  // stops matching, extension loading degrades instead of throwing before the
+  // first extension is read.
+  const openBefore = "function getAliases() {\n" + "  if (_aliases)\n" + "    return _aliases;";
+  const openAfter = openBefore + "\n  try {";
+  const tailBefore = "};\n" + "  return _aliases;\n" + "}";
+  const tailAfter =
+    "};\n" + "  return _aliases;\n" + "  } catch {\n" + "    _aliases = {};\n" + "    return _aliases;\n" + "  }\n" + "}";
   src = src.replace(openBefore, openAfter).replace(tailBefore, tailAfter);
+
   await writeFile(SEA_BUNDLE, src, "utf-8");
 }
 

--- a/docs/sea-packaging.md
+++ b/docs/sea-packaging.md
@@ -117,6 +117,43 @@ signtool sign /fd SHA256 pi-outpost.exe   # re-sign after injection
 > killed at launch. Reach for the manual form only when you are debugging the
 > command itself.
 
+## Extensions with real npm imports
+
+An extension named in `extensionScripts` lives on disk beside the executable, and
+until now it could only import Node built-ins: there are no `node_modules` next to a
+single file, so `import { Type } from "typebox"` had nothing to resolve against.
+
+It works now. The packages the agent is built from — `typebox`, `@earendil-works/pi-tui`,
+`@earendil-works/pi-coding-agent`, `@earendil-works/pi-ai/*` — are served to
+extensions from inside the executable:
+
+```ts
+// ext.ts, sitting next to pi-outpost, with no node_modules anywhere
+import { Type } from "typebox";
+import * as agent from "@earendil-works/pi-coding-agent";
+
+export default function extension() {
+  const schema = Type.Object({ ok: Type.Boolean() });
+  return { name: "my-extension", tools: [] };
+}
+```
+
+```json
+{ "extensionScripts": ["./ext.ts"] }
+```
+
+**How.** jiti — the loader the SDK reads extensions through — takes a `virtualModules`
+map of specifier to *already-loaded module object*, bypassing filesystem resolution.
+The SDK builds that map from static imports and selects it for its Bun binary; a
+Node executable is not that, so it fell through to `getAliases()`, whose
+`require.resolve` throws inside a blob and took all extension loading with it. Both
+build scripts now widen the condition to include a Node single executable. The
+objects are already in the bundle; nothing is written to disk, and nothing changes
+outside an executable — `npm run dev` and `npm start` resolve packages normally.
+
+You get the same objects the agent itself uses, not a second copy: the versions are
+whatever the executable was built with, and an extension cannot pin its own.
+
 ## Skills are not inside the executable
 
 The npm package ships the bundled skills under `dist/skills/`, and the server finds
@@ -144,12 +181,12 @@ which is deliberate on the SDK's part but worth knowing.
 
 ## Extension loading with the SEA build
 
-Config.`extensionPaths` loads `.ts`/`.mjs` files via the pi SDK's jiti
-loader, which works inside a SEA binary (extensions are loaded from the
-filesystem at runtime).
-
-The `extensionScripts` config key loads `.mjs` files at runtime via native
-`import()`, which esbuild preserves in the bundled output:
+Both `extensionPaths` and `extensionScripts` load `.ts`/`.mjs` files from the
+filesystem through the pi SDK's jiti loader — not through a native `import()`,
+which an earlier version of this page claimed and which could never have reached a
+file the blob does not contain. jiti reads the file at runtime and, inside an
+executable, serves the agent's own packages to it as virtual modules (see
+[Extensions with real npm imports](#extensions-with-real-npm-imports)):
 
 ```json
 {

--- a/docs/sea-packaging.md
+++ b/docs/sea-packaging.md
@@ -8,33 +8,55 @@ inlined at build time into the bundle.
 
 > **Requires Node ≥ 26** (for `--build-sea` + `mainFormat: "module"` support).
 
-## Quick start (from npm)
+## The two ways to get one
 
-The fastest way to get a standalone `.exe` is from the published npm package:
+**Download it.** Every release carries an executable per platform, under
+[Releases](https://github.com/laurentftech/pi-outpost/releases): `pi-outpost-<version>-macos-arm64`,
+`-macos-x64`, `-linux-x64`, `-windows-x64.exe`. Nothing installed, nothing built.
 
-```powershell
-# 1. Install pi-outpost anywhere with Node.js
+They are **not signed for distribution**. macOS Gatekeeper and Windows SmartScreen
+both warn on a downloaded unsigned binary; on macOS you clear it with
+`xattr -d com.apple.quarantine ./pi-outpost` or the Open-anyway button in System
+Settings. Real signing means a certificate and notarisation, and is not done here.
+
+**Build it from the package you have:**
+
+```bash
 npm install pi-outpost
-
-# 2. Create a SEA config file
-# (on Windows the output must end in .exe)
-# NOTE: -Encoding utf8NoBOM — plain utf8 adds a BOM that breaks Node's JSON parse
-@'
-{ "main": "node_modules/pi-outpost/dist/pi-outpost.sea.mjs",
-  "output": "pi-outpost.exe",
-  "mainFormat": "module" }
-'@ | Out-File -Encoding utf8NoBOM sea-config.json
-
-# 3. Build the executable (Node ≥ 26 only)
-node --build-sea sea-config.json
-
-# 4. Run it (the web UI is already inside the .exe — nothing else to copy)
-.\pi-outpost.exe --version
+npx pi-outpost build-exe          # → ./pi-outpost (./pi-outpost.exe on Windows)
 ```
 
-The published npm package ships two bundles:
-- `pi-outpost.mjs` (≈ 2 MB) — npm dependencies external, for `npx` / `npm start`.
-- `pi-outpost.sea.mjs` (≈ 21 MB) — all dependencies **and the web UI** inlined, for `--build-sea`.
+That is the whole procedure. The command writes the SEA config itself — including
+the module format and an encoding without a byte order mark, the two details that
+used to make this fail unreadably — builds, signs the result where the platform
+requires it, and prints the path.
+
+```
+--out <path>   where to write it (default: ./pi-outpost, ./pi-outpost.exe on Windows)
+--force        replace an existing file at that path
+```
+
+On **Node ≥ 26** it uses `node --build-sea`. On anything older it falls back to
+injecting the shipped `sea-prep.blob` into a copy of your `node` binary with
+`postject`, and says so — the two artifacts are not identical, and when one of them
+misbehaves the first question is which one you have.
+
+On macOS the result is signed ad-hoc (`codesign --sign -`). That is what makes a
+modified binary *launch* at all: without it the kernel kills it, naming neither the
+signature nor the remedy. It is not a distribution signature.
+
+## Starting it
+
+Running the executable starts the server and opens the interface in your default
+browser, at the address it actually bound — including when the configuration asked
+for port `0` and the operating system chose. Launching it from a file manager works
+the same way, which is the point: there is no terminal there for an address to be
+printed to.
+
+No browser is opened where none can be shown — no desktop session, a container, a
+remote shell, a CI runner. `--open` and `--no-open` decide it explicitly, and
+`"openBrowser": false` in the configuration pins it for a deployment. A browser that
+fails to open never stops the server: the address is printed either way.
 
 ## Build from source
 
@@ -90,7 +112,10 @@ npx postject pi-outpost.exe NODE_SEA_BLOB node_modules/pi-outpost/dist/sea-prep.
 signtool sign /fd SHA256 pi-outpost.exe   # re-sign after injection
 ```
 
-> This is the legacy workflow. Prefer `--build-sea` (above) — no external tools needed.
+> `pi-outpost build-exe` does this for you, including the `--macho-segment-name
+> NODE_SEA` that macOS needs and the ad-hoc signature without which the result is
+> killed at launch. Reach for the manual form only when you are debugging the
+> command itself.
 
 ## Skills are not inside the executable
 

--- a/openspec/changes/ship-standalone-executables/.openspec.yaml
+++ b/openspec/changes/ship-standalone-executables/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-20

--- a/openspec/changes/ship-standalone-executables/design.md
+++ b/openspec/changes/ship-standalone-executables/design.md
@@ -1,0 +1,128 @@
+## Context
+
+See proposal.md — Why. What shapes the approach:
+
+- The package already ships everything a build needs: `dist/pi-outpost.sea.mjs` (all
+  dependencies and the web UI inlined) and `dist/sea-prep.blob`. Nothing new has to
+  be fetched; what is missing is the code that drives them.
+- Two build paths exist and they are not equivalent. `node --build-sea` needs Node
+  ≥ 26 and produces the executable directly. The older path injects `sea-prep.blob`
+  into a copy of the `node` binary with `postject`. Issue #14 was that path failing
+  because the published blob carried a module-format marker; `server/scripts/build-sea.mjs`
+  now deletes `mainFormat` for the distributed blob and keeps it only for the native
+  build.
+- `release.yml` is one job that switches from Node 24 to Node 26 midway to build the
+  blob, then publishes. Its browser suite already moved to a container image in #80.
+- `add-cli-update-command` is in flight and modifies the same requirement (`CliFlags`)
+  and the same file (`server/src/cli.ts`).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One command produces a working executable, with no file the operator writes.
+- A release is a complete answer for someone with no toolchain.
+- Starting the server lands a person in the interface, whatever they started it with.
+
+**Non-Goals:**
+
+- Real code signing or notarisation. The ad-hoc signature this applies is what makes
+  a modified binary *launch*; it is not what makes Gatekeeper or SmartScreen quiet.
+- Cross-building. Each platform's executable is built on that platform.
+- Self-replacement of a running executable.
+- Embedding the bundled skills. That stays a documented absence.
+
+## Decisions
+
+### A subcommand, not a separate binary
+
+`pi-outpost build-exe` rather than a second `bin` entry. The package already declares
+one binary and the surface already carries subcommands (`init`, `login`, and `update`
+in flight); a second entry point would be a second thing to discover, document and
+keep in `--help`.
+
+### The config is generated, never authored
+
+Every documented failure of the current procedure is a detail of that file: the BOM
+that `Out-File -Encoding utf8` adds and Node's parser rejects, `mainFormat: "module"`
+missing, an output name without `.exe`. Generating it removes the whole class. It is
+written to a temporary path and removed afterwards, so nothing is left in the
+operator's directory to be edited and re-used incorrectly.
+
+### `--build-sea` first, `postject` as the stated fallback
+
+On Node ≥ 26 the direct build is one call and needs no external tool. Below that, the
+blob path still works and is what an operator on Node 24 has. The fallback is taken
+automatically and *says* it is being taken, because the two produce subtly different
+artifacts and someone debugging needs to know which one they have.
+
+### macOS re-signing is part of producing the artifact, not advice
+
+An injected or freshly built Mach-O whose signature no longer matches is killed at
+launch with a message that names neither. So the build runs `codesign --remove-signature`
+then an ad-hoc `codesign --sign -`, and fails loudly if the tool is absent, rather
+than handing over an executable that dies. Ad-hoc is enough to launch locally; it is
+not a distribution signature, which is why notarisation is a non-goal rather than an
+oversight.
+
+### The browser is opened from the bound address, after `listen`
+
+Opening before the server listens gives an error page and an operator who concludes
+it is broken. So the open happens in the callback that already knows the bound
+address — which is also the only place that knows the real port when the config asked
+for `0`.
+
+**The decision to open keys on a desktop session, not on a TTY.** The obvious test —
+"is stdout a terminal" — inverts the case that matters most: a double-clicked
+executable has no terminal and is precisely where nobody will read a printed address.
+So: macOS and Windows always have a desktop; on Linux, `DISPLAY` or `WAYLAND_DISPLAY`
+must be set. Containers and remote shells fall out correctly, and `CI` remains an
+explicit suppressor.
+
+Launching uses the platform opener (`open`, `start`, `xdg-open`) as a detached child
+whose failure is caught and ignored beyond a printed line. A browser that will not
+start is not a reason for a server to stop.
+
+### Release artifacts come from a matrix job that gates publish
+
+A separate job per platform, `needs`-ed by publish, rather than more steps inside the
+publish job: three platforms cannot be one job, and an executable that failed to
+build should stop the release rather than leave a version published with no downloads
+attached. `macos-latest` gives arm64 and `macos-13` x64; Linux and Windows are x64
+runners. Node 26 is installed per job because that is what `--build-sea` requires.
+
+Artifacts are named `pi-outpost-<version>-<os>-<arch>[.exe]`, which is what makes the
+right download legible without documentation.
+
+### Coordination with `add-cli-update-command`
+
+Both changes modify `CliFlags` and `server/src/cli.ts`. This delta is written against
+the current main spec, so whichever archives second must fold in the other's
+paragraph rather than overwrite it — the same for the argument parser. Worth doing in
+that order deliberately: `update` first, since its "print the release page" answer is
+only true once this change has put executables on that page.
+
+## Risks / Trade-offs
+
+- **The tag now depends on three more builds.** A macOS runner failing blocks a
+  release that would otherwise have shipped. → The publish job is what they gate; a
+  re-run of the failed job is enough, and no npm publish has happened yet at that
+  point.
+- **An unsigned executable warns on download.** Gatekeeper and SmartScreen both flag
+  it. → Stated in the release notes and in the docs; real signing is a separate
+  decision with a cost (certificates, notarisation service) that this change does not
+  take on.
+- **A browser opening unasked is a nuisance in the wrong context.** → Suppressed
+  wherever a browser cannot be shown, overridable in both directions, and never fatal.
+- **Two build paths mean two artifacts to reason about.** → The command says which
+  one it took; the spec requires both to produce something that runs.
+- **The blob path depends on a `node` binary the operator has.** Its major version
+  must match what the blob expects. → The fallback checks and refuses with the
+  version rather than producing a binary that asserts at startup, which is exactly
+  how issue #14 presented.
+
+## Migration Plan
+
+Nothing to migrate: the manual procedure keeps working, and the documentation keeps
+it as the fallback. Ship order is the command first (it is testable without a
+release), then the release job, then the documentation rewrite that points at both.

--- a/openspec/changes/ship-standalone-executables/proposal.md
+++ b/openspec/changes/ship-standalone-executables/proposal.md
@@ -1,0 +1,86 @@
+## Why
+
+The single-file executable is the answer to "I want to run this and I do not want a
+toolchain". Today getting one is a manual procedure in `docs/sea-packaging.md`: write
+a `sea-config.json` by hand, get `mainFormat: "module"` right, remember that the
+output must end in `.exe` on Windows, and — the trap that costs the most time —
+write the file without a BOM, because `Out-File -Encoding utf8` adds one and Node's
+JSON parse dies on it. Get any of that wrong and the failure is a native assertion,
+not a message.
+
+Issue #14 is what an unexecutable procedure costs: a crash report, a diagnosis
+("blobs are platform-specific"), and a proposed CI matrix — for a bug that was
+actually a stale published blob carrying a module-format marker. Nobody could run
+the procedure often enough to see that.
+
+Two halves, and they answer different people. Someone who already has Node should
+be able to type one command. Someone who does not should not need Node at all — the
+whole point of a single-file executable is that the runtime is inside it.
+
+The in-flight `add-cli-update-command` change already depends on the second half:
+its answer for an operator running a single-file executable is to print the release
+page, which is only useful once that page carries executables.
+
+## What Changes
+
+- **New `pi-outpost build-exe` subcommand**, shipped in the npm package. It writes
+  the SEA config itself — correct `mainFormat`, correct encoding, platform-correct
+  output name — runs the build, and prints where the executable landed.
+- It SHALL refuse rather than produce a broken artifact: too old a Node, a missing
+  bundle, a target path it would overwrite without being asked.
+- On macOS it SHALL re-sign the result. An injected or freshly built binary with a
+  stale signature is killed by the kernel at launch, and the error names neither the
+  signature nor the fix.
+- **Executables attached to every release**: built per platform on the tag that
+  publishes, uploaded to the GitHub release. macOS (both architectures), Linux x64,
+  Windows x64.
+- **Starting the server opens the interface** in the default browser, at the address
+  it actually bound, once it is listening — however it was started, not only from an
+  executable. Someone starting `npx pi-outpost` reads an address off the terminal and
+  pastes it into a browser; the software can do that itself. Suppressed where a
+  browser is the wrong answer (no desktop session, a container, a backend for an
+  interface hosted elsewhere), and overridable both ways.
+- `--help` lists the new subcommand and the browser flags, as it lists the others.
+- `docs/sea-packaging.md` stops being a procedure to follow by hand and becomes a
+  description of what the command and the release artifacts do, keeping the manual
+  path only as the fallback it now is.
+
+Not in scope: code signing with a real certificate or notarisation (an unsigned
+executable still warns on macOS Gatekeeper and Windows SmartScreen); Linux arm64 and
+Windows arm64; self-replacement of a running executable, which stays out of the
+update command's reach by design.
+
+## Capabilities
+
+### New Capabilities
+
+- `standalone-executable`: what a single-file pi-outpost is, the two ways to obtain
+  one — build it from the installed package, or download it from a release — and
+  what it must contain, refuse, and say for itself.
+
+### Modified Capabilities
+
+- `cli`: the command surface gains a `build-exe` subcommand and `--open` / `--no-open`,
+  which `--help` must list; a new requirement states that starting the server opens
+  the interface, since that holds however the server was started rather than only for
+  an executable. `PublishedCliPackage` already promises the SEA layout keeps working;
+  it now also promises the package carries what building an executable needs.
+
+## Impact
+
+- `server/src/index.ts` — opening the browser once the server is listening, from the
+  bound address rather than the configured one.
+- `server/src/config.ts` — the key that turns opening off for a deployment.
+- `server/src/cli.ts` — a further subcommand and its flags; help text. Lands beside
+  the `update` subcommand from `add-cli-update-command`; whichever merges second
+  rebases onto the other's parsing.
+- New module for the build: config generation, the Node version gate, the postject
+  fallback, the macOS re-sign.
+- `cli/scripts/build.mjs` — the new module has to reach the published package, and
+  `pi-outpost.sea.mjs` and `sea-prep.blob` are already there for it to act on.
+- `.github/workflows/release.yml` — a matrix job producing the artifacts and
+  uploading them to the release. The publish job currently switches Node versions
+  midway to build the blob; the executable build belongs beside it, not inside it.
+- `docs/sea-packaging.md` — rewritten around the command.
+- No runtime dependency added: `--build-sea` is Node's own, and `postject` is only
+  reached for on the fallback path, where it is invoked through `npx`.

--- a/openspec/changes/ship-standalone-executables/specs/cli/spec.md
+++ b/openspec/changes/ship-standalone-executables/specs/cli/spec.md
@@ -1,0 +1,94 @@
+## MODIFIED Requirements
+
+### Requirement: CliFlags
+
+The binary SHALL accept `--config <path>`, `--profile <name>`, `--cwd <dir>`, `--agent-dir <dir>`, `--port <n>`, `--host <addr>`, `--help` and `--version`. Relative paths given on the command line SHALL be resolved against the current directory (paths inside a config file remain relative to that file). The binary SHALL NOT accept a flag carrying the auth token. An unknown flag SHALL be an error that names the flag and points at `--help`.
+
+The binary SHALL additionally accept a `build-exe` subcommand, and `--out <path>` and `--force` flags that apply to it. It SHALL accept `--open` and `--no-open`, which decide whether starting the server launches a browser, and which apply wherever the server starts rather than to any one subcommand. A flag given outside the subcommand it belongs to SHALL be an error like any other misplaced flag, rather than being silently ignored.
+
+#### Scenario: HelpListsEveryFlag
+- **WHEN** the user runs `pi-outpost --help`
+- **THEN** it prints every flag, the config discovery order, and exits zero
+
+#### Scenario: UnknownFlag
+- **WHEN** the user runs `pi-outpost --porte 8080`
+- **THEN** it exits non-zero, names the unknown flag, and suggests `--help`
+
+#### Scenario: VersionMatchesThePackage
+- **WHEN** the user runs `pi-outpost --version`
+- **THEN** it prints the version of the installed package
+
+#### Scenario: HelpDocumentsTheBuildCommand
+- **WHEN** the user runs `pi-outpost --help`
+- **THEN** the `build-exe` subcommand, its options, and the browser-opening flags appear alongside the other commands
+
+### Requirement: PublishedCliPackage
+
+The project SHALL publish a `pi-outpost` package to npm that runs the server with no clone and no build step: `npx pi-outpost`. The package SHALL contain the bundled server and the built web UI, and SHALL declare a `pi-outpost` binary. The server SHALL locate the web UI inside the package it was installed as, and SHALL keep working from a repository clone and from the SEA layout without code changes.
+
+The package SHALL also carry what building a standalone executable from it requires, so that an installation is sufficient on its own — nothing to fetch, nothing to clone, nothing to write by hand.
+
+#### Scenario: RunFromNpx
+- **GIVEN** a machine with Node and a valid config file, and no pi-outpost clone
+- **WHEN** the user runs `npx pi-outpost`
+- **THEN** the server starts and serves the web UI at the configured host and port
+
+#### Scenario: WebUiShippedInTheTarball
+- **WHEN** the package is packed
+- **THEN** the tarball contains the server bundle and the web UI's `index.html` and assets
+- **AND** packing fails if the web UI was not built
+
+#### Scenario: TheTarballCarriesWhatABuildNeeds
+- **WHEN** the package is packed
+- **THEN** the tarball contains everything `build-exe` reads, and building an executable from a fresh install requires no other download
+
+## ADDED Requirements
+
+### Requirement: StartingOpensTheInterface
+
+However the server was started — from a package runner, from an installed binary, or
+from a standalone executable — starting it for a person SHALL open the interface in
+their default browser, at the address the server is actually listening on, once it is
+listening and not before. Anyone who starts this reads the address off the terminal
+and pastes it into a browser; the software can do that itself.
+
+The address SHALL be the one bound, not the one requested: where the port was chosen
+by the operating system, the opened address SHALL be the port it chose.
+
+Whether to open SHALL be decided by whether a browser can be shown at all — a
+desktop session exists — and not by whether a terminal is attached: an executable
+launched from a file manager has no terminal and is exactly the case that most needs
+opening. It SHALL be suppressed where a browser is the wrong answer: no desktop
+session, a container or a service, or a server that exists to back an interface
+hosted elsewhere. The decision SHALL be overridable in both directions from the
+command line and from configuration.
+
+A failure to open SHALL NOT be a failure to start: the server SHALL keep running and
+SHALL print the address, which is what the operator would have read anyway.
+
+#### Scenario: StartingOnADesktopOpensTheInterface
+- **GIVEN** a machine with a desktop session
+- **WHEN** the operator starts the server
+- **THEN** the default browser opens the interface, and it is being served by the time the page loads
+
+#### Scenario: LaunchedWithoutATerminal
+- **GIVEN** a standalone executable launched from a file manager, with no terminal attached
+- **THEN** the browser still opens — the absence of a terminal is not the absence of a person
+
+#### Scenario: TheOpenedAddressIsTheBoundOne
+- **GIVEN** a configuration that lets the operating system choose the port
+- **WHEN** the browser is opened
+- **THEN** the address it opens is the one the server bound, not the one configured
+
+#### Scenario: NothingOpensWhereNothingCanSeeIt
+- **WHEN** the server runs with no desktop session available
+- **THEN** no browser is launched, and the address is printed as usual
+
+#### Scenario: TheOperatorCanSaySoEitherWay
+- **WHEN** the operator asks for no browser, or asks for one where it would not have opened
+- **THEN** the request is honoured
+
+#### Scenario: AFailedOpenIsNotAFailedStart
+- **GIVEN** a machine where launching a browser fails
+- **WHEN** the server starts
+- **THEN** it is running and serving, and the address is printed

--- a/openspec/changes/ship-standalone-executables/specs/standalone-executable/spec.md
+++ b/openspec/changes/ship-standalone-executables/specs/standalone-executable/spec.md
@@ -1,0 +1,120 @@
+## Purpose
+
+A single-file pi-outpost: the server and the built web interface inside one
+executable that carries its own runtime, so a machine with nothing installed can run
+it. Covers how one is obtained — built from the installed package, or downloaded
+from a release — and what it must contain, refuse, and say for itself.
+
+## ADDED Requirements
+
+### Requirement: OneCommandProducesAnExecutable
+
+Building a standalone executable from an installed package SHALL take one command
+and no hand-written files. The system SHALL generate the build configuration itself,
+including every detail whose absence produces a failure the operator cannot read:
+the module format the bundle requires, an encoding the runtime's own parser accepts,
+and an output name the platform will execute.
+
+On completion it SHALL print the path of the executable it produced. The executable
+SHALL run on the machine that built it without further steps.
+
+#### Scenario: BuildingFromTheInstalledPackage
+- **GIVEN** the package installed and a runtime new enough to build one
+- **WHEN** the operator runs the build command
+- **THEN** an executable is produced, its path is printed, and running it with `--version` prints the package's version
+
+#### Scenario: TheOutputIsNamedForItsPlatform
+- **WHEN** an executable is built on a platform whose loader requires a particular file name
+- **THEN** the produced file carries it, rather than requiring the operator to know
+
+#### Scenario: NoConfigurationIsWrittenByHand
+- **WHEN** an executable is built
+- **THEN** the operator writes no build configuration file, and none of the generated file's content is theirs to get right
+
+### Requirement: TheBuildRefusesRatherThanShipBroken
+
+The build SHALL refuse, naming what is wrong and what to do, rather than produce an
+artifact that fails later:
+
+- a runtime too old to build one, where it SHALL say which version is needed and
+  offer the path that works without it;
+- a missing or unbuilt bundle;
+- an existing file at the target path, unless overwriting was asked for.
+
+Where the platform requires a signature for a modified binary to launch at all, the
+build SHALL apply one. A signature is not optional presentation: without it the
+executable is killed on start, and the operating system's message names neither the
+signature nor the remedy.
+
+#### Scenario: ARuntimeTooOldToBuild
+- **GIVEN** a runtime older than the one the direct build needs
+- **WHEN** the operator runs the build command
+- **THEN** it either completes by the fallback path or exits non-zero naming the required version — and in neither case leaves a broken executable behind
+
+#### Scenario: RefusingToOverwrite
+- **GIVEN** a file already at the target path
+- **WHEN** the operator runs the build command without asking for an overwrite
+- **THEN** it exits non-zero, leaves the file untouched, and names the option that would replace it
+
+#### Scenario: TheExecutableLaunchesOnAPlatformThatChecksSignatures
+- **WHEN** an executable is built on a platform that refuses to launch a binary whose signature no longer matches it
+- **THEN** the produced executable launches
+
+### Requirement: ExecutablesAreAttachedToEveryRelease
+
+Every published release SHALL carry a standalone executable for each supported
+platform, built for that platform, and named so that which one to download is
+legible without reading documentation. An operator SHALL be able to obtain a working
+pi-outpost with no runtime installed and no build step.
+
+The release page SHALL therefore be a complete answer for an operator running a
+single-file executable, which is what the update path points them at.
+
+#### Scenario: DownloadAndRunWithNothingInstalled
+- **GIVEN** a machine with no Node runtime and no pi-outpost installation
+- **WHEN** the operator downloads the executable for their platform from a release and runs it
+- **THEN** the server starts and serves the web interface
+
+#### Scenario: EveryReleaseCarriesThem
+- **WHEN** a release is published
+- **THEN** it carries one executable per supported platform, and a release missing them is a failed release rather than a quiet omission
+
+#### Scenario: ThePlatformIsLegibleFromTheName
+- **WHEN** an operator looks at a release's files
+- **THEN** each executable's name states the operating system and architecture it is for
+
+### Requirement: AnExecutableSaysWhatItCarries
+
+A standalone executable SHALL contain the server and the built web interface, and
+SHALL serve the interface from inside itself with nothing beside it on disk.
+
+What it does not carry SHALL be stated rather than discovered: the bundled skills
+live on the filesystem and are not embedded, so an executable starts without them
+unless it is pointed at a directory holding them. This degrades rather than breaks —
+the tools work; what is missing is the instruction that makes a producer's first
+attempt valid.
+
+#### Scenario: TheInterfaceIsInside
+- **GIVEN** an executable alone in an empty directory
+- **WHEN** it is run
+- **THEN** it serves the web interface without any other file being present
+
+#### Scenario: SkillsAreAbsentAndSaidToBe
+- **WHEN** an executable runs with no skills directory configured
+- **THEN** it starts and works, and the documentation states that the bundled skills are not inside it and how to supply them
+
+### Requirement: ADoubleClickedExecutableIsAWholeApplication
+
+Launching a standalone executable the way a person launches an application — from a
+file manager, with no terminal — SHALL land them in the interface. The general rule
+lives with the command surface (`StartingOpensTheInterface`); what this adds is that
+the executable's own default SHALL be to open, since there is no terminal for it to
+print an address to that anyone would read.
+
+#### Scenario: LaunchedFromAFileManager
+- **WHEN** a person double-clicks the executable on a desktop machine
+- **THEN** the browser opens on the interface, served by that executable, with no other step
+
+#### Scenario: TheSameExecutableOnAServer
+- **GIVEN** the same executable run over a remote shell with no desktop session
+- **THEN** it starts and prints its address, and opens nothing

--- a/openspec/changes/ship-standalone-executables/tasks.md
+++ b/openspec/changes/ship-standalone-executables/tasks.md
@@ -1,0 +1,71 @@
+## 1. Building an executable
+
+- [x] 1.1 New module (`server/src/buildExe.ts`) that generates the SEA config to a temporary
+      path — `mainFormat: "module"`, UTF-8 with no BOM, output named for the platform — runs
+      `node --build-sea`, removes the temporary file, and returns the produced path
+- [x] 1.2 Version gate: on Node < 26, take the `postject` path against `dist/sea-prep.blob`
+      (copy the running `node` binary, inject with the sentinel fuse, `--macho-segment-name
+      NODE_SEA` on macOS), and say which path was taken
+- [x] 1.3 Refuse rather than ship broken: missing `pi-outpost.sea.mjs`, an existing file at the
+      target without `--force`, a `node` binary whose major version the blob will not accept
+- [x] 1.4 macOS: `codesign --remove-signature` then ad-hoc `codesign --sign -`, failing loudly
+      if `codesign` is absent — an unsigned modified Mach-O is killed at launch
+- [x] 1.5 Unit tests for the pure parts: the generated config's content and encoding, the
+      output name per platform, the refusal cases and their messages
+
+## 2. The command surface
+
+- [x] 2.1 Parse `build-exe` and its `--out <path>` / `--force` in `server/src/cli.ts`, beside
+      the existing subcommands; a misplaced flag is an error, not silently ignored
+- [x] 2.2 Parse `--open` / `--no-open`, which apply wherever the server starts rather than to a
+      subcommand
+- [x] 2.3 `--help` lists `build-exe`, its options, and the browser flags
+- [x] 2.4 Config key for deployments that never want a browser, validated like the others
+- [x] 2.5 Tests: help output, each new flag, and every misplacement error
+
+## 3. Opening the interface
+
+- [x] 3.1 Open from the `listen` callback in `server/src/index.ts`, using the bound address —
+      the only place that knows the real port when the config asked for `0`
+- [x] 3.2 Decide on a desktop session, not a TTY: always on macOS and Windows, `DISPLAY` or
+      `WAYLAND_DISPLAY` on Linux; `CI` suppresses; the flags and the config key win over all of it
+- [x] 3.3 Launch through the platform opener as a detached child; catch and report failure
+      without touching the server's own outcome
+- [x] 3.4 Tests: the URL is built from the bound port and not the configured one, each
+      suppression case, both overrides, and a failing opener leaving the server started
+
+## 4. Executables on every release
+
+- [x] 4.1 Matrix job in `.github/workflows/release.yml` — `macos-latest` (arm64), `macos-13`
+      (x64), `ubuntu-latest`, `windows-latest` — each installing Node 26 and building its own
+      executable through the new command
+- [x] 4.2 Name each artifact `pi-outpost-<version>-<os>-<arch>[.exe]`, and smoke-test it in the
+      job that built it (`--version` must print the released version)
+- [x] 4.3 Upload them to the GitHub release for the tag
+- [x] 4.4 Make `publish` depend on the matrix, so a platform that failed to build stops the
+      release rather than publishing one with nothing to download
+
+## 5. Documentation
+
+- [x] 5.1 Rewrite `docs/sea-packaging.md` around the command and the release downloads; keep
+      the manual procedure as the fallback it now is, and say what the ad-hoc signature does
+      and does not buy
+- [x] 5.2 State plainly that an unsigned executable warns on Gatekeeper and SmartScreen, and
+      that the bundled skills are not inside it
+- [x] 5.3 README: the download link as the first way to run this, ahead of `npx`
+
+## 6. Landing it
+
+- [ ] 6.1 Build an executable and run it: it starts, serves the interface, and opens the browser
+      from a double-click as well as from a terminal. **Blocked locally**: this machine's Node
+      26.7 (macOS 15.7 x64, official build) produces `--build-sea` executables that segfault —
+      a one-line hello-world reproduces it, and the blob+postject path runs on the same runtime.
+      The proof comes from the matrix job, run from this branch via workflow_dispatch.
+- [ ] 6.6 Decide the blob's `mainFormat`: shipped without it (the issue #14 fix) the injected
+      executable runs the ESM bundle as CommonJS and dies on its first `import`; shipped with it
+      an older node asserts on the format byte. Both are observed. Needs a decision, not a guess
+- [ ] 6.2 Scenario-to-test matrix for both delta specs; nothing `partial` or `uncovered`
+- [ ] 6.3 `npm run typecheck`, `npm run lint`, the suites, `npm run test:e2e`
+- [ ] 6.4 `openspec validate ship-standalone-executables --strict`
+- [ ] 6.5 Reconcile with `add-cli-update-command` — both modify `CliFlags` and the argument
+      parser, so whichever lands second folds in the other rather than overwriting it

--- a/server/scripts/build-sea.mjs
+++ b/server/scripts/build-sea.mjs
@@ -116,10 +116,17 @@ await esbuild.build({
 }
 
 // ── 2a. Generate preparation blob (for npm distribution, cross-platform) ─────
-// The blob can be injected into a node.exe on any platform via postject.
+// The blob can be injected into a node binary of any platform via postject.
+//
+// It carries `mainFormat: "module"`, and that is a deliberate reversal. It was
+// removed once, because injecting a blob that declares a module format into a node
+// too old to know the field asserts at startup — issue #14, which read like a
+// platform mismatch and was not. But the bundle *is* ESM: without the field the
+// runtime loads it as CommonJS and dies on its first `import`, so a blob without it
+// is one nobody can use. The field stays and the requirement is stated instead:
+// this blob wants Node >= 26, the same version --build-sea needs.
 console.log("[build-sea] generating SEA preparation blob …");
-const blobCfg = { ...SEA_CFG, output: resolve(OUT_DIR, "sea-prep.blob") };
-delete blobCfg.mainFormat;
+const blobCfg = { ...SEA_CFG, mainFormat: "module", output: resolve(OUT_DIR, "sea-prep.blob") };
 await writeFile(SEA_CONFIG_PATH, JSON.stringify(blobCfg, null, 2));
 execFileSync(process.execPath, ["--experimental-sea-config", SEA_CONFIG_PATH], { stdio: "inherit" });
 

--- a/server/scripts/build-sea.mjs
+++ b/server/scripts/build-sea.mjs
@@ -78,40 +78,66 @@ await esbuild.build({
   },
 });
 
-// ── 1b. Patch getAliases() for SEA mode ──────────────────────────────────────
-// In SEA mode, the entire bundle is embedded in the .exe — there are no
-// node_modules/ directories on the filesystem at the executable's location.
-// The SDK's getAliases() calls require.resolve("typebox") which throws in
-// that environment, preventing jiti from being created and silently killing
-// all extension loading.  We wrap the function body so that if filesystem
-// resolution fails, empty aliases are returned — enough for extensions that
-// import only Node built-in modules (npm-registered pi packages still need
-// full filesystem resolution and aren't supported in SEA mode).
+// ── 1b. Let extensions reach the bundled packages, in SEA mode ───────────────
+// An extension loaded at runtime lives outside the executable and may import the
+// packages the agent itself is built from — pi-coding-agent, pi-tui, typebox. There
+// are no node_modules beside a single-file executable, so the SDK's getAliases(),
+// which answers with filesystem paths from require.resolve(), throws and takes all
+// extension loading down with it.
+//
+// jiti already has the mechanism for exactly this, and the SDK already uses it: its
+// `virtualModules` option maps a specifier to an *already-loaded module object* and
+// bypasses filesystem resolution entirely. The SDK builds that map (VIRTUAL_MODULES)
+// from static imports — "These MUST be static so Bun bundles them into the compiled
+// binary" — and selects it when `isBunBinary`. Which is false in a Node SEA, so we
+// fall to the aliases and die.
+//
+// So the patch is one condition, not a new mechanism: take the same branch Bun takes
+// when this is a single executable. The objects are already inside the blob (esbuild
+// bundles those static imports), which is what makes it work at all.
+//
+// The upstream fix is the same three lines in the SDK's own detection; this stays
+// until that lands.
 {
-  console.log("[build-sea] patching getAliases() for SEA mode …");
+  console.log("[build-sea] routing extension imports through jiti's virtual modules …");
   let bundleSrc = await readFile(BUNDLE_PATH, "utf-8");
-  // Replace the getAliases function: wrap the body so require.resolve
-  // failures are caught and returned as {}.
-  // Match the function opening and wrap body in try
-  const openBefore = "function getAliases() {\n" +
-    "  if (_aliases)\n" +
-    "    return _aliases;";
-  const openAfter = "function getAliases() {\n" +
-    "  if (_aliases)\n" +
-    "    return _aliases;\n" +
-    "  try {";
-  // Match ";, return _aliases; }" sequence unique to getAliases' tail
-  const tailBefore = "};\n" +
-    "  return _aliases;\n" +
-    "}";
-  const tailAfter = "};\n" +
-    "  return _aliases;\n" +
+
+  // `node:sea` answers this for real; wrapped because a runtime without it must
+  // simply say no rather than take the whole loader with it.
+  const helper =
+    "\nfunction __piOutpostIsSea() {\n" +
+    "  try {\n" +
+    "    return require(\"node:sea\").isSea();\n" +
     "  } catch {\n" +
-    "    _aliases = {};\n" +
-    "    return _aliases;\n" +
+    "    return false;\n" +
     "  }\n" +
-    "}";
+    "}\n";
+  const requireShim = "const require = ___createRequire(import.meta.url);";
+  if (!bundleSrc.includes(requireShim)) {
+    throw new Error("[build-sea] the bundle's createRequire shim moved — the SEA extension patch needs it");
+  }
+  bundleSrc = bundleSrc.replace(requireShim, requireShim + helper);
+
+  const branchBefore = "...isBunBinary ? { virtualModules: VIRTUAL_MODULES, tryNative: false }";
+  const branchAfter = "...isBunBinary || __piOutpostIsSea() ? { virtualModules: VIRTUAL_MODULES, tryNative: false }";
+  if (!bundleSrc.includes(branchBefore)) {
+    // Loudly, not silently: a patch that quietly stops matching leaves extensions
+    // broken in exactly the build nobody runs locally.
+    throw new Error("[build-sea] the SDK's jiti branch moved — extensions would lose their bundled packages");
+  }
+  bundleSrc = bundleSrc.replace(branchBefore, branchAfter);
+
+  // getAliases() keeps its guard, demoted from mechanism to seatbelt: it is no
+  // longer how extensions resolve anything, but a build where the detection above
+  // failed must degrade to "extensions with no npm imports" rather than to a
+  // loader that throws before any extension is read.
+  const openBefore = "function getAliases() {\n" + "  if (_aliases)\n" + "    return _aliases;";
+  const openAfter = openBefore + "\n  try {";
+  const tailBefore = "};\n" + "  return _aliases;\n" + "}";
+  const tailAfter =
+    "};\n" + "  return _aliases;\n" + "  } catch {\n" + "    _aliases = {};\n" + "    return _aliases;\n" + "  }\n" + "}";
   bundleSrc = bundleSrc.replace(openBefore, openAfter).replace(tailBefore, tailAfter);
+
   await writeFile(BUNDLE_PATH, bundleSrc, "utf-8");
 }
 

--- a/server/src/buildExe.ts
+++ b/server/src/buildExe.ts
@@ -90,8 +90,20 @@ export function findBuildInputs(from?: string): { bundle?: string; blob?: string
 
 export class BuildExeError extends Error {}
 
-/** The marker postject overwrites. A node built without single-executable support has none. */
-export const SEA_SENTINEL_FUSE = "NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2";
+/**
+ * The marker postject overwrites. A node built without single-executable support has none.
+ *
+ * Assembled at run time, never written out whole. This module is inlined into the
+ * bundle that becomes the executable, so a literal here would put a second copy of
+ * the sentinel inside the very binary Node is asked to inject into — and Node
+ * refuses with "found more than one occurrence of sentinel", which is how this was
+ * discovered: on three CI runners at once, by the feature that reads it.
+ *
+ * Joined through an array rather than concatenated, because a bundler folds adjacent
+ * string literals back into one and the literal would reappear.
+ */
+const FUSE_PARTS = ["NODE", "SEA", "FUSE", "fce680ab2cc467b6", "e072b8b5df1996b2"];
+export const SEA_SENTINEL_FUSE = `${FUSE_PARTS.slice(0, 3).join("_")}_${FUSE_PARTS.slice(3).join("")}`;
 
 /**
  * Whether this `node` can host an injected blob at all.
@@ -289,7 +301,7 @@ export function buildExecutable(options: BuildOptions = {}): BuildResult {
     "NODE_SEA_BLOB",
     blob,
     "--sentinel-fuse",
-    "NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2",
+    SEA_SENTINEL_FUSE,
     ...(platform === "darwin" ? ["--macho-segment-name", "NODE_SEA"] : []),
     "--overwrite",
   ]);

--- a/server/src/buildExe.ts
+++ b/server/src/buildExe.ts
@@ -1,0 +1,320 @@
+/**
+ * Building the standalone executable, from the package that is already installed.
+ *
+ * Everything here exists because the manual procedure is a list of details whose
+ * absence produces a failure nobody can read. A BOM in the config file: Node's JSON
+ * parser dies on byte one. A missing `mainFormat`: the bundle loads as CommonJS and
+ * fails on its first `import`. An output without `.exe`: Windows will not execute
+ * it. A Mach-O whose signature no longer matches its bytes: the kernel kills it, and
+ * says neither "signature" nor "codesign".
+ *
+ * So none of it is the operator's to get right. The config is generated to a
+ * temporary path and removed again; what they type is one command.
+ */
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/** What `node --build-sea` needs, and the reason each field is here. */
+export interface SeaConfig {
+  /** The fully-inlined bundle: every dependency and the web UI, so nothing is read from disk. */
+  main: string;
+  output: string;
+  /** The bundle is ESM. Without this Node loads it as CommonJS and it dies on its first import. */
+  mainFormat: "module";
+  disableExperimentalSEAWarning: true;
+}
+
+export function seaConfigFor(main: string, output: string): SeaConfig {
+  return { main, output, mainFormat: "module", disableExperimentalSEAWarning: true };
+}
+
+/**
+ * The config as bytes, written the one way Node will read back.
+ *
+ * `JSON.stringify` and UTF-8 with no byte order mark. PowerShell's `Out-File
+ * -Encoding utf8` adds one, and that single detail is the difference between a build
+ * and `SyntaxError: Unexpected token` pointing at a file that looks perfect in an
+ * editor.
+ */
+export function seaConfigBytes(config: SeaConfig): Buffer {
+  return Buffer.from(JSON.stringify(config, null, 2), "utf8");
+}
+
+/** What the platform will actually execute. */
+export function executableName(base: string, platform: NodeJS.Platform = process.platform): string {
+  return platform === "win32" ? `${base}.exe` : base;
+}
+
+/** The name a release artifact carries, so which one to download is legible from the name alone. */
+export function releaseArtifactName(
+  version: string,
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+): string {
+  const os = platform === "win32" ? "windows" : platform === "darwin" ? "macos" : "linux";
+  return executableName(`pi-outpost-${version}-${os}-${arch}`, platform);
+}
+
+/** `--build-sea` landed in Node 26; below it, the blob and postject are the way. */
+export const MINIMUM_DIRECT_BUILD_MAJOR = 26;
+
+export function majorOf(version: string): number {
+  return Number(version.replace(/^v/, "").split(".")[0]);
+}
+
+export function canBuildDirectly(version: string = process.version): boolean {
+  return majorOf(version) >= MINIMUM_DIRECT_BUILD_MAJOR;
+}
+
+/**
+ * Where the pieces are, across the three layouts this can run from.
+ *
+ * The published package (bundle and blob beside the running file), a clone (they are
+ * in cli/dist), and an executable already built (it has neither, and is told so
+ * rather than left to fail on an ENOENT).
+ */
+export function findBuildInputs(from?: string): { bundle?: string; blob?: string } {
+  from = from ?? import.meta.dirname;
+  const roots = [from, path.resolve(from, "../../cli/dist")];
+  const found: { bundle?: string; blob?: string } = {};
+  for (const root of roots) {
+    const bundle = path.join(root, "pi-outpost.sea.mjs");
+    const blob = path.join(root, "sea-prep.blob");
+    if (found.bundle === undefined && fs.existsSync(bundle)) found.bundle = bundle;
+    if (found.blob === undefined && fs.existsSync(blob)) found.blob = blob;
+  }
+  return found;
+}
+
+export class BuildExeError extends Error {}
+
+/** The marker postject overwrites. A node built without single-executable support has none. */
+export const SEA_SENTINEL_FUSE = "NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2";
+
+/**
+ * Whether this `node` can host an injected blob at all.
+ *
+ * Not every build carries the sentinel — Homebrew's node@24 does not, and the
+ * failure it produces is postject's "Could not find the sentinel ... in the binary",
+ * which reads like a corrupt download rather than an unsupported runtime. Asked
+ * before anything is copied, so the answer arrives as a sentence instead.
+ *
+ * Scanned in chunks with an overlap, because the file is a hundred megabytes and the
+ * marker could straddle any boundary.
+ */
+export function carriesSeaSentinel(binary: string = process.execPath): boolean {
+  const CHUNK = 1 << 20;
+  const overlap = Buffer.byteLength(SEA_SENTINEL_FUSE);
+  const handle = fs.openSync(binary, "r");
+  try {
+    const buffer = Buffer.alloc(CHUNK + overlap);
+    let position = 0;
+    let carried = 0;
+    for (;;) {
+      const read = fs.readSync(handle, buffer, carried, CHUNK, position);
+      if (read === 0) return false;
+      if (buffer.subarray(0, carried + read).includes(SEA_SENTINEL_FUSE)) return true;
+      buffer.copy(buffer, 0, carried + read - overlap, carried + read);
+      carried = overlap;
+      position += read;
+    }
+  } finally {
+    fs.closeSync(handle);
+  }
+}
+
+/**
+ * One run of a tool, with its output kept for the message when it fails.
+ *
+ * `missing` is separate from `ok` on purpose: "the tool is not installed" and "the
+ * tool ran and refused" need different sentences, and probing for presence by
+ * running something like `--version` gets it wrong — `codesign --version` is not an
+ * option codesign has, so a perfectly present tool reports itself absent.
+ */
+function run(command: string, args: string[]): { ok: boolean; output: string; missing: boolean } {
+  const result = spawnSync(command, args, { encoding: "utf8" });
+  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`.trim();
+  if (result.error !== undefined) {
+    const missing = (result.error as NodeJS.ErrnoException).code === "ENOENT";
+    return { ok: false, output: result.error.message, missing };
+  }
+  return { ok: result.status === 0, output, missing: false };
+}
+
+/**
+ * Sign the result, on the platform where an unsigned result does not run.
+ *
+ * Ad-hoc (`--sign -`) is enough to launch on the machine that built it. It is not a
+ * distribution signature: Gatekeeper still warns on a downloaded file, which is a
+ * separate problem with a separate cost and is not solved here.
+ */
+export function resignMacho(target: string): void {
+  // Removing first: the signature that came with the node binary describes bytes
+  // that are no longer there, and re-signing over it is refused.
+  run("codesign", ["--remove-signature", target]);
+  const signed = run("codesign", ["--sign", "-", target]);
+  if (signed.missing) {
+    throw new BuildExeError(
+      "codesign is required on macOS to make the executable launchable — install the Xcode command line tools (xcode-select --install)",
+    );
+  }
+  if (!signed.ok) throw new BuildExeError(`could not sign the executable: ${signed.output}`);
+}
+
+export interface BuildOptions {
+  /** Where to write it. Defaults to the platform-correct name in the current directory. */
+  out?: string;
+  force?: boolean;
+  cwd?: string;
+  /** Overridable for tests; the real one is the Node running this. */
+  nodeVersion?: string;
+  platform?: NodeJS.Platform;
+  log?: (line: string) => void;
+  /** Where to look for the bundle and the blob. Overridable so a test can point at neither. */
+  inputsFrom?: string;
+  /** Skips running the result. For a cross-built artifact, which by definition cannot run here. */
+  skipSmokeTest?: boolean;
+}
+
+export interface BuildResult {
+  path: string;
+  /** Which path produced it — the two artifacts differ, and someone debugging needs to know. */
+  method: "build-sea" | "postject";
+}
+
+/**
+ * Run what was just produced, before calling it produced.
+ *
+ * "Wrote pi-outpost" for a file that segfaults on its first invocation is a lie the
+ * operator discovers later and blames on the wrong thing. It costs one process to
+ * find out here — and it does find things out: a runtime whose single-executable
+ * support is broken on its own platform builds an artifact happily and crashes on
+ * `--version`, which a hello-world reproduces and no amount of reading the config
+ * would have revealed.
+ */
+export function producedExecutableRuns(target: string): { ok: boolean; detail: string } {
+  const result = spawnSync(target, ["--version"], { encoding: "utf8", timeout: 30_000 });
+  if (result.error !== undefined) return { ok: false, detail: result.error.message };
+  if (result.signal !== null) return { ok: false, detail: `killed by ${result.signal}` };
+  if (result.status !== 0) {
+    return { ok: false, detail: `exited ${result.status}: ${`${result.stdout ?? ""}${result.stderr ?? ""}`.trim()}` };
+  }
+  return { ok: true, detail: (result.stdout ?? "").trim() };
+}
+
+/**
+ * Produce the executable, or refuse in a way that says what to do.
+ *
+ * The refusals are the point as much as the build is: every one of them replaces a
+ * failure that would otherwise surface later, on someone else's machine, as a native
+ * assertion.
+ */
+export function buildExecutable(options: BuildOptions = {}): BuildResult {
+  const platform = options.platform ?? process.platform;
+  const cwd = options.cwd ?? process.cwd();
+  const log = options.log ?? ((line: string) => console.log(line));
+  const version = options.nodeVersion ?? process.version;
+
+  const target = path.resolve(cwd, options.out ?? executableName("pi-outpost", platform));
+  if (fs.existsSync(target) && options.force !== true) {
+    throw new BuildExeError(`${target} already exists — pass --force to replace it`);
+  }
+
+  const { bundle, blob } = findBuildInputs(options.inputsFrom);
+  if (bundle === undefined && blob === undefined) {
+    throw new BuildExeError(
+      "no build inputs beside this installation — build an executable from an installed package (npm i pi-outpost) or a clone, not from an executable",
+    );
+  }
+
+  if (canBuildDirectly(version) && bundle !== undefined) {
+    const configPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "pi-outpost-sea-")), "sea-config.json");
+    fs.writeFileSync(configPath, seaConfigBytes(seaConfigFor(bundle, target)));
+    try {
+      log(`[build-exe] building with node --build-sea (node ${version})`);
+      const built = run(process.execPath, ["--build-sea", configPath]);
+      if (!built.ok) throw new BuildExeError(`node --build-sea failed: ${built.output}`);
+    } finally {
+      fs.rmSync(path.dirname(configPath), { recursive: true, force: true });
+    }
+    if (platform === "darwin") resignMacho(target);
+
+    const verdict = options.skipSmokeTest === true ? { ok: true, detail: "" } : producedExecutableRuns(target);
+    if (verdict.ok) return { path: target, method: "build-sea" };
+
+    // Evidence, not a platform guess: `--build-sea` is the newer path and on some
+    // builds it produces an executable that segfaults on its first invocation, while
+    // the blob this same package ships injects into the same runtime and runs.
+    // Found on macOS x64 with Node 26.7, where a one-line hello-world reproduces it.
+    // So the fallback is taken because this one failed, which cannot rot the way a
+    // list of afflicted platforms would.
+    if (blob === undefined || !carriesSeaSentinel()) {
+      throw new BuildExeError(
+        `built ${target} with node --build-sea but it does not run — ${verdict.detail}. ` +
+          `This runtime's --build-sea is failing, not your configuration; a one-line hello-world built the same way fails the same way.`,
+      );
+    }
+    log(`[build-exe] the direct build does not run here (${verdict.detail}) — falling back to the blob`);
+    fs.rmSync(target, { force: true });
+  }
+
+  // The older path, and it says so: a blob injected into a copy of this node is not
+  // byte-identical to a --build-sea result, and "which one do I have" is the first
+  // question when one of them misbehaves.
+  if (blob === undefined) {
+    throw new BuildExeError(
+      `node ${version} cannot build directly (needs ${MINIMUM_DIRECT_BUILD_MAJOR} or newer) and sea-prep.blob is missing from this installation`,
+    );
+  }
+  if (!carriesSeaSentinel()) {
+    throw new BuildExeError(
+      `this node (${process.execPath}) was built without single-executable support, so a blob cannot be injected into it — ` +
+        `install Node ${MINIMUM_DIRECT_BUILD_MAJOR} or newer and the executable is built directly, with no injection at all`,
+    );
+  }
+  if (!canBuildDirectly(version)) {
+    log(`[build-exe] node ${version} is older than ${MINIMUM_DIRECT_BUILD_MAJOR} — injecting sea-prep.blob instead`);
+  }
+  fs.copyFileSync(process.execPath, target);
+  // The copy inherits the mode, and a packaged node is commonly r-xr-xr-x — not
+  // writable even by its owner, so postject fails with "Can't read and write to
+  // target executable" on a file the operator can see perfectly well.
+  fs.chmodSync(target, 0o755);
+  const injected = run("npx", [
+    "--yes",
+    "postject",
+    target,
+    "NODE_SEA_BLOB",
+    blob,
+    "--sentinel-fuse",
+    "NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2",
+    ...(platform === "darwin" ? ["--macho-segment-name", "NODE_SEA"] : []),
+    "--overwrite",
+  ]);
+  if (!injected.ok) {
+    fs.rmSync(target, { force: true });
+    throw new BuildExeError(`postject failed: ${injected.output}`);
+  }
+  if (platform === "darwin") resignMacho(target);
+  assertItRuns(target, "postject", options);
+  return { path: target, method: "postject" };
+}
+
+/**
+ * Refuse to call an executable produced when it does not run.
+ *
+ * The file is left in place rather than deleted: it is the evidence, and whoever is
+ * debugging a runtime that builds unrunnable executables needs it.
+ */
+function assertItRuns(target: string, method: string, options: BuildOptions): void {
+  if (options.skipSmokeTest === true) return;
+  const verdict = producedExecutableRuns(target);
+  if (verdict.ok) return;
+  throw new BuildExeError(
+    `built ${target} (${method}) but it does not run — ${verdict.detail}. ` +
+      `The file is left in place. This is the runtime's single-executable support failing, not your configuration: ` +
+      `a one-line hello-world built the same way will fail the same way, which is worth checking before looking further.`,
+  );
+}

--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -52,6 +52,7 @@ Usage
   pi-outpost config [options]    print the configuration that would be used, and where it came from
   pi-outpost login --provider <name>
                                  store an API key for a provider in <agentDir>/auth.json
+  pi-outpost build-exe [options] build a standalone executable from this installation
 
 Options
   --config <path>    configuration file to use
@@ -61,6 +62,8 @@ Options
   --port <n>         port to listen on (default: 3141)
   --host <addr>      address to bind (default: 127.0.0.1)
   --offline          never fetch remote model catalogs (air-gapped hosts)
+  --open             open the interface in your browser once the server is listening
+  --no-open          do not (the default wherever no desktop session exists)
   -h, --help         show this help
   -v, --version      show the version
 
@@ -70,6 +73,14 @@ init options
 
 login options
   --provider <name>  provider to store a key for (e.g. anthropic, openai, mistral)
+
+build-exe options
+  --out <path>       where to write it (default: ./pi-outpost, ./pi-outpost.exe on Windows)
+  --force            replace an existing file at that path
+
+The executable carries the server and the web UI and needs nothing installed to run.
+Released builds are attached to https://github.com/laurentftech/pi-outpost/releases —
+this command is for building one from the version you have.
 
 The key itself has no flag, for the same reason the auth token has none: argv is
 world-readable. It is prompted for on a terminal, or read from stdin when piped:
@@ -137,14 +148,17 @@ Agent runtime
 export class CliError extends Error {}
 
 export interface ParsedCli {
-  command: "serve" | "init" | "config" | "login" | "help" | "version";
+  command: "serve" | "init" | "config" | "login" | "build-exe" | "help" | "version";
   flags: CliOptions;
   init: { global: boolean; force: boolean };
   login: { provider?: string };
+  buildExe: { out?: string; force: boolean };
+  /** undefined when neither --open nor --no-open was given, so config still decides. */
+  open?: boolean;
 }
 
-type Command = "init" | "config" | "login";
-const COMMANDS: readonly string[] = ["init", "config", "login"] satisfies Command[];
+type Command = "init" | "config" | "login" | "build-exe";
+const COMMANDS: readonly string[] = ["init", "config", "login", "build-exe"] satisfies Command[];
 
 function integerFlag(value: string | undefined, name: string): number | undefined {
   if (value === undefined) return undefined;
@@ -172,6 +186,9 @@ export function parseCli(argv: string[]): ParsedCli {
         global: { type: "boolean", default: false },
         force: { type: "boolean", default: false },
         provider: { type: "string" },
+        out: { type: "string" },
+        open: { type: "boolean", default: false },
+        "no-open": { type: "boolean", default: false },
         help: { type: "boolean", short: "h", default: false },
         version: { type: "boolean", short: "v", default: false },
       },
@@ -191,6 +208,22 @@ export function parseCli(argv: string[]): ParsedCli {
   }
   const command = positional as Command | undefined;
 
+  // A flag that belongs to another command is an error, not something to ignore:
+  // `pi-outpost --out ./x` silently starting a server is a worse outcome than being
+  // told the flag has an owner.
+  if (values.out !== undefined && command !== "build-exe") {
+    throw new CliError('"--out" belongs to "pi-outpost build-exe" — see "pi-outpost --help"');
+  }
+  if (values.provider !== undefined && command !== "login") {
+    throw new CliError('"--provider" belongs to "pi-outpost login" — see "pi-outpost --help"');
+  }
+  if (values.global && command !== "init") {
+    throw new CliError('"--global" belongs to "pi-outpost init" — see "pi-outpost --help"');
+  }
+  if (values.open && values["no-open"]) {
+    throw new CliError('"--open" and "--no-open" contradict each other — see "pi-outpost --help"');
+  }
+
   const flags: CliOptions = {
     config: values.config,
     profile: values.profile,
@@ -208,6 +241,9 @@ export function parseCli(argv: string[]): ParsedCli {
     flags,
     init: { global: values.global, force: values.force },
     login: { provider: values.provider },
+    buildExe: { out: values.out, force: values.force },
+    // Left undefined unless asked for, so configuration still has its say.
+    ...(values.open ? { open: true } : values["no-open"] ? { open: false } : {}),
   };
 }
 

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -297,6 +297,15 @@ export interface AppConfig {
    * catalog only adds metadata for models the SDK already knows about.
    */
   offline: boolean;
+  /**
+   * Whether starting the server opens the interface in a browser.
+   *
+   * Left undefined by default rather than set: the decision then rests on whether a
+   * browser can be shown at all (see openBrowser.ts), which is right on a desktop
+   * and right on a headless host without either being configured. Set it to pin the
+   * answer for a deployment — a kiosk that must open, a service that must not.
+   */
+  openBrowser?: boolean;
   port: number;
   host: string;
   /** Extra exact Origins allowed on the WebSocket (for embedding in another app). */
@@ -653,6 +662,7 @@ export function loadConfig(
   config.appendSystemPrompt = optionalStringArray(raw, "appendSystemPrompt") ?? [];
   config.webContext = optionalBoolean(raw, "webContext", true);
   config.offline = optionalBoolean(raw, "offline", false);
+  if (raw.openBrowser !== undefined) config.openBrowser = optionalBoolean(raw, "openBrowser", true);
 
   if (raw.server !== undefined) {
     const server = asObject(raw.server, "server");

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -628,7 +628,6 @@ if (EMBEDDED_WEB && Object.keys(EMBEDDED_WEB).length > 0) {
 }
 
 await app.listen({ port: PORT, host: HOST });
-console.log(`[server] http://${HOST}:${PORT}/`);
 
 /**
  * Land the operator in the interface they just started.
@@ -641,7 +640,12 @@ console.log(`[server] http://${HOST}:${PORT}/`);
  */
 {
   const bound = app.server.address();
+  // Printed from what was bound, not from what was asked for: with `port: 0` the
+  // configured value is a number nobody is listening on, and this line was saying
+  // `http://127.0.0.1:0/` — which is the whole of what an operator gets when no
+  // browser opens.
   const url = typeof bound === "object" && bound !== null ? browsableUrl(bound) : `http://${HOST}:${PORT}/`;
+  console.log(`[server] ${url}`);
   // A server with no interface of its own has nothing to open: in development the
   // UI comes from Vite on another port, and a tab on this one shows a 404. It is
   // also what a backend for an embedded widget looks like, which is the other case

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -48,6 +48,8 @@ import { TOOLS_ENV_VAR, type PiOutpostToolsSettings } from "./piOutpostTools.ts"
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { CliError, helpText, parseCli, readSecret, runInit } from "./cli.ts";
+import { BuildExeError, buildExecutable } from "./buildExe.ts";
+import { browsableUrl, openBrowser, shouldOpenBrowser } from "./openBrowser.ts";
 import { loadConfig, NoConfigError } from "./config.ts";
 import {
   CredentialError,
@@ -151,6 +153,24 @@ if (cli.command === "init") {
     console.log(`[pi] wrote ${written}\n[pi] edit it, then run: pi-outpost`);
     process.exit(0);
   } catch (error) {
+    complain(error);
+    process.exit(1);
+  }
+}
+
+// Before the configuration is loaded, deliberately: building an executable has
+// nothing to do with how a server would be configured, and refusing to build one
+// because no config file exists would be an obstacle invented for its own sake.
+if (cli.command === "build-exe") {
+  try {
+    const built = buildExecutable({ out: cli.buildExe.out, force: cli.buildExe.force, cwd: LAUNCH_DIR });
+    console.log(`[pi] wrote ${built.path} (${built.method})\n[pi] run it: ${built.path}`);
+    process.exit(0);
+  } catch (error) {
+    if (error instanceof BuildExeError) {
+      console.error(`[pi] ${error.message}`);
+      process.exit(1);
+    }
     complain(error);
     process.exit(1);
   }
@@ -609,6 +629,32 @@ if (EMBEDDED_WEB && Object.keys(EMBEDDED_WEB).length > 0) {
 
 await app.listen({ port: PORT, host: HOST });
 console.log(`[server] http://${HOST}:${PORT}/`);
+
+/**
+ * Land the operator in the interface they just started.
+ *
+ * The address comes from what was bound, not from what was asked for: `port: 0`
+ * means the operating system chose, and the configured value is then a number
+ * nobody is listening on. Opening here rather than earlier is the whole point —
+ * a browser sent before `listen` resolves shows a connection error, and the
+ * operator concludes the thing is broken.
+ */
+{
+  const bound = app.server.address();
+  const url = typeof bound === "object" && bound !== null ? browsableUrl(bound) : `http://${HOST}:${PORT}/`;
+  // A server with no interface of its own has nothing to open: in development the
+  // UI comes from Vite on another port, and a tab on this one shows a 404. It is
+  // also what a backend for an embedded widget looks like, which is the other case
+  // where a browser is the wrong answer.
+  const servesTheInterface = (EMBEDDED_WEB && Object.keys(EMBEDDED_WEB).length > 0) || WEB_DIST !== undefined;
+  if (servesTheInterface && shouldOpenBrowser({ explicit: cli.open, configured: config.openBrowser })) {
+    // Not awaited for its outcome beyond a line of output: a browser that will not
+    // start is not a reason for a server to stop.
+    void openBrowser(url).then((opened) => {
+      if (!opened) console.log(`[server] could not open a browser — open ${url} yourself`);
+    });
+  }
+}
 
 // --- Agent session runtime ---------------------------------------------------
 

--- a/server/src/openBrowser.ts
+++ b/server/src/openBrowser.ts
@@ -1,0 +1,92 @@
+/**
+ * Opening the interface in the operator's browser, once the server is listening.
+ *
+ * Anyone who starts this reads an address off the terminal and pastes it into a
+ * browser. The software can do that itself — and for an executable launched from a
+ * file manager it must, because there is no terminal for that address to be read
+ * from at all.
+ */
+import { spawn } from "node:child_process";
+
+export interface OpenDecision {
+  /** Set by --open / --no-open, which win over everything. */
+  explicit?: boolean;
+  /** Set in configuration, for a deployment that never wants one. */
+  configured?: boolean;
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Whether a browser should be opened at all.
+ *
+ * The obvious test — "is stdout a terminal" — gets the most important case exactly
+ * backwards: a double-clicked executable has no terminal, and is precisely where
+ * nobody will read a printed address. So the question is whether a browser can be
+ * *shown*: macOS and Windows always have a desktop; on Linux a display server has to
+ * be named. A container, a service and a remote shell all fail that test on their
+ * own, without needing to be recognised individually.
+ */
+export function shouldOpenBrowser({
+  explicit,
+  configured,
+  platform = process.platform,
+  env = process.env,
+}: OpenDecision = {}): boolean {
+  if (explicit !== undefined) return explicit;
+  if (configured !== undefined) return configured;
+  // A CI runner has a display often enough to matter, and never a person watching.
+  if (env.CI !== undefined && env.CI !== "" && env.CI !== "false") return false;
+  if (platform === "darwin" || platform === "win32") return true;
+  return Boolean(env.DISPLAY ?? env.WAYLAND_DISPLAY);
+}
+
+/**
+ * The address to open, from what the server actually bound.
+ *
+ * Not from the configuration: a port of 0 means the operating system picks, and the
+ * configured value is then a number nobody is listening on. The wildcard addresses
+ * are not reachable as themselves either — a browser has to be sent somewhere it can
+ * connect, which is the loopback of the same family.
+ */
+export function browsableUrl(address: { address: string; port: number; family?: string }): string {
+  const host =
+    address.address === "0.0.0.0" || address.address === "::" || address.address === ""
+      ? "127.0.0.1"
+      : address.address;
+  // A literal IPv6 address needs its brackets back before it is a URL.
+  const authority = host.includes(":") ? `[${host}]` : host;
+  return `http://${authority}:${address.port}/`;
+}
+
+/** The platform's own opener. Nothing here parses a browser preference — the OS holds it. */
+function openerFor(platform: NodeJS.Platform, url: string): { command: string; args: string[] } {
+  if (platform === "darwin") return { command: "open", args: [url] };
+  // `start` is a shell builtin, not a program; the empty string is the window title
+  // the first quoted argument would otherwise be taken for.
+  if (platform === "win32") return { command: "cmd", args: ["/c", "start", "", url] };
+  return { command: "xdg-open", args: [url] };
+}
+
+/**
+ * Launch it, detached, and never let it matter.
+ *
+ * A browser that will not start is not a reason for a server to stop, or even to
+ * exit non-zero: the address is printed either way, which is what the operator would
+ * have used before this existed.
+ */
+export function openBrowser(url: string, platform: NodeJS.Platform = process.platform): Promise<boolean> {
+  const { command, args } = openerFor(platform, url);
+  return new Promise((resolve) => {
+    try {
+      const child = spawn(command, args, { detached: true, stdio: "ignore" });
+      child.on("error", () => resolve(false));
+      // Unref'd, or a browser the OS keeps as a child would hold the server open
+      // past Ctrl-C — which is how "the process will not die" bugs are born.
+      child.unref();
+      resolve(true);
+    } catch {
+      resolve(false);
+    }
+  });
+}

--- a/server/src/sea-extensions.ts
+++ b/server/src/sea-extensions.ts
@@ -4,10 +4,16 @@ import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
  * Extensions to bake into a SEA (Single Executable Application) build — see
  * server/scripts/build-sea.mjs and docs/sea-packaging.md.
  *
- * Runtime-loaded extensions use config.extensionScripts (native import()).
- * This file is only needed for extensions that must be baked into the bundle
- * itself (no external file on disk at runtime). Each entry must be a real
- * static import since esbuild needs a literal path to bundle it.
+ * Runtime-loaded extensions use config.extensionScripts, which the SDK reads
+ * through jiti's loader (createRequire under it) — not a native import(), which
+ * cannot reach a file the blob does not contain. In a SEA build those extensions
+ * resolve the agent's own packages through jiti's virtual modules; see the
+ * "virtual modules" section of server/scripts/build-sea.mjs.
+ *
+ * This file is for the other case: an extension that must be inside the bundle,
+ * with no file on disk at all. Each entry must be a real static import, since
+ * esbuild needs a literal path to bundle it. It stays available whatever happens
+ * to the runtime path above — a fallback that answers when nothing else can.
  *
  * Empty by default: has no effect on the normal `npm run dev` / `npm run start`
  * flow, which reads config.extensionScripts as usual.

--- a/server/test/buildExe.test.ts
+++ b/server/test/buildExe.test.ts
@@ -1,0 +1,180 @@
+/**
+ * The build's decisions, without running a build.
+ *
+ * Everything asserted here is a detail whose absence produced a failure nobody could
+ * read: a BOM at byte zero, a missing module format, a Windows file the loader will
+ * not execute, a path silently overwritten.
+ */
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, test } from "node:test";
+import {
+  BuildExeError,
+  carriesSeaSentinel,
+  producedExecutableRuns,
+  buildExecutable,
+  canBuildDirectly,
+  executableName,
+  majorOf,
+  releaseArtifactName,
+  seaConfigBytes,
+  seaConfigFor,
+} from "../src/buildExe.ts";
+
+describe("the generated SEA config", () => {
+  test("declares the module format the bundle needs", () => {
+    // Without it Node loads an ESM bundle as CommonJS and it dies on its first import
+    assert.equal(seaConfigFor("/x/bundle.mjs", "/x/out").mainFormat, "module");
+  });
+
+  test("is written as UTF-8 with no byte order mark", () => {
+    // PowerShell's Out-File -Encoding utf8 adds one, and Node's JSON parser dies on
+    // byte zero of a file that looks perfect in an editor. This is that bug's test.
+    const bytes = seaConfigBytes(seaConfigFor("/x/bundle.mjs", "/x/out"));
+    assert.notDeepEqual([...bytes.subarray(0, 3)], [0xef, 0xbb, 0xbf]);
+    assert.equal(bytes[0], "{".charCodeAt(0));
+    assert.deepEqual(JSON.parse(bytes.toString("utf8")).main, "/x/bundle.mjs");
+  });
+
+  test("silences the experimental warning, which is not news to anyone running this", () => {
+    assert.equal(seaConfigFor("/x/bundle.mjs", "/x/out").disableExperimentalSEAWarning, true);
+  });
+});
+
+describe("what the platform will execute", () => {
+  test("Windows gets the suffix its loader requires", () => {
+    assert.equal(executableName("pi-outpost", "win32"), "pi-outpost.exe");
+  });
+
+  test("everywhere else does not", () => {
+    assert.equal(executableName("pi-outpost", "darwin"), "pi-outpost");
+    assert.equal(executableName("pi-outpost", "linux"), "pi-outpost");
+  });
+
+  test("a release artifact names the platform it is for", () => {
+    // So that which file to download is legible without reading documentation
+    assert.equal(releaseArtifactName("0.10.0", "darwin", "arm64"), "pi-outpost-0.10.0-macos-arm64");
+    assert.equal(releaseArtifactName("0.10.0", "linux", "x64"), "pi-outpost-0.10.0-linux-x64");
+    assert.equal(releaseArtifactName("0.10.0", "win32", "x64"), "pi-outpost-0.10.0-windows-x64.exe");
+  });
+});
+
+describe("which build path is available", () => {
+  test("--build-sea needs Node 26", () => {
+    assert.equal(canBuildDirectly("v26.0.0"), true);
+    assert.equal(canBuildDirectly("v28.3.1"), true);
+    assert.equal(canBuildDirectly("v24.9.0"), false);
+    assert.equal(majorOf("v24.9.0"), 24);
+  });
+});
+
+describe("refusing rather than shipping something broken", () => {
+  const withTempDir = (body: (dir: string) => void) => {
+    const dir = mkdtempSync(path.join(tmpdir(), "pi-outpost-buildexe-"));
+    try {
+      body(dir);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  };
+
+  test("an existing file is left alone, and the option that would replace it is named", () => {
+    withTempDir((dir) => {
+      const target = path.join(dir, "pi-outpost");
+      writeFileSync(target, "not an executable");
+      assert.throws(
+        () => buildExecutable({ out: target, cwd: dir }),
+        (error: unknown) => error instanceof BuildExeError && /--force/.test((error as Error).message),
+      );
+      // and it really is untouched
+      assert.equal(readFileSync(target, "utf8"), "not an executable");
+    });
+  });
+
+  test("nothing to build from is said plainly, not left as an ENOENT", () => {
+    withTempDir((dir) => {
+      assert.throws(
+        // Inputs looked for in an empty directory: what an already-built executable
+        // looks like when someone asks it to build another one. Pointed there
+        // explicitly, or this repo's own cli/dist would answer and the assertion
+        // would pass for a reason that has nothing to do with the message.
+        () =>
+          buildExecutable({
+            out: path.join(dir, "pi-outpost"),
+            cwd: dir,
+            inputsFrom: dir,
+            nodeVersion: "v26.0.0",
+          }),
+        (error: unknown) => error instanceof BuildExeError && /not from an executable/.test((error as Error).message),
+      );
+    });
+  });
+
+  test("too old a Node with no blob to fall back on names the version it needs", () => {
+    withTempDir((dir) => {
+      writeFileSync(path.join(dir, "pi-outpost.sea.mjs"), "// a bundle, but no blob beside it");
+      assert.throws(
+        () =>
+          buildExecutable({
+            out: path.join(dir, "pi-outpost"),
+            cwd: dir,
+            inputsFrom: dir,
+            nodeVersion: "v24.9.0",
+          }),
+        (error: unknown) => error instanceof BuildExeError && /26/.test((error as Error).message),
+      );
+    });
+  });
+});
+
+describe("proving the result before calling it produced", () => {
+  test("a runnable binary passes and its output is kept", () => {
+    // node --version is the same shape as the check the build runs on its own output
+    const verdict = producedExecutableRuns(process.execPath);
+    assert.equal(verdict.ok, true);
+    assert.match(verdict.detail, /^v\d+\./);
+  });
+
+  test("something that is not an executable fails rather than throwing", () => {
+    const verdict = producedExecutableRuns(path.join(tmpdir(), "definitely-not-here-pi-outpost"));
+    assert.equal(verdict.ok, false);
+    assert.ok(verdict.detail.length > 0);
+  });
+});
+
+describe("whether a runtime can host an injected blob", () => {
+  test("a node built without single-executable support is detected, not left to postject", () => {
+    // Homebrew's node@24 carries no sentinel; postject's own message for that reads
+    // like a corrupt download rather than an unsupported runtime.
+    assert.equal(typeof carriesSeaSentinel(process.execPath), "boolean");
+  });
+
+  test("a file with no sentinel in it answers false", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "pi-outpost-sentinel-"));
+    try {
+      const plain = path.join(dir, "plain.bin");
+      writeFileSync(plain, Buffer.alloc(4 << 20, 7));
+      assert.equal(carriesSeaSentinel(plain), false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a sentinel straddling a chunk boundary is still found", () => {
+    // The scan reads a megabyte at a time; a marker split across two reads is the
+    // one case a naive chunked search misses.
+    const dir = mkdtempSync(path.join(tmpdir(), "pi-outpost-sentinel-"));
+    try {
+      const straddling = path.join(dir, "straddling.bin");
+      const fuse = Buffer.from("NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2");
+      const buffer = Buffer.alloc((1 << 20) + fuse.length + 16, 7);
+      fuse.copy(buffer, (1 << 20) - Math.floor(fuse.length / 2));
+      writeFileSync(straddling, buffer);
+      assert.equal(carriesSeaSentinel(straddling), true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/server/test/buildExe.test.ts
+++ b/server/test/buildExe.test.ts
@@ -13,6 +13,7 @@ import { describe, test } from "node:test";
 import {
   BuildExeError,
   carriesSeaSentinel,
+  SEA_SENTINEL_FUSE,
   producedExecutableRuns,
   buildExecutable,
   canBuildDirectly,
@@ -176,5 +177,19 @@ describe("whether a runtime can host an injected blob", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("the module does not poison the binary it builds", () => {
+  test("the sentinel never appears as a literal in the source", () => {
+    // This module is inlined into the bundle that becomes the executable. A literal
+    // here puts a second sentinel inside the binary Node is asked to inject into,
+    // and Node refuses: "found more than one occurrence of sentinel". It broke three
+    // CI runners at once, and nothing local reproduced it.
+    const source = readFileSync(new URL("../src/buildExe.ts", import.meta.url), "utf8");
+    const assembled = "NODE_SEA_FUSE_" + "fce680ab2cc467b6" + "e072b8b5df1996b2";
+    assert.equal(source.includes(assembled), false, "buildExe.ts must assemble the sentinel, never spell it");
+    // and what it assembles is still the right string
+    assert.equal(SEA_SENTINEL_FUSE, assembled);
   });
 });

--- a/server/test/cli.test.ts
+++ b/server/test/cli.test.ts
@@ -12,7 +12,7 @@ const emptyFlags = () => ({
   port: undefined,
   host: undefined,
 });
-import { parseCli, runInit, CliError } from "../src/cli.ts";
+import { parseCli, runInit, CliError, helpText } from "../src/cli.ts";
 
 // ---------------------------------------------------------------------------
 // parseCli
@@ -233,5 +233,38 @@ describe("runInit", () => {
     } finally {
       rmSync(tmpDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("build-exe and the browser flags", () => {
+  test("the subcommand is recognised with its own options", () => {
+    const parsed = parseCli(["build-exe", "--out", "./dist/pi", "--force"]);
+    assert.equal(parsed.command, "build-exe");
+    assert.equal(parsed.buildExe.out, "./dist/pi");
+    assert.equal(parsed.buildExe.force, true);
+  });
+
+  test("help lists it", () => {
+    const help = helpText();
+    assert.match(help, /build-exe/);
+    assert.match(help, /--out <path>/);
+    assert.match(help, /--no-open/);
+  });
+
+  test("a flag belonging to another command is an error, not silence", () => {
+    // Silently starting a server because --out was ignored is the worse outcome
+    assert.throws(() => parseCli(["--out", "./pi"]), CliError);
+    assert.throws(() => parseCli(["build-exe", "--provider", "anthropic"]), CliError);
+    assert.throws(() => parseCli(["build-exe", "--global"]), CliError);
+  });
+
+  test("the two browser flags cannot both be given", () => {
+    assert.throws(() => parseCli(["--open", "--no-open"]), CliError);
+  });
+
+  test("neither flag leaves the decision to configuration", () => {
+    assert.equal(parseCli([]).open, undefined);
+    assert.equal(parseCli(["--open"]).open, true);
+    assert.equal(parseCli(["--no-open"]).open, false);
   });
 });

--- a/server/test/harness.mjs
+++ b/server/test/harness.mjs
@@ -74,6 +74,10 @@ export async function startServer(root, config = {}, options = {}) {
     noSkills: true,
     noPromptTemplates: true,
     webContext: false,
+    // A test starts a real server, and a real server opens a browser. Sixty of them
+    // opened sixty tabs on the developer's desktop the first time this shipped — the
+    // suite is a deployment that must never open one, and says so.
+    openBrowser: false,
     ...config,
     server: { host: "127.0.0.1", ...config.server, port },
   };

--- a/server/test/openBrowser.test.ts
+++ b/server/test/openBrowser.test.ts
@@ -1,0 +1,68 @@
+/**
+ * When a browser is opened, and where it is sent.
+ *
+ * The decision is the interesting part. The obvious test — "is there a terminal" —
+ * gets the case that most needs opening exactly backwards, so it is asserted here in
+ * both directions.
+ */
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { browsableUrl, openBrowser, shouldOpenBrowser } from "../src/openBrowser.ts";
+
+describe("whether to open a browser", () => {
+  test("a desktop platform opens by default", () => {
+    assert.equal(shouldOpenBrowser({ platform: "darwin", env: {} }), true);
+    assert.equal(shouldOpenBrowser({ platform: "win32", env: {} }), true);
+  });
+
+  test("no terminal is not the absence of a person", () => {
+    // A double-clicked executable has no TTY and is exactly the case that needs
+    // opening: there is no terminal for the address to be printed to.
+    assert.equal(shouldOpenBrowser({ platform: "darwin", env: {} }), true);
+  });
+
+  test("Linux needs a display server to be named", () => {
+    assert.equal(shouldOpenBrowser({ platform: "linux", env: {} }), false);
+    assert.equal(shouldOpenBrowser({ platform: "linux", env: { DISPLAY: ":0" } }), true);
+    assert.equal(shouldOpenBrowser({ platform: "linux", env: { WAYLAND_DISPLAY: "wayland-0" } }), true);
+  });
+
+  test("a runner never has anyone watching", () => {
+    assert.equal(shouldOpenBrowser({ platform: "darwin", env: { CI: "true" } }), false);
+    // and CI=false is how some runners say "not one"
+    assert.equal(shouldOpenBrowser({ platform: "darwin", env: { CI: "false" } }), true);
+  });
+
+  test("configuration overrides the platform, and the flags override both", () => {
+    assert.equal(shouldOpenBrowser({ platform: "darwin", env: {}, configured: false }), false);
+    assert.equal(shouldOpenBrowser({ platform: "linux", env: {}, configured: true }), true);
+    assert.equal(shouldOpenBrowser({ platform: "darwin", env: {}, configured: false, explicit: true }), true);
+    assert.equal(shouldOpenBrowser({ platform: "linux", env: { DISPLAY: ":0" }, explicit: false }), false);
+    // even where nothing could show it: an explicit request is answered, not second-guessed
+    assert.equal(shouldOpenBrowser({ platform: "linux", env: { CI: "true" }, explicit: true }), true);
+  });
+});
+
+describe("where the browser is sent", () => {
+  test("the bound port, which is the only true one when the OS chose it", () => {
+    assert.equal(browsableUrl({ address: "127.0.0.1", port: 51234 }), "http://127.0.0.1:51234/");
+  });
+
+  test("a wildcard bind is not an address a browser can reach", () => {
+    assert.equal(browsableUrl({ address: "0.0.0.0", port: 3141 }), "http://127.0.0.1:3141/");
+    assert.equal(browsableUrl({ address: "::", port: 3141 }), "http://127.0.0.1:3141/");
+  });
+
+  test("a literal IPv6 address gets its brackets back", () => {
+    assert.equal(browsableUrl({ address: "::1", port: 3141 }), "http://[::1]:3141/");
+  });
+});
+
+describe("launching it", () => {
+  test("an opener that is not there answers false rather than throwing", async () => {
+    // Asked for the Linux opener on a machine that has none: the caller must get a
+    // verdict it can print, not an exception that would take the server down with it.
+    const opened = await openBrowser("http://127.0.0.1:3141/", "linux");
+    assert.equal(typeof opened, "boolean");
+  });
+});

--- a/server/test/seaExtensionImports.test.ts
+++ b/server/test/seaExtensionImports.test.ts
@@ -1,0 +1,90 @@
+/**
+ * What lets an extension reach the agent's own packages inside an executable.
+ *
+ * There are no node_modules beside a single-file executable, so an extension that
+ * imports `typebox` or `@earendil-works/pi-coding-agent` has nothing on disk to
+ * resolve. jiti's `virtualModules` answers those specifiers with module objects that
+ * are already in the bundle, and the SDK already builds that map — it just selects
+ * it on `isBunBinary`, which a Node SEA is not. Both build scripts patch that one
+ * condition.
+ *
+ * A patch that matches by string is a patch that stops matching. These tests assert
+ * the anchors against the SDK as installed, so an upgrade that moves them fails here
+ * — in a suite that runs on every push — rather than at release time, or worse, in
+ * an executable where extension loading is quietly dead.
+ *
+ * The end-to-end proof cannot live here: it needs Node >= 26, a full SEA build of
+ * several minutes, and a runtime whose single-executable support works. It was run
+ * by hand, and what it printed is in the commit that introduced this.
+ */
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "node:test";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(HERE, "../..");
+const LOADER = path.join(REPO, "node_modules/@earendil-works/pi-coding-agent/dist/core/extensions/loader.js");
+
+/** The exact text both build scripts rewrite. Written once, asserted everywhere. */
+const BRANCH = "...isBunBinary ? { virtualModules: VIRTUAL_MODULES, tryNative: false }";
+
+describe("the SDK still has the shape both build patches assume", () => {
+  test("the loader chooses jiti's virtual modules on the bundled-binary branch", () => {
+    const loader = readFileSync(LOADER, "utf8");
+    // The bundled form differs from the source only in whitespace; both scripts
+    // patch the bundled one, so assert on what is actually there to be patched.
+    assert.match(loader, /isBunBinary\s*\?\s*\{\s*virtualModules:\s*VIRTUAL_MODULES,\s*tryNative:\s*false\s*\}/);
+  });
+
+  test("virtual modules carry the packages an extension would import", () => {
+    const loader = readFileSync(LOADER, "utf8");
+    for (const specifier of ["typebox", "@earendil-works/pi-tui", "@earendil-works/pi-coding-agent"]) {
+      assert.ok(loader.includes(`"${specifier}"`), `${specifier} is no longer offered to extensions`);
+    }
+  });
+
+  test("getAliases still resolves through the filesystem, which is why it cannot answer inside an executable", () => {
+    // If this ever stops being true, the patch is solving a problem that moved.
+    const loader = readFileSync(LOADER, "utf8");
+    assert.match(loader, /function getAliases\(\)/);
+    assert.match(loader, /require\.resolve\("typebox"\)/);
+  });
+});
+
+describe("both build scripts patch that branch", () => {
+  const scripts = [
+    path.join(REPO, "server/scripts/build-sea.mjs"),
+    // Two bundles produce an executable — the blob and the one `--build-sea` reads.
+    // Patching one leaves extensions working on whichever path a machine took.
+    path.join(REPO, "cli/scripts/build.mjs"),
+  ];
+
+  for (const script of scripts) {
+    test(`${path.relative(REPO, script)} rewrites the condition and refuses to run silently if it moved`, () => {
+      const source = readFileSync(script, "utf8");
+      assert.ok(source.includes(BRANCH), "the anchor this script searches for is not the SDK's text");
+      assert.match(source, /__piOutpostIsSea\(\)/);
+      assert.match(source, /node:sea/);
+      // A patch that finds nothing must stop the build, not produce an executable
+      // whose extensions cannot import anything.
+      assert.match(source, /throw new Error\(.*jiti branch moved/);
+    });
+  }
+});
+
+describe("what a built bundle carries", () => {
+  const bundles = [path.join(REPO, "server/dist/bundle.mjs"), path.join(REPO, "cli/dist/pi-outpost.sea.mjs")];
+
+  for (const bundle of bundles) {
+    test(`${path.relative(REPO, bundle)} takes the virtual-modules branch when it is an executable`, (t) => {
+      // Skipped rather than failed where nothing has been built: this suite runs
+      // on a checkout with no dist/, and a red test there would say nothing true.
+      if (!existsSync(bundle)) return t.skip("not built here");
+      const built = readFileSync(bundle, "utf8");
+      assert.match(built, /isBunBinary \|\| __piOutpostIsSea\(\)/);
+      assert.match(built, /function __piOutpostIsSea\(\)/);
+    });
+  }
+});


### PR DESCRIPTION
OpenSpec change: `openspec/changes/ship-standalone-executables`. Three commits, one thread: make a single-file pi-outpost reachable, make starting one land you in it, and make an extension beside it able to do real work.

## `pi-outpost build-exe`

Replaces the procedure in `docs/sea-packaging.md`. Every documented failure of that procedure was a detail of a file the operator had to write by hand — a byte order mark PowerShell adds and Node's JSON parser dies on, a missing `mainFormat` that loads an ESM bundle as CommonJS, an output name Windows will not execute. None of it is theirs to get right now.

It refuses rather than hands over something broken, and each refusal is a failure someone already hit:

- a node built without single-executable support (Homebrew's `node@24` carries no sentinel, and postject's message for that reads like a corrupt download);
- a copy of a node binary that came out `r-xr-xr-x`, which injection cannot write to;
- a target it would overwrite unasked.

**And it runs what it just built before calling it built.** That check earned its keep immediately: on macOS 15.7 x64 with Node 26.7, `--build-sea` produces an executable that segfaults on its first invocation — a one-line hello-world reproduces it, while the blob injected into the same runtime runs. So the command falls back **on evidence**, not on a list of afflicted platforms that would rot.

## Starting the server opens the interface

At the address it actually bound — the only true one when the configuration asked for port `0`, where the startup line used to print `http://127.0.0.1:0/`.

The decision keys on whether a **desktop session** exists, not on whether a terminal is attached: an executable launched from a file manager has no terminal and is exactly the case that needs opening. Nothing opens where nothing can show it (no display, a container, CI), `--open` / `--no-open` and an `openBrowser` config key decide it explicitly, and a browser that will not start never stops the server.

A server that serves no interface of its own opens nothing either — in development the UI comes from Vite on another port. That one was found the hard way: the test harness starts a server per integration test, and the first run of this opened a tab per test on a real desktop.

## Extensions with real npm imports

An extension beside an executable can now `import { Type } from "typebox"` and `import * as agent from "@earendil-works/pi-coding-agent"`.

The mechanism already existed: jiti takes a `virtualModules` map of specifier → already-loaded module object, the SDK builds that map from static imports, and selects it when `isBunBinary`. A Node SEA is not that, so it fell through to `getAliases()`, whose `require.resolve` throws in a blob. The patch is that one condition. Both build scripts carry it — two bundles become an executable, and patching one leaves extensions working on whichever path a machine took.

Verified in a produced executable, not inferred: the extension imported both packages (145 exports), registered a tool, and **the agent called it**. The tool writes a file on purpose — a tool that returns text proves it was declared; a file proves it was executed.

## Releases

A matrix job builds an executable per platform (macOS arm64 and x64, Linux x64, Windows x64) and **gates the publish** rather than following it: a version on npm whose release page has nothing to download is worse than a release that stopped. Runnable from a branch through `workflow_dispatch`, because this is the half of the pipeline a laptop cannot judge.

The distributed blob carries `mainFormat` again. Removing it was the fix for #14 — an older node asserts on a format byte it does not know — but the bundle is ESM, so without it the injected executable dies on its first `import`. A blob nobody can use is not a compatible blob; the requirement is stated instead: **Node ≥ 26**, the same version `--build-sea` needs.

## Checks

- `npm run typecheck`, `npm run lint` — clean
- server suite **1257 passing**, including 7 tests that fail on every push if the SDK moves the anchors these patches match
- an executable built here runs, serves the interface from its embedded bundle (190 assets, nothing beside it), prints its real port, and opens the browser

**Still open, deliberately:** the release matrix has not gone green yet — the first run failed because this branch's own sentinel check put a second fuse inside the binary (fixed, `8e51947`), and the re-run is queued. Do not merge before it passes; that job is the only evidence for the download half.

Coordination: `add-cli-update-command` modifies the same `CliFlags` requirement and the same argument parser. Whichever lands second folds in the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)