### PR TITLE
fix(ui): a bubble that tells the truth about what was sent, and what failed

### DIFF
--- a/server/src/convert.ts
+++ b/server/src/convert.ts
@@ -4,6 +4,7 @@
 import path from "node:path";
 import { rewriteMentionedPathsSync } from "@pi-outpost/shared/mentions";
 import type { AssistantBlock, ChatItem, TurnUsage, WireImage } from "@pi-outpost/shared";
+import { describeProviderError } from "@pi-outpost/shared/provider-error";
 import {
   renderCustomMessageHtml,
   renderToolCallHtml,
@@ -218,7 +219,7 @@ export function historyToItems(
           trailingAssistantItem = {
             kind: "assistant",
             blocks,
-            ...(message.errorMessage ? { errorMessage: message.errorMessage } : {}),
+            ...(message.errorMessage ? { errorMessage: describeProviderError(message.errorMessage) } : {}),
             ...(usage ? { usage } : {}),
           };
           items.push(trailingAssistantItem);
@@ -346,7 +347,7 @@ export function assistantToItem(message: AnyMessage): ChatItem {
   return {
     kind: "assistant",
     blocks: assistantBlocks(message.content),
-    ...(message.errorMessage ? { errorMessage: message.errorMessage } : {}),
+    ...(message.errorMessage ? { errorMessage: describeProviderError(message.errorMessage) } : {}),
     ...(usage ? { usage } : {}),
   };
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -40,6 +40,7 @@ import { rewriteMentionedPaths } from "@pi-outpost/shared/mentions";
 import { readStructuredExchangeDocument } from "@pi-outpost/shared/structured-exchange/document";
 import { checkStructuredExchangeSchema } from "@pi-outpost/shared/structured-exchange/schema-node";
 import { validateWorkPlan } from "@pi-outpost/shared/work-plan";
+import { describeProviderError } from "@pi-outpost/shared/provider-error";
 import {
   type AgentRuntime,
   type RuntimeEvent,
@@ -1286,7 +1287,9 @@ function onRuntimeEvent(event: RuntimeEvent): void {
       broadcast(event.request);
       break;
     case "error":
-      broadcast({ type: "error", message: event.message });
+      // Same treatment as an assistant turn's own failure: a provider reached
+      // through a proxy answers with an HTML page, and the reader gets markup.
+      broadcast({ type: "error", message: describeProviderError(event.message) });
       break;
     case "runtime_failed":
       // Fail closed: /health already reports unready, and this is the one visible

--- a/server/test/convert.test.ts
+++ b/server/test/convert.test.ts
@@ -309,6 +309,20 @@ describe("historyToItems", () => {
     assert.equal(asst.errorMessage, "something broke");
     assert.deepEqual(asst.blocks, []);
   });
+
+  test("a provider failure reaches the bubble as prose, not as a web page", () => {
+    // The SDK persists whatever the provider's proxy answered, markup included,
+    // so a reopened session replays the page unless this conversion cleans it.
+    const items = historyToItems([
+      {
+        role: "assistant",
+        content: [],
+        errorMessage: "504 <html><body><h1>504 Gateway Time-out</h1> The server didn't respond in time. </body></html>",
+      },
+    ]);
+    const asst = items[0] as Extract<(typeof items)[0], { kind: "assistant" }>;
+    assert.equal(asst.errorMessage, "504 Gateway Time-out The server didn't respond in time.");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/server/test/providerError.test.ts
+++ b/server/test/providerError.test.ts
@@ -1,0 +1,64 @@
+/**
+ * What a failed provider request says in the bubble the user reads.
+ *
+ * The reported case is verbatim: a proxy in front of the model answered with a
+ * whole HTML page, and it reached the transcript with its markup intact.
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { describeProviderError } from "@pi-outpost/shared/provider-error";
+
+describe("describeProviderError", () => {
+  it("turns the reported gateway timeout into one line", () => {
+    const reported = "504 <html><body><h1>504 Gateway Time-out</h1> The server didn't respond in time. </body></html>";
+    assert.equal(describeProviderError(reported), "504 Gateway Time-out The server didn't respond in time.");
+  });
+
+  it("leaves a message somebody wrote to be read exactly as it is", () => {
+    // The normal case, and the one worth protecting: a provider that explains
+    // itself must not be reworded, reflowed, or truncated into a summary.
+    for (const message of [
+      "The provider refused the request: context length exceeded",
+      "rate limit reached for gpt-4o; retry in 20s",
+      "Connection lost",
+      "Error: read ECONNRESET",
+    ]) {
+      assert.equal(describeProviderError(message), message);
+    }
+  });
+
+  it("keeps a status the caller prefixed, without repeating it", () => {
+    assert.equal(
+      describeProviderError("502 <html><head><title>502 Bad Gateway</title></head><body>nginx</body></html>"),
+      "502 Bad Gateway nginx",
+    );
+    // No prefix to keep: the page carries the code itself.
+    assert.equal(describeProviderError("<html><body><h1>503 Service Unavailable</h1></body></html>"), "503 Service Unavailable");
+  });
+
+  it("drops markup that is not prose, and decodes what the page escaped", () => {
+    const page = [
+      "<!doctype html><html><head><style>body{color:red}</style>",
+      "<script>location.reload()</script></head>",
+      "<body><p>Upstream said &quot;too many requests&quot; &amp; closed the connection</p></body></html>",
+    ].join("");
+    assert.equal(describeProviderError(page), 'Upstream said "too many requests" & closed the connection');
+  });
+
+  it("bounds a page that is mostly furniture", () => {
+    const long = `<html><body><p>${"the upstream server is unavailable. ".repeat(40)}</p></body></html>`;
+    const described = describeProviderError(long);
+    assert.ok(described.length <= 300, `bounded, got ${described.length}`);
+    assert.ok(described.endsWith("…"), "says it was cut");
+    assert.ok(described.startsWith("the upstream server is unavailable."));
+  });
+
+  it("returns the input untouched when there is nothing to recover", () => {
+    // A page with no text at all: better the raw body than an empty bubble that
+    // says an error happened and nothing else.
+    const empty = "<html><body></body></html>";
+    assert.equal(describeProviderError(empty), empty);
+    assert.equal(describeProviderError(""), "");
+    assert.equal(describeProviderError("   "), "");
+  });
+});

--- a/server/test/providerErrorWire.test.mjs
+++ b/server/test/providerErrorWire.test.mjs
@@ -1,0 +1,73 @@
+/**
+ * A provider failure, as it reaches the browser.
+ *
+ * The unit test next door fixes what `describeProviderError` returns. This one
+ * answers the question that decides what the user actually reads: does a real
+ * server, handed the real event a runtime emits when a turn fails, put the
+ * cleaned line on the wire — or the web page the proxy sent?
+ */
+import assert from "node:assert/strict";
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import { connect, makeWorkspace, startServer } from "./harness.mjs";
+
+const FAKE = fileURLToPath(new URL("./fixtures/fake-pi-rpc.mjs", import.meta.url));
+
+/** Verbatim from the report: a gateway timeout, as a whole HTML document. */
+const GATEWAY_TIMEOUT =
+  "504 <html><body><h1>504 Gateway Time-out</h1> The server didn't respond in time. </body></html>";
+
+test("a turn that failed on the provider reads as a sentence, not as a web page", async () => {
+  const root = await makeWorkspace();
+  const fakeConfig = path.join(root, "fake-rpc.json");
+  await writeFile(
+    fakeConfig,
+    JSON.stringify({
+      commands_: {
+        prompt: {
+          after: [
+            {
+              type: "message_end",
+              message: { role: "assistant", content: [], errorMessage: GATEWAY_TIMEOUT },
+            },
+          ],
+        },
+      },
+    }),
+  );
+
+  const server = await startServer(
+    root,
+    {
+      sandbox: undefined,
+      agentRuntime: { mode: "rpc", executable: process.execPath, args: [FAKE], startupTimeoutMs: 5_000 },
+    },
+    { env: { FAKE_PI_RPC_CONFIG: fakeConfig } },
+  );
+  const client = connect(server.wsUrl());
+  try {
+    await client.waitFor("hello");
+    client.send({ type: "prompt", text: "anything" });
+
+    const ended = await client.waitFor((message) => message.type === "assistant_end");
+    assert.equal(ended.item.errorMessage, "504 Gateway Time-out The server didn't respond in time.");
+    // The markup must be gone from the wire, not merely hidden by the renderer:
+    // the same string is what a reopened session replays.
+    assert.ok(!/<[a-z]/i.test(ended.item.errorMessage), `markup survived: ${ended.item.errorMessage}`);
+
+    const reconnected = connect(server.wsUrl());
+    try {
+      const hello = await reconnected.waitFor("hello");
+      const replayed = hello.items.find((item) => item.kind === "assistant" && item.errorMessage);
+      assert.ok(replayed, `no assistant item carried the failure; saw ${JSON.stringify(hello.items.map((i) => i.kind))}`);
+      assert.equal(replayed.errorMessage, "504 Gateway Time-out The server didn't respond in time.");
+    } finally {
+      reconnected.close();
+    }
+  } finally {
+    client.close();
+    await server.stop();
+  }
+});

--- a/shared/package.json
+++ b/shared/package.json
@@ -5,6 +5,7 @@
   "exports": {
     ".": "./src/protocol.ts",
     "./mentions": "./src/mentions.ts",
+    "./provider-error": "./src/providerError.ts",
     "./work-plan": "./src/workPlan.ts",
     "./structured-exchange": "./src/structuredExchange.ts",
     "./structured-exchange/validation": "./src/structuredExchangeValidation.ts",

--- a/shared/src/providerError.ts
+++ b/shared/src/providerError.ts
@@ -1,0 +1,79 @@
+/**
+ * What a failed request from a model provider should say in a chat bubble.
+ *
+ * Providers do not fail in JSON. A proxy in front of one answers with a whole
+ * HTML page, and the SDK hands that body on verbatim, so a gateway timeout
+ * reached the transcript as:
+ *
+ *   504 <html><body><h1>504 Gateway Time-out</h1> The server didn't respond in
+ *   time. </body></html>
+ *
+ * Every word a reader needs is in there, wrapped in markup that is not for them.
+ * This turns such a body into one line, and leaves anything that was already a
+ * sentence alone — a provider that writes a plain message is the normal case and
+ * must not be reworded.
+ *
+ * Deliberately not a parser: the input is whatever an unknown intermediary chose
+ * to send, so this reads as "recover the words", never "understand the document".
+ */
+
+/** Long enough for a real explanation, short enough to stay a bubble. */
+const MAX_LENGTH = 300;
+
+const ENTITIES: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  "#39": "'",
+  apos: "'",
+  nbsp: " ",
+};
+
+const decodeEntities = (text: string): string =>
+  text.replace(/&(#x?[0-9a-f]+|[a-z]+);/gi, (whole, name: string) => {
+    const known = ENTITIES[name.toLowerCase()];
+    if (known !== undefined) return known;
+    const numeric = /^#x/i.test(name)
+      ? Number.parseInt(name.slice(2), 16)
+      : /^#/.test(name)
+        ? Number.parseInt(name.slice(1), 10)
+        : Number.NaN;
+    return Number.isFinite(numeric) ? String.fromCodePoint(numeric) : whole;
+  });
+
+/** Whether this body is markup rather than a message somebody wrote to be read. */
+const looksLikeMarkup = (text: string): boolean => /<\s*(!doctype|html|body|head|h[1-6]|p|div|title|center|pre)\b/i.test(text);
+
+function textFromMarkup(markup: string): string {
+  const withoutInvisible = markup
+    // Script and style carry text that is not prose, and reads as noise.
+    .replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1>/gi, " ")
+    .replace(/<!--[\s\S]*?-->/g, " ");
+  return decodeEntities(withoutInvisible.replace(/<[^>]*>/g, " "))
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * One readable line for a provider failure.
+ *
+ * The status code a caller prefixed is kept, and dropped from the recovered text
+ * when the page repeats it — "504 504 Gateway Time-out" says nothing twice.
+ */
+export function describeProviderError(raw: string): string {
+  const input = raw?.trim() ?? "";
+  if (input === "") return input;
+  if (!looksLikeMarkup(input)) return input.length > MAX_LENGTH ? `${input.slice(0, MAX_LENGTH - 1).trimEnd()}…` : input;
+
+  const start = input.search(/<\s*(!doctype|html|body|head|h[1-6]|p|div|title|center|pre)\b/i);
+  const prefix = input.slice(0, start).trim();
+  const recovered = textFromMarkup(input.slice(start));
+  if (recovered === "") return prefix === "" ? input : prefix;
+
+  const status = /^\d{3}$/.test(prefix) ? prefix : "";
+  // "504" then "504 Gateway Time-out": the page already opens with the code.
+  const body = status !== "" && recovered.startsWith(`${status} `) ? recovered.slice(status.length + 1) : recovered;
+  const line = [status !== "" ? status : prefix, body].filter((part) => part !== "").join(" ");
+  return line.length > MAX_LENGTH ? `${line.slice(0, MAX_LENGTH - 1).trimEnd()}…` : line;
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -655,6 +655,27 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
                 );
               })}
 
+              {/*
+                The prompt this client just sent, until the server echoes it back.
+                Dimmed and not editable: it has no persisted entry to rewind to,
+                and it is a claim about what was sent, not yet a record of it.
+              */}
+              {state.pendingPrompt && (
+                <div className="flex flex-col gap-3 opacity-60" data-pending-prompt>
+                  <UserMessage
+                    item={{ kind: "user", ...state.pendingPrompt }}
+                    canEdit={false}
+                    onEdit={() => {}}
+                  />
+                  <div className="flex justify-end px-4">
+                    <div className="flex items-center gap-2 py-1">
+                      <span className="inline-block h-4 w-4 animate-spin rounded-full border-[3px] border-zinc-300 border-t-blue-500 dark:border-zinc-600 dark:border-t-blue-400 motion-reduce:animate-pulse" />
+                      <span className="text-xs text-zinc-400 dark:text-zinc-500">sending…</span>
+                    </div>
+                  </div>
+                </div>
+              )}
+
               {(state.queue.steering.length > 0 || state.queue.followUp.length > 0) && (
                 <div className="rounded-lg border border-dashed border-zinc-300 px-3 py-2 text-xs text-zinc-500 dark:border-zinc-700">
                   {state.queue.steering.map((text, i) => (

--- a/ui/src/useAgent.test.ts
+++ b/ui/src/useAgent.test.ts
@@ -219,6 +219,71 @@ describe("hello message handling", () => {
   });
 });
 
+describe("the prompt bubble, before the server has echoed it", () => {
+  it("appears as soon as it is sent", async () => {
+    // The server broadcasts `user` only once the runtime accepts the prompt —
+    // after session creation, runtime start-up, and the wait for a loaded
+    // provider to take the request. Until this, those seconds showed nothing:
+    // the composer emptied and the transcript did not move.
+    const result = await connected();
+    act(() => result.current.prompt("what does this repo do?"));
+    expect(result.current.state.pendingPrompt).toEqual({ text: "what does this repo do?" });
+    // It is not in `items`: `user_entries` pairs bubbles to persisted entry ids
+    // counting from the end, and an unsent one would take its neighbour's id.
+    expect(result.current.state.items).toEqual([]);
+    expect(JSON.parse(mockWs!.sent[mockWs!.sent.length - 1])).toEqual({
+      type: "prompt",
+      text: "what does this repo do?",
+    });
+  });
+
+  it("gives way to the real bubble, without doubling it", async () => {
+    const result = await connected();
+    act(() => result.current.prompt("hello"));
+    act(() => mockWs!.receive({ type: "user", text: "hello" }));
+    expect(result.current.state.pendingPrompt).toBeNull();
+    expect(result.current.state.items).toEqual([{ kind: "user", text: "hello" }]);
+  });
+
+  it("carries its attachments while it waits", async () => {
+    const result = await connected();
+    const images = [{ dataUrl: "data:image/png;base64,AAA", name: "shot.png" }];
+    act(() => result.current.prompt("look", images as never));
+    expect(result.current.state.pendingPrompt).toEqual({ text: "look", images });
+  });
+
+  it("disappears when the server refuses the prompt", async () => {
+    // A refusal is an `error` and never a `user`. Left behind, the placeholder
+    // would stand there as a message that was never sent.
+    const result = await connected();
+    act(() => result.current.prompt("during a session switch"));
+    act(() => mockWs!.receive({ type: "error", message: "Session change already in progress" }));
+    expect(result.current.state.pendingPrompt).toBeNull();
+    expect(result.current.state.items).toEqual([]);
+  });
+
+  it("does not survive a snapshot that says what the conversation contains", async () => {
+    const result = await connected();
+    act(() => result.current.prompt("sent just before the switch"));
+    act(() =>
+      mockWs!.receive({
+        type: "session_replaced",
+        sessionId: "sess_2",
+        branding: {},
+        model: "",
+        thinkingLevel: "off",
+        models: [],
+        commands: [],
+        isStreaming: false,
+        items: [],
+        contextUsage: null,
+        gitAvailable: false,
+      }),
+    );
+    expect(result.current.state.pendingPrompt).toBeNull();
+  });
+});
+
 describe("Work Plan synchronization", () => {
   it("applies live changes and replaces the plan with the selected session snapshot", async () => {
     const result = await connected();

--- a/ui/src/useAgent.ts
+++ b/ui/src/useAgent.ts
@@ -189,6 +189,21 @@ export interface AgentState {
   tree: TreeNode[] | null;
   isStreaming: boolean;
   items: ChatItem[];
+  /**
+   * A prompt this client has sent and the server has not echoed back yet.
+   *
+   * The authoritative bubble arrives on `user`, which the server broadcasts only
+   * once the runtime *accepts* the prompt — after session creation, runtime
+   * start-up and, on a loaded provider, the wait for the request to be taken.
+   * Those seconds used to show nothing at all: the composer emptied and the
+   * transcript did not move, which reads as a lost message.
+   *
+   * Kept out of `items` deliberately. `user_entries` pairs bubbles to persisted
+   * entry ids counting from the end, so an unsent bubble sitting in that list
+   * would take the previous message's id — and editing it would rewind the wrong
+   * turn.
+   */
+  pendingPrompt: { text: string; images?: WireImage[] } | null;
   workPlan: WorkPlan | null;
   queue: { steering: string[]; followUp: string[] };
   errors: string[];
@@ -262,6 +277,7 @@ const initialState: AgentState = {
   tree: null,
   isStreaming: false,
   items: [],
+  pendingPrompt: null,
   workPlan: null,
   queue: { steering: [], followUp: [] },
   errors: [],
@@ -303,6 +319,7 @@ type Action =
   | { type: "auth_required" }
   | { type: "auth_retrying" }
   | { type: "server"; message: ServerMessage }
+  | { type: "prompt_sent"; text: string; images?: WireImage[] }
   | { type: "dismiss_notification"; id: string }
   | { type: "dialog_answered" }
   | { type: "dir_list_started"; path: string; requestId: string; preserveEntries?: boolean }
@@ -373,6 +390,10 @@ function applySnapshot(state: AgentState, message: ServerMessage & { sessionId: 
     commands: message.commands,
     isStreaming: message.isStreaming,
     items: message.items,
+    // A snapshot is the authority on what this conversation contains. A prompt
+    // still waiting for its echo when one arrives — a reconnect, a session
+    // switch — either made it into these items or never landed at all.
+    pendingPrompt: null,
     workPlan: message.workPlan ?? null,
     queue: { steering: [], followUp: [] },
     errors: [],
@@ -423,6 +444,9 @@ function reduce(state: AgentState, action: Action): AgentState {
   // (see the /branding fetch below); "hello" still wins if it arrives with a different value.
   if (action.type === "branding_settled") return { ...state, brandingReady: true };
   if (action.type === "branding_loaded") return { ...state, brandingReady: true, branding: action.branding };
+  if (action.type === "prompt_sent") {
+    return { ...state, pendingPrompt: { text: action.text, ...(action.images?.length ? { images: action.images } : {}) } };
+  }
   if (action.type === "dismiss_notification") {
     return { ...state, notifications: state.notifications.filter((n) => n.id !== action.id) };
   }
@@ -563,6 +587,9 @@ function reduce(state: AgentState, action: Action): AgentState {
     case "user":
       return {
         ...state,
+        // Ours or another client's: either way the placeholder has served its
+        // purpose, and leaving it would double the bubble.
+        pendingPrompt: null,
         items: [
           ...state.items,
           { kind: "user", text: message.text, ...(message.images ? { images: message.images } : {}) },
@@ -673,6 +700,12 @@ function reduce(state: AgentState, action: Action): AgentState {
       return {
         ...state,
         errors: [...state.errors, message.message],
+        // A prompt the server refused — a session change in flight, attachments it
+        // would not take — is answered with an error and never with a `user`. The
+        // placeholder must go with it, or it stands there as a message that was
+        // never sent. Nothing is lost by clearing it on an unrelated error either:
+        // an accepted prompt has already been replaced by its real bubble.
+        pendingPrompt: null,
         // An apply is a modal wait on one answer, and the server answers a refused
         // one with exactly this. Attributing the first error that lands during the
         // wait keeps the menu open on the message that explains the refusal.
@@ -1213,8 +1246,12 @@ export function useAgent(serverUrl = "", explicitToken?: string, embedded = fals
       dispatch({ type: "auth_retrying" });
       setAuthNonce((n) => n + 1);
     },
-    prompt: (text: string, images?: WireImage[]) =>
-      sendMessage({ type: "prompt", text, ...(images?.length ? { images } : {}) }),
+    prompt: (text: string, images?: WireImage[]) => {
+      // Shown immediately, before the server has accepted anything: the round
+      // trip is long enough at the start of a conversation to read as a failure.
+      dispatch({ type: "prompt_sent", text, ...(images?.length ? { images } : {}) });
+      sendMessage({ type: "prompt", text, ...(images?.length ? { images } : {}) });
+    },
     abort: () => sendMessage({ type: "abort" }),
     setModel: (provider: string, id: string) => sendMessage({ type: "set_model", provider, id }),
     setThinking: (level: ThinkingLevel) => sendMessage({ type: "set_thinking", level }),


### PR DESCRIPTION
## Why

Reported from the office: after sending a prompt, nothing happens. The composer empties, the transcript does not move, and the message appears a few seconds later — "juste le temps de se demander s'il n'y a pas un problème". Most often at the start of a conversation, or when the provider is loaded.

`handlePrompt` (`server/src/index.ts`) says why:

```ts
await runtime.prompt(promptText, {
  // Echo the user message only once accepted (avoids ghost bubbles on reject).
  onAccepted: (accepted) => {
    if (accepted) broadcast({ type: "user", text, … });
  },
});
```

The client renders nothing of its own: `prompt()` puts a frame on the socket and waits. The bubble is the server's `user` broadcast, and that waits for the runtime to *accept* — behind session creation, runtime start-up, and, on a loaded provider, the wait for the request to be taken. The rule it protects is real (a refused prompt must not leave a bubble behind), but it pays for it with the latency of the most frequent gesture in the interface.

## What changes

The prompt appears the moment it is sent — dimmed, with a `sending…` spinner — and gives way to the authoritative bubble when the echo lands.

- A refusal (`Session change already in progress`, rejected attachments) arrives as an `error` with no `user`, and takes the placeholder with it.
- A snapshot — reconnect, session switch, config apply — is the authority on what the conversation contains, and clears it too.
- Another client's `user` clears it as well: the bubble is on screen either way, and leaving it would double it.

**It is deliberately not in `items`.** `user_entries` pairs bubbles to persisted entry ids counting **from the end**; a bubble the server has never seen would shift that alignment and take its neighbour's id — and editing it would then rewind the wrong turn. It lives in its own `pendingPrompt` state field instead, rendered after the list.

## Verification

- Five tests in `useAgent.test.ts`: it appears on send and stays out of `items`; the echo replaces it without doubling; attachments ride along; an error clears it; a snapshot clears it. Full UI suite 1287 passing.
- **Driven by hand in the widget** (`BENCH_LIVE=1 npm run bench`, real model), sampling the DOM from the click:

  | t | placeholder | bubbles carrying that text |
  |---|---|---|
  | 3 ms | present | 1 |
  | 19 ms | gone | 1 |

  19 ms is what acceptance costs on this machine; the reported case is the same round trip taking seconds.

---

## Also here: a provider failure that was showing its markup

Same subject — what the bubble tells the reader — so it rides along.

Providers do not fail in JSON. A proxy in front of one answers with a whole HTML document, the SDK passes that body on verbatim, and it reached the transcript as:

```
504 <html><body><h1>504 Gateway Time-out</h1> The server didn't respond in time. </body></html>
```

`describeProviderError` (`shared/src/providerError.ts`) recovers the words: drops tags, script and style, decodes escaped entities, keeps a status code the caller prefixed without repeating the one the page already carries, and bounds the length. A message somebody wrote to be read — the normal case, and the one worth protecting — comes back untouched: never reworded, reflowed, or truncated into a summary.

It is applied where the text enters the protocol, not where it is drawn: `convert.ts` for an assistant turn's own failure (live and on replay) and the runtime `error` broadcast. A reopened session then reads the same line the turn showed, and the renderer is unchanged.

Verified with a real server and a real RPC child emitting that exact body (`providerErrorWire.test.mjs`): the wire carries `504 Gateway Time-out The server didn't respond in time.`, no markup survives, and a reconnect replays the same sentence. Six unit tests cover the recovery rules, including the pass-through guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
