### PR TITLE
feat: add persistent agent work plans

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,9 +117,11 @@ jobs:
         run: |
           tag="${GITHUB_REF_NAME#v}"
           publish=""
+          matched=""
           for pkg in cli embed; do
             version=$(node -p "require('./$pkg/package.json').version")
             if [ "$version" = "$tag" ]; then
+              matched="$matched $pkg"
               name=$(node -p "require('./$pkg/package.json').name")
               if npm view "$name@$tag" version > /dev/null 2>&1; then
                 echo "$name@$tag is already on npm — skipping"
@@ -128,9 +130,12 @@ jobs:
               fi
             fi
           done
-          if [ -z "$publish" ]; then
-            echo "::error::no package is at version $tag (or all are already published)"
+          if [ -z "$matched" ]; then
+            echo "::error::no package is at version $tag"
             exit 1
+          fi
+          if [ -z "$publish" ]; then
+            echo "All matching packages are already on npm — continuing to repair or refresh the GitHub Release"
           fi
           echo "publish=$publish" >> "$GITHUB_OUTPUT"
 
@@ -195,7 +200,15 @@ jobs:
         with:
           path: executables
           merge-multiple: true
-      - name: Attach the executables to the release
+      - name: Create the release if needed and attach the executables
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "$GITHUB_REF_NAME" executables/* --clobber --repo "$GITHUB_REPOSITORY"
+        run: |
+          if ! gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            gh release create "$GITHUB_REF_NAME" \
+              --verify-tag \
+              --generate-notes \
+              --title "$GITHUB_REF_NAME" \
+              --repo "$GITHUB_REPOSITORY"
+          fi
+          gh release upload "$GITHUB_REF_NAME" executables/* --clobber --repo "$GITHUB_REPOSITORY"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A Node server runs the agent — a pi `AgentSession` in its own process, or a su
 - [Model credentials](#model-credentials)
 - [Standalone configuration](#standalone-configuration)
 - [Embedding](#embedding)
+- [Work Plans](#work-plans)
 - [Architecture](#architecture)
 
 ## Features
@@ -33,6 +34,7 @@ A Node server runs the agent — a pi `AgentSession` in its own process, or a su
 - First-run setup in the browser: no credentials, no cryptic failure — paste an API key, or declare your own OpenAI-compatible endpoint (see [Model credentials](#model-credentials))
 - Sessions: list, resume, rename, delete, and full-text search across saved transcripts
 - Conversation tree: edit a past message to re-ask it, and the old exchange stays reachable as a branch you can navigate back to
+- Persistent Work Plans: for non-trivial work the agent maintains an explicit hierarchy of objectives, dependencies, resources, and verification state beside the conversation. It is working state that guides the work—not merely a progress report—and the initial UI is deliberately read-only
 - File browser: lazy-loaded tree, full-size viewer (syntax-highlighted, Markdown rendered) and an editor with save inside the writable zone — all confined to the same root the agent's own tools can see. A file with a rendering — a structured-exchange document, or Markdown — can be shown **beside** it: the editor in one half and the rendering in the other, following what is typed rather than what was last saved. Text under revision does not parse for most of the keystrokes that produce it, so the last rendering that was good stays put, marked as no longer matching the editor and saying why, instead of the picture vanishing on every `{`. Entries outside `sandbox.writableRoot` render dimmed, and truncated entries reveal their complete name on hover. Create a file or folder from the tree itself: `+` on a writable directory opens an input where the file will land (a trailing `/` makes it a folder), and a new file opens straight into the editor. Files can also be opened with the operating system's associated application, renamed, or deleted after confirmation. Drag a writable file onto a writable directory to move it, or drag a read-only file there to copy it
 - PDF: select one in the tree and it renders in the viewer (pages, zoom, keyboard paging); the agent reads its text and tables through a `pdf_extract` tool — no shell, no external binary, no OCR
 - Office documents: `docx_extract`, `xlsx_extract` and `pptx_extract` give the agent Word text and tables, one markdown table per spreadsheet sheet (values rendered from their number format), and slide structure with speaker notes. Same rules as `pdf_extract` — available wherever `read` is, never behind `allowBash`, confined to the sandbox root, each with its own size ceiling. Every extractor also takes `output_path`: write the whole document to a workspace file and get a summary back, instead of paging through it and then writing it out, which spends the context twice
@@ -330,6 +332,14 @@ iframeWindow.postMessage({ type: "pi-outpost:set-theme", theme: "light" }, "http
 Extensions using pi's [Custom UI](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/extensions.md#custom-ui) (`ctx.ui.select/confirm/input/editor/notify/setStatus/setWidget/setTitle/setEditorText`) work in the web UI: dialogs render as a modal, `notify()` as a toast, `setStatus()` as a header badge, `setWidget()` above/below the composer. The bridge binds with `mode: "rpc"`, mirroring pi's own RPC-mode protocol — so `ctx.hasUI` is `true` and dialogs get real answers, but TUI-only features (`custom()`, custom footers/headers/editors, terminal input, themes) have no web equivalent and are no-ops, same as RPC mode.
 
 Custom messages (`pi.sendMessage()` with a `customType`, see [Message and Entry Rendering](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/extensions.md#message-and-entry-rendering)) show up too, but without the extension's `MessageRenderer` — that returns a terminal `Component`, which has no browser equivalent. Instead it falls back to pi's own default look (violet card, markdown-rendered content), with any `details` payload collapsed behind a toggle (never verbose JSON by default). Messages sent with `display: false` stay hidden, same as in the TUI.
+
+## Work Plans
+
+The Work Plan belongs to the agent. For non-trivial work it is the agent's explicit working-state representation: a persistent hierarchy used to decompose objectives, track execution and dependencies, record resources and blockers, and reconcile verification before declaring the work complete. It is not a second activity log or a ceremonial progress report; trivial interactions need no plan.
+
+Tasks use five states: `todo`, `in_progress`, `blocked`, `needs_review`, and `done`. A blocked or review state can carry a reason, and tasks can link to generic resources; workspace resources open directly in the file viewer. The companion panel is read-only in the initial release, so the conversation remains the user's control surface while the agent owns plan mutation through the atomic `work_plan` tool.
+
+Each plan is stored beside its session file. It is restored on reconnect and session resume, replaced when the active session changes, copied when a conversation is forked, and independent thereafter. Conversation compaction only summarizes conversational context: it does not remove, summarize, alter, or invalidate the sidecar, and the agent can still read the complete current plan directly without reconstructing it from the compacted summary. Sessions created before Work Plans remain valid and simply open without a panel.
 
 ## Architecture
 

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,5 +1,5 @@
 import { createServer } from "node:http";
-import { access, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { access, mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { SEEDED_MESSAGES } from "./fixtures/seeded-transcript";
@@ -224,13 +224,116 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
     { env: { ...onlyOneFakeProvider(), FAKE_PI_RPC_CONFIG: fakeConfig } },
   );
 
+  // A fourth real app server drives the Work Plan lifecycle. Its RPC child is
+  // scripted because browser CI is offline, but it emits the same tool events
+  // and writes the same per-session sidecars as the real work_plan extension.
+  const planRoot = await makeWorkspace({ "readme.md": "# work plan\n" });
+  const planSessionDir = path.join(planRoot, ".pi-agent", "sessions");
+  await mkdir(planSessionDir, { recursive: true });
+  const sourceSession = path.join(planSessionDir, "2026-08-23T00-00-00-000Z_source.jsonl");
+  const otherSession = path.join(planSessionDir, "2026-08-23T00-01-00-000Z_other.jsonl");
+  const forkSession = path.join(planSessionDir, "2026-08-23T00-02-00-000Z_fork.jsonl");
+  const entry = {
+    id: "user-1",
+    parentId: null,
+    timestamp: "2026-08-23T00:00:01.000Z",
+    type: "message",
+    message: { role: "user", content: [{ type: "text", text: "Ship the release" }], timestamp: 1 },
+  };
+  const sessionText = (id: string, name: string) =>
+    `${JSON.stringify({ type: "session", version: 3, id, timestamp: "2026-08-23T00:00:00.000Z", cwd: planRoot })}\n` +
+    `${JSON.stringify(entry)}\n` +
+    `${JSON.stringify({ type: "session_info", id: `${id}-name`, parentId: "user-1", timestamp: "2026-08-23T00:00:02.000Z", name })}\n`;
+  await writeFile(sourceSession, sessionText("source", "Release source"));
+  await writeFile(otherSession, sessionText("other", "Other work"));
+
+  const sourcePlan = (status: "in_progress" | "done") => ({
+    version: 1,
+    id: "release",
+    title: "Release plan",
+    updatedAt: "2026-08-23T00:00:03.000Z",
+    tasks: [{
+      id: "publish",
+      title: "Publish release",
+      description: "Build, verify, and publish the release.",
+      status,
+      dependsOn: [],
+      resources: [{ uri: "workspace:readme.md", label: "Release notes" }],
+    }],
+  });
+  const otherPlan = {
+    version: 1,
+    id: "other",
+    title: "Other plan",
+    updatedAt: "2026-08-23T00:00:03.000Z",
+    tasks: [{ id: "wait", title: "Wait", status: "todo", dependsOn: [], resources: [] }],
+  };
+  await writeFile(`${otherSession}.work-plan.json`, `${JSON.stringify(otherPlan, null, 2)}\n`);
+
+  const toolEnd = (sessionFile: string, workPlan: object, call: string) => ({
+    type: "tool_execution_end",
+    toolCallId: call,
+    toolName: "work_plan",
+    result: {
+      content: [{ type: "text", text: "Work Plan updated." }],
+      details: { type: "work_plan", sessionFile, plan: workPlan, changed: true },
+    },
+    isError: false,
+  });
+  const planFakeConfig = path.join(planRoot, "fake-rpc.json");
+  await writeFile(planFakeConfig, JSON.stringify({
+    state: { sessionId: "source", sessionFile: sourceSession },
+    entries: [entry],
+    tree: [{ entry, children: [] }],
+    leafId: "user-1",
+    commands_: {
+      prompt: [
+        {
+          replacement: { state: { isStreaming: false } },
+          writes: [{ path: `${sourceSession}.work-plan.json`, content: `${JSON.stringify(sourcePlan("in_progress"), null, 2)}\n` }],
+          after: [toolEnd(sourceSession, sourcePlan("in_progress"), "plan-create"), { type: "agent_settled" }],
+        },
+        {
+          replacement: { state: { isStreaming: false } },
+          writes: [{ path: `${sourceSession}.work-plan.json`, content: `${JSON.stringify(sourcePlan("done"), null, 2)}\n` }],
+          after: [toolEnd(sourceSession, sourcePlan("done"), "plan-update"), { type: "agent_settled" }],
+        },
+        {
+          replacement: { state: { isStreaming: false } },
+          writes: [{ path: `${forkSession}.work-plan.json`, content: `${JSON.stringify(sourcePlan("in_progress"), null, 2)}\n` }],
+          after: [toolEnd(forkSession, sourcePlan("in_progress"), "fork-update"), { type: "agent_settled" }],
+        },
+      ],
+      switch_session: [
+        { data: { cancelled: false }, replacement: { state: { sessionId: "other", sessionFile: otherSession }, entries: [entry], tree: [{ entry, children: [] }], leafId: "user-1" } },
+        { data: { cancelled: false }, replacement: { state: { sessionId: "source", sessionFile: sourceSession }, entries: [entry], tree: [{ entry, children: [] }], leafId: "user-1" } },
+      ],
+      fork: {
+        data: { cancelled: false, text: "Ship the release" },
+        replacement: { state: { sessionId: "fork", sessionFile: forkSession }, entries: [entry], tree: [{ entry, children: [] }], leafId: "user-1" },
+      },
+    },
+  }));
+  const plans = await startServer(
+    planRoot,
+    {
+      agentRuntime: { mode: "rpc", executable: process.execPath, args: [path.join(REPO, "server/test/fixtures/fake-pi-rpc.mjs")], startupTimeoutMs: 20_000 },
+      sandbox: undefined,
+    },
+    { env: { ...onlyOneFakeProvider(), FAKE_PI_RPC_CONFIG: planFakeConfig } },
+  );
+
   process.env.PI_E2E_HOST_URL = host.url;
   process.env.PI_E2E_SERVER_URL = server.base;
   process.env.PI_E2E_GUARDED_URL = guarded.base;
   process.env.PI_E2E_DIAGRAMS_URL = diagrams.base;
+  process.env.PI_E2E_PLANS_URL = plans.base;
+  process.env.PI_E2E_PLAN_SOURCE = sourceSession;
+  process.env.PI_E2E_PLAN_FORK = forkSession;
   process.env.PI_E2E_TOKEN = E2E_TOKEN;
 
   return async () => {
+    await plans.stop();
     await diagrams.stop();
     await guarded.stop();
     await server.stop();

--- a/e2e/work-plan.spec.ts
+++ b/e2e/work-plan.spec.ts
@@ -1,0 +1,55 @@
+import { readFile } from "node:fs/promises";
+import { expect, test } from "@playwright/test";
+
+async function prompt(page: import("@playwright/test").Page, text: string) {
+  const composer = page.getByRole("textbox", { name: /message pi/i });
+  await expect(composer).toBeEnabled();
+  await composer.fill(text);
+  await composer.press("Enter");
+}
+
+test("agent-owned Work Plan survives reload, switches with sessions, and isolates a fork", async ({ page }) => {
+  await page.goto(process.env.PI_E2E_PLANS_URL!);
+  await expect(page.getByTitle("connected")).toBeVisible();
+  await expect(page.getByRole("complementary", { name: "Work Plan" })).toHaveCount(0);
+
+  // The scripted offline agent executes the real work_plan wire contract and
+  // persists the same sidecar the extension writes in production.
+  await prompt(page, "Create a plan for this release");
+  const panel = page.getByRole("complementary", { name: "Work Plan" });
+  await expect(panel).toBeVisible();
+  await expect(panel.getByRole("heading", { name: "Release plan" })).toBeVisible();
+  await expect(panel.getByLabel("In progress")).toBeVisible();
+
+  await panel.getByRole("button", { name: "Publish release" }).click();
+  await panel.getByRole("button", { name: "Release notes" }).click();
+  await expect(page.getByRole("button", { name: "Close file viewer" })).toBeVisible();
+  await page.getByRole("button", { name: "Close file viewer" }).click();
+
+  await prompt(page, "Mark the release task done");
+  await expect(panel.getByLabel("Done")).toBeVisible();
+  await page.reload();
+  await expect(page.getByRole("complementary", { name: "Work Plan" }).getByLabel("Done")).toBeVisible();
+
+  await page.getByRole("button", { name: "sessions" }).click();
+  await page.getByRole("button", { name: /Other work/ }).click();
+  await expect(page.getByRole("heading", { name: "Other plan" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Wait" })).toBeVisible();
+
+  await page.getByRole("button", { name: "sessions" }).click();
+  await page.getByRole("button", { name: /Release source/ }).click();
+  await expect(page.getByRole("heading", { name: "Release plan" })).toBeVisible();
+  await expect(page.getByRole("complementary", { name: "Work Plan" }).getByLabel("Done")).toBeVisible();
+
+  await page.getByRole("button", { name: "tree" }).click();
+  await page.getByRole("button", { name: /fork/i }).last().click();
+  await expect(page.getByRole("heading", { name: "Release plan" })).toBeVisible();
+
+  await prompt(page, "Reopen the task only in this fork");
+  await expect(page.getByRole("complementary", { name: "Work Plan" }).getByLabel("In progress")).toBeVisible();
+
+  const source = JSON.parse(await readFile(`${process.env.PI_E2E_PLAN_SOURCE}.work-plan.json`, "utf8"));
+  const fork = JSON.parse(await readFile(`${process.env.PI_E2E_PLAN_FORK}.work-plan.json`, "utf8"));
+  expect(source.tasks[0].status).toBe("done");
+  expect(fork.tasks[0].status).toBe("in_progress");
+});

--- a/e2e/work-plan.spec.ts
+++ b/e2e/work-plan.spec.ts
@@ -21,7 +21,22 @@ test("agent-owned Work Plan survives reload, switches with sessions, and isolate
   await expect(panel.getByRole("heading", { name: "Release plan" })).toBeVisible();
   await expect(panel.getByLabel("In progress")).toBeVisible();
 
-  await panel.getByRole("button", { name: "Publish release" }).click();
+  await panel.getByRole("button", { name: "Close Work Plan" }).click();
+  const collapsedPlan = page.getByRole("button", { name: "Open Work Plan" });
+  await collapsedPlan.hover();
+  const preview = page.getByRole("tooltip");
+  await expect(preview).toBeVisible();
+  await expect(preview.getByText("Publish release")).toBeVisible();
+  await preview.hover();
+  await expect(preview).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(preview).toBeHidden();
+  await collapsedPlan.hover();
+  await expect(preview).toBeVisible();
+  await collapsedPlan.click();
+  await expect(panel).toBeVisible();
+
+  await panel.getByRole("treeitem", { name: /Publish release/ }).click();
   await panel.getByRole("button", { name: "Release notes" }).click();
   await expect(page.getByRole("button", { name: "Close file viewer" })).toBeVisible();
   await page.getByRole("button", { name: "Close file viewer" }).click();
@@ -34,7 +49,7 @@ test("agent-owned Work Plan survives reload, switches with sessions, and isolate
   await page.getByRole("button", { name: "sessions" }).click();
   await page.getByRole("button", { name: /Other work/ }).click();
   await expect(page.getByRole("heading", { name: "Other plan" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "Wait" })).toBeVisible();
+  await expect(page.getByRole("treeitem", { name: "Wait" })).toBeVisible();
 
   await page.getByRole("button", { name: "sessions" }).click();
   await page.getByRole("button", { name: /Release source/ }).click();

--- a/openspec/changes/add-persistent-agent-work-plan/.openspec.yaml
+++ b/openspec/changes/add-persistent-agent-work-plan/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-23

--- a/openspec/changes/add-persistent-agent-work-plan/design.md
+++ b/openspec/changes/add-persistent-agent-work-plan/design.md
@@ -1,0 +1,44 @@
+## Context
+
+See proposal.md for motivation. Pi Outpost has one authoritative server-side session shared by connected clients, a typed WebSocket protocol, and saved/forked Pi sessions. The Work Plan must become a third persistent representation while remaining independent of transcript activity and Structured Exchange.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Store a small, versionable plan document per session and make it available to both agent and UI.
+- Preserve plan ownership boundaries: the agent mutates intent; the server validates and persists it; the UI renders it.
+- Copy plan state at a session fork and avoid cross-branch mutation.
+
+**Non-Goals:**
+- A workflow engine, automatic task completion, user editing, project-management integrations, or domain-specific resource schemas.
+- Full historical provenance or automatic activity-to-task association; the model leaves extension points for both.
+
+## Decisions
+
+### A separate session sidecar owns Work Plan persistence
+Persist a versioned Work Plan document adjacent to, and keyed by, the Pi session rather than embedding UI state in transcript messages. This permits atomic writes, restores without replaying a transcript, and independent fork copies. A per-server global plan was rejected because it breaks session isolation; transcript-only encoding was rejected because it couples progress to conversation history and branch navigation.
+
+Because the sidecar is neither a transcript entry nor derived by replaying transcript content, Pi compaction cannot summarize, mutate, or invalidate it. After compaction, the same structured `get` operation reads the authoritative sidecar directly; the agent never has to reconstruct planning state from the compaction summary.
+
+### Agent mutations use a narrow structured tool surface
+Expose plan replacement and validated task-level mutations through the runtime's agent-facing capability, then broadcast the resulting complete authoritative plan. The capability describes the plan as operational working state: for non-trivial work the agent maintains it during decomposition, execution, and verification, then reconciles it before reporting completion. Trivial interactions need no plan. A generic JSON patch endpoint was rejected: it weakens invariants such as unique IDs, parent/child consistency, and dependency validation.
+
+### Snapshot replacement is the synchronization contract
+The protocol carries a full Work Plan in initial and session-replacement snapshots, with accepted changes broadcast as a complete plan. This makes reconnection and session switches deterministic and avoids client-side operation replay. Optimistic client editing is unnecessary because the initial UI is read-only.
+
+### The first UI is a task-focused companion panel
+Use a persistent/collapsible companion surface with status icons, nesting, focus indication, progress, and inspection. It links generic references only through existing resolvers. This prioritizes the operational overview over a project-management experience.
+
+## Risks / Trade-offs
+
+- [Sidecar lifecycle may diverge from session lifecycle] → Use the same canonical session identity/path and fork/switch/delete hooks; test each lifecycle operation.
+- [A plan can become very large] → Validate bounded titles, descriptions, resources, and task counts; send full snapshots only after accepted mutations.
+- [Agent tool availability differs between embedded and RPC runtimes] → Define one runtime capability contract and test both supported runtimes before claiming parity.
+- [Dependencies can form cycles] → Reject self-dependencies and cycles atomically.
+
+## Migration Plan
+
+1. Introduce an absent-plan-compatible protocol and sidecar loader; existing sessions continue with no plan.
+2. Add agent operations, persistence, fork copying, and snapshots behind the compatible model.
+3. Add the read-only UI and running-app tests.
+4. Rollback by ignoring/removing the feature; existing conversation sessions remain valid and sidecar files can be retained for a future re-enable.

--- a/openspec/changes/add-persistent-agent-work-plan/design.md
+++ b/openspec/changes/add-persistent-agent-work-plan/design.md
@@ -32,8 +32,8 @@ Use a persistent/collapsible companion surface with status icons, nesting, focus
 ## Risks / Trade-offs
 
 - [Sidecar lifecycle may diverge from session lifecycle] → Use the same canonical session identity/path and fork/switch/delete hooks; test each lifecycle operation.
-- [A plan can become very large] → Validate bounded titles, descriptions, resources, and task counts; send full snapshots only after accepted mutations.
-- [Agent tool availability differs between embedded and RPC runtimes] → Define one runtime capability contract and test both supported runtimes before claiming parity.
+- [A plan can become very large] → Cap the complete serialized plan at 64 KiB so a post-compaction `get` cannot refill the model context; also bound titles, descriptions, resources, and task counts.
+- [Agent tool availability differs between embedded and RPC runtimes] → Define one runtime capability contract and execute `work_plan` through a real `pi --mode rpc` child before claiming parity.
 - [Dependencies can form cycles] → Reject self-dependencies and cycles atomically.
 
 ## Migration Plan

--- a/openspec/changes/add-persistent-agent-work-plan/proposal.md
+++ b/openspec/changes/add-persistent-agent-work-plan/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Pi Outpost currently preserves the conversation and workspace, but neither gives a concise, durable account of the agent's intended work, progress, and unresolved decisions. Long-running work therefore loses its operational context when interrupted and forces the user or agent to reconstruct it from a transcript. The Work Plan is an explicit working-state representation that encourages systematic decomposition, execution tracking, and verification—not merely a progress-reporting mechanism.
+
+## What Changes
+
+- Add an agent-owned Work Plan: a persistent, hierarchical task representation with stable task identifiers, human-readable titles, statuses, dependencies, resource references, and optional status reasons.
+- Expose atomic Work Plan mutations to the agent through a structured interface, without prescribing a workflow or deriving progress from tool activity.
+- Guide the agent to maintain the Work Plan throughout non-trivial work and reconcile it before declaring the work complete, while avoiding ceremony for trivial interactions.
+- Persist the Work Plan with each Pi session, restore it on session reopening, and seed an independently mutable plan when a session is forked.
+- Keep Work Plan persistence independent from conversation compaction so the complete current plan remains directly available to the agent after context is summarized.
+- Add protocol and client state for live Work Plan snapshots and updates, plus an accessible persistent Work Plan view and task inspection.
+- Keep Work Plans distinct from conversation activity and Structured Exchange; task-resource links may reference those artifacts without duplicating them.
+- Reserve human steering as a compatible future extension; the initial slice is read-only for users.
+
+## Capabilities
+
+### New Capabilities
+
+- `work-plan`: Agent-driven, session-persistent hierarchical work planning, including the task model, agent operations, lifecycle semantics, and user-facing view.
+
+### Modified Capabilities
+
+- `model`: Extend the typed client/server protocol and snapshot model to transport Work Plan state and updates.
+- `agent`: Keep the browser agent state synchronized with authoritative Work Plan snapshots and changes.
+- `conversation-tree`: Define the Work Plan copy-and-isolation behavior when a conversation session is forked.
+
+## Impact
+
+- Shared protocol types and WebSocket server dispatch/snapshot handling.
+- Agent runtime extensions or tools, session persistence, session switching and forking.
+- React `useAgent` state and a new Work Plan UI surface beside the conversation.
+- Server, protocol, session-lifecycle, and running-app UI tests.

--- a/openspec/changes/add-persistent-agent-work-plan/scenario-test-matrix.md
+++ b/openspec/changes/add-persistent-agent-work-plan/scenario-test-matrix.md
@@ -1,0 +1,20 @@
+# Scenario-to-test matrix
+
+All delta scenarios are covered. The modified main specifications remain covered by their existing suites; this change adds no alternate behavior to scenarios outside these deltas.
+
+| Delta scenario | Coverage | Test evidence |
+|---|---|---|
+| Switching sessions replaces the plan | covered | `ui/src/useAgent.test.ts` — “applies live changes and replaces the plan with the selected session snapshot”; `e2e/work-plan.spec.ts` — switches between distinct visible plans |
+| Fork preserves then isolates work | covered | `server/test/work-plan-server.test.mjs` — “running server restores, forks, reconnects, and broadcasts authoritative Work Plans”; `e2e/work-plan.spec.ts` — fork mutation leaves source sidecar unchanged |
+| Snapshot supplies Work Plan | covered | `server/test/work-plan-server.test.mjs` — initial and reconnect `hello` assertions |
+| Change reaches all clients | covered | `server/test/work-plan-server.test.mjs` — both clients receive the same completed plan |
+| Progressive decomposition | covered | `server/test/work-plan.test.ts` — “progressively decomposes a task without changing its identity” |
+| Blocked work is explained | covered | `ui/src/components/WorkPlanPanel.test.tsx` — blocked/review states and blocked reason inspection |
+| Atomic task update | covered | `server/test/work-plan.test.ts` — “rejects invalid hierarchy and dependency cycles without changing the input” and tool persistence refusal assertion |
+| Activity does not complete work | covered | `server/test/work-plan.test.ts` — “does not infer completion from unrelated activity” |
+| Reconcile before completion | covered | `server/test/work-plan.test.ts` — agent guidance requires maintained working state, verification, and reconciliation before declaring completion |
+| Resume interrupted work | covered | `server/test/work-plan.test.ts` — sidecar restoration and `action=get`; `server/test/work-plan-server.test.mjs` — restored initial/reconnect snapshots |
+| Compaction preserves the plan | covered | `server/test/work-plan-server.test.mjs` — real server compaction rewrites the transcript while the sidecar and reconnect snapshot remain unchanged |
+| Agent reads the plan after compaction | covered | `server/test/work-plan.test.ts` — after replacing transcript content with a compacted summary, `work_plan action=get` returns the complete authoritative plan |
+| Readable overview | covered | `ui/src/components/WorkPlanPanel.test.tsx` — “shows hierarchy, distinct states, focus, and aggregate progress” |
+| Navigate a resource | covered | `ui/src/components/WorkPlanPanel.test.tsx` — workspace resolver assertion; `e2e/work-plan.spec.ts` — opens the real file viewer from a task resource |

--- a/openspec/changes/add-persistent-agent-work-plan/scenario-test-matrix.md
+++ b/openspec/changes/add-persistent-agent-work-plan/scenario-test-matrix.md
@@ -11,10 +11,11 @@ All delta scenarios are covered. The modified main specifications remain covered
 | Progressive decomposition | covered | `server/test/work-plan.test.ts` — “progressively decomposes a task without changing its identity” |
 | Blocked work is explained | covered | `ui/src/components/WorkPlanPanel.test.tsx` — blocked/review states and blocked reason inspection |
 | Atomic task update | covered | `server/test/work-plan.test.ts` — “rejects invalid hierarchy and dependency cycles without changing the input” and tool persistence refusal assertion |
-| Activity does not complete work | covered | `server/test/work-plan.test.ts` — “does not infer completion from unrelated activity” |
-| Reconcile before completion | covered | `server/test/work-plan.test.ts` — agent guidance requires maintained working state, verification, and reconciliation before declaring completion |
+| Activity does not complete work | covered | `server/test/work-plan-server.test.mjs` — the running server executes an unrelated read tool while the task remains `in_progress`, then a fresh snapshot still carries that status |
+| Reconcile before completion | covered | `server/test/work-plan.test.ts` — “publishes maintenance and reconciliation guidance on the model-visible tool contract” verifies the guidance consumed in both embedded mode and the RPC extension |
 | Resume interrupted work | covered | `server/test/work-plan.test.ts` — sidecar restoration and `action=get`; `server/test/work-plan-server.test.mjs` — restored initial/reconnect snapshots |
-| Compaction preserves the plan | covered | `server/test/work-plan-server.test.mjs` — real server compaction rewrites the transcript while the sidecar and reconnect snapshot remain unchanged |
+| Compaction preserves the plan | covered | `server/test/work-plan-server.test.mjs` — a scripted RPC child rewrites the transcript during compaction; the real server keeps the separate sidecar and reconnect snapshot unchanged |
 | Agent reads the plan after compaction | covered | `server/test/work-plan.test.ts` — after replacing transcript content with a compacted summary, `work_plan action=get` returns the complete authoritative plan |
 | Readable overview | covered | `ui/src/components/WorkPlanPanel.test.tsx` — “shows hierarchy, distinct states, focus, and aggregate progress” |
+| Preview a collapsed plan | covered | `ui/src/components/WorkPlanPanel.test.tsx` — “previews task lines from the collapsed progress control before opening details”; `e2e/work-plan.spec.ts` — hover preview and click-through in the running app |
 | Navigate a resource | covered | `ui/src/components/WorkPlanPanel.test.tsx` — workspace resolver assertion; `e2e/work-plan.spec.ts` — opens the real file viewer from a task resource |

--- a/openspec/changes/add-persistent-agent-work-plan/specs/agent/spec.md
+++ b/openspec/changes/add-persistent-agent-work-plan/specs/agent/spec.md
@@ -1,0 +1,9 @@
+## ADDED Requirements
+
+### Requirement: Work Plan client synchronization
+The agent client SHALL keep its Work Plan state synchronized with authoritative snapshots and Work Plan change frames. Replacing or switching a session SHALL replace the visible Work Plan with the plan belonging to the newly active session, without retaining tasks from the previous session.
+
+#### Scenario: Switching sessions replaces the plan
+- **GIVEN** two sessions with different Work Plans
+- **WHEN** the user switches sessions
+- **THEN** the client displays only the newly active session's Work Plan

--- a/openspec/changes/add-persistent-agent-work-plan/specs/conversation-tree/spec.md
+++ b/openspec/changes/add-persistent-agent-work-plan/specs/conversation-tree/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: Forked Work Plan isolation
+When the user forks a session, the new session SHALL begin with a copy of the Work Plan state applicable at the fork point. Subsequent Work Plan mutations in either session SHALL be independent and SHALL NOT modify the other session's plan.
+
+#### Scenario: Fork preserves then isolates work
+- **GIVEN** a session with an existing Work Plan
+- **WHEN** the user forks the session
+- **THEN** the fork initially shows the copied plan
+- **AND** changing a task in the fork does not change that task in the original session

--- a/openspec/changes/add-persistent-agent-work-plan/specs/model/spec.md
+++ b/openspec/changes/add-persistent-agent-work-plan/specs/model/spec.md
@@ -1,0 +1,13 @@
+## ADDED Requirements
+
+### Requirement: Work Plan protocol state
+The typed server protocol SHALL carry the current session Work Plan in authoritative state snapshots and SHALL broadcast accepted Work Plan changes to connected clients. The serialized form SHALL include stable task IDs, hierarchy, status, dependencies, generic resources, and status reason; it SHALL not expose UI-specific markup or domain-specific resource types.
+
+#### Scenario: Snapshot supplies Work Plan
+- **WHEN** a client connects to a session with a Work Plan
+- **THEN** its initial authoritative state includes that plan
+
+#### Scenario: Change reaches all clients
+- **GIVEN** two clients display the same session
+- **WHEN** the agent changes the Work Plan
+- **THEN** both clients receive the same updated authoritative plan

--- a/openspec/changes/add-persistent-agent-work-plan/specs/work-plan/spec.md
+++ b/openspec/changes/add-persistent-agent-work-plan/specs/work-plan/spec.md
@@ -1,0 +1,65 @@
+## Purpose
+
+Provides an agent-owned, human-readable account of the current work that survives session interruption without becoming a workflow engine.
+
+## ADDED Requirements
+
+### Requirement: Agent-owned hierarchical Work Plan
+The system SHALL represent an optional Work Plan for a session as a title and a hierarchy of tasks. Every task SHALL have a stable identifier, a human-readable title, one of `todo`, `in_progress`, `done`, `blocked`, or `needs_review`, and optional description, parent, dependencies, generic resource references, and status reason. The hierarchy SHALL allow arbitrary depth; task identity SHALL survive renaming and moving.
+
+#### Scenario: Progressive decomposition
+- **WHEN** the agent adds children to an existing task
+- **THEN** the plan shows the parent and its newly decomposed children without changing the parent's identity
+
+#### Scenario: Blocked work is explained
+- **WHEN** the agent marks a task `blocked` with a reason
+- **THEN** the plan distinguishes it from `needs_review` and shows the reason during inspection
+
+### Requirement: Structured agent management
+The system SHALL expose structured operations for the agent to create a plan, add, edit, move, remove, and reopen tasks, set status and status reason, add or remove dependencies and resource references, and replace the plan. Each accepted operation SHALL be atomic. The system SHALL describe the Work Plan to the agent as explicit working state for systematic decomposition, execution tracking, and verification, not merely progress reporting. For non-trivial work, it SHALL guide the agent to maintain and reconcile that state before declaring completion; trivial interactions SHALL NOT require a plan. The system SHALL NOT infer task state or completion from tool calls, messages, or Structured Exchange artifacts.
+
+#### Scenario: Atomic task update
+- **WHEN** an agent operation is invalid
+- **THEN** no partial Work Plan mutation becomes visible or persisted
+
+#### Scenario: Activity does not complete work
+- **WHEN** the agent performs tools while a task remains `in_progress`
+- **THEN** the task remains `in_progress` until the agent explicitly changes it
+
+#### Scenario: Reconcile before completion
+- **GIVEN** the agent used a Work Plan for non-trivial work
+- **WHEN** the agent is preparing to declare that work complete
+- **THEN** its Work Plan guidance requires the agent to reconcile the plan with execution and verification outcomes first
+
+### Requirement: Session-scoped persistence and restoration
+The system SHALL persist the Work Plan with its owning session and restore it when that session is reopened. A restored plan SHALL preserve task hierarchy, identities, statuses, dependencies, resources, and reasons, and SHALL be available to the resumed agent as compact operational context.
+
+#### Scenario: Resume interrupted work
+- **GIVEN** a saved session with a task in progress and remaining tasks
+- **WHEN** the session is reopened
+- **THEN** the same Work Plan is shown and supplied to the agent
+
+### Requirement: Compaction-independent working state
+Work Plan persistence SHALL be independent from Pi conversation compaction. Compaction of conversational context SHALL NOT remove, summarize, alter, or invalidate the persisted Work Plan. Following compaction, the current Work Plan state SHALL remain directly accessible to the agent through the structured Work Plan interface without reconstructing it from the compacted conversation summary.
+
+#### Scenario: Compaction preserves the plan
+- **GIVEN** a session with a persisted Work Plan
+- **WHEN** Pi compacts the session's conversational context
+- **THEN** the complete persisted Work Plan remains unchanged and valid
+
+#### Scenario: Agent reads the plan after compaction
+- **GIVEN** Pi has compacted a session that has a Work Plan
+- **WHEN** the agent reads the current Work Plan through the structured interface
+- **THEN** it receives the authoritative current state without using or reconstructing information from the conversation summary
+
+### Requirement: Work Plan view and inspection
+The system SHALL provide a persistent or readily accessible Work Plan view alongside the conversation. It SHALL make task status, hierarchy, current focus, and aggregate progress understandable without reading the transcript. Selecting a task SHALL reveal its description, children, dependencies, reason, resources, and associated activity or outputs when available.
+
+#### Scenario: Readable overview
+- **WHEN** a session has completed, active, blocked, and review tasks
+- **THEN** the overview makes every state and the current focus distinguishable
+
+#### Scenario: Navigate a resource
+- **GIVEN** a task references a resource the system can resolve
+- **WHEN** the user selects that resource
+- **THEN** the system navigates to it using the existing applicable UI

--- a/openspec/changes/add-persistent-agent-work-plan/specs/work-plan/spec.md
+++ b/openspec/changes/add-persistent-agent-work-plan/specs/work-plan/spec.md
@@ -59,6 +59,11 @@ The system SHALL provide a persistent or readily accessible Work Plan view along
 - **WHEN** a session has completed, active, blocked, and review tasks
 - **THEN** the overview makes every state and the current focus distinguishable
 
+#### Scenario: Preview a collapsed plan
+- **GIVEN** the Work Plan detail panel is collapsed
+- **WHEN** the user hovers or focuses its progress control
+- **THEN** a compact summary shows task lines and completion boxes, and selecting the control opens the full detail panel
+
 #### Scenario: Navigate a resource
 - **GIVEN** a task references a resource the system can resolve
 - **WHEN** the user selects that resource

--- a/openspec/changes/add-persistent-agent-work-plan/tasks.md
+++ b/openspec/changes/add-persistent-agent-work-plan/tasks.md
@@ -1,0 +1,28 @@
+## 1. Work Plan domain and persistence
+
+- [x] 1.1 Define shared Work Plan, task, status, dependency, and generic resource contracts with validation limits and stable identities.
+- [x] 1.2 Implement an atomic, session-keyed Work Plan store with compatible absent-plan loading and safe persistence.
+- [x] 1.3 Add lifecycle operations to load, replace, mutate, delete, and independently copy a plan when a session is forked.
+- [x] 1.4 Add unit and integration tests for hierarchy changes, identity stability, validation failures, dependency cycles, persistence, restoration, and fork isolation.
+- [x] 1.5 Prove that conversation compaction leaves the persisted plan unchanged and that the agent can still read it directly afterward.
+
+## 2. Agent and protocol integration
+
+- [x] 2.1 Define the agent-facing structured Work Plan operations and expose them consistently through supported runtimes.
+- [x] 2.2 Include Work Plan state in initial and session-replacement snapshots and broadcast accepted authoritative changes to all connected clients.
+- [x] 2.3 Update WebSocket validation and server dispatch so malformed plan operations cannot partially mutate or persist state.
+- [x] 2.4 Test tool operations, multi-client synchronization, session switches, reconnects, and existing-session compatibility.
+
+## 3. Work Plan interface
+
+- [x] 3.1 Extend `useAgent` state and reducer for authoritative Work Plan snapshots, updates, and session replacement.
+- [x] 3.2 Build an accessible companion Work Plan overview with hierarchy, distinct statuses, current-focus indication, and progress.
+- [x] 3.3 Add task inspection for descriptions, dependencies, status reasons, resources, and resolvable resource navigation.
+- [x] 3.4 Add UI tests covering state replacement, task inspection, status presentation, and unavailable-resource behavior.
+
+## 4. End-to-end verification and documentation
+
+- [x] 4.1 Add running-app Playwright coverage that drives agent plan creation and mutation, verifies visible state, reload restoration, session switching, and fork isolation.
+- [x] 4.2 Verify both embedded and RPC runtime behavior, or document a supported-runtime limitation before release.
+- [x] 4.3 Update user and agent-facing documentation to explain agent ownership, the status vocabulary, persistence behavior, and the read-only initial user experience.
+- [x] 4.4 Run the focused and relevant full test suites, strict OpenSpec validation, and a scenario-to-test matrix for every delta scenario.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -33,10 +33,12 @@ import {
   THINKING_LEVELS,
   type TreeNode,
   type WireImage,
+  type WorkPlan,
   WORKTREE_REVISION,
 } from "@pi-outpost/shared";
 import { readStructuredExchangeDocument } from "@pi-outpost/shared/structured-exchange/document";
 import { checkStructuredExchangeSchema } from "@pi-outpost/shared/structured-exchange/schema-node";
+import { validateWorkPlan } from "@pi-outpost/shared/work-plan";
 import {
   type AgentRuntime,
   type RuntimeEvent,
@@ -97,6 +99,8 @@ import { createXlsxExtractToolDefinition } from "./xlsxTool.ts";
 import { createPptxExtractToolDefinition } from "./pptxTool.ts";
 import { createStructuredExchangeToolDefinition } from "./structuredExchangeTool.ts";
 import { createStructuredExchangeFigureToolDefinition } from "./structuredExchangeFigureTool.ts";
+import { createWorkPlanToolDefinition } from "./workPlanTool.ts";
+import { copyWorkPlan, deleteWorkPlan, loadWorkPlan } from "./workPlanStore.ts";
 import { createPdfExtractToolDefinition } from "./pdfTool.ts";
 import { createDirectoryWatcher, type DirectoryWatcher } from "./fileWatcher.ts";
 import { createSandboxedTools, isWithin, realResolve } from "./sandbox.ts";
@@ -286,6 +290,7 @@ if (cli.command === "login") {
  * other custom tool it is the same tool on both sides of the sandbox.
  */
 const structuredExchangeTool = createStructuredExchangeToolDefinition();
