### PR TITLE
Fix two ways CI fails with every test passing

### DIFF
--- a/server/src/update.ts
+++ b/server/src/update.ts
@@ -154,6 +154,23 @@ export function resolveRegistry(configured?: string): string {
 const trimSlash = (url: string): string => url.replace(/\/+$/, "");
 
 /** npm's stored registry, or nothing if npm is absent or slow to answer. */
+/**
+ * The environment for a short-lived npm child, without the parent's coverage sink.
+ *
+ * Under `--experimental-test-coverage` node exports NODE_V8_COVERAGE, and any child
+ * that inherits it writes its own coverage file into the same directory. npm is a
+ * large program and these calls have a five-second ceiling, so a slow one is killed
+ * partway through writing — and the parent's reporter then dies on the truncated file
+ * with "failed to parse coverage". Every test passes and the job fails anyway, naming
+ * nothing. The same reasoning as server/test/harness.mjs, at the other spawn site.
+ *
+ * Nothing is lost: npm's own coverage was never attributable to this project.
+ */
+function envForNpm(): NodeJS.ProcessEnv {
+  const { NODE_V8_COVERAGE: _sink, ...rest } = process.env;
+  return rest;
+}
+
 let npmRegistryMemo: { value: string | undefined } | undefined;
 
 function npmConfiguredRegistry(): string | undefined {
@@ -172,6 +189,7 @@ function npmConfiguredRegistry(): string | undefined {
       timeout: 5_000,
       stdio: ["ignore", "pipe", "ignore"],
       shell: false,
+      env: envForNpm(),
     }).trim();
     // npm prints "undefined" rather than nothing when a key is unset.
     npmRegistryMemo.value = out && out !== "undefined" && out !== "null" ? out : undefined;
@@ -651,6 +669,7 @@ function globalNodeModules(): string | undefined {
       timeout: 5_000,
       stdio: ["ignore", "pipe", "ignore"],
       shell: false,
+      env: envForNpm(),
     }).trim();
     globalRootMemo.value = out && out !== "undefined" ? out : undefined;
     return globalRootMemo.value;

--- a/server/test/fileWatcher.test.ts
+++ b/server/test/fileWatcher.test.ts
@@ -62,9 +62,18 @@ function recorder() {
   };
 }
 
-/** Long enough that a coalescing window has certainly closed. */
+/**
+ * Long enough that a coalescing window has certainly closed.
+ *
+ * Generously so, and deliberately not `COALESCE_MS * 4`. That was 100 ms, which is
+ * ample on an idle laptop and not always ample on a CI runner doing three other
+ * things: a setup-era announcement then arrives *after* the drain and lands in the
+ * next assertion, which reads as the watcher announcing something it should not.
+ * Waiting longer costs a few hundred milliseconds across this file and removes a
+ * failure mode that looks exactly like a real defect.
+ */
 function settle(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, COALESCE_MS * 4));
