### PR TITLE
chore(release): v0.16.3

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-outpost",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "type": "module",
   "description": "A web interface for the pi coding agent: a browser chat UI you run with npx — no clone, no build.",
   "license": "MIT",

--- a/embed/package.json
+++ b/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-outpost/embed",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "type": "module",
   "description": "Mount pi-outpost as a Shadow-DOM-isolated widget inside another web app.",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "cli": {
       "name": "pi-outpost",
-      "version": "0.16.2",
+      "version": "0.16.3",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "^0.84.3",
@@ -42,7 +42,7 @@
     },
     "embed": {
       "name": "@pi-outpost/embed",
-      "version": "0.16.2",
+      "version": "0.16.3",
       "license": "MIT",
       "devDependencies": {
         "@microsoft/api-extractor": "^7.58.9",


### PR DESCRIPTION
Version bump for the fix merged in #110.

`pi-outpost` and `@pi-outpost/embed` move to 0.16.3, with the two matching
workspace entries in `package-lock.json`. Four lines, the same shape as the
v0.16.2 bump.

The lock was edited directly rather than through `npm install`: the tooling
available here runs an npm older than this repo's engine requirement, and an
install rewrites ~200 unrelated `"peer": true` lines into it. The file is valid
JSON and both entries read 0.16.3.

### Merge before tagging

The tag is the version claim, and the release job refuses to publish when the
packages disagree with it. On v0.16.2 the tag went onto main's head while the
bump was still on the branch, and the run stopped at its own guard with
`no package is at version 0.16.2`. Nothing was published and nothing was lost,
but the run had to be redone.

So: merge this first, then tag the resulting commit on main.

```
git checkout main && git pull
git tag v0.16.3 && git push origin v0.16.3
```

---
_Generated by [Claude Code](https://claude.ai/code/session_016edYBQPxb8sBnVGsAh2xwi)_