+const workPlanTool = createWorkPlanToolDefinition();
 
 let sandboxedTools = config.sandbox
   ? [
@@ -298,6 +303,7 @@ let sandboxedTools = config.sandbox
         config.structuredExchange.maxBytes,
       )),
       structuredExchangeTool,
+      workPlanTool,
     ]
   : undefined;
 let BROWSER_ROOT = await resolveBrowserRoot(config);
@@ -871,6 +877,7 @@ const createRuntime: CreateAgentSessionRuntimeFactory = async ({
                 writableRoot: await fs.realpath(cwd),
               }),
               structuredExchangeTool,
+              workPlanTool,
             ],
           }),
     })),
@@ -940,6 +947,46 @@ const runtime: AgentRuntime = await (async () => {
   }
 })();
 
+let activeWorkPlan: WorkPlan | null = await loadWorkPlan(runtime.snapshot().sessionFile);
+let activeWorkPlanSessionFile = runtime.snapshot().sessionFile;
+let workPlanSessionSync: Promise<void> = Promise.resolve();
+
+/**
+ * Session replacement events are synchronous, while their sidecar reads are not.
+ * Keep those reads ordered so a fork can wait for the replacement snapshot before
+ * copying and announcing its inherited plan. Without the queue, a late ENOENT read
+ * could overwrite the copied plan with null.
+ */
+function queueWorkPlanSessionSync(): Promise<void> {
+  const sessionFile = runtime.snapshot().sessionFile;
+  workPlanSessionSync = workPlanSessionSync.catch(() => {}).then(async () => {
+    let plan: WorkPlan | null = null;
+    try {
+      plan = await loadWorkPlan(sessionFile);
+    } catch (error) {
+      reportError(error);
+    }
+    if (runtime.snapshot().sessionFile !== sessionFile) return;
+    activeWorkPlan = plan;
+    activeWorkPlanSessionFile = sessionFile;
+    broadcast({ type: "session_replaced", ...snapshot() });
+    console.log(`[pi] session ${runtime.snapshot().sessionId}`);
+  });
+  workPlanSessionSync.catch(reportError);
+  return workPlanSessionSync;
+}
+
+function queueWorkPlanToolSync(sessionFile: string, changed: boolean): void {
+  workPlanSessionSync = workPlanSessionSync.catch(() => {}).then(async () => {
+    const plan = await loadWorkPlan(sessionFile);
+    if (runtime.snapshot().sessionFile !== sessionFile) return;
+    activeWorkPlan = plan;
+    activeWorkPlanSessionFile = sessionFile;
+    if (changed) broadcast({ type: "work_plan_changed", workPlan: plan });
+  });
+  workPlanSessionSync.catch(reportError);
+}
+
 function modelName(): string {
   const model = runtime.snapshot().model;
   return model ? `${model.provider}/${model.id}` : "unknown";
@@ -1008,6 +1055,9 @@ function snapshot(): SessionSnapshot {
     models: availableModels(),
     commands: state.commands,
     contextUsage: state.contextUsage,
+    // A runtime replacement is synchronous but its sidecar read is not. Never
+    // combine the new transcript/session id with the previous session's plan.
+    workPlan: state.sessionFile === activeWorkPlanSessionFile ? activeWorkPlan : null,
     writableRoot: WRITABLE_ROOT,
     gitAvailable: GIT !== null,
     credentials: credentialStatus(),
@@ -1190,6 +1240,25 @@ function onRuntimeEvent(event: RuntimeEvent): void {
       // Only announce once the write has actually landed on disk — the client
       // may otherwise refetch a directory/file before the change is visible.
       if (args !== undefined && !event.isError) void announceFileChange(args);
+      const workPlanDetails = event.details as
+        | { type?: unknown; sessionFile?: unknown; plan?: WorkPlan | null; changed?: unknown }
+        | undefined;
+      if (
+        event.toolName === "work_plan" &&
+        !event.isError &&
+        workPlanDetails?.type === "work_plan" &&
+        workPlanDetails.sessionFile === runtime.snapshot().sessionFile
+      ) {
+        try {
+          // Reject malformed tool details at the runtime boundary, then reload
+          // the sidecar: persistence, not an extension-supplied event payload,
+          // is the authoritative state that must survive resume/compaction.
+          if (workPlanDetails.plan !== null) validateWorkPlan(workPlanDetails.plan);
+          queueWorkPlanToolSync(workPlanDetails.sessionFile as string, workPlanDetails.changed === true);
+        } catch (error) {
+          reportError(new Error(`Ignoring invalid Work Plan tool result: ${error instanceof Error ? error.message : String(error)}`));
+        }
+      }
       break;
     }
     case "queue":
@@ -1211,8 +1280,7 @@ function onRuntimeEvent(event: RuntimeEvent): void {
       // The runtime has already rebound itself; renderers may belong to a new
       // extension runner, so refresh the HTML bridge before the snapshot goes out.
       refreshExtensionRender();
-      broadcast({ type: "session_replaced", ...snapshot() });
-      console.log(`[pi] session ${runtime.snapshot().sessionId}`);
+      void queueWorkPlanSessionSync();
       break;
     case "extension_ui_request":
       broadcast(event.request);
@@ -1249,7 +1317,8 @@ async function replaceSession(socket: WebSocket, action: () => Promise<{ cancell
   try {
     // The runtime rebinds and emits `session_replaced` itself; this only has to
     // decide whether a replacement happened at all.
-    await action();
+    const result = await action();
+    if (!result.cancelled) await workPlanSessionSync;
   } catch (error) {
     reportError(error);
     // The old session may be disposed — land on a fresh one instead. A runtime that
@@ -1454,14 +1523,18 @@ async function handleUpdateConfig(
     fileWatcher?.close();
     fileWatcher = buildFileWatcher();
     sandboxedTools = config.sandbox
-      ? await createSandboxedTools(
-          config.sandbox,
-          config.pdf.maxBytes,
-          config.docx.maxBytes,
-          config.xlsx.maxBytes,
-          config.pptx.maxBytes,
-          config.structuredExchange.maxBytes,
-        )
+      ? [
+          ...(await createSandboxedTools(
+            config.sandbox,
+            config.pdf.maxBytes,
+            config.docx.maxBytes,
+            config.xlsx.maxBytes,
+            config.pptx.maxBytes,
+            config.structuredExchange.maxBytes,
+          )),
+          structuredExchangeTool,
+          workPlanTool,
+        ]
       : undefined;
     // Replace the current session so the new runtime picks up the updated tools
     // and re-runs skill discovery over the new paths.
@@ -1638,6 +1711,7 @@ async function deleteSession(socket: WebSocket, path: string): Promise<void> {
     return;
   }
   await fs.unlink(path);
+  await deleteWorkPlan(path);
   invalidateSessionScan();
   await listSessions(socket);
 }
@@ -1944,9 +2018,17 @@ async function forkSession(socket: WebSocket, entryId: string): Promise<void> {
     return;
   }
   let selectedText: string | undefined;
+  const sourceSessionFile = runtime.snapshot().sessionFile;
   await replaceSession(socket, async () => {
     const result = await runtime.fork(entryId);
     selectedText = result.selectedText;
+    if (!result.cancelled) {
+      await workPlanSessionSync;
+      await copyWorkPlan(sourceSessionFile, runtime.snapshot().sessionFile);
+      activeWorkPlan = await loadWorkPlan(runtime.snapshot().sessionFile);
+      activeWorkPlanSessionFile = runtime.snapshot().sessionFile;
+      broadcast({ type: "work_plan_changed", workPlan: activeWorkPlan });
+    }
     return result;
   });
   if (selectedText) send(socket, { type: "editor_prefill", text: selectedText });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -100,7 +100,7 @@ import { createPptxExtractToolDefinition } from "./pptxTool.ts";
 import { createStructuredExchangeToolDefinition } from "./structuredExchangeTool.ts";
 import { createStructuredExchangeFigureToolDefinition } from "./structuredExchangeFigureTool.ts";
 import { createWorkPlanToolDefinition } from "./workPlanTool.ts";
-import { copyWorkPlan, deleteWorkPlan, loadWorkPlan } from "./workPlanStore.ts";
+import { copyWorkPlan, deleteWorkPlan, loadWorkPlan, sameSessionFile } from "./workPlanStore.ts";
 import { createPdfExtractToolDefinition } from "./pdfTool.ts";
 import { createDirectoryWatcher, type DirectoryWatcher } from "./fileWatcher.ts";
 import { createSandboxedTools, isWithin, realResolve } from "./sandbox.ts";
@@ -950,6 +950,7 @@ const runtime: AgentRuntime = await (async () => {
 let activeWorkPlan: WorkPlan | null = await loadWorkPlan(runtime.snapshot().sessionFile);
 let activeWorkPlanSessionFile = runtime.snapshot().sessionFile;
 let workPlanSessionSync: Promise<void> = Promise.resolve();
+let workPlanInheritanceSource: string | undefined;
 
 /**
  * Session replacement events are synchronous, while their sidecar reads are not.
@@ -960,16 +961,21 @@ let workPlanSessionSync: Promise<void> = Promise.resolve();
 function queueWorkPlanSessionSync(): Promise<void> {
   const sessionFile = runtime.snapshot().sessionFile;
   workPlanSessionSync = workPlanSessionSync.catch(() => {}).then(async () => {
+    const inheritanceSource = workPlanInheritanceSource;
+    const inherited =
+      inheritanceSource !== undefined && !sameSessionFile(inheritanceSource, sessionFile);
     let plan: WorkPlan | null = null;
     try {
+      if (inherited) await copyWorkPlan(inheritanceSource, sessionFile);
       plan = await loadWorkPlan(sessionFile);
     } catch (error) {
       reportError(error);
     }
-    if (runtime.snapshot().sessionFile !== sessionFile) return;
+    if (!sameSessionFile(runtime.snapshot().sessionFile, sessionFile)) return;
     activeWorkPlan = plan;
     activeWorkPlanSessionFile = sessionFile;
     broadcast({ type: "session_replaced", ...snapshot() });
+    if (inherited) broadcast({ type: "work_plan_changed", workPlan: plan });
     console.log(`[pi] session ${runtime.snapshot().sessionId}`);
   });
   workPlanSessionSync.catch(reportError);
@@ -978,8 +984,14 @@ function queueWorkPlanSessionSync(): Promise<void> {
 
 function queueWorkPlanToolSync(sessionFile: string, changed: boolean): void {
   workPlanSessionSync = workPlanSessionSync.catch(() => {}).then(async () => {
-    const plan = await loadWorkPlan(sessionFile);
-    if (runtime.snapshot().sessionFile !== sessionFile) return;
+    let plan: WorkPlan | null;
+    try {
+      plan = await loadWorkPlan(sessionFile);
+    } catch (error) {
+      reportError(error);
+      return;
+    }
+    if (!sameSessionFile(runtime.snapshot().sessionFile, sessionFile)) return;
     activeWorkPlan = plan;
     activeWorkPlanSessionFile = sessionFile;
     if (changed) broadcast({ type: "work_plan_changed", workPlan: plan });
@@ -1057,7 +1069,7 @@ function snapshot(): SessionSnapshot {
     contextUsage: state.contextUsage,
     // A runtime replacement is synchronous but its sidecar read is not. Never
     // combine the new transcript/session id with the previous session's plan.
-    workPlan: state.sessionFile === activeWorkPlanSessionFile ? activeWorkPlan : null,
+    workPlan: sameSessionFile(state.sessionFile, activeWorkPlanSessionFile) ? activeWorkPlan : null,
     writableRoot: WRITABLE_ROOT,
     gitAvailable: GIT !== null,
     credentials: credentialStatus(),
@@ -1247,7 +1259,8 @@ function onRuntimeEvent(event: RuntimeEvent): void {
         event.toolName === "work_plan" &&
         !event.isError &&
         workPlanDetails?.type === "work_plan" &&
-        workPlanDetails.sessionFile === runtime.snapshot().sessionFile
+        typeof workPlanDetails.sessionFile === "string" &&
+        sameSessionFile(workPlanDetails.sessionFile, runtime.snapshot().sessionFile)
       ) {
         try {
           // Reject malformed tool details at the runtime boundary, then reload
@@ -1539,6 +1552,7 @@ async function handleUpdateConfig(
     // Replace the current session so the new runtime picks up the updated tools
     // and re-runs skill discovery over the new paths.
     await rebuildTools.call(runtime);
+    await workPlanSessionSync;
     // Only now: the settings are on disk and the session in front of the user was
     // built from them.
     send(socket, { type: "update_config_ack", ...snapshot() });
@@ -2019,18 +2033,27 @@ async function forkSession(socket: WebSocket, entryId: string): Promise<void> {
   }
   let selectedText: string | undefined;
   const sourceSessionFile = runtime.snapshot().sessionFile;
-  await replaceSession(socket, async () => {
-    const result = await runtime.fork(entryId);
-    selectedText = result.selectedText;
-    if (!result.cancelled) {
-      await workPlanSessionSync;
-      await copyWorkPlan(sourceSessionFile, runtime.snapshot().sessionFile);
-      activeWorkPlan = await loadWorkPlan(runtime.snapshot().sessionFile);
-      activeWorkPlanSessionFile = runtime.snapshot().sessionFile;
-      broadcast({ type: "work_plan_changed", workPlan: activeWorkPlan });
-    }
-    return result;
-  });
+  let ownsInheritance = false;
+  try {
+    await replaceSession(socket, async () => {
+      // `replaceSession` calls this action only after acquiring the global
+      // replacement lock. A concurrent rejected fork must never clear the
+      // inheritance marker owned by this invocation.
+      workPlanInheritanceSource = sourceSessionFile;
+      ownsInheritance = true;
+      try {
+        const result = await runtime.fork(entryId);
+        selectedText = result.selectedText;
+        return result;
+      } catch (error) {
+        workPlanInheritanceSource = undefined;
+        ownsInheritance = false;
+        throw error;
+      }
+    });
+  } finally {
+    if (ownsInheritance) workPlanInheritanceSource = undefined;
+  }
   if (selectedText) send(socket, { type: "editor_prefill", text: selectedText });
   broadcast({ type: "tree", roots: buildTree() });
 }

--- a/server/src/piOutpostTools.ts
+++ b/server/src/piOutpostTools.ts
@@ -1,10 +1,10 @@
 /**
  * pi-outpost's own tools, packaged as a pi extension so an RPC child has them.
  *
- * The embedded runtime hands these six tool definitions straight to the SDK
+ * The embedded runtime hands these seven tool definitions straight to the SDK
  * session (`customTools` in index.ts). A `pi --mode rpc` child is a separate
  * process and builds its own toolset from its own flags, so without this file the
- * agent would lose `present_structure` and the four document extractors the moment
+ * agent would lose `present_structure`, `work_plan`, and the document extractors the moment
  * an operator switched runtimes — including the bundled structured-exchange skill,
  * which instructs the model to call a tool that would not exist.
  *
@@ -31,6 +31,7 @@ import { createPptxExtractToolDefinition } from "./pptxTool.ts";
 import { createStructuredExchangeFigureToolDefinition } from "./structuredExchangeFigureTool.ts";
 import { createStructuredExchangeToolDefinition } from "./structuredExchangeTool.ts";
 import { createXlsxExtractToolDefinition } from "./xlsxTool.ts";
+import { createWorkPlanToolDefinition } from "./workPlanTool.ts";
 
 /** What the parent must tell the child. Mirrors the fields index.ts uses embedded. */
 export interface PiOutpostToolsSettings {
@@ -81,6 +82,7 @@ export async function createPiOutpostTools(settings: PiOutpostToolsSettings): Pr
     createPptxExtractToolDefinition({ ...common, maxBytes: settings.maxBytes.pptx }),
     createStructuredExchangeFigureToolDefinition({ ...common, maxBytes: settings.maxBytes.structuredExchange }),
     createStructuredExchangeToolDefinition(),
+    createWorkPlanToolDefinition(),
   ];
 }
 

--- a/server/src/workPlanStore.ts
+++ b/server/src/workPlanStore.ts
@@ -1,8 +1,20 @@
 import fs from "node:fs/promises";
+import { realpathSync } from "node:fs";
 import path from "node:path";
 import { mutateWorkPlan, validateWorkPlan, type WorkPlan, type WorkPlanMutation } from "@pi-outpost/shared/work-plan";
 
 export const workPlanPath = (sessionFile: string): string => `${sessionFile}.work-plan.json`;
+
+/** Session paths may cross aliases such as macOS `/var` and `/private/var`. */
+export function sameSessionFile(left: string | undefined, right: string | undefined): boolean {
+  if (left === undefined || right === undefined) return left === right;
+  try {
+    return realpathSync.native(path.resolve(left)) === realpathSync.native(path.resolve(right));
+  } catch {
+    // A just-deleted session still has a stable lexical identity.
+    return path.resolve(left) === path.resolve(right);
+  }
+}
 
 export async function loadWorkPlan(sessionFile: string | undefined): Promise<WorkPlan | null> {
   if (!sessionFile) return null;

--- a/server/src/workPlanStore.ts
+++ b/server/src/workPlanStore.ts
@@ -1,0 +1,48 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { mutateWorkPlan, validateWorkPlan, type WorkPlan, type WorkPlanMutation } from "@pi-outpost/shared/work-plan";
+
+export const workPlanPath = (sessionFile: string): string => `${sessionFile}.work-plan.json`;
+
+export async function loadWorkPlan(sessionFile: string | undefined): Promise<WorkPlan | null> {
+  if (!sessionFile) return null;
+  try {
+    return validateWorkPlan(JSON.parse(await fs.readFile(workPlanPath(sessionFile), "utf8")));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw new Error(`Cannot load the Work Plan: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+async function persist(sessionFile: string, plan: WorkPlan | null): Promise<void> {
+  const target = workPlanPath(sessionFile);
+  if (plan === null) {
+    await fs.unlink(target).catch((error: NodeJS.ErrnoException) => { if (error.code !== "ENOENT") throw error; });
+    return;
+  }
+  const temporary = path.join(path.dirname(target), `.${path.basename(target)}.${process.pid}.${Date.now()}.tmp`);
+  try {
+    await fs.writeFile(temporary, `${JSON.stringify(plan, null, 2)}\n`, { encoding: "utf8", mode: 0o600, flag: "wx" });
+    await fs.rename(temporary, target);
+  } catch (error) {
+    await fs.unlink(temporary).catch(() => {});
+    throw error;
+  }
+}
+
+export async function applyWorkPlanMutation(sessionFile: string | undefined, mutation: WorkPlanMutation): Promise<WorkPlan | null> {
+  if (!sessionFile) throw new Error("The session has no persistent file yet");
+  const current = await loadWorkPlan(sessionFile);
+  const next = mutateWorkPlan(current, mutation);
+  if (mutation.action !== "get") await persist(sessionFile, next);
+  return next;
+}
+
+export async function copyWorkPlan(sourceSessionFile: string | undefined, targetSessionFile: string | undefined): Promise<void> {
+  if (!sourceSessionFile || !targetSessionFile || sourceSessionFile === targetSessionFile) return;
+  await persist(targetSessionFile, await loadWorkPlan(sourceSessionFile));
+}
+
+export async function deleteWorkPlan(sessionFile: string): Promise<void> {
+  await persist(sessionFile, null);
+}

--- a/server/src/workPlanTool.ts
+++ b/server/src/workPlanTool.ts
@@ -1,0 +1,54 @@
+import { Type } from "typebox";
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { applyWorkPlanMutation } from "./workPlanStore.ts";
+
+const parameters = Type.Object({
+  action: Type.Union([
+    Type.Literal("get"), Type.Literal("clear"), Type.Literal("replace"), Type.Literal("add_task"),
+    Type.Literal("update_task"), Type.Literal("move_task"), Type.Literal("remove_task"),
+    Type.Literal("set_dependencies"), Type.Literal("set_resources"),
+  ]),
+  plan: Type.Optional(Type.Unknown()),
+  task: Type.Optional(Type.Unknown()),
+  taskId: Type.Optional(Type.String()),
+  changes: Type.Optional(Type.Unknown()),
+  parentId: Type.Optional(Type.String()),
+  dependsOn: Type.Optional(Type.Array(Type.String())),
+  resources: Type.Optional(Type.Array(Type.Object({ uri: Type.String(), label: Type.Optional(Type.String()) }))),
+});
+
+export function createWorkPlanToolDefinition(): ToolDefinition {
+  return {
+    name: "work_plan",
+    label: "Work Plan",
+    description: "Read or atomically update the persistent Work Plan for this session. It is the agent's explicit working-state representation, not merely progress reporting: use it to drive systematic decomposition, execution tracking, and verification. Use human-readable outcomes, not tool mechanics. Create a plan only for non-trivial work that benefits from explicit decomposition; refine it as understanding changes. On a resumed session, call action=get before continuing substantial work, and reconcile the plan before declaring that work complete.",
+    promptSnippet: "Create, inspect, and update the session's persistent Work Plan",
+    promptGuidelines: [
+      "Use work_plan for substantial multi-step work; keep it current when work is discovered, blocked, reopened, completed, or needs review.",
+      "Treat the Work Plan as working state that guides decomposition, execution, and verification—not as a retrospective progress report. Reconcile it before declaring non-trivial work complete.",
+      "The plan describes objectives and outcomes, not tool calls. Do not create one for trivial interactions.",
+    ],
+    parameters,
+    executionMode: "sequential",
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const mutation = params as never;
+      try {
+        const sessionFile = ctx.sessionManager.getSessionFile();
+        const plan = await applyWorkPlanMutation(sessionFile, mutation);
+        const action = (params as { action: string }).action;
+        const summary = plan === null
+          ? "This session has no Work Plan."
+          : `Work Plan \"${plan.title}\": ${plan.tasks.length} tasks (${plan.tasks.filter((task) => task.status === "done").length} done).`;
+        return {
+          // `details` drives authoritative UI synchronization but is not model
+          // context. A resumed agent must receive the complete working state in
+          // content; otherwise post-compaction `get` would expose only a counter.
+          content: [{ type: "text", text: action === "get" && plan !== null ? `${summary}\n${JSON.stringify(plan)}` : summary }],
+          details: { type: "work_plan", sessionFile, plan, changed: action !== "get" },
+        };
+      } catch (error) {
+        return { content: [{ type: "text", text: `Work Plan update refused: ${error instanceof Error ? error.message : String(error)}` }], details: undefined, isError: true };
+      }
+    },
+  };
+}

--- a/server/src/workPlanTool.ts
+++ b/server/src/workPlanTool.ts
@@ -12,7 +12,7 @@ const parameters = Type.Object({
   task: Type.Optional(Type.Unknown()),
   taskId: Type.Optional(Type.String()),
   changes: Type.Optional(Type.Unknown()),
-  parentId: Type.Optional(Type.String()),
+  parentId: Type.Optional(Type.Union([Type.String(), Type.Null()])),
   dependsOn: Type.Optional(Type.Array(Type.String())),
   resources: Type.Optional(Type.Array(Type.Object({ uri: Type.String(), label: Type.Optional(Type.String()) }))),
 });

--- a/server/test/fixtures/fake-pi-rpc.mjs
+++ b/server/test/fixtures/fake-pi-rpc.mjs
@@ -144,11 +144,6 @@ function handle(command) {
 
   emitAll(script?.before);
 
-  if (config.dialogBlocksCommand === type) {
-    pendingDialogCommand = command;
-    return;
-  }
-
   const failure = config.failures?.[type];
   if (failure !== undefined) {
     emit({ ...responseId, type: "response", command: type, success: false, error: failure });
@@ -156,6 +151,23 @@ function handle(command) {
     return;
   }
 
+  // Keep a command in flight while another client reaches the server. This is
+  // used for replacement-lock races that cannot be reproduced with an
+  // immediate scripted response.
+  if (script?.delayMs !== undefined) {
+    setTimeout(() => finishSuccessfulCommand(command, type, script, responseId), script.delayMs);
+    return;
+  }
+
+  if (config.dialogBlocksCommand === type) {
+    pendingDialogCommand = command;
+    return;
+  }
+
+  finishSuccessfulCommand(command, type, script, responseId);
+}
+
+function finishSuccessfulCommand(command, type, script, responseId) {
   // Commands that change what the state queries return
   if (type === "set_model") state.model = { provider: command.provider, id: command.modelId, name: command.modelId, reasoning: true };
   if (type === "set_thinking_level") state.thinkingLevel = command.level;

--- a/server/test/fixtures/fake-pi-rpc.mjs
+++ b/server/test/fixtures/fake-pi-rpc.mjs
@@ -105,6 +105,7 @@ const DATA = {
 // --- reading ---------------------------------------------------------------
 
 const seen = [];
+const commandCounts = new Map();
 let pendingDialogCommand;
 
 function recordCommand(command) {
@@ -129,7 +130,10 @@ function handle(command) {
   recordCommand(command);
 
   const scripted = config.commands_ ?? {};
-  const script = scripted[type];
+  const configured = scripted[type];
+  const count = commandCounts.get(type) ?? 0;
+  commandCounts.set(type, count + 1);
+  const script = Array.isArray(configured) ? configured[Math.min(count, configured.length - 1)] : configured;
   const responseId = (config.omitResponseIdsFor ?? []).includes(type) ? {} : { id: command.id };
 
   if (config.stallCommand === type) return; // never answer: exercises the command timeout
@@ -162,6 +166,7 @@ function handle(command) {
   const data = script && "data" in script ? script.data : DATA[type]?.();
   emit({ ...responseId, type: "response", command: type, success: true, ...(data === undefined ? {} : { data }) });
 
+  for (const write of script?.writes ?? []) fs.writeFileSync(write.path, write.content);
   emitAll(script?.after);
   if (config.malformedAfter === type) emitRaw(`${config.malformedLine ?? "{not json"}\n`);
   if (config.exitAfter === type) process.exit(config.exitCode ?? 7);

--- a/server/test/fixtures/work-plan-rpc-provider.mjs
+++ b/server/test/fixtures/work-plan-rpc-provider.mjs
@@ -1,0 +1,78 @@
+import { createAssistantMessageEventStream } from "@earendil-works/pi-ai/compat";
+
+const usage = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function message(model, content, stopReason) {
+  return {
+    role: "assistant",
+    content,
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage,
+    stopReason,
+    timestamp: Date.now(),
+  };
+}
+
+function streamWorkPlan(model, context) {
+  const stream = createAssistantMessageEventStream();
+  queueMicrotask(() => {
+    const afterTool = context.messages.at(-1)?.role === "toolResult";
+    if (afterTool) {
+      const output = message(model, [{ type: "text", text: "Plan updated." }], "stop");
+      stream.push({ type: "start", partial: output });
+      stream.push({ type: "text_start", contentIndex: 0, partial: output });
+      stream.push({ type: "text_end", contentIndex: 0, content: "Plan updated.", partial: output });
+      stream.push({ type: "done", reason: "stop", message: output });
+    } else {
+      const toolCall = {
+        type: "toolCall",
+        id: "real-rpc-work-plan",
+        name: "work_plan",
+        arguments: {
+          action: "replace",
+          plan: {
+            version: 1,
+            id: "rpc-release",
+            title: "RPC release",
+            updatedAt: "2026-08-23T00:00:00.000Z",
+            tasks: [{ id: "verify", title: "Verify RPC", status: "done", dependsOn: [], resources: [] }],
+          },
+        },
+      };
+      const output = message(model, [toolCall], "toolUse");
+      stream.push({ type: "start", partial: output });
+      stream.push({ type: "toolcall_start", contentIndex: 0, partial: output });
+      stream.push({ type: "toolcall_end", contentIndex: 0, toolCall, partial: output });
+      stream.push({ type: "done", reason: "toolUse", message: output });
+    }
+    stream.end();
+  });
+  return stream;
+}
+
+export default function (pi) {
+  pi.registerProvider("work-plan-test", {
+    baseUrl: "http://127.0.0.1",
+    apiKey: "test",
+    api: "work-plan-test-api",
+    models: [{
+      id: "work-plan-test",
+      name: "Work Plan Test",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 16_000,
+      maxTokens: 1_000,
+    }],
+    streamSimple: streamWorkPlan,
+  });
+}

--- a/server/test/piOutpostTools.test.ts
+++ b/server/test/piOutpostTools.test.ts
@@ -5,8 +5,8 @@
  * child. The child builds its own toolset from `PI_OUTPOST_TOOLS`, so a missing
  * or malformed value must stop startup with a message that names the setting,
  * rather than an agent that silently runs with the wrong (or no) extractors.
- * The wiring test guards parity: the six tools the embedded runtime registers
- * are the same six the child gets, built the same way.
+ * The wiring test guards parity: the seven tools the embedded runtime registers
+ * are the same seven the child gets, built the same way.
  */
 import assert from "node:assert/strict";
 import { mkdtemp, rm } from "node:fs/promises";
@@ -137,9 +137,9 @@ describe("createPiOutpostTools", () => {
     await Promise.all(roots.map((r) => rm(r, { recursive: true, force: true })));
   });
 
-  test("returns the six tools the agent needs, in the documented order", async () => {
+  test("returns the seven tools the agent needs, in the documented order", async () => {
     const tools = await createPiOutpostTools({ cwd: root, maxBytes: VALID.maxBytes });
-    assert.equal(tools.length, 6);
+    assert.equal(tools.length, 7);
     const names = tools.map((t) => t.name);
     assert.deepEqual(names, [
       "pdf_extract",
@@ -148,6 +148,7 @@ describe("createPiOutpostTools", () => {
       "pptx_extract",
       "write_structure_figure",
       "present_structure",
+      "work_plan",
     ]);
   });
 
@@ -195,14 +196,14 @@ describe("default export (extension entry)", () => {
     });
   }
 
-  test("registers the six tools when the env var is set", async () => {
+  test("registers the seven tools when the env var is set", async () => {
     await withEnv(JSON.stringify({ cwd: root, maxBytes: VALID.maxBytes }), async () => {
       const registered: ToolDefinition[] = [];
       const pi = { registerTool: (t: ToolDefinition) => void registered.push(t) } as unknown as ExtensionAPI;
 
       await piOutpostExtension(pi);
 
-      assert.equal(registered.length, 6);
+      assert.equal(registered.length, 7);
       assert.deepEqual(
         registered.map((t) => t.name),
         [
@@ -212,6 +213,7 @@ describe("default export (extension entry)", () => {
           "pptx_extract",
           "write_structure_figure",
           "present_structure",
+          "work_plan",
         ],
       );
     });

--- a/server/test/release-workflow.test.mjs
+++ b/server/test/release-workflow.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const workflow = readFileSync(
+  new URL("../../.github/workflows/release.yml", import.meta.url),
+  "utf8",
+);
+
+test("EveryReleaseCarriesThem: a missing GitHub Release is created before assets are uploaded", () => {
+  const publishJob = workflow.slice(workflow.indexOf("\n  publish:"), workflow.indexOf("\n  attach:"));
+  const attachJob = workflow.slice(workflow.indexOf("\n  attach:"));
+  const view = attachJob.indexOf('gh release view "$GITHUB_REF_NAME"');
+  const create = attachJob.indexOf('gh release create "$GITHUB_REF_NAME"');
+  const upload = attachJob.indexOf('gh release upload "$GITHUB_REF_NAME"');
+
+  assert.ok(view >= 0, "the attach job must check whether the GitHub Release exists");
+  assert.ok(create > view, "a missing GitHub Release must be created after the check");
+  assert.ok(upload > create, "assets must be uploaded after the GitHub Release exists");
+  assert.match(publishJob, /matched=""[\s\S]+matched="\$matched \$pkg"/);
+  assert.match(publishJob, /if \[ -z "\$matched" \]; then[\s\S]+exit 1/);
+  assert.doesNotMatch(
+    publishJob,
+    /if \[ -z "\$publish" \]; then[\s\S]+exit 1/,
+    "an npm-complete rerun must continue to the release repair job",
+  );
+  assert.match(attachJob, /if ! gh release view[\s\S]+then[\s\S]+gh release create/);
+  assert.match(attachJob, /gh release upload[^\n]+--clobber/);
+});

--- a/server/test/settings-persistence.test.mjs
+++ b/server/test/settings-persistence.test.mjs
@@ -21,6 +21,7 @@ const FIXTURES = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "fix
 const CONFIG_FILE = "pi-outpost.test.json";
 
 const skills = (message) => (message.commands ?? []).filter((c) => c.source === "skill").map((c) => c.name);
+const activeTools = (message) => (message.tools ?? []).filter((tool) => tool.active).map((tool) => tool.name);
 
 describe("persistent runtime settings", () => {
   test("an applied skill path reaches the session, the config file, and the next start", async () => {
@@ -44,6 +45,8 @@ describe("persistent runtime settings", () => {
       await client.open();
       const hello = await client.waitFor("hello", 30_000);
       assert.deepEqual(skills(hello), ["skill:deployment-skill"], "precondition: only the deployment's skill");
+      assert.ok(activeTools(hello).includes("present_structure"));
+      assert.ok(activeTools(hello).includes("work_plan"));
       assert.deepEqual(hello.userSkillPaths, [], "the snapshot carries the user's own list");
 
       client.send({ type: "update_config", userSkillPaths: [skillDir] });
@@ -55,6 +58,8 @@ describe("persistent runtime settings", () => {
         "the replacement session loaded the new skill, and kept the deployment's",
       );
       assert.deepEqual(ack.userSkillPaths, [skillDir]);
+      assert.ok(activeTools(ack).includes("present_structure"), "config apply keeps the Structured Exchange tool");
+      assert.ok(activeTools(ack).includes("work_plan"), "config apply keeps the Work Plan tool");
       assert.notEqual(ack.sessionId, hello.sessionId, "the session was replaced");
 
       const persisted = JSON.parse(await readFile(path.join(root, CONFIG_FILE), "utf8"));

--- a/server/test/work-plan-server.test.mjs
+++ b/server/test/work-plan-server.test.mjs
@@ -1,11 +1,13 @@
 import assert from "node:assert/strict";
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile, readdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { test } from "node:test";
 import { connect, makeWorkspace, startServer } from "./harness.mjs";
 
 const FAKE = fileURLToPath(new URL("./fixtures/fake-pi-rpc.mjs", import.meta.url));
+const REAL_PI = fileURLToPath(new URL("../../node_modules/@earendil-works/pi-coding-agent/dist/cli.js", import.meta.url));
+const WORK_PLAN_PROVIDER = fileURLToPath(new URL("./fixtures/work-plan-rpc-provider.mjs", import.meta.url));
 
 const plan = (status = "in_progress") => ({
   version: 1,
@@ -44,6 +46,8 @@ test("running server restores, forks, reconnects, and broadcasts authoritative W
           after: [{ type: "compaction_start" }, { type: "compaction_end" }],
         },
         fork: {
+          delayMs: 500,
+          before: [{ type: "agent_start" }],
           data: { cancelled: false, text: "Prepare it" },
           replacement: {
             state: { sessionId: "fork", sessionFile: target },
@@ -52,19 +56,29 @@ test("running server restores, forks, reconnects, and broadcasts authoritative W
             leafId: "user-1",
           },
         },
-        prompt: {
-          writes: [{ path: `${target}.work-plan.json`, content: `${JSON.stringify(plan("done"), null, 2)}\n` }],
-          after: [{
-            type: "tool_execution_end",
-            toolCallId: "plan-1",
-            toolName: "work_plan",
-            result: {
-              content: [{ type: "text", text: "Work Plan updated." }],
-              details: { type: "work_plan", sessionFile: target, plan: plan("done"), changed: true },
-            },
-            isError: false,
-          }],
-        },
+        prompt: [
+          {
+            after: [
+              { type: "agent_start" },
+              { type: "tool_execution_start", toolCallId: "read-1", toolName: "read", args: { path: "README.md" } },
+              { type: "tool_execution_end", toolCallId: "read-1", toolName: "read", result: { content: [{ type: "text", text: "read" }] }, isError: false },
+              { type: "agent_end", messages: [] },
+            ],
+          },
+          {
+            writes: [{ path: `${target}.work-plan.json`, content: `${JSON.stringify(plan("done"), null, 2)}\n` }],
+            after: [{
+              type: "tool_execution_end",
+              toolCallId: "plan-1",
+              toolName: "work_plan",
+              result: {
+                content: [{ type: "text", text: "Work Plan updated." }],
+                details: { type: "work_plan", sessionFile: target, plan: plan("done"), changed: true },
+              },
+              isError: false,
+            }],
+          },
+        ],
       },
     }),
   );
@@ -81,6 +95,8 @@ test("running server restores, forks, reconnects, and broadcasts authoritative W
   let second;
   let third;
   let postCompaction;
+  let afterUnrelatedTool;
+  let concurrentFork;
   try {
     const hello = await first.waitFor("hello");
     assert.deepEqual(hello.workPlan, plan(), "the initial snapshot restores the session sidecar");
@@ -93,17 +109,46 @@ test("running server restores, forks, reconnects, and broadcasts authoritative W
     postCompaction.close();
     postCompaction = undefined;
 
+    concurrentFork = connect(server.wsUrl());
+    await concurrentFork.waitFor("hello");
     first.send({ type: "fork_session", entryId: "user-1" });
+    await first.waitFor("agent_start");
+    concurrentFork.send({ type: "fork_session", entryId: "user-1" });
+    await concurrentFork.waitFor(
+      (message) => message.type === "error" && message.message === "Session change already in progress",
+    );
+    const forkSnapshot = await first.waitFor(
+      (message) => message.type === "session_replaced" && message.sessionId === "fork",
+    );
+    assert.deepEqual(forkSnapshot.workPlan, plan(), "the first fork snapshot already carries the inherited plan");
     const inherited = await first.waitFor(
       (message) => message.type === "work_plan_changed" && message.workPlan?.tasks[0]?.status === "in_progress",
     );
     assert.deepEqual(inherited.workPlan, plan());
+    concurrentFork.close();
+    concurrentFork = undefined;
+    assert.equal(
+      first.received.some((message) => message.type === "session_replaced" && message.sessionId === "fork" && message.workPlan === null),
+      false,
+      "the fork never broadcasts a transient empty plan",
+    );
     assert.deepEqual(JSON.parse(await readFile(`${target}.work-plan.json`, "utf8")), plan());
 
     second = connect(server.wsUrl());
     const reconnected = await second.waitFor("hello");
     assert.equal(reconnected.sessionId, "fork");
     assert.deepEqual(reconnected.workPlan, plan(), "a reconnect receives the copied authoritative plan");
+
+    first.send({ type: "prompt", text: "Inspect without changing the plan" });
+    await first.waitFor((message) => message.type === "tool_end" && message.toolCallId === "read-1");
+    afterUnrelatedTool = connect(server.wsUrl());
+    assert.equal(
+      (await afterUnrelatedTool.waitFor("hello")).workPlan.tasks[0].status,
+      "in_progress",
+      "ordinary tool activity does not infer Work Plan completion",
+    );
+    afterUnrelatedTool.close();
+    afterUnrelatedTool = undefined;
 
     first.send({ type: "prompt", text: "Finish the plan" });
     const finished = (message) => message.type === "work_plan_changed" && message.workPlan?.tasks[0]?.status === "done";
@@ -121,6 +166,45 @@ test("running server restores, forks, reconnects, and broadcasts authoritative W
     second?.close();
     third?.close();
     postCompaction?.close();
+    afterUnrelatedTool?.close();
+    concurrentFork?.close();
+    await server.stop();
+  }
+});
+
+test("a real Pi RPC child executes work_plan and synchronizes its persisted result", async () => {
+  const root = await makeWorkspace();
+  const server = await startServer(root, {
+    sandbox: undefined,
+    agentRuntime: {
+      mode: "rpc",
+      executable: process.execPath,
+      args: [
+        REAL_PI,
+        "--provider", "work-plan-test",
+        "--model", "work-plan-test",
+        "--api-key", "test",
+        "--extension", WORK_PLAN_PROVIDER,
+        "--no-approve",
+      ],
+      startupTimeoutMs: 15_000,
+    },
+  });
+  const client = connect(server.wsUrl());
+  try {
+    const hello = await client.waitFor("hello", 30_000);
+    client.send({ type: "prompt", text: "Replace the Work Plan" });
+    const changed = await client.waitFor(
+      (message) => message.type === "work_plan_changed" && message.workPlan?.id === "rpc-release",
+      30_000,
+    );
+    assert.equal(changed.workPlan.tasks[0].status, "done");
+    const sidecars = (await readdir(root, { recursive: true }))
+      .filter((entry) => entry.endsWith(".work-plan.json"));
+    assert.equal(sidecars.length, 1, "the real child persisted exactly one Work Plan sidecar");
+    assert.deepEqual(JSON.parse(await readFile(path.join(root, sidecars[0]), "utf8")), changed.workPlan);
+  } finally {
+    client.close();
     await server.stop();
   }
 });

--- a/server/test/work-plan-server.test.mjs
+++ b/server/test/work-plan-server.test.mjs
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import { connect, makeWorkspace, startServer } from "./harness.mjs";
+
+const FAKE = fileURLToPath(new URL("./fixtures/fake-pi-rpc.mjs", import.meta.url));
+
+const plan = (status = "in_progress") => ({
+  version: 1,
+  id: "release",
+  title: "Prepare release",
+  updatedAt: "2026-08-23T00:00:00.000Z",
+  tasks: [
+    { id: "build", title: "Build", status, dependsOn: [], resources: [] },
+  ],
+});
+
+test("running server restores, forks, reconnects, and broadcasts authoritative Work Plans", async () => {
+  const root = await makeWorkspace();
+  const source = path.join(root, "source.jsonl");
+  const target = path.join(root, "fork.jsonl");
+  const fakeConfig = path.join(root, "fake-rpc.json");
+  const userEntry = {
+    id: "user-1",
+    parentId: null,
+    timestamp: "2026-08-23T00:00:00.000Z",
+    type: "message",
+    message: { role: "user", content: [{ type: "text", text: "Prepare it" }], timestamp: 1 },
+  };
+  await writeFile(source, "");
+  await writeFile(`${source}.work-plan.json`, `${JSON.stringify(plan(), null, 2)}\n`);
+  await writeFile(
+    fakeConfig,
+    JSON.stringify({
+      state: { sessionId: "source", sessionFile: source },
+      entries: [userEntry],
+      tree: [{ entry: userEntry, children: [] }],
+      leafId: "user-1",
+      commands_: {
+        compact: {
+          writes: [{ path: source, content: "compacted conversation summary\n" }],
+          after: [{ type: "compaction_start" }, { type: "compaction_end" }],
+        },
+        fork: {
+          data: { cancelled: false, text: "Prepare it" },
+          replacement: {
+            state: { sessionId: "fork", sessionFile: target },
+            entries: [userEntry],
+            tree: [{ entry: userEntry, children: [] }],
+            leafId: "user-1",
+          },
+        },
+        prompt: {
+          writes: [{ path: `${target}.work-plan.json`, content: `${JSON.stringify(plan("done"), null, 2)}\n` }],
+          after: [{
+            type: "tool_execution_end",
+            toolCallId: "plan-1",
+            toolName: "work_plan",
+            result: {
+              content: [{ type: "text", text: "Work Plan updated." }],
+              details: { type: "work_plan", sessionFile: target, plan: plan("done"), changed: true },
+            },
+            isError: false,
+          }],
+        },
+      },
+    }),
+  );
+
+  const server = await startServer(
+    root,
+    {
+      sandbox: undefined,
+      agentRuntime: { mode: "rpc", executable: process.execPath, args: [FAKE], startupTimeoutMs: 5_000 },
+    },
+    { env: { FAKE_PI_RPC_CONFIG: fakeConfig } },
+  );
+  const first = connect(server.wsUrl());
+  let second;
+  let third;
+  let postCompaction;
+  try {
+    const hello = await first.waitFor("hello");
+    assert.deepEqual(hello.workPlan, plan(), "the initial snapshot restores the session sidecar");
+
+    first.send({ type: "compact" });
+    await first.waitFor("compaction_end");
+    assert.deepEqual(JSON.parse(await readFile(`${source}.work-plan.json`, "utf8")), plan());
+    postCompaction = connect(server.wsUrl());
+    assert.deepEqual((await postCompaction.waitFor("hello")).workPlan, plan(), "compaction does not alter plan availability");
+    postCompaction.close();
+    postCompaction = undefined;
+
+    first.send({ type: "fork_session", entryId: "user-1" });
+    const inherited = await first.waitFor(
+      (message) => message.type === "work_plan_changed" && message.workPlan?.tasks[0]?.status === "in_progress",
+    );
+    assert.deepEqual(inherited.workPlan, plan());
+    assert.deepEqual(JSON.parse(await readFile(`${target}.work-plan.json`, "utf8")), plan());
+
+    second = connect(server.wsUrl());
+    const reconnected = await second.waitFor("hello");
+    assert.equal(reconnected.sessionId, "fork");
+    assert.deepEqual(reconnected.workPlan, plan(), "a reconnect receives the copied authoritative plan");
+
+    first.send({ type: "prompt", text: "Finish the plan" });
+    const finished = (message) => message.type === "work_plan_changed" && message.workPlan?.tasks[0]?.status === "done";
+    assert.deepEqual((await first.waitFor(finished)).workPlan, plan("done"));
+    assert.deepEqual((await second.waitFor(finished)).workPlan, plan("done"), "all clients receive one authoritative update");
+
+    // There is deliberately no client-side mutation message in the protocol.
+    // An unsolicited server-shaped frame is ignored and cannot replace state.
+    first.send({ type: "work_plan_changed", workPlan: plan("blocked") });
+    third = connect(server.wsUrl());
+    assert.deepEqual((await third.waitFor("hello")).workPlan, plan("done"));
+    assert.deepEqual(JSON.parse(await readFile(`${source}.work-plan.json`, "utf8")), plan(), "fork changes stay isolated");
+  } finally {
+    first.close();
+    second?.close();
+    third?.close();
+    postCompaction?.close();
+    await server.stop();
+  }
+});

--- a/server/test/work-plan.test.ts
+++ b/server/test/work-plan.test.ts
@@ -3,8 +3,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, it } from "node:test";
-import { mutateWorkPlan, validateWorkPlan, type WorkPlan } from "@pi-outpost/shared/work-plan";
-import { applyWorkPlanMutation, copyWorkPlan, deleteWorkPlan, loadWorkPlan, workPlanPath } from "../src/workPlanStore.ts";
+import { mutateWorkPlan, validateWorkPlan, WORK_PLAN_LIMITS, type WorkPlan } from "@pi-outpost/shared/work-plan";
+import { applyWorkPlanMutation, copyWorkPlan, deleteWorkPlan, loadWorkPlan, sameSessionFile, workPlanPath } from "../src/workPlanStore.ts";
 import { createWorkPlanToolDefinition } from "../src/workPlanTool.ts";
 
 const base = (): WorkPlan => ({
@@ -36,7 +36,7 @@ describe("Work Plan contract", () => {
     assert.equal(next?.tasks.find((task) => task.id === "verify")?.parentId, "build");
   });
 
-  it("does not infer completion from unrelated activity", () => {
+  it("keeps status unchanged when an explicit Work Plan operation only reads it", () => {
     const current = base();
     assert.deepEqual(mutateWorkPlan(current, { action: "get" }), current);
     assert.equal(current.tasks[1].status, "in_progress");
@@ -55,6 +55,27 @@ describe("Work Plan contract", () => {
     });
     assert.equal(reopened?.tasks[1].description, undefined);
     assert.equal(reopened?.tasks[1].statusReason, undefined);
+  });
+
+  it("promotes a task to the root when update_task clears parentId with JSON null", () => {
+    const nested = mutateWorkPlan(base(), { action: "move_task", taskId: "build", parentId: "analyse" });
+    const promoted = mutateWorkPlan(nested, {
+      action: "update_task",
+      taskId: "build",
+      changes: { parentId: null },
+    });
+    assert.equal(promoted?.tasks[1].parentId, undefined);
+  });
+
+  it("rejects duplicate resource URIs before they reach keyed UI rows", () => {
+    assert.throws(
+      () => mutateWorkPlan(base(), {
+        action: "set_resources",
+        taskId: "build",
+        resources: [{ uri: "workspace:a" }, { uri: "workspace:a", label: "duplicate" }],
+      }),
+      /duplicate resource URI/,
+    );
   });
 
   it("rejects invalid hierarchy and dependency cycles without changing the input", () => {
@@ -76,7 +97,11 @@ describe("Work Plan contract", () => {
         resources: [],
       })),
     };
-    assert.throws(() => validateWorkPlan(oversized), /larger than 500000 bytes/);
+    assert.throws(
+      () => validateWorkPlan(oversized),
+      new RegExp(`larger than ${WORK_PLAN_LIMITS.serializedBytes} bytes`),
+    );
+    assert.ok(WORK_PLAN_LIMITS.serializedBytes <= 64 * 1024, "a get must not refill a compacted model context");
   });
 
   it("removes descendants and cleans dependencies atomically", () => {
@@ -87,6 +112,18 @@ describe("Work Plan contract", () => {
 });
 
 describe("Work Plan persistence", () => {
+  it("recognises equivalent relative and canonical session paths", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "pi-outpost-work-plan-path-"));
+    try {
+      const sessionFile = path.join(root, "session.jsonl");
+      await fs.writeFile(sessionFile, "");
+      const relative = path.relative(process.cwd(), sessionFile);
+      assert.equal(sameSessionFile(relative, await fs.realpath(sessionFile)), true);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("loads absence, persists atomically, copies forks, and deletes with the session", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "pi-outpost-work-plan-"));
     try {
@@ -110,7 +147,7 @@ describe("Work Plan persistence", () => {
 });
 
 describe("work_plan tool", () => {
-  it("frames the plan as maintained working state rather than progress ceremony", () => {
+  it("publishes maintenance and reconciliation guidance on the model-visible tool contract", () => {
     const tool = createWorkPlanToolDefinition();
     const guidance = [tool.description, ...(tool.promptGuidelines ?? [])].join(" ");
     assert.match(guidance, /working.state/i);
@@ -133,6 +170,10 @@ describe("work_plan tool", () => {
       const restored = await tool.execute("call-resume", { action: "get" }, undefined, undefined, ctx);
       assert.deepEqual((restored.details as { plan: WorkPlan }).plan, base());
       const modelContent = (restored.content[0] as { text: string }).text;
+      assert.ok(
+        Buffer.byteLength(modelContent) <= WORK_PLAN_LIMITS.serializedBytes + 512,
+        "the model-facing response stays within the plan's compact context budget",
+      );
       assert.match(modelContent, /\"id\":\"build\"/);
       assert.match(modelContent, /workspace:src\/index\.ts/);
       const refused = await tool.execute("call-2", { action: "move_task", taskId: "build", parentId: "missing" }, undefined, undefined, ctx);

--- a/server/test/work-plan.test.ts
+++ b/server/test/work-plan.test.ts
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { mutateWorkPlan, validateWorkPlan, type WorkPlan } from "@pi-outpost/shared/work-plan";
+import { applyWorkPlanMutation, copyWorkPlan, deleteWorkPlan, loadWorkPlan, workPlanPath } from "../src/workPlanStore.ts";
+import { createWorkPlanToolDefinition } from "../src/workPlanTool.ts";
+
+const base = (): WorkPlan => ({
+  version: 1,
+  id: "delivery",
+  title: "Deliver the change",
+  updatedAt: "2026-08-23T00:00:00.000Z",
+  tasks: [
+    { id: "analyse", title: "Analyse", status: "done", dependsOn: [], resources: [] },
+    { id: "build", title: "Build", status: "in_progress", dependsOn: ["analyse"], resources: [{ uri: "workspace:src/index.ts" }] },
+  ],
+});
+
+describe("Work Plan contract", () => {
+  it("keeps task identity while editing and moving", () => {
+    const edited = mutateWorkPlan(base(), { action: "update_task", taskId: "build", changes: { title: "Build safely", status: "done" } });
+    assert.equal(edited?.tasks[1].id, "build");
+    assert.equal(edited?.tasks[1].title, "Build safely");
+    const moved = mutateWorkPlan(edited, { action: "move_task", taskId: "build", parentId: "analyse" });
+    assert.equal(moved?.tasks[1].parentId, "analyse");
+  });
+
+  it("progressively decomposes a task without changing its identity", () => {
+    const next = mutateWorkPlan(base(), {
+      action: "add_task",
+      task: { id: "verify", title: "Verify", status: "todo", parentId: "build", dependsOn: [], resources: [] },
+    });
+    assert.equal(next?.tasks.find((task) => task.id === "build")?.title, "Build");
+    assert.equal(next?.tasks.find((task) => task.id === "verify")?.parentId, "build");
+  });
+
+  it("does not infer completion from unrelated activity", () => {
+    const current = base();
+    assert.deepEqual(mutateWorkPlan(current, { action: "get" }), current);
+    assert.equal(current.tasks[1].status, "in_progress");
+  });
+
+  it("clears optional task text through JSON null", () => {
+    const blocked = mutateWorkPlan(base(), {
+      action: "update_task",
+      taskId: "build",
+      changes: { description: "Still working", status: "blocked", statusReason: "Waiting" },
+    });
+    const reopened = mutateWorkPlan(blocked, {
+      action: "update_task",
+      taskId: "build",
+      changes: { description: null, status: "in_progress", statusReason: null },
+    });
+    assert.equal(reopened?.tasks[1].description, undefined);
+    assert.equal(reopened?.tasks[1].statusReason, undefined);
+  });
+
+  it("rejects invalid hierarchy and dependency cycles without changing the input", () => {
+    const plan = base();
+    assert.throws(() => mutateWorkPlan(plan, { action: "move_task", taskId: "analyse", parentId: "missing" }), /unknown parent/);
+    assert.throws(() => mutateWorkPlan(plan, { action: "set_dependencies", taskId: "analyse", dependsOn: ["build"] }), /dependency cycle/);
+    assert.deepEqual(plan, base());
+  });
+
+  it("rejects a plan whose aggregate serialized state is too large", () => {
+    const oversized = {
+      ...base(),
+      tasks: Array.from({ length: 130 }, (_, index) => ({
+        id: `task-${index}`,
+        title: `Task ${index}`,
+        description: "x".repeat(4_000),
+        status: "todo",
+        dependsOn: [],
+        resources: [],
+      })),
+    };
+    assert.throws(() => validateWorkPlan(oversized), /larger than 500000 bytes/);
+  });
+
+  it("removes descendants and cleans dependencies atomically", () => {
+    const nested = validateWorkPlan({ ...base(), tasks: [...base().tasks, { id: "verify", title: "Verify", status: "todo", parentId: "build", dependsOn: ["build"], resources: [] }] });
+    const next = mutateWorkPlan(nested, { action: "remove_task", taskId: "build" });
+    assert.deepEqual(next?.tasks.map((task) => task.id), ["analyse"]);
+  });
+});
+
+describe("Work Plan persistence", () => {
+  it("loads absence, persists atomically, copies forks, and deletes with the session", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "pi-outpost-work-plan-"));
+    try {
+      const source = path.join(root, "source.jsonl");
+      const fork = path.join(root, "fork.jsonl");
+      assert.equal(await loadWorkPlan(source), null);
+      await applyWorkPlanMutation(source, { action: "replace", plan: base() });
+      assert.deepEqual(await loadWorkPlan(source), base());
+      await copyWorkPlan(source, fork);
+      await applyWorkPlanMutation(fork, { action: "update_task", taskId: "build", changes: { status: "done" } });
+      assert.equal((await loadWorkPlan(source))?.tasks[1].status, "in_progress");
+      assert.equal((await loadWorkPlan(fork))?.tasks[1].status, "done");
+      await deleteWorkPlan(source);
+      assert.equal(await loadWorkPlan(source), null);
+      assert.equal(await fs.stat(workPlanPath(source)).catch(() => null), null);
+      assert.deepEqual((await fs.readdir(root)).filter((name) => name.includes(".tmp")), []);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("work_plan tool", () => {
+  it("frames the plan as maintained working state rather than progress ceremony", () => {
+    const tool = createWorkPlanToolDefinition();
+    const guidance = [tool.description, ...(tool.promptGuidelines ?? [])].join(" ");
+    assert.match(guidance, /working.state/i);
+    assert.match(guidance, /decomposition/i);
+    assert.match(guidance, /verification/i);
+    assert.match(guidance, /reconcile.*before declaring/i);
+    assert.match(guidance, /trivial/i);
+  });
+
+  it("returns authoritative details and refuses a partial invalid mutation", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "pi-outpost-work-plan-tool-"));
+    try {
+      const sessionFile = path.join(root, "session.jsonl");
+      await fs.writeFile(sessionFile, "original conversation\n");
+      const tool = createWorkPlanToolDefinition();
+      const ctx = { sessionManager: { getSessionFile: () => sessionFile } } as never;
+      const replaced = await tool.execute("call-1", { action: "replace", plan: base() }, undefined, undefined, ctx);
+      assert.equal((replaced.details as { type: string }).type, "work_plan");
+      await fs.writeFile(sessionFile, "compacted conversation summary\n");
+      const restored = await tool.execute("call-resume", { action: "get" }, undefined, undefined, ctx);
+      assert.deepEqual((restored.details as { plan: WorkPlan }).plan, base());
+      const modelContent = (restored.content[0] as { text: string }).text;
+      assert.match(modelContent, /\"id\":\"build\"/);
+      assert.match(modelContent, /workspace:src\/index\.ts/);
+      const refused = await tool.execute("call-2", { action: "move_task", taskId: "build", parentId: "missing" }, undefined, undefined, ctx);
+      assert.equal(refused.isError, true);
+      assert.deepEqual(await loadWorkPlan(sessionFile), base());
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/shared/package.json
+++ b/shared/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "exports": {
     ".": "./src/protocol.ts",
+    "./work-plan": "./src/workPlan.ts",
     "./structured-exchange": "./src/structuredExchange.ts",
     "./structured-exchange/validation": "./src/structuredExchangeValidation.ts",
     "./structured-exchange/parse": "./src/structuredExchangeParse.ts",

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -163,6 +163,9 @@ export interface ContextUsage {
   percent: number | null;
 }
 
+export type { WorkPlan, WorkPlanResource, WorkPlanStatus, WorkPlanTask } from "./workPlan.ts";
+import type { WorkPlan } from "./workPlan.ts";
+
 /**
  * Extension "Custom UI" bridge (see pi's extensions.md#custom-ui). Mirrors the
  * shape of pi's own RPC-mode protocol (`RpcExtensionUIRequest`/Response) so the
@@ -309,6 +312,8 @@ export interface SessionSnapshot {
   models: ModelChoice[];
   commands: CommandInfo[];
   contextUsage?: ContextUsage;
+  /** Agent-owned, session-persistent plan; null when this session has none. */
+  workPlan?: WorkPlan | null;
   /**
    * File-browser writable zone, relative to the browser root (posix separators):
    * absent when no sandbox is configured (nothing to distinguish), `null` when the
@@ -428,6 +433,7 @@ export type ServerMessage =
     }
   | { type: "queue"; steering: string[]; followUp: string[] }
   | { type: "context_usage"; usage: ContextUsage }
+  | { type: "work_plan_changed"; workPlan: WorkPlan | null }
   | { type: "compaction_start" }
   | { type: "compaction_end"; errorMessage?: string }
   | { type: "error"; message: string }

--- a/shared/src/workPlan.ts
+++ b/shared/src/workPlan.ts
@@ -1,0 +1,200 @@
+export const WORK_PLAN_STATUSES = ["todo", "in_progress", "done", "blocked", "needs_review"] as const;
+export type WorkPlanStatus = (typeof WORK_PLAN_STATUSES)[number];
+
+export interface WorkPlanResource {
+  /** Generic address. `workspace:<path>` is navigable by Pi Outpost. */
+  uri: string;
+  label?: string;
+}
+
+export interface WorkPlanTask {
+  id: string;
+  title: string;
+  description?: string;
+  status: WorkPlanStatus;
+  parentId?: string;
+  dependsOn: string[];
+  resources: WorkPlanResource[];
+  statusReason?: string;
+}
+
+export interface WorkPlan {
+  version: 1;
+  id: string;
+  title: string;
+  tasks: WorkPlanTask[];
+  updatedAt: string;
+}
+
+export const WORK_PLAN_LIMITS = {
+  serializedBytes: 500_000,
+  tasks: 500,
+  title: 200,
+  description: 4_000,
+  reason: 2_000,
+  resourcesPerTask: 50,
+  uri: 2_000,
+} as const;
+
+export type WorkPlanMutation =
+  | { action: "get" }
+  | { action: "clear" }
+  | { action: "replace"; plan: unknown }
+  | { action: "add_task"; task: unknown }
+  | { action: "update_task"; taskId: string; changes: unknown }
+  | { action: "move_task"; taskId: string; parentId?: string }
+  | { action: "remove_task"; taskId: string }
+  | { action: "set_dependencies"; taskId: string; dependsOn: unknown }
+  | { action: "set_resources"; taskId: string; resources: unknown };
+
+function object(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error("must be an object");
+  return value as Record<string, unknown>;
+}
+
+function text(value: unknown, field: string, max: number): string {
+  if (typeof value !== "string" || value.trim() === "") throw new Error(`${field} must be a non-empty string`);
+  if (value.length > max) throw new Error(`${field} is longer than ${max} characters`);
+  return value.trim();
+}
+
+function optionalText(value: unknown, field: string, max: number): string | undefined {
+  // `null` is the JSON-representable way for an agent to clear an optional
+  // field; `undefined` cannot survive the tool-call serialization boundary.
+  if (value === undefined || value === null) return undefined;
+  return text(value, field, max);
+}
+
+function ids(value: unknown, field: string): string[] {
+  if (!Array.isArray(value)) throw new Error(`${field} must be an array`);
+  const result = value.map((item, index) => text(item, `${field}[${index}]`, WORK_PLAN_LIMITS.title));
+  if (new Set(result).size !== result.length) throw new Error(`${field} contains duplicates`);
+  return result;
+}
+
+function resources(value: unknown): WorkPlanResource[] {
+  if (!Array.isArray(value)) throw new Error("resources must be an array");
+  if (value.length > WORK_PLAN_LIMITS.resourcesPerTask) throw new Error("too many resources");
+  return value.map((item, index) => {
+    const raw = object(item);
+    return {
+      uri: text(raw.uri, `resources[${index}].uri`, WORK_PLAN_LIMITS.uri),
+      ...(raw.label === undefined ? {} : { label: text(raw.label, `resources[${index}].label`, WORK_PLAN_LIMITS.title) }),
+    };
+  });
+}
+
+function task(value: unknown): WorkPlanTask {
+  const raw = object(value);
+  const status = raw.status;
+  if (typeof status !== "string" || !WORK_PLAN_STATUSES.includes(status as WorkPlanStatus)) {
+    throw new Error(`status must be one of ${WORK_PLAN_STATUSES.join(", ")}`);
+  }
+  return {
+    id: text(raw.id, "task.id", WORK_PLAN_LIMITS.title),
+    title: text(raw.title, "task.title", WORK_PLAN_LIMITS.title),
+    ...(raw.description === undefined ? {} : { description: optionalText(raw.description, "task.description", WORK_PLAN_LIMITS.description) }),
+    status: status as WorkPlanStatus,
+    ...(raw.parentId === undefined ? {} : { parentId: text(raw.parentId, "task.parentId", WORK_PLAN_LIMITS.title) }),
+    dependsOn: raw.dependsOn === undefined ? [] : ids(raw.dependsOn, "task.dependsOn"),
+    resources: raw.resources === undefined ? [] : resources(raw.resources),
+    ...(raw.statusReason === undefined ? {} : { statusReason: optionalText(raw.statusReason, "task.statusReason", WORK_PLAN_LIMITS.reason) }),
+  };
+}
+
+function assertGraph(tasks: WorkPlanTask[]): void {
+  const byId = new Map<string, WorkPlanTask>();
+  for (const item of tasks) {
+    if (byId.has(item.id)) throw new Error(`duplicate task id: ${item.id}`);
+    byId.set(item.id, item);
+  }
+  for (const item of tasks) {
+    if (item.parentId !== undefined && !byId.has(item.parentId)) throw new Error(`unknown parent task: ${item.parentId}`);
+    if (item.parentId === item.id) throw new Error(`task ${item.id} cannot parent itself`);
+    for (const dependency of item.dependsOn) {
+      if (!byId.has(dependency)) throw new Error(`unknown dependency: ${dependency}`);
+      if (dependency === item.id) throw new Error(`task ${item.id} cannot depend on itself`);
+    }
+  }
+  const visit = (id: string, edge: "parent" | "dependency", visiting: Set<string>, visited: Set<string>) => {
+    if (visiting.has(id)) throw new Error(`${edge} cycle detected at task ${id}`);
+    if (visited.has(id)) return;
+    visiting.add(id);
+    const item = byId.get(id)!;
+    const next = edge === "parent" ? (item.parentId ? [item.parentId] : []) : item.dependsOn;
+    for (const target of next) visit(target, edge, visiting, visited);
+    visiting.delete(id);
+    visited.add(id);
+  };
+  for (const id of byId.keys()) {
+    visit(id, "parent", new Set(), new Set());
+    visit(id, "dependency", new Set(), new Set());
+  }
+}
+
+export function validateWorkPlan(value: unknown): WorkPlan {
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(value);
+  } catch {
+    throw new Error("work plan must be JSON-serializable");
+  }
+  if (new TextEncoder().encode(serialized).byteLength > WORK_PLAN_LIMITS.serializedBytes) {
+    throw new Error(`work plan is larger than ${WORK_PLAN_LIMITS.serializedBytes} bytes`);
+  }
+  const raw = object(value);
+  if (raw.version !== 1) throw new Error("work plan version must be 1");
+  if (!Array.isArray(raw.tasks)) throw new Error("tasks must be an array");
+  if (raw.tasks.length > WORK_PLAN_LIMITS.tasks) throw new Error(`a work plan may contain at most ${WORK_PLAN_LIMITS.tasks} tasks`);
+  const tasks = raw.tasks.map(task);
+  assertGraph(tasks);
+  const updatedAt = typeof raw.updatedAt === "string" && !Number.isNaN(Date.parse(raw.updatedAt)) ? raw.updatedAt : new Date().toISOString();
+  return {
+    version: 1,
+    id: text(raw.id, "plan.id", WORK_PLAN_LIMITS.title),
+    title: text(raw.title, "plan.title", WORK_PLAN_LIMITS.title),
+    tasks,
+    updatedAt,
+  };
+}
+
+export function mutateWorkPlan(current: WorkPlan | null, mutation: WorkPlanMutation): WorkPlan | null {
+  if (mutation.action === "get") return current;
+  if (mutation.action === "clear") return null;
+  if (mutation.action === "replace") return validateWorkPlan(mutation.plan);
+  if (current === null) throw new Error("create a plan with action=replace before mutating tasks");
+  let tasks = current.tasks.map((item) => ({ ...item, dependsOn: [...item.dependsOn], resources: item.resources.map((resource) => ({ ...resource })) }));
+  const index = "taskId" in mutation ? tasks.findIndex((item) => item.id === mutation.taskId) : -1;
+  if ("taskId" in mutation && index < 0) throw new Error(`unknown task: ${mutation.taskId}`);
+  switch (mutation.action) {
+    case "add_task":
+      tasks.push(task(mutation.task));
+      break;
+    case "update_task": {
+      const changes = object(mutation.changes);
+      if (changes.id !== undefined) throw new Error("task identity cannot be changed");
+      tasks[index] = task({ ...tasks[index], ...changes, id: tasks[index].id });
+      break;
+    }
+    case "move_task":
+      tasks[index] = { ...tasks[index], ...(mutation.parentId === undefined ? { parentId: undefined } : { parentId: text(mutation.parentId, "parentId", WORK_PLAN_LIMITS.title) }) };
+      break;
+    case "remove_task": {
+      const removed = new Set<string>([mutation.taskId]);
+      let changed = true;
+      while (changed) {
+        changed = false;
+        for (const item of tasks) if (item.parentId && removed.has(item.parentId) && !removed.has(item.id)) { removed.add(item.id); changed = true; }
+      }
+      tasks = tasks.filter((item) => !removed.has(item.id)).map((item) => ({ ...item, dependsOn: item.dependsOn.filter((id) => !removed.has(id)) }));
+      break;
+    }
+    case "set_dependencies":
+      tasks[index] = { ...tasks[index], dependsOn: ids(mutation.dependsOn, "dependsOn") };
+      break;
+    case "set_resources":
+      tasks[index] = { ...tasks[index], resources: resources(mutation.resources) };
+      break;
+  }
+  return validateWorkPlan({ ...current, tasks, updatedAt: new Date().toISOString() });
+}

--- a/shared/src/workPlan.ts
+++ b/shared/src/workPlan.ts
@@ -27,7 +27,9 @@ export interface WorkPlan {
 }
 
 export const WORK_PLAN_LIMITS = {
-  serializedBytes: 500_000,
+  // `action=get` returns the complete plan to the model after resume/compaction.
+  // Keep that recovery state useful without letting it refill an entire context.
+  serializedBytes: 64 * 1024,
   tasks: 500,
   title: 200,
   description: 4_000,
@@ -42,7 +44,7 @@ export type WorkPlanMutation =
   | { action: "replace"; plan: unknown }
   | { action: "add_task"; task: unknown }
   | { action: "update_task"; taskId: string; changes: unknown }
-  | { action: "move_task"; taskId: string; parentId?: string }
+  | { action: "move_task"; taskId: string; parentId?: string | null }
   | { action: "remove_task"; taskId: string }
   | { action: "set_dependencies"; taskId: string; dependsOn: unknown }
   | { action: "set_resources"; taskId: string; resources: unknown };
@@ -75,13 +77,17 @@ function ids(value: unknown, field: string): string[] {
 function resources(value: unknown): WorkPlanResource[] {
   if (!Array.isArray(value)) throw new Error("resources must be an array");
   if (value.length > WORK_PLAN_LIMITS.resourcesPerTask) throw new Error("too many resources");
-  return value.map((item, index) => {
+  const result = value.map((item, index) => {
     const raw = object(item);
     return {
       uri: text(raw.uri, `resources[${index}].uri`, WORK_PLAN_LIMITS.uri),
       ...(raw.label === undefined ? {} : { label: text(raw.label, `resources[${index}].label`, WORK_PLAN_LIMITS.title) }),
     };
   });
+  if (new Set(result.map((resource) => resource.uri)).size !== result.length) {
+    throw new Error("resources contains a duplicate resource URI");
+  }
+  return result;
 }
 
 function task(value: unknown): WorkPlanTask {
@@ -95,7 +101,9 @@ function task(value: unknown): WorkPlanTask {
     title: text(raw.title, "task.title", WORK_PLAN_LIMITS.title),
     ...(raw.description === undefined ? {} : { description: optionalText(raw.description, "task.description", WORK_PLAN_LIMITS.description) }),
     status: status as WorkPlanStatus,
-    ...(raw.parentId === undefined ? {} : { parentId: text(raw.parentId, "task.parentId", WORK_PLAN_LIMITS.title) }),
+    ...(raw.parentId === undefined || raw.parentId === null
+      ? {}
+      : { parentId: text(raw.parentId, "task.parentId", WORK_PLAN_LIMITS.title) }),
     dependsOn: raw.dependsOn === undefined ? [] : ids(raw.dependsOn, "task.dependsOn"),
     resources: raw.resources === undefined ? [] : resources(raw.resources),
     ...(raw.statusReason === undefined ? {} : { statusReason: optionalText(raw.statusReason, "task.statusReason", WORK_PLAN_LIMITS.reason) }),
@@ -177,7 +185,12 @@ export function mutateWorkPlan(current: WorkPlan | null, mutation: WorkPlanMutat
       break;
     }
     case "move_task":
-      tasks[index] = { ...tasks[index], ...(mutation.parentId === undefined ? { parentId: undefined } : { parentId: text(mutation.parentId, "parentId", WORK_PLAN_LIMITS.title) }) };
+      tasks[index] = {
+        ...tasks[index],
+        ...(mutation.parentId === undefined || mutation.parentId === null
+          ? { parentId: undefined }
+          : { parentId: text(mutation.parentId, "parentId", WORK_PLAN_LIMITS.title) }),
+      };
       break;
     case "remove_task": {
       const removed = new Set<string>([mutation.taskId]);

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -35,6 +35,7 @@ import { ModelBar } from "./components/ModelBar";
 import { Onboarding } from "./components/Onboarding";
 import { Sidebar } from "./components/Sidebar";
 import { TokenGate } from "./components/TokenGate";
+import { WorkPlanPanel } from "./components/WorkPlanPanel";
 import { useAgent } from "./useAgent";
 
 export interface AppHandle {
@@ -146,6 +147,17 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
   }
   // Session analysis drawer: closed until asked for, from the model bar's usage indicator.
   const [analysisOpen, setAnalysisOpen] = useState(false);
+  const [workPlanOpen, setWorkPlanOpen] = useState(true);
+  function toggleAnalysis() {
+    const next = !analysisOpen;
+    setAnalysisOpen(next);
+    if (next) setWorkPlanOpen(false);
+  }
+  function toggleWorkPlan() {
+    const next = !workPlanOpen;
+    setWorkPlanOpen(next);
+    if (next) setAnalysisOpen(false);
+  }
   const [attachmentErrors, setAttachmentErrors] = useState<string[]>([]);
   // Files being copied into the workspace right now — the composer shows one chip
   // each and refuses to send while any of them is outstanding.
@@ -509,6 +521,17 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
               viewer, a commit view) stays below the header's menus no matter what
               z-index it asks for. */}
           <div className="relative z-0 flex min-h-0 flex-1 flex-col">
+          {state.workPlan && (
+            <WorkPlanPanel
+              plan={state.workPlan}
+              open={workPlanOpen}
+              onToggle={toggleWorkPlan}
+              onOpenWorkspace={(path) => {
+                setDiffOnOpen(false);
+                readFile(path);
+              }}
+            />
+          )}
           {state.openFile && (
             <FileViewer
               // Remount per file: edit drafts must never survive a switch to another path
@@ -557,7 +580,7 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
           <main
             ref={mainRef}
             onScroll={handleScroll}
-            className={`flex-1 overflow-y-auto ${analysisOpen ? "md:pr-[26rem]" : ""}`}
+            className={`flex-1 overflow-y-auto ${analysisOpen ? "md:pr-[26rem]" : ""} ${state.workPlan && workPlanOpen ? "md:pr-[23rem]" : ""}`}
           >
             <div className="mx-auto flex max-w-3xl flex-col gap-3 px-4 py-6">
               {state.items.length === 0 && (
@@ -698,7 +721,7 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
                 contextUsage={state.contextUsage}
                 sessionUsage={usage}
                 analysisOpen={analysisOpen}
-                onToggleAnalysis={() => setAnalysisOpen((open) => !open)}
+                onToggleAnalysis={toggleAnalysis}
                 isCompacting={state.isCompacting}
                 onSetModel={setModel}
                 onSetThinking={setThinking}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -580,7 +580,7 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
           <main
             ref={mainRef}
             onScroll={handleScroll}
-            className={`flex-1 overflow-y-auto ${analysisOpen ? "md:pr-[26rem]" : ""} ${state.workPlan && workPlanOpen ? "md:pr-[23rem]" : ""}`}
+            className={`flex-1 overflow-y-auto ${analysisOpen ? "md:pr-[26rem]" : state.workPlan && workPlanOpen ? "md:pr-[23rem]" : ""}`}
           >
             <div className="mx-auto flex max-w-3xl flex-col gap-3 px-4 py-6">
               {state.items.length === 0 && (

--- a/ui/src/components/WorkPlanPanel.test.tsx
+++ b/ui/src/components/WorkPlanPanel.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { WorkPlan } from "@pi-outpost/shared";
+import { WorkPlanPanel } from "./WorkPlanPanel";
+
+const plan: WorkPlan = {
+  version: 1,
+  id: "release",
+  title: "Ship the feature",
+  updatedAt: "2026-08-23T00:00:00.000Z",
+  tasks: [
+    { id: "analyse", title: "Analyse impact", status: "done", dependsOn: [], resources: [] },
+    { id: "build", title: "Build UI", description: "Keep the plan readable.", status: "in_progress", dependsOn: ["analyse"], resources: [{ uri: "workspace:ui/src/App.tsx", label: "App" }] },
+    { id: "review", title: "Review output", status: "needs_review", parentId: "build", dependsOn: ["build"], resources: [{ uri: "model:SYS-421", label: "SYS-421" }], statusReason: "Needs human acceptance" },
+    { id: "blocked", title: "Publish", status: "blocked", dependsOn: ["review"], resources: [], statusReason: "Credentials unavailable" },
+  ],
+};
+
+describe("WorkPlanPanel", () => {
+  it("shows hierarchy, distinct states, focus, and aggregate progress", () => {
+    render(<WorkPlanPanel plan={plan} open onToggle={() => {}} onOpenWorkspace={() => {}} />);
+    expect(screen.getByText("Progress: 1 / 4")).toBeTruthy();
+    expect(screen.getByLabelText("In progress").closest("button")?.getAttribute("aria-current")).toBe("step");
+    expect(screen.getByLabelText("Done")).toBeTruthy();
+    expect(screen.getByLabelText("Needs review")).toBeTruthy();
+    expect(screen.getByLabelText("Blocked")).toBeTruthy();
+  });
+
+  it("inspects details and navigates known workspace resources", () => {
+    const onOpenWorkspace = vi.fn();
+    render(<WorkPlanPanel plan={plan} open onToggle={() => {}} onOpenWorkspace={onOpenWorkspace} />);
+    fireEvent.click(screen.getByRole("button", { name: /Build UI/ }));
+    expect(screen.getByText("Keep the plan readable.")).toBeTruthy();
+    expect(screen.getByLabelText("Task details").textContent).toContain("Depends on: Analyse impact");
+    fireEvent.click(screen.getByRole("button", { name: "App" }));
+    expect(onOpenWorkspace).toHaveBeenCalledWith("ui/src/App.tsx");
+  });
+
+  it("keeps an unresolved generic resource visible but not clickable", () => {
+    render(<WorkPlanPanel plan={plan} open onToggle={() => {}} onOpenWorkspace={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: /Review output/ }));
+    expect(screen.getByText("Needs human acceptance")).toBeTruthy();
+    expect(screen.getByText("SYS-421").tagName).toBe("SPAN");
+    fireEvent.click(screen.getByRole("button", { name: /Publish/ }));
+    expect(screen.getByText("Credentials unavailable")).toBeTruthy();
+  });
+
+  it("collapses to a readily accessible progress control", () => {
+    const onToggle = vi.fn();
+    render(<WorkPlanPanel plan={plan} open={false} onToggle={onToggle} onOpenWorkspace={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: "Open Work Plan" }));
+    expect(onToggle).toHaveBeenCalledOnce();
+  });
+});

--- a/ui/src/components/WorkPlanPanel.test.tsx
+++ b/ui/src/components/WorkPlanPanel.test.tsx
@@ -24,12 +24,14 @@ describe("WorkPlanPanel", () => {
     expect(screen.getByLabelText("Done")).toBeTruthy();
     expect(screen.getByLabelText("Needs review")).toBeTruthy();
     expect(screen.getByLabelText("Blocked")).toBeTruthy();
+    expect(screen.getByRole("treeitem", { name: /Build UI/ })).toHaveAttribute("aria-level", "1");
+    expect(screen.getByRole("treeitem", { name: /Review output/ })).toHaveAttribute("aria-level", "2");
   });
 
   it("inspects details and navigates known workspace resources", () => {
     const onOpenWorkspace = vi.fn();
     render(<WorkPlanPanel plan={plan} open onToggle={() => {}} onOpenWorkspace={onOpenWorkspace} />);
-    fireEvent.click(screen.getByRole("button", { name: /Build UI/ }));
+    fireEvent.click(screen.getByRole("treeitem", { name: /Build UI/ }));
     expect(screen.getByText("Keep the plan readable.")).toBeTruthy();
     expect(screen.getByLabelText("Task details").textContent).toContain("Depends on: Analyse impact");
     fireEvent.click(screen.getByRole("button", { name: "App" }));
@@ -38,17 +40,44 @@ describe("WorkPlanPanel", () => {
 
   it("keeps an unresolved generic resource visible but not clickable", () => {
     render(<WorkPlanPanel plan={plan} open onToggle={() => {}} onOpenWorkspace={() => {}} />);
-    fireEvent.click(screen.getByRole("button", { name: /Review output/ }));
+    fireEvent.click(screen.getByRole("treeitem", { name: /Review output/ }));
     expect(screen.getByText("Needs human acceptance")).toBeTruthy();
     expect(screen.getByText("SYS-421").tagName).toBe("SPAN");
-    fireEvent.click(screen.getByRole("button", { name: /Publish/ }));
+    fireEvent.click(screen.getByRole("treeitem", { name: /Publish/ }));
     expect(screen.getByText("Credentials unavailable")).toBeTruthy();
   });
 
-  it("collapses to a readily accessible progress control", () => {
+  it("does not make a traversing workspace reference navigable", () => {
+    const unsafe: WorkPlan = {
+      ...plan,
+      tasks: [{ ...plan.tasks[0], resources: [{ uri: "workspace:../../etc/passwd", label: "outside" }] }],
+    };
+    const onOpenWorkspace = vi.fn();
+    render(<WorkPlanPanel plan={unsafe} open onToggle={() => {}} onOpenWorkspace={onOpenWorkspace} />);
+    fireEvent.click(screen.getByRole("treeitem", { name: /Analyse impact/ }));
+    expect(screen.getByText("outside").tagName).toBe("SPAN");
+    expect(onOpenWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("previews task lines from the collapsed progress control before opening details", () => {
     const onToggle = vi.fn();
     render(<WorkPlanPanel plan={plan} open={false} onToggle={onToggle} onOpenWorkspace={() => {}} />);
-    fireEvent.click(screen.getByRole("button", { name: "Open Work Plan" }));
+    const control = screen.getByRole("button", { name: "Open Work Plan" });
+    const preview = screen.getByRole("tooltip");
+    expect(control).toHaveAttribute("aria-describedby", preview.id);
+    expect(preview).toHaveClass("hidden");
+    fireEvent.mouseEnter(control.parentElement!);
+    expect(preview).toHaveClass("block");
+    expect(preview.textContent).toContain("Analyse impact");
+    expect(preview.textContent).toContain("Build UI");
+    expect(preview.textContent).toContain("Review output");
+    expect(preview.textContent).toContain("Publish");
+    expect(preview.querySelectorAll("li")).toHaveLength(4);
+    expect(screen.getByLabelText("Done").textContent).toBe("☑");
+    expect(screen.getByLabelText("In progress").textContent).toBe("☐");
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(preview).toHaveClass("hidden");
+    fireEvent.click(control);
     expect(onToggle).toHaveBeenCalledOnce();
   });
 });

--- a/ui/src/components/WorkPlanPanel.tsx
+++ b/ui/src/components/WorkPlanPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
 import type { WorkPlan, WorkPlanResource, WorkPlanStatus, WorkPlanTask } from "@pi-outpost/shared";
 
 const STATUS: Record<WorkPlanStatus, { icon: string; label: string; className: string }> = {
@@ -9,6 +9,8 @@ const STATUS: Record<WorkPlanStatus, { icon: string; label: string; className: s
   needs_review: { icon: "?", label: "Needs review", className: "text-amber-600 dark:text-amber-400" },
 };
 
+const PREVIEW_TASK_LIMIT = 8;
+
 interface WorkPlanPanelProps {
   plan: WorkPlan;
   open: boolean;
@@ -17,16 +19,31 @@ interface WorkPlanPanelProps {
 }
 
 function workspacePath(resource: WorkPlanResource): string | null {
-  if (resource.uri.startsWith("workspace:")) return resource.uri.slice("workspace:".length);
-  if (!/^[a-z][a-z0-9+.-]*:/i.test(resource.uri)) return resource.uri;
-  return null;
+  const candidate = resource.uri.startsWith("workspace:")
+    ? resource.uri.slice("workspace:".length)
+    : !/^[a-z][a-z0-9+.-]*:/i.test(resource.uri)
+      ? resource.uri
+      : null;
+  if (candidate === null || candidate === "" || /^(?:[\\/]|[a-z]:[\\/])/i.test(candidate)) return null;
+  if (candidate.replaceAll("\\", "/").split("/").includes("..")) return null;
+  return candidate;
 }
 
 export function WorkPlanPanel({ plan, open, onToggle, onOpenWorkspace }: WorkPlanPanelProps) {
+  const previewId = useId();
+  const [previewVisible, setPreviewVisible] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   useEffect(() => {
     if (selectedId !== null && !plan.tasks.some((task) => task.id === selectedId)) setSelectedId(null);
   }, [plan, selectedId]);
+  useEffect(() => {
+    if (!previewVisible) return;
+    const dismiss = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setPreviewVisible(false);
+    };
+    document.addEventListener("keydown", dismiss);
+    return () => document.removeEventListener("keydown", dismiss);
+  }, [previewVisible]);
 
   const children = useMemo(() => {
     const result = new Map<string | undefined, WorkPlanTask[]>();
@@ -34,6 +51,17 @@ export function WorkPlanPanel({ plan, open, onToggle, onOpenWorkspace }: WorkPla
     return result;
   }, [plan.tasks]);
   const byId = useMemo(() => new Map(plan.tasks.map((task) => [task.id, task])), [plan.tasks]);
+  const previewTasks = useMemo(() => {
+    const result: Array<{ task: WorkPlanTask; depth: number }> = [];
+    const visit = (parentId: string | undefined, depth: number) => {
+      for (const task of children.get(parentId) ?? []) {
+        result.push({ task, depth });
+        visit(task.id, depth + 1);
+      }
+    };
+    visit(undefined, 0);
+    return result.slice(0, PREVIEW_TASK_LIMIT);
+  }, [children]);
   const selected = selectedId ? byId.get(selectedId) : undefined;
   const done = plan.tasks.filter((task) => task.status === "done").length;
 
@@ -41,7 +69,7 @@ export function WorkPlanPanel({ plan, open, onToggle, onOpenWorkspace }: WorkPla
     (children.get(parentId) ?? []).flatMap((task) => {
       const status = STATUS[task.status];
       return [
-        <button key={task.id} type="button" onClick={() => setSelectedId(task.id)} aria-current={task.status === "in_progress" ? "step" : undefined}
+        <button key={task.id} type="button" role="treeitem" aria-level={depth + 1} aria-selected={selectedId === task.id} onClick={() => setSelectedId(task.id)} aria-current={task.status === "in_progress" ? "step" : undefined}
           className={`flex w-full items-start gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800 ${selectedId === task.id ? "bg-zinc-100 dark:bg-zinc-800" : ""}`}
           style={{ paddingLeft: `${0.5 + depth * 0.85}rem` }}>
           <span className={`mt-px w-4 shrink-0 text-center font-semibold ${status.className}`} aria-label={status.label}>{status.icon}</span>
@@ -51,7 +79,21 @@ export function WorkPlanPanel({ plan, open, onToggle, onOpenWorkspace }: WorkPla
       ];
     });
 
-  if (!open) return <button type="button" onClick={onToggle} className="absolute right-3 top-3 z-20 rounded-md border border-zinc-300 bg-white px-2 py-1 text-xs shadow-sm dark:border-zinc-700 dark:bg-zinc-900" aria-label="Open Work Plan">Plan {done}/{plan.tasks.length}</button>;
+  if (!open) return (
+    <div className="absolute right-3 top-3 z-20" onMouseEnter={() => setPreviewVisible(true)} onMouseLeave={() => setPreviewVisible(false)} onFocusCapture={() => setPreviewVisible(true)} onBlurCapture={() => setPreviewVisible(false)}>
+      <button type="button" onClick={() => { setPreviewVisible(false); onToggle(); }} className="rounded-md border border-zinc-300 bg-white px-2 py-1 text-xs shadow-sm dark:border-zinc-700 dark:bg-zinc-900" aria-label="Open Work Plan" aria-describedby={previewId}>Plan {done}/{plan.tasks.length}</button>
+      <div id={previewId} role="tooltip" className={`absolute right-0 top-full w-72 pt-2 ${previewVisible ? "block" : "hidden"}`}>
+        <div className="rounded-md border border-zinc-200 bg-white p-2 shadow-lg dark:border-zinc-700 dark:bg-zinc-900"><ul className="space-y-1">
+          {previewTasks.map(({ task, depth }) => <li key={task.id} className="flex min-w-0 items-start gap-1.5 text-xs" style={{ paddingLeft: `${depth * 0.75}rem` }}>
+            <span aria-label={STATUS[task.status].label} className={`shrink-0 font-semibold ${STATUS[task.status].className}`}>{task.status === "done" ? "☑" : "☐"}</span>
+            <span className={`truncate ${task.status === "done" ? "text-zinc-500 line-through" : "text-zinc-800 dark:text-zinc-200"}`}>{task.title}</span>
+          </li>)}
+        </ul>
+        {plan.tasks.length > previewTasks.length && <div className="mt-1 text-[11px] text-zinc-500">+{plan.tasks.length - previewTasks.length} more</div>}
+        </div>
+      </div>
+    </div>
+  );
 
   return (
     <aside aria-label="Work Plan" className="absolute inset-y-0 right-0 z-10 flex w-full flex-col border-l border-zinc-200 bg-white/95 shadow-lg backdrop-blur md:w-[23rem] dark:border-zinc-800 dark:bg-zinc-950/95">
@@ -60,7 +102,7 @@ export function WorkPlanPanel({ plan, open, onToggle, onOpenWorkspace }: WorkPla
         <div className="mt-2 text-xs text-zinc-500">Progress: {done} / {plan.tasks.length}</div>
         <div className="mt-1 h-1.5 overflow-hidden rounded-full bg-zinc-200 dark:bg-zinc-800" aria-hidden><div className="h-full bg-emerald-500" style={{ width: `${plan.tasks.length === 0 ? 0 : (done / plan.tasks.length) * 100}%` }} /></div>
       </header>
-      <div className="min-h-0 flex-1 overflow-y-auto p-2">{rows(undefined)}</div>
+      <div role="tree" aria-label="Work Plan tasks" className="min-h-0 flex-1 overflow-y-auto p-2">{rows(undefined)}</div>
       {selected && <section aria-label="Task details" className="max-h-[45%] overflow-y-auto border-t border-zinc-200 p-3 text-xs dark:border-zinc-800">
         <div className={`font-semibold ${STATUS[selected.status].className}`}>{STATUS[selected.status].label}</div><h3 className="mt-1 text-sm font-semibold text-zinc-900 dark:text-zinc-100">{selected.title}</h3>
         {selected.description && <p className="mt-2 whitespace-pre-wrap text-zinc-600 dark:text-zinc-300">{selected.description}</p>}

--- a/ui/src/components/WorkPlanPanel.tsx
+++ b/ui/src/components/WorkPlanPanel.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useMemo, useState } from "react";
+import type { WorkPlan, WorkPlanResource, WorkPlanStatus, WorkPlanTask } from "@pi-outpost/shared";
+
+const STATUS: Record<WorkPlanStatus, { icon: string; label: string; className: string }> = {
+  todo: { icon: "○", label: "To do", className: "text-zinc-500" },
+  in_progress: { icon: "●", label: "In progress", className: "text-blue-600 dark:text-blue-400" },
+  done: { icon: "✓", label: "Done", className: "text-emerald-600 dark:text-emerald-400" },
+  blocked: { icon: "!", label: "Blocked", className: "text-red-600 dark:text-red-400" },
+  needs_review: { icon: "?", label: "Needs review", className: "text-amber-600 dark:text-amber-400" },
+};
+
+interface WorkPlanPanelProps {
+  plan: WorkPlan;
+  open: boolean;
+  onToggle(): void;
+  onOpenWorkspace(path: string): void;
+}
+
+function workspacePath(resource: WorkPlanResource): string | null {
+  if (resource.uri.startsWith("workspace:")) return resource.uri.slice("workspace:".length);
+  if (!/^[a-z][a-z0-9+.-]*:/i.test(resource.uri)) return resource.uri;
+  return null;
+}
+
+export function WorkPlanPanel({ plan, open, onToggle, onOpenWorkspace }: WorkPlanPanelProps) {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  useEffect(() => {
+    if (selectedId !== null && !plan.tasks.some((task) => task.id === selectedId)) setSelectedId(null);
+  }, [plan, selectedId]);
+
+  const children = useMemo(() => {
+    const result = new Map<string | undefined, WorkPlanTask[]>();
+    for (const task of plan.tasks) result.set(task.parentId, [...(result.get(task.parentId) ?? []), task]);
+    return result;
+  }, [plan.tasks]);
+  const byId = useMemo(() => new Map(plan.tasks.map((task) => [task.id, task])), [plan.tasks]);
+  const selected = selectedId ? byId.get(selectedId) : undefined;
+  const done = plan.tasks.filter((task) => task.status === "done").length;
+
+  const rows = (parentId: string | undefined, depth = 0): React.ReactNode[] =>
+    (children.get(parentId) ?? []).flatMap((task) => {
+      const status = STATUS[task.status];
+      return [
+        <button key={task.id} type="button" onClick={() => setSelectedId(task.id)} aria-current={task.status === "in_progress" ? "step" : undefined}
+          className={`flex w-full items-start gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800 ${selectedId === task.id ? "bg-zinc-100 dark:bg-zinc-800" : ""}`}
+          style={{ paddingLeft: `${0.5 + depth * 0.85}rem` }}>
+          <span className={`mt-px w-4 shrink-0 text-center font-semibold ${status.className}`} aria-label={status.label}>{status.icon}</span>
+          <span className={task.status === "done" ? "text-zinc-500 line-through" : "text-zinc-800 dark:text-zinc-200"}>{task.title}</span>
+        </button>,
+        ...rows(task.id, depth + 1),
+      ];
+    });
+
+  if (!open) return <button type="button" onClick={onToggle} className="absolute right-3 top-3 z-20 rounded-md border border-zinc-300 bg-white px-2 py-1 text-xs shadow-sm dark:border-zinc-700 dark:bg-zinc-900" aria-label="Open Work Plan">Plan {done}/{plan.tasks.length}</button>;
+
+  return (
+    <aside aria-label="Work Plan" className="absolute inset-y-0 right-0 z-10 flex w-full flex-col border-l border-zinc-200 bg-white/95 shadow-lg backdrop-blur md:w-[23rem] dark:border-zinc-800 dark:bg-zinc-950/95">
+      <header className="border-b border-zinc-200 px-3 py-3 dark:border-zinc-800">
+        <div className="flex items-start justify-between gap-2"><div className="min-w-0"><div className="text-[11px] font-semibold uppercase tracking-wide text-zinc-500">Work Plan</div><h2 className="truncate text-sm font-semibold text-zinc-900 dark:text-zinc-100">{plan.title}</h2></div><button type="button" onClick={onToggle} className="rounded px-2 py-1 text-xs text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-800" aria-label="Close Work Plan">×</button></div>
+        <div className="mt-2 text-xs text-zinc-500">Progress: {done} / {plan.tasks.length}</div>
+        <div className="mt-1 h-1.5 overflow-hidden rounded-full bg-zinc-200 dark:bg-zinc-800" aria-hidden><div className="h-full bg-emerald-500" style={{ width: `${plan.tasks.length === 0 ? 0 : (done / plan.tasks.length) * 100}%` }} /></div>
+      </header>
+      <div className="min-h-0 flex-1 overflow-y-auto p-2">{rows(undefined)}</div>
+      {selected && <section aria-label="Task details" className="max-h-[45%] overflow-y-auto border-t border-zinc-200 p-3 text-xs dark:border-zinc-800">
+        <div className={`font-semibold ${STATUS[selected.status].className}`}>{STATUS[selected.status].label}</div><h3 className="mt-1 text-sm font-semibold text-zinc-900 dark:text-zinc-100">{selected.title}</h3>
+        {selected.description && <p className="mt-2 whitespace-pre-wrap text-zinc-600 dark:text-zinc-300">{selected.description}</p>}
+        {selected.statusReason && <p className="mt-2 rounded bg-zinc-100 p-2 text-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">{selected.statusReason}</p>}
+        {selected.dependsOn.length > 0 && <div className="mt-3"><span className="font-semibold">Depends on:</span> {selected.dependsOn.map((id) => byId.get(id)?.title ?? id).join(", ")}</div>}
+        {selected.resources.length > 0 && <div className="mt-3 space-y-1"><div className="font-semibold">Resources</div>{selected.resources.map((resource) => { const target = workspacePath(resource); const label = resource.label ?? resource.uri; if (target !== null) return <button key={resource.uri} type="button" className="block max-w-full truncate text-left text-blue-600 hover:underline dark:text-blue-400" onClick={() => onOpenWorkspace(target)}>{label}</button>; if (/^https?:/i.test(resource.uri)) return <a key={resource.uri} href={resource.uri} target="_blank" rel="noreferrer" className="block truncate text-blue-600 hover:underline dark:text-blue-400">{label}</a>; return <span key={resource.uri} className="block truncate text-zinc-500" title="No navigator is available for this resource">{label}</span>; })}</div>}
+      </section>}
+    </aside>
+  );
+}

--- a/ui/src/useAgent.test.ts
+++ b/ui/src/useAgent.test.ts
@@ -219,6 +219,31 @@ describe("hello message handling", () => {
   });
 });
 
+describe("Work Plan synchronization", () => {
+  it("applies live changes and replaces the plan with the selected session snapshot", async () => {
+    const result = await connected();
+    const first = { version: 1, id: "first", title: "First", updatedAt: "2026-08-23T00:00:00.000Z", tasks: [] };
+    act(() => mockWs!.receive({ type: "work_plan_changed", workPlan: first }));
+    await waitFor(() => expect(result.current.state.workPlan?.id).toBe("first"));
+
+    act(() => mockWs!.receive({
+      type: "session_replaced",
+      sessionId: "sess_2",
+      branding: {},
+      model: "",
+      thinkingLevel: "off",
+      models: [],
+      commands: [],
+      isStreaming: false,
+      items: [],
+      workPlan: null,
+      gitAvailable: false,
+    }));
+    await waitFor(() => expect(result.current.state.sessionId).toBe("sess_2"));
+    expect(result.current.state.workPlan).toBeNull();
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Streaming
 // ---------------------------------------------------------------------------

--- a/ui/src/useAgent.ts
+++ b/ui/src/useAgent.ts
@@ -23,6 +23,7 @@ import type {
   ThinkingLevel,
   TreeNode,
   WireImage,
+  WorkPlan,
 } from "@pi-outpost/shared";
 import { UPLOADS_DIRECTORY, UploadError } from "./uploads";
 import { isImageFile, isPdfFile } from "./util/workspacePath";
@@ -178,6 +179,7 @@ export interface AgentState {
   tree: TreeNode[] | null;
   isStreaming: boolean;
   items: ChatItem[];
+  workPlan: WorkPlan | null;
   queue: { steering: string[]; followUp: string[] };
   errors: string[];
   contextUsage: ContextUsage | null;
@@ -250,6 +252,7 @@ const initialState: AgentState = {
   tree: null,
   isStreaming: false,
   items: [],
+  workPlan: null,
   queue: { steering: [], followUp: [] },
   errors: [],
   contextUsage: null,
@@ -360,6 +363,7 @@ function applySnapshot(state: AgentState, message: ServerMessage & { sessionId: 
     commands: message.commands,
     isStreaming: message.isStreaming,
     items: message.items,
+    workPlan: message.workPlan ?? null,
     queue: { steering: [], followUp: [] },
     errors: [],
     contextUsage: message.contextUsage ?? null,
@@ -538,6 +542,8 @@ function reduce(state: AgentState, action: Action): AgentState {
     }
     case "thinking_changed":
       return { ...state, thinkingLevel: message.level };
+    case "work_plan_changed":
+      return { ...state, workPlan: message.workPlan };
     case "user":
       return {
         ...state,


### PR DESCRIPTION
## Summary

- add an agent-owned persistent Work Plan with hierarchical tasks, stable identities, dependencies, resources, status reasons, and atomic structured mutations
- persist plans beside Pi sessions, restore them across reconnects and session switches, copy and isolate them on forks, and keep them independent from conversation compaction
- synchronize authoritative plan snapshots over WebSocket and add an accessible companion panel with a compact hover/focus preview
- harden tagged releases so reruns create or repair the GitHub Release even when npm packages are already published

## Key behavior

- Work Plans are explicit working state for decomposition, execution tracking, and verification, not merely progress reporting
- agents are guided to maintain and reconcile plans before declaring non-trivial work complete
- `work_plan get` returns the full authoritative state after resume or compaction, bounded to 64 KiB
- embedded and RPC runtimes expose the same tool; a real `pi --mode rpc` child now proves execution and persistence
- canonical session-path comparison tolerates aliases such as macOS `/var` and `/private/var`
- concurrent forks cannot clear another fork inheritance state, and the first fork snapshot never broadcasts a transient null plan
- collapsed plans preview task lines and completion boxes on hover/focus; Escape dismisses and click opens full details
- settings changes preserve `present_structure` and `work_plan`

## Release recovery

- create the GitHub Release when a tag exists but no release object does
- continue to the attach job when all matching npm packages are already published
- upload executable assets idempotently with `--clobber`

## Verification

- OpenSpec strict validation: 37/37
- server full suite: 1447 passed
- UI full suite: 1280 passed
- focused Work Plan/release/RPC suite: 16 passed
- running-app Playwright lifecycle: preview hover/transfer/Escape/click, creation, mutation, reload, session switch, fork isolation, and resource navigation passed
- typecheck and lint passed
- independent code review: APPROVE; no CRITICAL, HIGH, or MEDIUM findings

## Known non-blocking follow-up

- LOW: the detailed hierarchy uses `role=tree` without the full arrow-key/roving-focus tree pattern; native tab navigation remains available
