### PR TITLE
fix(server): stop cutting a provider's prose at 300 characters

### DIFF
--- a/server/test/providerError.test.ts
+++ b/server/test/providerError.test.ts
@@ -27,6 +27,28 @@ describe("describeProviderError", () => {
     }
   });
 
+  it("never cuts prose, however long — the long one is the one worth reading", () => {
+    // The failure this guard exists for. A tool-call parser refusing the model's
+    // output quotes that output back, and the quote is the diagnosis: which byte
+    // it choked on, and what surrounded it. The old 300-character bound landed
+    // mid-quote and threw exactly that away, leaving a position with nothing to
+    // look at. Bounding is for a page's furniture, never for a sentence.
+    const quoted = [
+      'Failed to parse input at pos 2040: <tool_call>',
+      '<function=write>',
+      '<parameter=content>',
+      '# Specification: ci-taskfile'.padEnd(2400, ' .'),
+      '</parameter>',
+    ].join('\n');
+    assert.ok(quoted.length > 2000, `the case is a long one, got ${quoted.length}`);
+    assert.equal(describeProviderError(quoted), quoted);
+
+    // Nothing in a Qwen tool call reads as a page: <parameter> is not <p>, so
+    // this must not fall into the markup branch and be flattened either.
+    assert.ok(describeProviderError(quoted).includes('<function=write>'), 'tags survive');
+    assert.ok(describeProviderError(quoted).includes('\n'), 'line structure survives');
+  });
+
   it("keeps a status the caller prefixed, without repeating it", () => {
     assert.equal(
       describeProviderError("502 <html><head><title>502 Bad Gateway</title></head><body>nginx</body></html>"),

--- a/shared/src/providerError.ts
+++ b/shared/src/providerError.ts
@@ -11,14 +11,19 @@
  * Every word a reader needs is in there, wrapped in markup that is not for them.
  * This turns such a body into one line, and leaves anything that was already a
  * sentence alone — a provider that writes a plain message is the normal case and
- * must not be reworded.
+ * must not be reworded or cut. Only text recovered from a page is bounded.
  *
  * Deliberately not a parser: the input is whatever an unknown intermediary chose
  * to send, so this reads as "recover the words", never "understand the document".
  */
 
-/** Long enough for a real explanation, short enough to stay a bubble. */
-const MAX_LENGTH = 300;
+/**
+ * Bounds what is recovered from a page, and nothing else.
+ *
+ * A page is furniture around a sentence, and the sentence is near the top, so
+ * cutting the rest costs nothing. Prose is not bounded at all: see below.
+ */
+const MAX_RECOVERED_LENGTH = 300;
 
 const ENTITIES: Record<string, string> = {
   amp: "&",
@@ -64,7 +69,13 @@ function textFromMarkup(markup: string): string {
 export function describeProviderError(raw: string): string {
   const input = raw?.trim() ?? "";
   if (input === "") return input;
-  if (!looksLikeMarkup(input)) return input.length > MAX_LENGTH ? `${input.slice(0, MAX_LENGTH - 1).trimEnd()}…` : input;
+  // Untouched, at any length. A provider that writes prose is explaining itself,
+  // and the explanation is the whole value of the bubble: a tool-call parser
+  // quoting the 2 KB of model output it choked on is the diagnosis, not noise to
+  // be capped — a 300-character cut lands mid-quote and hides the offending byte.
+  // A pathologically long answer is information about the provider in its own
+  // right, so it is shown rather than summarized away.
+  if (!looksLikeMarkup(input)) return input;
 
   const start = input.search(/<\s*(!doctype|html|body|head|h[1-6]|p|div|title|center|pre)\b/i);
   const prefix = input.slice(0, start).trim();
@@ -75,5 +86,5 @@ export function describeProviderError(raw: string): string {
   // "504" then "504 Gateway Time-out": the page already opens with the code.
   const body = status !== "" && recovered.startsWith(`${status} `) ? recovered.slice(status.length + 1) : recovered;
   const line = [status !== "" ? status : prefix, body].filter((part) => part !== "").join(" ");
-  return line.length > MAX_LENGTH ? `${line.slice(0, MAX_LENGTH - 1).trimEnd()}…` : line;
+  return line.length > MAX_RECOVERED_LENGTH ? `${line.slice(0, MAX_RECOVERED_LENGTH - 1).trimEnd()}…` : line;
 }


### PR DESCRIPTION
`describeProviderError` (#104, shipped in v0.16.0) bounds its result at 300
characters so a proxy's HTML page cannot fill the transcript with navigation
and boilerplate. That bound was applied to every message, including the ones
that were already prose — and those are the ones a reader needs whole.

### How it surfaced

A local inference server refused a tool call and said so:

```
Failed to parse input at pos 2040: <tool_call> <function=write> <parameter=content> # Specification: ci-taskfile Domain: `undomained` > Generated from deterministic evidence. Every requirement anchors to an exact symbol in source code. ## Purpose The **ci-taskfile** domain provides the `Taskfil…
```

The server quotes the model output it choked on, and that quote is the whole
diagnosis: which byte it stopped at, and what surrounded it. At 300 characters
the cut lands mid-quote, so the message names a position and then throws away
everything anyone could have looked at. The trailing `…` is this function's
own truncation marker.

Nothing about a tool call reads as a page, so this never went through the
markup branch — `<parameter=` is not `<p>`, there being no word boundary after
the p. The line structure survived; only the length did not.

### The change

Prose is returned untouched, at any length. The bound stays where its reason
holds — text recovered from a page, where the sentence sits near the top and
the rest is furniture — and the constant is renamed `MAX_RECOVERED_LENGTH` so
it says what it applies to.

This makes the existing test's claim true. It already asserted that a message
somebody wrote to be read "must not be reworded, reflowed, or truncated into a
summary", but only exercised short ones.

### Tests

A new case covers a 2.4 KB parse error quoting a `<function=write>` call:
returned byte for byte, tags and newlines intact. Verified it fails with the
bound restored and passes without it, so it pins the behaviour rather than
merely describing it. All 7 cases in the suite pass, including the one that
still bounds a page that is mostly furniture.

### Not addressed

`looksLikeMarkup` recognises `!doctype|html|body|head|h[1-6]|p|div|title|center|pre`,
so a real page opening on `<span>` or `<table>` still falls through to the
prose branch. That is a separate defect from this one and is left alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_016edYBQPxb8sBnVGsAh2xwi)_