### PR TITLE
chore(release): v0.11.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-outpost",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "description": "A web interface for the pi coding agent: a browser chat UI you run with npx — no clone, no build.",
   "license": "MIT",

--- a/embed/package.json
+++ b/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-outpost/embed",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "description": "Mount pi-outpost as a Shadow-DOM-isolated widget inside another web app.",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
     },
     "cli": {
       "name": "pi-outpost",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "^0.84.1",
@@ -44,7 +44,7 @@
     },
     "embed": {
       "name": "@pi-outpost/embed",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "devDependencies": {
         "@microsoft/api-extractor": "^7.58.9",


### PR DESCRIPTION
Version bump only — `cli` and `embed` 0.10.0 → 0.11.0, plus the lock. Everything it releases is already on `main` (#84).

## What v0.11.0 ships

- **`pi-outpost build-exe`** — one command produces a standalone executable from an installed package. It writes the SEA config itself (the module format, an encoding without a BOM, a name the platform will execute), signs the result where that is what makes it launchable, and **runs what it built before calling it built**. It refuses rather than hand over something broken, and falls back from `--build-sea` to the shipped blob on evidence — a machine whose `--build-sea` segfaults still gets a working executable.
- **Starting the server opens the interface** at the address it actually bound. The decision keys on a desktop session, not on a terminal, so a double-clicked executable opens where a printed address would have been read by nobody. `--open` / `--no-open` and an `openBrowser` config key decide it explicitly; a browser that will not start never stops the server.
- **Extensions can import the agent's own packages inside an executable** — `typebox`, `@earendil-works/pi-tui`, `@earendil-works/pi-coding-agent` — with no `node_modules` beside the binary. Verified end to end: an external extension registered a tool and the agent called it.
- **Executables attached to every release**, built per platform, gating the publish rather than following it.
- The distributed blob carries its module format again; the SEA paths want **Node ≥ 26**.

## Before tagging

`release.yml` now builds four executables and each one runs itself before upload — so the tag cannot publish a version whose release page has nothing to download. That matrix has not yet completed a full green run: the dispatch on this branch's parent was still queued at the time of writing. **Wait for it before pushing the tag**, or the first real proof arrives during the release rather than before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)