### PR TITLE
test(pdf): wait for the observer before pretending the page scrolled

### DIFF
--- a/ui/src/components/PdfViewer.test.tsx
+++ b/ui/src/components/PdfViewer.test.tsx
@@ -365,8 +365,16 @@ describe("PdfViewer scrolling", () => {
     render(<PdfViewer path="report.pdf" />);
     await screen.findByText("Page 1 / 5");
 
-    // What the browser reports when page 4 scrolls across the middle line
-    notify?.([{ isIntersecting: true, target: { dataset: { page: "4" } } }]);
+    // The observer is created only once the document has loaded, which is later
+    // than the page indicator appearing. `notify?.()` on a callback that is not
+    // there yet does nothing at all, and the test then waits for a change that
+    // will never come — one ubuntu CI run in a few, never locally.
+    await waitFor(() => expect(notify).toBeDefined());
+
+    // What the browser reports when page 4 scrolls across the middle line. Not
+    // optional: a missing observer must fail here, naming itself, rather than
+    // being swallowed and reported as a page indicator that would not update.
+    notify!([{ isIntersecting: true, target: { dataset: { page: "4" } } }]);
     expect(await screen.findByText("Page 4 / 5")).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Why

`PdfViewer > follows the scroll: the page crossing the middle becomes the current one` failed the ubuntu job on #105, and passes every local run — three in a row plainly, and again under the same coverage instrumentation CI uses.

## The mechanism

The viewer creates its `IntersectionObserver` in an effect gated on the loaded document:

```ts
useEffect(() => {
  if (doc === null || typeof IntersectionObserver === "undefined") return;
  …
  const observer = new IntersectionObserver(…);
}, [doc, pageCount]);
```

The test captures that callback from a fake observer's constructor, waits for `Page 1 / 5` — which the component renders before the document has finished loading — and then calls:

```ts
notify?.([{ isIntersecting: true, target: { dataset: { page: "4" } } }]);
```

On a slower runner the observer has not been constructed yet, so `notify` is `undefined` and the optional call **does nothing**. The test then waits for `Page 4 / 5`, which nobody asked for, and times out.

## What changes

Two lines, in the test only:

- it waits for the callback to exist before using it;
- it calls it as `notify!(…)`, so an observer that never arrives fails there and names itself, rather than being swallowed and re-reported as a page indicator that would not update.

## Verification

The suite passes locally, and the full UI coverage gate CI runs passes with it: lines 94.08% (≥ 91), branches 87.41% (≥ 85), functions 93.21% (≥ 93).

Worth knowing separately: that functions threshold has 0.21 points of headroom, so one untested function is enough to turn it red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
