### PR TITLE
Run the server suite on Linux the way CI runs it

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,22 @@ npm run dev
 npm run test --workspace server        # integration tests: no model auth needed, no tokens spent
 npm run test --workspace ui            # component unit tests (vitest, jsdom, testing-library)
 npm run test:live --workspace server   # drives real agent turns (needs model auth, costs tokens)
+npm run test:linux                     # the server suite on Linux, non-root, the way CI runs it
 ```
+
+`test:linux` needs Docker and exists for one class of bug that a macOS or Windows
+checkout cannot see, because it does not fail there — it *passes* there. A test asserting
+"this path cannot be written" by naming `/proc/...` succeeds instantly where there is no
+`/proc`, and on Linux the write never returns; the runner then reports every test as
+passing and prints no summary, because a test file that never exits never reports. Run it
+before pushing anything that touches paths, permissions, signals, or file watching.
+
+It runs as a non-root user on purpose: as root, every "refuses an unwritable path"
+assertion in this repository passes for the wrong reason. Dependencies are cached in a
+Docker volume and reinstalled only when `package-lock.json` changes, so a second run costs
+about what a local one does. `--fresh` ignores that cache; `--shell` drops you into the
+same container; any other arguments replace the command (`npm run test:linux -- npm test
+--workspace ui`).
 
 Server integration tests boot a real server against a throwaway workspace (isolated `agentDir` — your
 sessions and extensions are never touched) and talk to it over HTTP/WebSocket. See `server/test/README.md`.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "check:css": "node scripts/check-web-css.mjs",
     "check:embed": "node scripts/check-embed-package.mjs",
     "check:cli": "node scripts/check-cli-package.mjs",
+    "test:linux": "node scripts/test-linux.mjs",
     "build:e2e-host": "vite build --config e2e/vite.config.ts",
     "test:e2e": "npm run build:e2e-host && playwright test --config e2e/playwright.config.ts",
     "bench": "tsx scripts/embed-bench.mts"

--- a/scripts/test-linux.mjs
+++ b/scripts/test-linux.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * Run the server suite on Linux, as a non-root user, the way CI does.
+ *
+ * There is one class of bug this repository cannot see from a developer's machine,
+ * and it does not fail loudly — it fails *silently green*. A test that asserts
+ * "this path cannot be written" by naming `/proc/...` passes on macOS and Windows
+ * because there is no `/proc` to reach, and on Linux the write never returns. The
+ * suite then prints every test as passing and produces no summary at all, because a
+ * test file that never exits never reports. That cost four CI rounds and three
+ * commits that fixed the wrong thing; a container named the file on its first run.
+ *
+ * Two details are what make this worth running rather than decorative:
+ *
+ * - **Non-root.** GitHub's runners are not root, and root is not a stricter test —
+ *   it is a weaker one. As root, every "refuses an unwritable path" assertion in
+ *   this repository passes for the wrong reason, including the one that was broken.
+ * - **Cached dependencies.** `npm ci` is most of the wall time, so it runs only when
+ *   `package-lock.json` has actually changed. Without that this takes six minutes and
+ *   nobody runs it.
+ *
+ * What this is not: `ubuntu-latest`. It is `node:24-bookworm` — the same major Node
+ * and the same kernel interfaces, which is what the failing class depends on, but not
+ * a byte-for-byte runner image.
+ *
+ * Usage:
+ *   npm run test:linux                    # the server suite, as CI runs it
+ *   npm run test:linux -- --shell         # a shell in the same container, to poke about
+ *   npm run test:linux -- npm test --workspace ui
+ *   npm run test:linux -- --fresh         # ignore the dependency cache
+ */
+import { execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+const IMAGE = "node:24-bookworm";
+const VOLUME = "pi-outpost-linux-deps";
+
+const argv = process.argv.slice(2);
+const fresh = argv.includes("--fresh");
+const shell = argv.includes("--shell");
+const rest = argv.filter((arg) => arg !== "--fresh" && arg !== "--shell");
+const command = rest.length > 0 ? rest.join(" ") : "npm test --workspace server";
+
+const die = (message, detail) => {
+  console.error(`[test-linux] ${message}`);
+  if (detail) console.error(`\n${detail}`);
+  process.exit(1);
+};
+
+if (spawnSync("docker", ["info"], { stdio: "ignore" }).status !== 0) {
+  die(
+    "docker is not available (or its daemon is not running).",
+    "This is the one check that cannot be done from macOS: it needs a Linux kernel.\n" +
+      "Start Docker Desktop, or run the suite on CI and read the job log instead.",
+  );
+}
+
+// The lock file decides whether the cached dependencies are still the right ones.
+// Anything else — a source edit, a new test — costs nothing and reuses them.
+const lockHash = createHash("sha256").update(readFileSync(path.join(ROOT, "package-lock.json"))).digest("hex");
+
+/**
+ * Everything below runs inside the container.
+ *
+ * The source tree is copied in rather than mounted read-write, so a run cannot write
+ * back into the working tree — a Linux `node_modules` landing in a macOS checkout is
+ * a mess to notice and a worse one to undo. `node_modules` is the exception: it is a
+ * named volume, which is what makes a second run fast.
+ */
+const script = `
+set -euo pipefail
+
+echo "[test-linux] copying the working tree (node_modules excluded) …"
+mkdir -p /w
+cd /src
+tar cf - --exclude=./node_modules --exclude=./.git --exclude='*/node_modules' . | (cd /w && tar xf -)
+cd /w
+
+STAMP=/w/node_modules/.pi-outpost-lock-hash
+if [ "${fresh ? "1" : "0"}" = "1" ] || [ ! -f "$STAMP" ] || [ "$(cat "$STAMP" 2>/dev/null)" != "${lockHash}" ]; then
+  echo "[test-linux] package-lock.json changed (or --fresh) — installing dependencies …"
+  npm ci --no-audit --no-fund
+  echo "${lockHash}" > "$STAMP"
+else
+  echo "[test-linux] dependencies are current for this lock file — reusing them"
+fi
+
+# Not root. As root the "refuses an unwritable path" tests pass for the wrong reason,
+# which is exactly how the bug this exists for stayed invisible.
+id -u runner >/dev/null 2>&1 || useradd -m runner
+chown -R runner /w
+
+echo "[test-linux] running as: ${shell ? "an interactive shell" : command}"
+${
+  shell
+    ? 'exec su runner -s /bin/bash'
+    : `su runner -s /bin/bash -c ${JSON.stringify(`cd /w && ${command}`)}`
+}
+`;
+
+const args = [
+  "run",
+  "--rm",
+  ...(shell ? ["-it"] : []),
+  "-v",
+  `${ROOT}:/src:ro`,
+  "-v",
+  `${VOLUME}:/w/node_modules`,
+  "-w",
+  "/w",
+  IMAGE,
+  "bash",
+  "-c",
+  script,
+];
+
+const started = Date.now();
+const run = spawnSync("docker", args, { stdio: "inherit" });
+const seconds = Math.round((Date.now() - started) / 1000);
+
+if (run.status === 0) {
+  console.log(`\n[test-linux] passed on Linux, as a non-root user (${seconds}s)`);
+  process.exit(0);
+}
+
+// 124 is `timeout`'s; a suite that hangs is the failure mode this exists for, so it
+// gets its own sentence rather than an exit code nobody recognises.
+if (run.status === 124) {
+  die(
+    `the suite hung on Linux and was killed (${seconds}s).`,
+    "A test file that never exits never reports, so the runner will have printed every\n" +
+      "test as passing and no summary. The culprit is NOT the last file listed — that is\n" +
+      "merely the last one that finished. Re-run with a per-test timeout to name it:\n" +
+      "  npm run test:linux -- npm test --workspace server",
+  );
+}
+
+die(`failed on Linux (exit ${run.status}, ${seconds}s).`, "The output above is the container's, verbatim.");


### PR DESCRIPTION
Adds `npm run test:linux`.

## Why

There is one class of bug this repository cannot see from a macOS checkout, because it does not fail there — it **passes** there.

A test asserting "this path cannot be written" by naming `/proc/...` succeeds instantly where there is no `/proc`. On Linux the write never returns, and since a test file that never exits never *reports*, the runner prints every test as passing, produces no summary, and the job has to be cancelled with nothing in the log naming the file.

That is what happened to #90: four CI rounds and three commits that fixed the wrong thing, each looking like it was converging because the suite kept passing locally — which was the problem, not evidence against it. A container named the file on its first honest run.

## What makes it worth running rather than decorative

- **Non-root.** GitHub's runners are not root, and root is the *weaker* test: as root, every "refuses an unwritable path" assertion in this repository passes for the wrong reason — including the one that was broken.
- **Cached dependencies.** `npm ci` was most of the wall time. It now reinstalls only when `package-lock.json` changes.

Measured: **156s cold, 111s warm**, against ~125s for the same suite locally. A Linux check costs about what a local run does, which is the only reason anyone will run it.

## Usage

```bash
npm run test:linux                      # the server suite, as CI runs it
npm run test:linux -- --fresh           # ignore the dependency cache
npm run test:linux -- --shell           # a shell in the same container
npm run test:linux -- npm test --workspace ui
```

Run it before pushing anything touching paths, permissions, signals, or file watching.

## Limits, stated

It is `node:24-bookworm`, not `ubuntu-latest` — same major Node and the same kernel interfaces, which is what this class of failure depends on, but not the runner image byte for byte. The cached `node_modules` volume is keyed on the lock file's hash, so it cannot silently drift; `--fresh` forces a reinstall.

The source tree is copied in rather than mounted read-write, so a run cannot leave a Linux `node_modules` in your macOS checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)