### PR TITLE
feat(agent): absolutize an @-mentioned path before the model reads it

### DIFF
--- a/server/src/convert.ts
+++ b/server/src/convert.ts
@@ -1,6 +1,8 @@
 /**
  * Conversion from SDK AgentMessage history to wire ChatItems.
  */
+import path from "node:path";
+import { rewriteMentionedPathsSync } from "@pi-outpost/shared/mentions";
 import type { AssistantBlock, ChatItem, TurnUsage, WireImage } from "@pi-outpost/shared";
 import {
   renderCustomMessageHtml,
@@ -9,6 +11,21 @@ import {
 } from "./extensionRender.ts";
 
 const MAX_TOOL_OUTPUT = 20_000;
+
+/**
+ * `maybePath` back to root-relative, posix-separated form — undefined for
+ * anything that isn't actually an absolute path under `root`, which
+ * `rewriteMentionedPathsSync` treats as "leave this mention alone": most
+ * mentions were never absolutized (they didn't resolve to a real path in the
+ * first place — see absolutizeMentions in index.ts) and must round-trip
+ * unchanged, not get mangled by a relative computed against the wrong thing.
+ */
+function relativizeUnderRoot(root: string, maybePath: string): string | undefined {
+  if (!path.isAbsolute(maybePath)) return undefined;
+  const rel = path.relative(root, maybePath);
+  if (rel === "" || rel.startsWith("..") || path.isAbsolute(rel)) return undefined;
+  return rel.split(path.sep).join("/");
+}
 
 interface AnyContent {
   type: string;
@@ -133,8 +150,19 @@ function assistantBlocks(content: string | AnyContent[]): AssistantBlock[] {
  * branch, oldest first. They are matched to the emitted user items from the END:
  * compaction drops a prefix of the history, so the items are a suffix of the
  * branch. Items left unmatched simply carry no entryId (edit stays disabled).
+ *
+ * `browserRoot`, when given, turns an `@`-mentioned path back from the absolute
+ * form the model was handed (see absolutizeMentions in index.ts) into the
+ * relative one the composer actually sent — what replaying history from a
+ * reconnect or a page reload shows must match what a live turn showed, or the
+ * "transparent" half of that trade stops being true the moment someone reloads.
  */
-export function historyToItems(messages: AnyMessage[], streaming = false, userEntryIds: string[] = []): ChatItem[] {
+export function historyToItems(
+  messages: AnyMessage[],
+  streaming = false,
+  userEntryIds: string[] = [],
+  browserRoot?: string,
+): ChatItem[] {
   const items: ChatItem[] = [];
   const userItems: Extract<ChatItem, { kind: "user" }>[] = [];
   const pendingCalls = new Map<string, { name: string; args: unknown }>();
@@ -164,7 +192,7 @@ export function historyToItems(messages: AnyMessage[], streaming = false, userEn
         if (text || images.length > 0) {
           const item: Extract<ChatItem, { kind: "user" }> = {
             kind: "user",
-            text,
+            text: browserRoot ? rewriteMentionedPathsSync(text, (p) => relativizeUnderRoot(browserRoot, p)) : text,
             ...(images.length > 0 ? { images } : {}),
           };
           items.push(item);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -36,6 +36,7 @@ import {
   type WorkPlan,
   WORKTREE_REVISION,
 } from "@pi-outpost/shared";
+import { rewriteMentionedPaths } from "@pi-outpost/shared/mentions";
 import { readStructuredExchangeDocument } from "@pi-outpost/shared/structured-exchange/document";
 import { checkStructuredExchangeSchema } from "@pi-outpost/shared/structured-exchange/schema-node";
 import { validateWorkPlan } from "@pi-outpost/shared/work-plan";
@@ -88,6 +89,7 @@ import {
   readFileRaw,
   renameFileFromBrowser,
   resolveBrowserRoot,
+  resolveConfined,
   resolveWritableRoot,
   searchFiles,
   uploadFileFromBrowser,
@@ -1047,6 +1049,7 @@ function snapshot(): SessionSnapshot {
       state.messages as never,
       state.isStreaming,
       branchUserEntries().map((entry) => entry.entryId),
+      BROWSER_ROOT,
     ),
     models: availableModels(),
     commands: state.commands,
@@ -1629,10 +1632,49 @@ function validImages(images: unknown): WireImage[] | undefined {
   return valid;
 }
 
+/**
+ * Makes an `@`-mentioned path unambiguous before the model ever reads it.
+ *
+ * The composer sends `@ui/src/App.tsx` — a path relative to the browser root,
+ * which is also the agent's own sandbox root. That should be enough, but the
+ * model resolves it itself (there is no structured wire field for a mention,
+ * just text it reads and acts on), and a bash tool call earlier in the turn
+ * can leave it assuming a different current directory. An absolute path has
+ * no "relative to what" left to get wrong.
+ *
+ * Left untouched, not failed, when a mention doesn't resolve — a name that
+ * isn't a real path (an email-shaped "@work.md" typo, `@someone` in prose) is
+ * exactly as informative to the model as it always was; this only removes
+ * ambiguity from a mention that already named something real.
+ *
+ * `resolveConfined` alone is not enough to decide that: it resolves the
+ * existing prefix of a path and is deliberately fine with a nonexistent tail
+ * (a save destination isn't there yet either), so on its own it would turn
+ * "@someone" into a confident-looking absolute path under the root for a file
+ * that was never there — worse than leaving it alone, since it now reads as
+ * resolved. `fs.stat` is the one extra check that keeps this to mentions of
+ * something that actually exists.
+ */
+async function absolutizeMentions(text: string): Promise<string> {
+  return rewriteMentionedPaths(text, async (relPath) => {
+    try {
+      const absolute = await resolveConfined(BROWSER_ROOT, relPath);
+      await fs.stat(absolute);
+      return absolute;
+    } catch {
+      return undefined;
+    }
+  });
+}
+
 async function handlePrompt(text: string, images?: WireImage[]): Promise<void> {
-  await runtime.prompt(text, {
+  const promptText = await absolutizeMentions(text);
+  await runtime.prompt(promptText, {
     ...(images?.length ? { images } : {}),
-    // Echo the user message only once accepted (avoids ghost bubbles on reject)
+    // Echo the user message only once accepted (avoids ghost bubbles on reject).
+    // The *original* text, not promptText: the absolute path is for the model,
+    // never for what the user sees — see historyToItems for the reload side of
+    // the same rule.
     onAccepted: (accepted) => {
       if (accepted) broadcast({ type: "user", text, ...(images?.length ? { images } : {}) });
     },

--- a/server/test/mentionAbsolutization.test.mjs
+++ b/server/test/mentionAbsolutization.test.mjs
@@ -1,0 +1,121 @@
+/**
+ * `@`-mentioned paths, made unambiguous for the model without the user ever
+ * seeing the change.
+ *
+ * A real server, a real WebSocket client, and a real (scripted) RPC child —
+ * the boundary under test is literally what text reaches the process the
+ * model runs in, which only a running server can show. A unit test of
+ * `rewriteMentionedPaths` alone would prove the string transform works and
+ * say nothing about whether `handlePrompt` actually applies it, or whether
+ * the live broadcast and the reconnect-derived history agree with each other
+ * afterwards — which is exactly the kind of gap a fake would paper over.
+ */
+import assert from "node:assert/strict";
+import { readFile, realpath, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import { connect, makeWorkspace, startServer } from "./harness.mjs";
+
+const FAKE = fileURLToPath(new URL("./fixtures/fake-pi-rpc.mjs", import.meta.url));
+
+async function commands(commandLog) {
+  const raw = await readFile(commandLog, "utf8").catch(() => "");
+  return raw
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+test("an @-mentioned path reaches the model absolute, and the user still sees it relative", async () => {
+  const root = await makeWorkspace({ "notes/todo.md": "- [ ] write the thing\n" });
+  const commandLog = path.join(root, "commands.jsonl");
+  const fakeConfig = path.join(root, "fake-rpc.json");
+  const expectedAbsolute = await realpath(path.join(root, "notes/todo.md"));
+  const absolutized = `please check @${expectedAbsolute}`;
+  // What the SDK persists after a prompt is whatever reached it — the
+  // absolutized text — so the reconnect assertion below needs the fake to
+  // echo it back as a real Pi would: a `message_end` event is how
+  // rpcRuntime.ts learns of a user message at all (see its own comment —
+  // "the browser already echoed its own prompt" — it otherwise trusts the
+  // child, not the text pi-outpost itself sent, for what to persist).
+  await writeFile(
+    fakeConfig,
+    JSON.stringify({
+      commandLog,
+      commands_: {
+        prompt: { after: [{ type: "message_end", message: { role: "user", content: absolutized } }] },
+      },
+    }),
+  );
+
+  const server = await startServer(
+    root,
+    { sandbox: undefined, agentRuntime: { mode: "rpc", executable: process.execPath, args: [FAKE], startupTimeoutMs: 5_000 } },
+    { env: { FAKE_PI_RPC_CONFIG: fakeConfig } },
+  );
+  const client = connect(server.wsUrl());
+  try {
+    await client.waitFor("hello");
+
+    client.send({ type: "prompt", text: "please check @notes/todo.md" });
+
+    // The live echo — what the sender themselves sees — must be exactly what
+    // they typed. This is the half of the trade that costs nothing to keep.
+    const echoed = await client.waitFor("user");
+    assert.equal(echoed.text, "please check @notes/todo.md");
+
+    // What actually reached the process the model runs in must not be that
+    // same string: an absolute path, not a root-relative one a bash `cd`
+    // earlier in the turn could make ambiguous.
+    const sent = await commands(commandLog);
+    const prompt = sent.find((command) => command.type === "prompt");
+    assert.ok(prompt, `no prompt command recorded; saw ${JSON.stringify(sent.map((c) => c.type))}`);
+    assert.equal(prompt.message, absolutized);
+
+    // Reconnecting replays history from what the SDK persisted — which is
+    // whatever reached runtime.prompt(), the absolute form. The relative
+    // mention must survive that round trip too, or "transparent" stops being
+    // true the moment the tab reloads.
+    const reconnected = connect(server.wsUrl());
+    try {
+      const hello = await reconnected.waitFor("hello");
+      const replayed = hello.items.find((item) => item.kind === "user");
+      assert.ok(replayed, `no replayed user item; saw ${JSON.stringify(hello.items.map((i) => i.kind))}`);
+      assert.equal(replayed.text, "please check @notes/todo.md");
+    } finally {
+      reconnected.close();
+    }
+  } finally {
+    client.close();
+    await server.stop();
+  }
+});
+
+test("a mention that isn't a real path is left exactly as typed", async () => {
+  const root = await makeWorkspace();
+  const commandLog = path.join(root, "commands.jsonl");
+  const fakeConfig = path.join(root, "fake-rpc.json");
+  await writeFile(fakeConfig, JSON.stringify({ commandLog }));
+
+  const server = await startServer(
+    root,
+    { sandbox: undefined, agentRuntime: { mode: "rpc", executable: process.execPath, args: [FAKE], startupTimeoutMs: 5_000 } },
+    { env: { FAKE_PI_RPC_CONFIG: fakeConfig } },
+  );
+  const client = connect(server.wsUrl());
+  try {
+    await client.waitFor("hello");
+
+    client.send({ type: "prompt", text: "ask @someone about this, not @nonexistent.md" });
+    await client.waitFor("user");
+
+    const sent = await commands(commandLog);
+    const prompt = sent.find((command) => command.type === "prompt");
+    assert.equal(prompt.message, "ask @someone about this, not @nonexistent.md");
+  } finally {
+    client.close();
+    await server.stop();
+  }
+});

--- a/server/test/mentions.test.ts
+++ b/server/test/mentions.test.ts
@@ -1,0 +1,80 @@
+/**
+ * The pure parsing/rewriting rule behind @-mention absolutization — see
+ * mentionAbsolutization.test.mjs for the running-server proof that
+ * handlePrompt and historyToItems actually use it correctly together.
+ */
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { mentionedPaths, rewriteMentionedPaths, rewriteMentionedPathsSync } from "@pi-outpost/shared/mentions";
+
+describe("mentionedPaths", () => {
+  test("finds a mention anywhere in the text", () => {
+    assert.deepEqual(mentionedPaths("please check @src/App.tsx now"), ["src/App.tsx"]);
+  });
+
+  test("drops trailing sentence punctuation, not a path character", () => {
+    assert.deepEqual(mentionedPaths("see @src/App.tsx, then @notes.md."), ["src/App.tsx", "notes.md"]);
+    assert.deepEqual(mentionedPaths("@src/App.tsx.bak is the backup"), ["src/App.tsx.bak"]);
+  });
+
+  test("finds every distinct mention, duplicates included", () => {
+    assert.deepEqual(mentionedPaths("@a.md and @b.md, also @a.md again"), ["a.md", "b.md", "a.md"]);
+  });
+
+  test("no mentions is an empty list, not an error", () => {
+    assert.deepEqual(mentionedPaths("nothing to see here"), []);
+  });
+});
+
+describe("rewriteMentionedPaths (async)", () => {
+  test("replaces every occurrence of a resolved mention, leaving punctuation and the @ alone", async () => {
+    const out = await rewriteMentionedPaths("see @a.md, then @a.md again — not @b.md", async (path) =>
+      path === "a.md" ? "/root/a.md" : undefined,
+    );
+    assert.equal(out, "see @/root/a.md, then @/root/a.md again — not @b.md");
+  });
+
+  test("resolve returning the same path is a no-op, not an infinite substitution", async () => {
+    const out = await rewriteMentionedPaths("@same.md", async (path) => path);
+    assert.equal(out, "@same.md");
+  });
+
+  test("text with no mentions never calls resolve", async () => {
+    let called = false;
+    const out = await rewriteMentionedPaths("no mentions here", async () => {
+      called = true;
+      return "unused";
+    });
+    assert.equal(out, "no mentions here");
+    assert.equal(called, false);
+  });
+
+  test("resolves mentions concurrently, not one at a time", async () => {
+    const order: string[] = [];
+    const out = await rewriteMentionedPaths("@slow.md and @fast.md", async (p) => {
+      if (p === "slow.md") await new Promise((resolve) => setTimeout(resolve, 20));
+      order.push(p);
+      return `/root/${p}`;
+    });
+    assert.equal(out, "@/root/slow.md and @/root/fast.md");
+    // fast.md's resolve settles first if they ran concurrently; sequentially it
+    // would always be slow.md first, whatever the delay.
+    assert.deepEqual(order, ["fast.md", "slow.md"]);
+  });
+});
+
+describe("rewriteMentionedPathsSync", () => {
+  test("mirrors the async version's substitution rule without awaiting anything", () => {
+    const out = rewriteMentionedPathsSync("read @/root/a.md please", (p) =>
+      p === "/root/a.md" ? "a.md" : undefined,
+    );
+    assert.equal(out, "read @a.md please");
+  });
+
+  test("leaves a mention resolve does not recognise exactly as it was", () => {
+    const out = rewriteMentionedPathsSync("@/elsewhere/b.md stays absolute", (p) =>
+      p.startsWith("/root/") ? p.slice("/root/".length) : undefined,
+    );
+    assert.equal(out, "@/elsewhere/b.md stays absolute");
+  });
+});

--- a/shared/package.json
+++ b/shared/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "exports": {
     ".": "./src/protocol.ts",
+    "./mentions": "./src/mentions.ts",
     "./work-plan": "./src/workPlan.ts",
     "./structured-exchange": "./src/structuredExchange.ts",
     "./structured-exchange/validation": "./src/structuredExchangeValidation.ts",

--- a/shared/src/mentions.ts
+++ b/shared/src/mentions.ts
@@ -1,0 +1,105 @@
+/**
+ * `@path` file references inside a composed prompt.
+ *
+ * The composer writes a browser-root-relative path after `@` as plain text —
+ * there is no structured wire field for it, the model reads it as a hint and
+ * calls its own tools. Both the client (deduping a mention against an
+ * attachment chip) and the server (making that path unambiguous before the
+ * model sees it, and readable again on reload) parse the same convention, so
+ * it is defined once here rather than twice.
+ */
+
+const MENTION_PATTERN = /(?:^|\s)@([^\s@]+)/g;
+const TRAILING_PUNCTUATION = new Set([",", ".", ";", ":", "!", "?", ")", "]"]);
+
+/**
+ * Drop sentence punctuation from the end of a path, by hand.
+ *
+ * A trailing-`+` regex here is a polynomial ReDoS (CodeQL #9): anchoring `+`
+ * to the end makes the engine retry the run from every position, so a draft
+ * holding a long stretch of `!` costs O(n²). This loop is linear.
+ */
+function withoutTrailingPunctuation(path: string): string {
+  let end = path.length;
+  while (end > 0 && TRAILING_PUNCTUATION.has(path[end - 1]!)) end--;
+  return path.slice(0, end);
+}
+
+/**
+ * Paths named with `@` in free text. Trailing sentence punctuation
+ * ("…@src/App.tsx, please") is not part of the path; another path character
+ * is ("@src/App.tsx.bak" names a different file).
+ */
+export function mentionedPaths(text: string): string[] {
+  const found = text.matchAll(MENTION_PATTERN);
+  return [...found].map(([, path]) => withoutTrailingPunctuation(path ?? "")).filter((path) => path.length > 0);
+}
+
+/**
+ * Rewrites each `@path` mention text finds, replacing `path` with whatever
+ * `resolve` answers for it — the `@` and any trailing punctuation are left
+ * exactly as typed. `resolve` returning `undefined` leaves that mention
+ * untouched (the model sees exactly what it would have without this call).
+ *
+ * Async because the server's use of this — making a mentioned path absolute —
+ * needs the filesystem (symlink resolution, confinement). The reverse
+ * direction, turning an absolutized mention back into its relative form for
+ * display, is pure string math; `rewriteMentionedPathsSync` below is that one,
+ * kept separate so it can run inside otherwise-synchronous history conversion.
+ */
+export async function rewriteMentionedPaths(
+  text: string,
+  resolve: (path: string) => Promise<string | undefined>,
+): Promise<string> {
+  const matches = [...text.matchAll(MENTION_PATTERN)];
+  if (matches.length === 0) return text;
+  const changes = await Promise.all(
+    matches.map(async (match) => {
+      const raw = match[1] ?? "";
+      const path = withoutTrailingPunctuation(raw);
+      if (!path) return undefined;
+      const next = await resolve(path);
+      return next !== undefined && next !== path ? { raw, path, next } : undefined;
+    }),
+  );
+  return applyMentionChanges(text, changes);
+}
+
+/** Sync counterpart of {@link rewriteMentionedPaths} — see its doc for why both exist. */
+export function rewriteMentionedPathsSync(text: string, resolve: (path: string) => string | undefined): string {
+  const matches = [...text.matchAll(MENTION_PATTERN)];
+  if (matches.length === 0) return text;
+  const changes = matches.map((match) => {
+    const raw = match[1] ?? "";
+    const path = withoutTrailingPunctuation(raw);
+    if (!path) return undefined;
+    const next = resolve(path);
+    return next !== undefined && next !== path ? { raw, path, next } : undefined;
+  });
+  return applyMentionChanges(text, changes);
+}
+
+interface MentionChange {
+  /** Exactly what followed `@` in the source text, punctuation included. */
+  raw: string;
+  /** `raw` with trailing punctuation stripped — what `resolve` was asked about. */
+  path: string;
+  /** What `resolve` answered — replaces `path`, keeping `raw`'s own trailing punctuation. */
+  next: string;
+}
+
+/**
+ * Every mention with the same `raw` text names the same file, so replacing all
+ * of them with the same substitution is correct — not just the first. A plain
+ * split/join is exact here (no regex escaping to get wrong): `raw` came from
+ * `matchAll` on this same text, so it is a literal substring of it.
+ */
+function applyMentionChanges(text: string, changes: (MentionChange | undefined)[]): string {
+  let out = text;
+  for (const change of changes) {
+    if (!change) continue;
+    const trailing = change.raw.slice(change.path.length);
+    out = out.split(`@${change.raw}`).join(`@${change.next}${trailing}`);
+  }
+  return out;
+}

--- a/ui/src/attachments.ts
+++ b/ui/src/attachments.ts
@@ -6,6 +6,7 @@
  * ask about. A file supplied from outside that root is copied in first, which is what
  * gives it a path to reference (see uploads.ts).
  */
+import { mentionedPaths as sharedMentionedPaths } from "@pi-outpost/shared/mentions";
 import { MAX_UPLOAD_BYTES, UploadError, type UploadFile } from "./uploads";
 import { hasPathExtractionTool, isPdfFile } from "./util/workspacePath";
 
@@ -240,32 +241,15 @@ function mentions(text: string, path: string): boolean {
   return new RegExp(`(^|\\s)@${escaped}[,.;:!?)\\]]*(\\s|$)`).test(text);
 }
 
-const TRAILING_PUNCTUATION = new Set([",", ".", ";", ":", "!", "?", ")", "]"]);
-
-/**
- * Drop sentence punctuation from the end of a path, by hand.
- *
- * The regex this replaces — `/[,.;:!?)\]]+$/` — is a polynomial ReDoS (CodeQL #9):
- * anchoring `+` to the end makes the engine retry the run from every position, so a
- * draft holding a long stretch of `!` costs O(n²). The text comes from the composer,
- * which means a user can only hang their own tab, but the loop below is linear and
- * every bit as clear.
- */
-function withoutTrailingPunctuation(path: string): string {
-  let end = path.length;
-  while (end > 0 && TRAILING_PUNCTUATION.has(path[end - 1])) end--;
-  return path.slice(0, end);
-}
-
 /**
  * Paths the user named with `@` in their draft. They reference a file just as an
  * attachment does, so the tree marks them too — the file tree cannot see the composer's
  * text on its own. Trailing sentence punctuation is not part of the path.
+ *
+ * Re-exported from `@pi-outpost/shared/mentions`, which the server parses the same
+ * mentions with — kept as one rule so the two cannot drift apart.
  */
-export function mentionedPaths(text: string): string[] {
-  const found = text.matchAll(/(?:^|\s)@([^\s@]+)/g);
-  return [...found].map(([, path]) => withoutTrailingPunctuation(path)).filter((path) => path.length > 0);
-}
+export const mentionedPaths = sharedMentionedPaths;
 
 /**
  * The prompt the composer sends: typed text, then previewed paths as `@` mentions and


### PR DESCRIPTION
## Why

The composer sends `@ui/src/App.tsx` — a path relative to the browser root, which is also the agent's own sandbox root. That should be enough, but there is no structured wire field for a mention: the model reads it as plain text and resolves it itself, and a bash tool call earlier in the turn can leave it assuming a different current directory. Reported as: the agent mis-resolving an `@`-mentioned path roughly half the time.

## What changes

- **`server/src/index.ts`** (`handlePrompt` / `absolutizeMentions`): before the prompt reaches `runtime.prompt()`, every `@`-mentioned path that both resolves under the browser root (`resolveConfined`) *and actually exists* (`fs.stat`) is rewritten to its absolute form. A mention that isn't a real path (`@someone` in prose, a typo) is left exactly as it was.
  - `resolveConfined` alone is not enough for this: it deliberately tolerates a nonexistent tail (a save destination isn't there yet either), so without the extra existence check a typo would turn into a confident-looking absolute path under the root for a file that was never there. Caught by the test below, by hand.
- **Transparent to the user, both live and after a reload**: the live `user` broadcast still carries the original relative text; `server/src/convert.ts` (`historyToItems`) reverses the same substitution when replaying persisted history, so a mention absolutized for the model reads back as `@relative/path` after a reconnect too. The SDK persists whatever reached `runtime.prompt()` — without that reversal, a page reload would leak the absolute path into the same bubble that showed the relative one live.
- **`shared/src/mentions.ts`**: the one parsing/rewriting rule both directions (and the client's own dedup check) share, so client and server cannot drift into disagreeing about what counts as a mention. `ui/src/attachments.ts` now re-exports `mentionedPaths` from it instead of keeping a second copy.

## Verification

- **Real server, real WebSocket client, real (scripted) RPC child** (`server/test/mentionAbsolutization.test.mjs`) — the boundary that matters is literally what text reaches the process the model runs in, which a unit test of the string transform alone cannot show:
  - a real mention of a real file arrives at the RPC child absolutized, the live `user` bubble stays relative, and a second connection (reconnect) replays it relative too;
  - a mention of something that doesn't exist reaches the child completely unchanged.
  - The first version of this test caught the existence-check gap above by hand: two invented file names resolved to confident absolute paths that named nothing real.
- Unit tests for the shared parsing/rewriting rule (`server/test/mentions.test.ts`), plus the existing `ui/src/attachments.test.ts` (53/53) confirming the re-export changed nothing about the client's own behavior.

- **Live run in the browser against a real model** (`BENCH_LIVE=1 npm run bench`, widget on the host page at 127.0.0.1:4321, plain bench server behind it, `mistral/devstral-medium-latest`) — the pass this PR was previously missing. Both directions, driven by hand through the composer's own `@` picker:
  - `@readme.md` (a real file in the bench workspace): asked to echo back the exact path it was given and nothing else, the model answered `/private/var/folders/.../pi-outpost-test-J2YAhL/readme.md`. The absolute path is what actually reached it.
  - `@nowhere/ghost.md` (nothing there): the model echoed `nowhere/ghost.md`, unchanged — the existence check holds outside the test harness too.
  - The user bubble read `@readme.md` while the turn was live, and still read `@readme.md` after a full page reload replayed the persisted history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
