### PR TITLE
test(agent): make the mention replay assert what a real child persists

### DIFF
--- a/server/test/mentionAbsolutization.test.mjs
+++ b/server/test/mentionAbsolutization.test.mjs
@@ -45,7 +45,21 @@ test("an @-mentioned path reaches the model absolute, and the user still sees it
     JSON.stringify({
       commandLog,
       commands_: {
-        prompt: { after: [{ type: "message_end", message: { role: "user", content: absolutized } }] },
+        prompt: {
+          // What the child's own history holds once the turn is over. A real Pi
+          // persists the prompt it was given; the server replaces its in-memory
+          // messages with this on every completed turn, so a fixture that answers
+          // nothing makes a reconnect replay nothing.
+          replacement: { messages: [{ role: "user", content: absolutized, timestamp: 1 }] },
+          after: [
+            { type: "message_end", message: { role: "user", content: absolutized } },
+            // The turn has to *end*, not merely be accepted. The server persists
+            // the history and announces it then; without this the reconnect below
+            // raced the write and read an empty session — rarely on macOS, often
+            // enough on Windows CI to fail one run in two.
+            { type: "agent_settled" },
+          ],
+        },
       },
     }),
   );
@@ -78,6 +92,10 @@ test("an @-mentioned path reaches the model absolute, and the user still sees it
     // whatever reached runtime.prompt(), the absolute form. The relative
     // mention must survive that round trip too, or "transparent" stops being
     // true the moment the tab reloads.
+    // `user_entries` is broadcast once the turn is persisted — the server saying
+    // the history now holds what a reconnect would replay.
+    await client.waitFor("user_entries");
+
     const reconnected = connect(server.wsUrl());
     try {
       const hello = await reconnected.waitFor("hello");


### PR DESCRIPTION
## Why

`an @-mentioned path reaches the model absolute, and the user still sees it relative` failed one Windows CI run in two, with:

```
AssertionError: no replayed user item; saw []
```

It reconnected as soon as the prompt was accepted, and read the first `hello` it received — so it raced the very write it exists to check.

## What was actually wrong

Waiting alone would have papered over it. Looking for something deterministic to wait *for* is what found the hole.

The server replaces its in-memory history with the child's `get_messages` at the end of every turn (`rpcRuntime.refreshConversation`). The fake child in this fixture answered that command with nothing. So the test only ever passed because the turn had not finished yet and the message it asserted on was still the one the server held in memory.

Making the turn actually end — the fake now emits `agent_settled` — turned the failure from intermittent into **certain, on macOS, every run**. The Windows CI runs were not flaky so much as occasionally fast enough to reach a real refresh before the assertion.

## What changes

- The fake keeps the message a real Pi would have persisted (`replacement.messages` on the `prompt` command), so `get_messages` answers like the real thing.
- The scripted turn ends (`agent_settled`), which is what a real turn does.
- The test waits for `user_entries` — the server saying the history now holds what a reconnect would replay — before reconnecting.

The assertion is stronger than it was: the relative mention is now recovered from what the child stored, which is the path a reloaded tab actually takes, rather than from whatever survived in memory.

## Verification

Five consecutive local runs, green. The failure it replaces was reproducible on macOS once the turn was allowed to finish, so the fix is verified against a deterministic failure rather than against a coin flip.

Unrelated, seen in the same CI run and not addressed here: `PdfViewer > follows the scroll: the page crossing the middle becomes the current one` fails on the ubuntu job under coverage instrumentation while passing 3/3 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
