### PR TITLE
ci(release): drop the retired Intel macOS runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,12 @@ jobs:
         include:
           - runner: macos-latest
             arch: arm64
-          - runner: macos-13
-            arch: x64
+          # No Intel macOS build. `macos-13` was the last x64 label and GitHub has
+          # retired it: a job requesting it does not fail, it queues until the 24h
+          # timeout — which would hang `publish`, since the publish waits on this
+          # matrix. `macos-15-intel` is the successor label and is worth adding
+          # once someone has watched a job actually start on it; queuing forever is
+          # not a thing to discover on a tag.
           - runner: ubuntu-latest
             arch: x64
           - runner: windows-latest

--- a/docs/sea-packaging.md
+++ b/docs/sea-packaging.md
@@ -12,7 +12,12 @@ inlined at build time into the bundle.
 
 **Download it.** Every release carries an executable per platform, under
 [Releases](https://github.com/laurentftech/pi-outpost/releases): `pi-outpost-<version>-macos-arm64`,
-`-macos-x64`, `-linux-x64`, `-windows-x64.exe`. Nothing installed, nothing built.
+`-linux-x64`, `-windows-x64.exe`. Nothing installed, nothing built.
+
+No Intel macOS build: GitHub retired the `macos-13` runner, and a job asking for it
+queues until it times out rather than failing. On an Intel Mac, build your own with
+`npx pi-outpost build-exe` — it works, and it is what produced the executables this
+feature was tested with.
 
 They are **not signed for distribution**. macOS Gatekeeper and Windows SmartScreen
 both warn on a downloaded unsigned binary; on macOS you clear it with


### PR DESCRIPTION
`macos-13` is retired. A job asking for a retired label does not fail — it **queues until the 24-hour timeout**. The matrix dispatched for #84 sat there five hours while `ubuntu-latest`, `macos-latest` (arm64) and `windows-latest` all went green.

That is not a missing artifact, it is a stuck release: `publish` has `needs: executables`, so pushing `v0.11.0` today would hang and publish nothing.

- matrix: macOS arm64, Linux x64, Windows x64
- docs: stop promising an Intel download; point Intel Mac users at `npx pi-outpost build-exe`, which is what produced the executables this feature was tested with
- `macos-15-intel` is the successor label — worth adding once someone has watched a job actually start on it

Blocks the v0.11.0 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)