### PR TITLE
fix(ui): keep the open file preview mounted during a background re-read

### DIFF
--- a/ui/src/useAgent.test.ts
+++ b/ui/src/useAgent.test.ts
@@ -688,6 +688,29 @@ describe("file lifecycle operations", () => {
     expect(followUps).toContainEqual(expect.objectContaining({ type: "read_file", path: "final.docx" }));
   });
 
+  it("keeps the open file's content on screen while a self-triggered re-read is in flight", async () => {
+    // Regression: file_read_started used to blank openFile to "loading" for this
+    // re-read too, unmounting the rendered markdown for a moment on every save —
+    // the same class of bug the file tree already guards against for directory
+    // refreshes (see the "directory_changed" suite), just never carried over here.
+    const result = await withLoadedFile();
+
+    act(() => mockWs!.receive({ type: "file_changed", path: "draft.docx" }));
+    expect(result.current.state.openFile).toMatchObject({ status: "loaded", path: "draft.docx", content: "draft" });
+
+    act(() =>
+      mockWs!.receive({
+        type: "file_content",
+        requestId: lastRequestId(),
+        path: "draft.docx",
+        content: "draft, edited elsewhere",
+        size: 20,
+        mtimeMs: 20,
+      }),
+    );
+    expect(result.current.state.openFile).toMatchObject({ status: "loaded", content: "draft, edited elsewhere" });
+  });
+
   it("moves an open viewer to the acknowledged destination path", async () => {
     const result = await withLoadedFile("inbox/report.docx");
     act(() => result.current.moveFile("inbox/report.docx", "archive"));
@@ -1560,6 +1583,34 @@ describe("directory_changed", () => {
     act(() => mockWs!.receive({ type: "directory_changed", path: "docs" }));
 
     expect(sentSince(before)).toContainEqual(expect.objectContaining({ type: "read_file", path: "docs/note.md" }));
+  });
+
+  it("keeps the open preview's content on screen while its directory's re-read is in flight", async () => {
+    // Same regression as the file tree's "keeps a refreshed directory's entries on
+    // screen" test above: flipping openFile to "loading" for this re-read unmounts
+    // the rendered markdown for the length of the round trip, on every directory
+    // event — chatty on Windows, where a single write can fire several.
+    const result = await connected();
+    act(() => result.current.readFile("docs/note.md"));
+    act(() =>
+      mockWs!.receive({ type: "file_content", requestId: lastRequestId(), path: "docs/note.md", content: "old", size: 3, mtimeMs: 1 }),
+    );
+    await waitFor(() => expect(result.current.state.openFile?.status).toBe("loaded"));
+
+    act(() => mockWs!.receive({ type: "directory_changed", path: "docs" }));
+    expect(result.current.state.openFile).toMatchObject({ status: "loaded", path: "docs/note.md", content: "old" });
+
+    act(() =>
+      mockWs!.receive({
+        type: "file_content",
+        requestId: lastRequestId(),
+        path: "docs/note.md",
+        content: "new",
+        size: 3,
+        mtimeMs: 2,
+      }),
+    );
+    expect(result.current.state.openFile).toMatchObject({ status: "loaded", content: "new" });
   });
 
   it("invalidates a raw PDF preview when its directory changed", async () => {

--- a/ui/src/useAgent.ts
+++ b/ui/src/useAgent.ts
@@ -66,6 +66,16 @@ export type OpenFile =
        * reason to give.
        */
       documentIssues?: { rule: string; path: string; message: string }[];
+      /**
+       * In-flight background re-read (`file_changed` / `directory_changed`), if any.
+       *
+       * Kept on the "loaded" variant instead of flipping to "loading", the same
+       * choice `dir_list_started`'s `preserveEntries` makes for the tree: the file
+       * that changed underneath the viewer is still the best answer to "what does
+       * this file contain" until the new read lands, and blanking it would unmount
+       * the rendered markdown for no reason the user did anything to deserve.
+       */
+      refreshRequestId?: string;
     }
   | { status: "error"; path: string; message: string };
 
@@ -297,7 +307,7 @@ type Action =
   | { type: "dialog_answered" }
   | { type: "dir_list_started"; path: string; requestId: string; preserveEntries?: boolean }
   | { type: "raw_preview_changed"; path: string }
-  | { type: "file_read_started"; path: string; requestId: string }
+  | { type: "file_read_started"; path: string; requestId: string; preserveContent?: boolean }
   | { type: "file_save_started"; path: string; requestId: string; content: string }
   | { type: "close_file_preview" }
   | { type: "file_create_started" }
@@ -433,6 +443,12 @@ function reduce(state: AgentState, action: Action): AgentState {
     return { ...state, previewRevision: state.previewRevision + 1 };
   }
   if (action.type === "file_read_started") {
+    const current = state.openFile;
+    // A background refresh of the file already on screen: keep showing it — see
+    // `refreshRequestId` on the "loaded" variant.
+    if (action.preserveContent && current?.status === "loaded" && current.path === action.path) {
+      return { ...state, openFile: { ...current, refreshRequestId: action.requestId } };
+    }
     return { ...state, openFile: { status: "loading", path: action.path, requestId: action.requestId } };
   }
   if (action.type === "file_save_started") {
@@ -702,9 +718,14 @@ function reduce(state: AgentState, action: Action): AgentState {
         // A listing answered under a creation request id *is* the creation's answer.
         ...(message.requestId.startsWith("create:") ? { created: message.path, createError: null } : {}),
       };
-    case "file_content":
-      // Ignore stale responses from a since-superseded read (user opened another file meanwhile)
-      if (state.openFile?.status !== "loading" || state.openFile.requestId !== message.requestId) return state;
+    case "file_content": {
+      // Ignore stale responses from a since-superseded read (user opened another file
+      // meanwhile) — either the initial-open "loading" request, or a background refresh
+      // ("loaded" the whole time, correlated by `refreshRequestId` instead).
+      const file = state.openFile;
+      const answersLoad = file?.status === "loading" && file.requestId === message.requestId;
+      const answersRefresh = file?.status === "loaded" && file.refreshRequestId === message.requestId;
+      if (!answersLoad && !answersRefresh) return state;
       return {
         ...state,
         openFile: {
@@ -716,6 +737,7 @@ function reduce(state: AgentState, action: Action): AgentState {
           ...(message.documentIssues === undefined ? {} : { documentIssues: message.documentIssues }),
         },
       };
+    }
     case "file_written": {
       if (message.requestId.startsWith("create:")) {
         // A file that did not exist a moment ago: open it, empty, in edit mode.
@@ -803,8 +825,16 @@ function reduce(state: AgentState, action: Action): AgentState {
           },
         };
       }
-      if (state.openFile?.status !== "loading" || state.openFile.requestId !== message.requestId) return state;
-      return { ...state, openFile: { status: "error", path: message.path, message: message.message } };
+      if (state.openFile?.status === "loading" && state.openFile.requestId === message.requestId) {
+        return { ...state, openFile: { status: "error", path: message.path, message: message.message } };
+      }
+      if (state.openFile?.status === "loaded" && state.openFile.refreshRequestId === message.requestId) {
+        // A background refresh failed — e.g. the read raced a write mid-way through.
+        // What is on screen is still the last good read; keep it rather than replace
+        // a shown file with an error banner over something the user did not do.
+        return { ...state, openFile: { ...state.openFile, refreshRequestId: undefined } };
+      }
+      return state;
     }
     case "file_search_results":
       // Ignore stale responses from a since-superseded (or since-cleared) search
@@ -1078,7 +1108,7 @@ export function useAgent(serverUrl = "", explicitToken?: string, embedded = fals
           const openFile = openFileRef.current;
           if (openFile?.status === "loaded" && openFile.path === message.path) {
             const requestId = `file:${crypto.randomUUID()}`;
-            dispatch({ type: "file_read_started", path: message.path, requestId });
+            dispatch({ type: "file_read_started", path: message.path, requestId, preserveContent: true });
             sendMessage({ type: "read_file", path: message.path, requestId });
           }
           // An open "± diff" pane for this file would silently go stale otherwise
@@ -1100,7 +1130,7 @@ export function useAgent(serverUrl = "", explicitToken?: string, embedded = fals
               dispatch({ type: "raw_preview_changed", path: openFile.path });
             } else if (openFile.status === "loaded") {
               const requestId = `file:${crypto.randomUUID()}`;
-              dispatch({ type: "file_read_started", path: openFile.path, requestId });
+              dispatch({ type: "file_read_started", path: openFile.path, requestId, preserveContent: true });
               sendMessage({ type: "read_file", path: openFile.path, requestId });
             }
           }


### PR DESCRIPTION
## Why

\`file_changed\` and \`directory_changed\` both trigger a silent re-read of the open file preview when it lives in the affected directory. That re-read dispatched \`file_read_started\` unconditionally, which flipped \`openFile\` to \`"loading"\` and blanked its content — unmounting the rendered markdown (and the structured-exchange diagram, and code highlighting) for the length of the round trip, on every event.

Reported as: an open markdown file's rendered view flickering \`loading… → rendered → loading… \` repeatedly on Windows, sometimes with no external write at all — consistent with \`fs.watch\`/\`ReadDirectoryChangesW\` firing on metadata-only touches (indexing, OneDrive, antivirus), not just real content changes.

This is the same class of bug already fixed for the file tree ([D8](openspec/changes/archive/2026-08-22-add-live-file-tree-refresh/design.md): "a refresh must not blank a directory it can still show") but never carried over to the file preview.

## What changes

\`file_read_started\` now takes a \`preserveContent\` flag: when the file being re-read is already loaded, \`openFile\` stays \`"loaded"\` with its existing content, correlated to the new read by a \`refreshRequestId\` instead of flipping through \`"loading"\`. A transient read error during such a refresh is now ignored rather than replacing a shown file with an error banner.

## Verification

- Two regression tests (\`ui/src/useAgent.test.ts\`) assert \`openFile.status\` stays \`"loaded"\` across both trigger paths (\`file_changed\`, \`directory_changed\`); both fail against the prior code (\`status: "loading"\`).
- 118/118 \`useAgent\` unit tests pass.
- Verified live in a real browser against a real server (harness-started, not jsdom): 5 disk writes to an open markdown file, and separately to an open structured-exchange diagram, produced **0 remounts / 0 "loading…" flashes** after the fix, versus **5 / 10** before it — including losing the diagram's DOM identity (would have reset pan/zoom) on every write pre-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)