### PR TITLE
Run the ubuntu leg's coverage step in the Linux container too

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ npm run dev
 npm run test --workspace server        # integration tests: no model auth needed, no tokens spent
 npm run test --workspace ui            # component unit tests (vitest, jsdom, testing-library)
 npm run test:live --workspace server   # drives real agent turns (needs model auth, costs tokens)
-npm run test:linux                     # the server suite on Linux, non-root, the way CI runs it
+npm run test:linux                     # the ubuntu CI leg — suite then coverage — on Linux, non-root
 ```
 
 `test:linux` needs Docker and exists for one class of bug that a macOS or Windows
@@ -101,12 +101,19 @@ checkout cannot see, because it does not fail there — it *passes* there. A tes
 passing and prints no summary, because a test file that never exits never reports. Run it
 before pushing anything that touches paths, permissions, signals, or file watching.
 
+It runs both server steps of the ubuntu leg — `npm test` and then `npm run test:coverage` —
+because each has gone red on its own while the other was green, and coverage runs on no
+other platform. That step failed on `main` with 1250 tests passing and none failing: npm
+children spawned by the code under test inherited `NODE_V8_COVERAGE`, were killed at their
+timeout mid-write, and the parent's reporter died parsing the truncated file. Nothing short
+of running the real step would have shown it.
+
 It runs as a non-root user on purpose: as root, every "refuses an unwritable path"
 assertion in this repository passes for the wrong reason. Dependencies are cached in a
 Docker volume and reinstalled only when `package-lock.json` changes, so a second run costs
 about what a local one does. `--fresh` ignores that cache; `--shell` drops you into the
-same container; any other arguments replace the command (`npm run test:linux -- npm test
---workspace ui`).
+same container; any other arguments replace the command, which is how you run one step at a
+time while iterating (`npm run test:linux -- npm test --workspace server`).
 
 Server integration tests boot a real server against a throwaway workspace (isolated `agentDir` — your
 sessions and extensions are never touched) and talk to it over HTTP/WebSocket. See `server/test/README.md`.

--- a/scripts/test-linux.mjs
+++ b/scripts/test-linux.mjs
@@ -23,10 +23,17 @@
  * and the same kernel interfaces, which is what the failing class depends on, but not
  * a byte-for-byte runner image.
  *
+ * What runs by default is both of the ubuntu leg's server steps — the suite, and then
+ * the coverage run — with CI=true, as the runner sets it. The second step is not a
+ * formality. `main` went red on it with every test passing: npm children spawned by the
+ * code under test inherited `NODE_V8_COVERAGE`, were killed at their timeout mid-write,
+ * and the parent's reporter died on the truncated file. That step is ubuntu-only on CI,
+ * so it is only reachable from here; running `npm test` alone would reproduce nothing.
+ *
  * Usage:
- *   npm run test:linux                    # the server suite, as CI runs it
+ *   npm run test:linux                    # both server steps, as the ubuntu leg runs them
  *   npm run test:linux -- --shell         # a shell in the same container, to poke about
- *   npm run test:linux -- npm test --workspace ui
+ *   npm run test:linux -- npm test --workspace server   # one step, when iterating
  *   npm run test:linux -- --fresh         # ignore the dependency cache
  */
 import { execFileSync, spawnSync } from "node:child_process";
@@ -42,7 +49,10 @@ const argv = process.argv.slice(2);
 const fresh = argv.includes("--fresh");
 const shell = argv.includes("--shell");
 const rest = argv.filter((arg) => arg !== "--fresh" && arg !== "--shell");
-const command = rest.length > 0 ? rest.join(" ") : "npm test --workspace server";
+// The ubuntu leg of CI, in order: the suite, then coverage over the unit suites. Both,
+// because each has failed on its own while the other was green.
+const DEFAULT_COMMAND = "npm test --workspace server && npm run test:coverage --workspace server";
+const command = rest.length > 0 ? rest.join(" ") : DEFAULT_COMMAND;
 
 const die = (message, detail) => {
   console.error(`[test-linux] ${message}`);
@@ -94,10 +104,12 @@ id -u runner >/dev/null 2>&1 || useradd -m runner
 chown -R runner /w
 
 echo "[test-linux] running as: ${shell ? "an interactive shell" : command}"
+# CI=true is set the way the runner sets it: some code declines to open a browser
+# under it, and some tests assert exactly that.
 ${
   shell
-    ? 'exec su runner -s /bin/bash'
-    : `su runner -s /bin/bash -c ${JSON.stringify(`cd /w && ${command}`)}`
+    ? `exec su runner -s /bin/bash -c ${JSON.stringify("export CI=true; cd /w; exec bash")}`
+    : `su runner -s /bin/bash -c ${JSON.stringify(`cd /w && export CI=true && ${command}`)}`
 }
 `;
 
@@ -133,7 +145,7 @@ if (run.status === 124) {
     `the suite hung on Linux and was killed (${seconds}s).`,
     "A test file that never exits never reports, so the runner will have printed every\n" +
       "test as passing and no summary. The culprit is NOT the last file listed — that is\n" +
-      "merely the last one that finished. Re-run with a per-test timeout to name it:\n" +
+      "merely the last one that finished. Narrow it by running one step at a time:\n" +
       "  npm run test:linux -- npm test --workspace server",
   );
 }


### PR DESCRIPTION
`npm run test:linux` ran `npm test --workspace server` and stopped. That is half the ubuntu leg. The other half — `npm run test:coverage --workspace server` — runs on no other platform, so nothing a developer can run reached it.

It is exactly where `main` went red last night: 1252 tests, 1250 passing, 0 failing, and a red job.

```
Warning: Could not report code coverage. ERR_OPERATION_FAILED: failed to parse coverage
```

npm children spawned by the code under test inherited `NODE_V8_COVERAGE`, were SIGTERM'd at their 5s ceiling mid-write, and the parent's reporter died on the truncated file. A container running only the suite would have been green — which is what happened.

Both server steps now run by default, in the ubuntu leg's order, with `CI=true` exported inside the container the way the runner sets it. Passing an explicit command still replaces them, which is how to run one step at a time while iterating.

**Verified**: green on Linux as a non-root user in 163s. Coverage 97.16 lines / 87.69 branches / 91.73 functions against thresholds 92/86/90, no parse error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)