### PR TITLE
chore(release): v0.16.2

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-outpost",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "type": "module",
   "description": "A web interface for the pi coding agent: a browser chat UI you run with npx — no clone, no build.",
   "license": "MIT",

--- a/embed/package.json
+++ b/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-outpost/embed",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "type": "module",
   "description": "Mount pi-outpost as a Shadow-DOM-isolated widget inside another web app.",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "cli": {
       "name": "pi-outpost",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "^0.84.3",
@@ -42,7 +42,7 @@
     },
     "embed": {
       "name": "@pi-outpost/embed",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "license": "MIT",
       "devDependencies": {
         "@microsoft/api-extractor": "^7.58.9",


### PR DESCRIPTION
Version bump for the hotfix merged in #108.

`pi-outpost` and `@pi-outpost/embed` move to 0.16.2, with the two matching
workspace entries in `package-lock.json`. Four lines, the same shape as the
v0.16.1 bump (231a42d).

The lock was edited directly rather than through `npm install`: the tooling
available here runs an npm older than this repo's engine requirement, and an
install rewrote ~200 unrelated `"peer": true` lines into the lock. The file is
valid JSON and both entries read 0.16.2.

### Why this is needed now

The `v0.16.2` tag was pushed onto `14c7e7c` (main's head) while this bump was
still sitting on the branch, so the tag claimed a version the packages did not
carry. The release run stopped at its own guard:

```
##[error]no package is at version 0.16.2
```

Nothing was published to npm and no GitHub Release was created — `publish`
failed before any of it, and `attach` was skipped. The state is clean.

### After merging

The tag has to move onto the merge commit, since it currently points at a
commit that still says 0.16.1:

```
git tag -f v0.16.2 && git push -f origin v0.16.2
```

That re-triggers the workflow from scratch. Re-running the failed job on the
existing run would not work: it would start from `14c7e7c` again, and the
executables that run already built are labelled 0.16.1.

---
_Generated by [Claude Code](https://claude.ai/code/session_016edYBQPxb8sBnVGsAh2xwi)_