### PR TITLE
fix(ui): diff lines by their content, not by the terminator that ended them

### DIFF
--- a/ui/src/components/GitFileHistory.tsx
+++ b/ui/src/components/GitFileHistory.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 import { WORKTREE_REVISION, type GitRevision } from "@pi-outpost/shared";
 import type { GitFileDiffState, GitFileHistoryState } from "../useAgent";
-import { diffLines } from "../util/diff";
+import { differsOnlyInLineEndings, diffLines } from "../util/diff";
 import { HISTORY_LIST_WIDTH } from "../util/panelWidth";
 import { SplitDiffBlock } from "./DiffBlocks";
 import { PanelResizeHandle, useResizablePanelWidth } from "./PanelResizeHandle";
@@ -404,6 +404,16 @@ function DiffPane({ diff, base, target }: { diff: GitFileDiffState | null; base:
   if (diff === null) return <p className="text-sm text-zinc-400 dark:text-zinc-600">Loading…</p>;
   if (diff.status === "loaded" && diff.beforeText === diff.afterText) {
     return <p className="text-sm text-zinc-400 dark:text-zinc-600">These two versions are identical.</p>;
+  }
+  // The diff compares lines without their terminators, so a pair that differs
+  // only in those has nothing to mark — and a screen of unchanged lines would
+  // read as "identical", which is not what happened.
+  if (diff.status === "loaded" && differsOnlyInLineEndings(diff.beforeText, diff.afterText)) {
+    return (
+      <p className="text-sm text-zinc-400 dark:text-zinc-600">
+        These two versions differ only in their line endings.
+      </p>
+    );
   }
   return (
     // Dim rather than clear while reloading: the pane must not flash empty between pairs

--- a/ui/src/util/diff.test.ts
+++ b/ui/src/util/diff.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { diffLines, toSideBySide, rowsWithContext, withContext } from "./diff";
+import { differsOnlyInLineEndings, diffLines, toSideBySide, rowsWithContext, withContext } from "./diff";
 
 describe("diffLines", () => {
   it("returns all same lines for identical text", () => {
@@ -122,5 +122,39 @@ describe("withContext", () => {
     // 'away' is skipped (consecutive non-kept)
     // 'change' is kept
     expect(result[1]).not.toBeNull();
+  });
+});
+
+describe("line endings", () => {
+  // The reported case: the "before" side is a git blob (LF, as stored) and the
+  // "after" side is the working tree on Windows (CRLF, as checked out). Split on
+  // "\n" alone, every line of one side keeps a trailing "\r", nothing matches,
+  // and a one-line edit is drawn as a rewritten file.
+  it("marks only the line that changed when the sides disagree on terminators", () => {
+    const blob = "one\ntwo\nthree\n";
+    const worktree = "one\r\nTWO\r\nthree\r\n";
+    const lines = diffLines(blob, worktree);
+    expect(lines.filter((line) => line.type !== "same").map((line) => `${line.type}:${line.text}`)).toEqual([
+      "del:two",
+      "add:TWO",
+    ]);
+    expect(lines.filter((line) => line.type === "same").map((line) => line.text)).toEqual(["one", "three", ""]);
+  });
+
+  it("keeps a carriage return that is not a terminator", () => {
+    // A lone \r inside a line is content, not a line ending, and must survive.
+    const lines = diffLines("a\rb\n", "a\rc\n");
+    expect(lines.filter((line) => line.type !== "same")).toEqual([
+      { type: "del", text: "a\rb" },
+      { type: "add", text: "a\rc" },
+    ]);
+  });
+
+  it("recognises a pair that differs only in how its lines end", () => {
+    expect(differsOnlyInLineEndings("one\ntwo\n", "one\r\ntwo\r\n")).toBe(true);
+    // Identical texts have no difference to explain away.
+    expect(differsOnlyInLineEndings("one\n", "one\n")).toBe(false);
+    // A real edit is a real edit, whatever the terminators.
+    expect(differsOnlyInLineEndings("one\n", "two\r\n")).toBe(false);
   });
 });

--- a/ui/src/util/diff.ts
+++ b/ui/src/util/diff.ts
@@ -1,3 +1,17 @@
+/** Lines, without the terminator that ended them. */
+const splitLines = (text: string): string[] => text.split(/\r?\n/);
+
+/**
+ * Whether two texts differ only in how their lines end.
+ *
+ * A diff of such a pair has nothing to mark, and drawing the whole file as
+ * unchanged says the file is unchanged — which is not what happened. The
+ * caller can say what did.
+ */
+export function differsOnlyInLineEndings(oldText: string, newText: string): boolean {
+  return oldText !== newText && splitLines(oldText).join("\n") === splitLines(newText).join("\n");
+}
+
 /** One rendered diff row. */
 export interface DiffLine {
   type: "same" | "add" | "del";
@@ -11,8 +25,13 @@ export interface DiffLine {
  * burning O(n²) on a huge file.
  */
 export function diffLines(oldText: string, newText: string): DiffLine[] {
-  const a = oldText.split("\n");
-  const b = newText.split("\n");
+  // Split on either terminator. The two sides of a diff rarely come from the
+  // same place — a git blob is stored with LF, the working tree on Windows is
+  // checked out with CRLF — and splitting on "\n" alone leaves every line of
+  // one side carrying a trailing "\r". Nothing then matches anything, and a
+  // file with one edited line is drawn as entirely rewritten.
+  const a = splitLines(oldText);
+  const b = splitLines(newText);
 
   let start = 0;
   while (start < a.length && start < b.length && a[start] === b[start]) start++;


### PR DESCRIPTION
## Why

Reported from the office, on Windows: a text file with one changed line is shown as **entirely** modified — every line marked, on both sides.

The two sides of a diff do not come from the same place. The before side is a git blob, stored with LF; the after side is the working tree, which Windows checks out with CRLF. `diffLines` split on `"\n"` alone, so every line of the working-tree side kept a trailing `\r`, no line equalled its counterpart, the common prefix/suffix trim found nothing, and the LCS had no common subsequence. On macOS and Linux both sides are LF, which is why it only shows up there.

## What changes

- `diffLines` splits on either terminator (`/\r?\n/`). The comparison unit is a line, and `\r` is part of what ended it — not part of it. A carriage return that is *not* a line ending stays: it is content.
- A pair that differs **only** in how its lines end now has nothing to mark, and a screen of unchanged rows would read as "identical" — which is not what happened. `differsOnlyInLineEndings` names that case, and the git history view says so.

The fix is in the shared line-diff, so the file preview's `± diff`, the git history pane, and the tool cards' before/after all get it.

## Verification

Driven in the running app, on a repository put in the state a Windows checkout is in — committed with LF, rewritten on disk with CRLF, one word changed (`bravo` → `BRAVO`) — with the file preview's `± diff` open on the same page, before and after the fix:

| | marked rows |
|---|---|
| without the fix | **10** — `alpha/alpha, bravo/BRAVO, charlie/charlie, delta/delta, echo/echo`: every line, deleted and added |
| with it | **2** — `bravo`, `BRAVO` |

Three unit tests cover the mixed-terminator diff, the carriage return that is content, and the line-endings-only pair. Full UI suite: 1290 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