+  return new Promise((resolve) => setTimeout(resolve, Math.max(COALESCE_MS * 12, 300)));
 }
 
 describe("createDirectoryWatcher", () => {
@@ -159,14 +168,27 @@ describe("createDirectoryWatcher", () => {
   test("collapses a burst into one announcement", async () => {
     const root = await workspace();
     const log = recorder();
-    const burstWindowMs = 100;
+    // Wide enough that forty writes provably finish inside it, on a loaded CI runner
+    // as well as here. The window opens on the first event and is never extended, so
+    // a burst that outlives it opens a second one — correctly, and the spec says so:
+    // "at most one notification for that directory *and that window*". With 100 ms
+    // the writes themselves straddled the boundary on Windows, and the test failed
+    // for the one reason that is not a defect.
+    const burstWindowMs = 2_000;
     const watcher = createDirectoryWatcher({ root, onChange: log.onChange, coalesceMs: burstWindowMs });
     try {
       await watcher.watch("");
       // One `npm install` is thousands of these. The client's reaction is to
       // re-list, which is idempotent, so collapsing them costs nothing.
+      const began = Date.now();
       await Promise.all(Array.from({ length: 40 }, (_, i) => writeFile(path.join(root, `f${i}.txt`), "x")));
-      await new Promise((resolve) => setTimeout(resolve, burstWindowMs * 4));
+      const writing = Date.now() - began;
+      assert.ok(
+        writing < burstWindowMs,
+        `the burst took ${writing} ms, which is not inside a ${burstWindowMs} ms window — this test proves nothing`,
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, burstWindowMs + 500));
       assert.deepEqual(log.seen, [""], `expected one announcement, got ${log.seen.length}`);
     } finally {
       watcher.close();

--- a/server/test/update-startup.test.mjs
+++ b/server/test/update-startup.test.mjs
@@ -25,6 +25,12 @@ import { startServer } from "./harness.mjs";
 
 const SERVER_SRC = fileURLToPath(new URL("../src", import.meta.url));
 
+/** The parent's environment, minus the coverage sink a child must not write into. */
+function envWithoutCoverageSink() {
+  const { NODE_V8_COVERAGE: _sink, ...rest } = process.env;
+  return rest;
+}
+
 /**
  * A registry that accepts and never answers, for the duration of one test.
  *
@@ -121,7 +127,12 @@ describe("a check still in flight", () => {
           const child = execFile(
             process.execPath,
             ["--import", "tsx/esm", "--input-type=module", "--eval", script],
-            { cwd: path.dirname(SERVER_SRC), timeout: 9_000 },
+            // NODE_V8_COVERAGE dropped for the reason harness.mjs drops it: a child
+            // that inherits it writes a coverage file the parent's reporter then has
+            // to parse, and a child killed partway through writing one fails the job
+            // with every test passing. This file is not in the coverage glob today;
+            // the guard is here so that stops being load-bearing.
+            { cwd: path.dirname(SERVER_SRC), timeout: 9_000, env: envWithoutCoverageSink() },
             (error) => {
               if (error && error.killed)
                 reject(


### PR DESCRIPTION
`main` is red on two separate causes, and neither of them is a failing test.

## 1. The coverage step, killed by npm's own coverage

```
ℹ Warning: Could not report code coverage. Error [ERR_OPERATION_FAILED]: failed to parse coverage
ℹ tests 1252  pass 1250  fail 0
```

Under `--experimental-test-coverage` node exports `NODE_V8_COVERAGE`, and any child that inherits it writes its own coverage file into the same directory. `resolveRegistry` and the global-root lookup each run npm with a five-second ceiling, so a slow npm is killed partway through writing one — and the parent's reporter dies on the truncated file. The job fails naming nothing, because nothing failed.

`server/test/harness.mjs` already strips the variable for exactly this reason, with the comment that explains it. These are the other spawn sites — added by #90, reached from a file that *is* in the coverage glob (`test/*.test.ts`).

Verified by running the step that failed: `npm run test:coverage --workspace server` now exits 0, reporting 97.10 lines / 87.68 branches / 91.73 functions against thresholds of 92 / 86 / 90.

## 2. The watcher tests, failing on time rather than behaviour

```
✖ collapses a burst into one announcement — expected one announcement, got 2
```

The test is wrong, not the watcher. The window opens on the first event and is never extended, and the spec promises "at most one notification for that directory **and that window**". Writing forty files with a 100 ms window and demanding exactly one announcement asks for something the spec does not offer: on a loaded Windows runner the writes straddle the boundary, a second window opens correctly, and the assertion fails for the one reason that is not a defect.

The window is now two seconds, and the test asserts the burst actually finished inside it before drawing any conclusion — a run that cannot prove anything now says so instead of failing.

`settle()` had the same shape of assumption at `COALESCE_MS * 4` (100 ms). A setup-era announcement arriving after the drain lands in the next assertion and reads as the watcher announcing something it should not, which is how the eviction test flaked locally under full-suite load.

Neither the watcher nor its spec changes. That file goes from ~4s to ~10s, against a 125s suite.

## Verification

Local server suite, `npm run test:coverage --workspace server`, and `npm run test:linux` (Linux, non-root) all green. Watcher file stable over five consecutive runs.

I cannot reproduce the Windows timing locally, so that half rests on repeated runs and on the test now refusing to conclude from a burst that overran its window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)