### PR TITLE
diag(server): record what a stack-exhausted turn was given

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -73,6 +73,7 @@ import {
 } from "./credentials.ts";
 import { assistantToItem, contentText, customMessageToItem, historyToItems, structuredExchangeField, truncate } from "./convert.ts";
 import { configureExtensionRender, renderToolCallHtml, renderToolResultHtml } from "./extensionRender.ts";
+import { isStackExhaustion, recordTurnFailure } from "./turnFailureLog.ts";
 import {
   assertWithinRoot,
   createDirectoryFromBrowser,
@@ -1193,10 +1194,24 @@ function onRuntimeEvent(event: RuntimeEvent): void {
     case "block_delta":
       broadcast({ type: "block_delta", block: event.block, contentIndex: event.contentIndex, delta: event.delta });
       break;
-    case "assistant_end":
+    case "assistant_end": {
       // Full sync of the finished message (covers retries/partial rebuilds)
       broadcast({ type: "assistant_end", item: assistantToItem(event.message as never) });
+      // A turn that died of stack exhaustion arrives here as a message and no
+      // stack: every provider's catch keeps `error.message` and drops the Error.
+      // Record the input instead, while the branch that produced it is still
+      // the branch on screen — see turnFailureLog.ts.
+      const failure = (event.message as { errorMessage?: unknown } | null)?.errorMessage;
+      if (typeof failure === "string" && isStackExhaustion(failure)) {
+        recordTurnFailure(AGENT_DIR, {
+          source: "assistant",
+          message: failure,
+          assistantMessage: event.message,
+          entries: runtime.contextEntries(),
+        });
+      }
       break;
+    }
     case "custom_message":
       broadcast({ type: "custom_message", item: customMessageToItem(event.message as never) });
       break;
@@ -1273,6 +1288,11 @@ function onRuntimeEvent(event: RuntimeEvent): void {
       break;
     case "compaction_end": {
       broadcast({ type: "compaction_end", ...(event.errorMessage ? { errorMessage: event.errorMessage } : {}) });
+      // Compaction summarizes the branch with a model call of its own, so it
+      // fails the same ways a turn does — and reaches the same red list.
+      if (event.errorMessage && isStackExhaustion(event.errorMessage)) {
+        recordTurnFailure(AGENT_DIR, { source: "compaction", message: event.errorMessage, entries: runtime.contextEntries() });
+      }
       const usage = contextUsage();
       if (usage) broadcast({ type: "context_usage", usage });
       break;
@@ -1290,12 +1310,20 @@ function onRuntimeEvent(event: RuntimeEvent): void {
       // Same treatment as an assistant turn's own failure: a provider reached
       // through a proxy answers with an HTML page, and the reader gets markup.
       broadcast({ type: "error", message: describeProviderError(event.message) });
+      if (isStackExhaustion(event.message)) {
+        recordTurnFailure(AGENT_DIR, { source: "runtime", message: event.message, entries: runtime.contextEntries() });
+      }
       break;
     case "runtime_failed":
       // Fail closed: /health already reports unready, and this is the one visible
       // notice. No restart, no replay — a prompt or tool may have had side effects.
       console.error(`[pi] agent runtime failed: ${event.message}`);
       broadcast({ type: "error", message: `Agent runtime failed: ${event.message}` });
+      // Fail-closed means nothing runs after this, so the census is written
+      // synchronously or not at all.
+      if (isStackExhaustion(event.message)) {
+        recordTurnFailure(AGENT_DIR, { source: "runtime_failed", message: event.message });
+      }
       break;
   }
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -73,7 +73,7 @@ import {
 } from "./credentials.ts";
 import { assistantToItem, contentText, customMessageToItem, historyToItems, structuredExchangeField, truncate } from "./convert.ts";
 import { configureExtensionRender, renderToolCallHtml, renderToolResultHtml } from "./extensionRender.ts";
-import { isStackExhaustion, recordTurnFailure } from "./turnFailureLog.ts";
+import { isStackExhaustion, noteCompaction, noteToolOutcome, noteTurnOutcome, recordTurnFailure } from "./turnFailureLog.ts";
 import {
   assertWithinRoot,
   createDirectoryFromBrowser,
@@ -1208,8 +1208,13 @@ function onRuntimeEvent(event: RuntimeEvent): void {
           message: failure,
           assistantMessage: event.message,
           entries: runtime.contextEntries(),
+          contextUsage: contextUsage(),
         });
       }
+      // After the census, so a turn does not appear in its own run-up: every
+      // reported occurrence followed a cut request, and the cut is the context
+      // the overflow is missing.
+      noteTurnOutcome(event.message);
       break;
     }
     case "custom_message":
@@ -1235,6 +1240,9 @@ function onRuntimeEvent(event: RuntimeEvent): void {
       break;
     }
     case "tool_end": {
+      // The reported run-up opens with a red tool card; its name and the weight
+      // of what it returned are the two facts that survive into the census.
+      noteToolOutcome(event.toolName, event.isError, event.content);
       const rendered = renderToolResultHtml(
         event.toolCallId,
         event.toolName,
@@ -1285,14 +1293,21 @@ function onRuntimeEvent(event: RuntimeEvent): void {
       break;
     case "compaction_start":
       broadcast({ type: "compaction_start" });
+      noteCompaction("start");
       break;
     case "compaction_end": {
       broadcast({ type: "compaction_end", ...(event.errorMessage ? { errorMessage: event.errorMessage } : {}) });
       // Compaction summarizes the branch with a model call of its own, so it
       // fails the same ways a turn does — and reaches the same red list.
       if (event.errorMessage && isStackExhaustion(event.errorMessage)) {
-        recordTurnFailure(AGENT_DIR, { source: "compaction", message: event.errorMessage, entries: runtime.contextEntries() });
+        recordTurnFailure(AGENT_DIR, {
+          source: "compaction",
+          message: event.errorMessage,
+          entries: runtime.contextEntries(),
+          contextUsage: contextUsage(),
+        });
       }
+      noteCompaction("end", event.errorMessage);
       const usage = contextUsage();
       if (usage) broadcast({ type: "context_usage", usage });
       break;
@@ -1311,7 +1326,12 @@ function onRuntimeEvent(event: RuntimeEvent): void {
       // through a proxy answers with an HTML page, and the reader gets markup.
       broadcast({ type: "error", message: describeProviderError(event.message) });
       if (isStackExhaustion(event.message)) {
-        recordTurnFailure(AGENT_DIR, { source: "runtime", message: event.message, entries: runtime.contextEntries() });
+        recordTurnFailure(AGENT_DIR, {
+          source: "runtime",
+          message: event.message,
+          entries: runtime.contextEntries(),
+          contextUsage: contextUsage(),
+        });
       }
       break;
     case "runtime_failed":

--- a/server/src/turnFailureLog.ts
+++ b/server/src/turnFailureLog.ts
@@ -198,6 +198,64 @@ function censusOfTurn(message: unknown): Record<string, unknown> {
   };
 }
 
+/**
+ * The run-up, kept because the failure is never the whole story.
+ *
+ * The reported sequence is three red things in a row: a `bash` or `read` card,
+ * then "Request was aborted", then the overflow. Only the last one matches
+ * `isStackExhaustion`, so a record of that one alone throws away the two events
+ * that say what the process was doing when the stack went. This ring holds the
+ * recent outcomes — tool results and failed turns — and the census carries them
+ * along, so one occurrence shows the shape of the run-up instead of its last
+ * frame.
+ *
+ * Sizes, names and flags only; no tool output and no message text.
+ */
+const RECENT_LIMIT = 32;
+const recent: Record<string, unknown>[] = [];
+
+function note(entry: Record<string, unknown>): void {
+  recent.push({ at: new Date().toISOString(), ...entry });
+  if (recent.length > RECENT_LIMIT) recent.shift();
+}
+
+/** A finished tool call: which one, whether it failed, and how much it returned. */
+export function noteToolOutcome(toolName: string, isError: boolean, content: unknown): void {
+  note({ kind: "tool", toolName, isError, bytes: serializedBytes(content) });
+}
+
+/**
+ * A finished turn that carried an error.
+ *
+ * Every failed turn, not only the exhausted ones: "Request was aborted" is not
+ * itself the bug and is exactly the context the bug is missing.
+ */
+export function noteTurnOutcome(message: unknown): void {
+  const record = (message ?? {}) as Record<string, unknown>;
+  if (typeof record.errorMessage !== "string") return;
+  note({
+    kind: "turn",
+    provider: record.provider,
+    model: record.model,
+    stopReason: record.stopReason,
+    rawStopReason: record.rawStopReason,
+    errorMessage: record.errorMessage,
+    usage: record.usage,
+  });
+}
+
+/**
+ * Compaction, which is what pi does *after* a turn fails.
+ *
+ * Every reported occurrence follows a cut request — an abort, a timeout — and
+ * never the nominal path, so what runs between the cut and the overflow is the
+ * part worth seeing. A compaction in the run-up is a model call of its own over
+ * a rebuilt branch; its absence is just as informative.
+ */
+export function noteCompaction(phase: "start" | "end", errorMessage?: string): void {
+  note({ kind: "compaction", phase, ...(errorMessage === undefined ? {} : { errorMessage }) });
+}
+
 /** Which red bubble the failure became, so a record can be matched to what was seen. */
 export type TurnFailureSource = "assistant" | "compaction" | "runtime" | "runtime_failed";
 
@@ -209,6 +267,8 @@ export interface TurnFailureReport {
   assistantMessage?: unknown;
   /** The active branch as it stood — the input the overflow is a function of. */
   entries?: readonly unknown[];
+  /** Context tokens at the moment it failed, when the server has a reading. */
+  contextUsage?: unknown;
 }
 
 /** Roll the log rather than let it grow without bound. */
@@ -246,6 +306,9 @@ function writeRecord(agentDir: string, report: TurnFailureReport): void {
     message: report.message,
     ...(report.assistantMessage === undefined ? {} : { turn: censusOfTurn(report.assistantMessage) }),
     ...(report.entries === undefined ? {} : { context: censusOfEntries(report.entries) }),
+    ...(report.contextUsage === undefined ? {} : { contextUsage: report.contextUsage }),
+    // Oldest first, so the record reads in the order the user watched it happen.
+    recent: [...recent],
   };
 
   const context = record.context as { count?: number; deepest?: EntryCensus[]; cyclic?: EntryCensus[] } | undefined;

--- a/server/src/turnFailureLog.ts
+++ b/server/src/turnFailureLog.ts
@@ -1,0 +1,272 @@
+/**
+ * What a turn that died of stack exhaustion leaves behind — which is almost
+ * nothing, unless something writes it down.
+ *
+ * "Maximum call stack size exceeded" reaches the red bubble under an assistant
+ * turn as eight words with no frame and no stack, and that is not pi-outpost
+ * throwing information away. Every provider's stream loop ends in the same
+ * catch:
+ *
+ *   catch (error) { output.errorMessage = error instanceof Error ? error.message
+ *                                       : JSON.stringify(error) }
+ *
+ * The message is kept and the Error is dropped, so by the time `assistant_end`
+ * crosses the runtime seam there is no `.stack` left to read anywhere in the
+ * process. Two providers (pi-messages, openai-codex-responses) additionally
+ * attach a diagnostic that does carry one; the Anthropic path does not. Logging
+ * the error harder is therefore not an option that exists.
+ *
+ * What is an option: a stack overflow is a deterministic function of its input,
+ * so this records the input. The number that matters is **depth**. A recursive-
+ * descent parser — and the request path is full of them, from the streaming
+ * tool-argument parser to the JSON-repair pass on every SSE event — dies of
+ * nesting depth and is indifferent to length. A census that comes back with a
+ * depth in the thousands names the culprit; one that comes back with a depth in
+ * the tens clears every parser in the process at once and sends the search to
+ * the schema-walking code instead. Either way the next occurrence settles it,
+ * rather than adding a third anecdote.
+ *
+ * A self-reference gets its own flag, because that is the shape that has already
+ * caused this exact failure once here: jiti's interop `default` pointing back at
+ * the schema it decorated, which sent TypeBox's compiler round forever (see
+ * `shared/src/structuredExchangeSchemaNode.ts`). A cycle anywhere in a turn's
+ * payload is the single most likely explanation and the cheapest to confirm.
+ *
+ * What is written is a census and not a transcript: counts, byte sizes, depths,
+ * roles, block and tool names. No message text, no tool arguments, no file
+ * contents. A shape is enough to find a recursion, and a forensic file that
+ * accumulates conversations is not something a deployment should have to think
+ * about before turning this on. The one verbatim field is a provider's own
+ * `diagnostics`, which is the only object in the pipeline that ever carries a
+ * stack — and which the provider wrote to be read.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+/** Where the census stops descending. Far past any legitimate payload. */
+const DEPTH_CAP = 20_000;
+
+/** Above this the log is rolled to `.1`, so a long-lived server cannot fill a disk. */
+const MAX_LOG_BYTES = 4 * 1024 * 1024;
+
+/** How many entries the record names individually. The rest are counted, not listed. */
+const WORST_LISTED = 8;
+
+/**
+ * Recognises the failure this exists for.
+ *
+ * Deliberately narrow. Every other turn failure — a rate limit, a dropped
+ * connection, a refusal — is already legible in the bubble and needs no forensic
+ * file; widening this would bury the rare event in the common ones.
+ */
+export function isStackExhaustion(message: string): boolean {
+  return /maximum call stack size exceeded|call stack size exceeded|stack overflow/i.test(message);
+}
+
+/** What a value's shape says about why a recursive walk over it might not return. */
+export interface ShapeCensus {
+  /** Deepest nesting reached, counting the value itself as 1. */
+  depth: number;
+  /** A value reachable from itself: the shape that makes a recursive walk never end. */
+  cyclic: boolean;
+  /** The descent stopped at DEPTH_CAP, so `depth` is a floor rather than the answer. */
+  capped: boolean;
+}
+
+/**
+ * Measure nesting depth without recursing.
+ *
+ * The obvious implementation — a function that calls itself per level — would
+ * overflow on precisely the input worth measuring, and report a crash instead of
+ * a number. So the descent is an explicit stack, and the set of nodes currently
+ * *on the path* (not merely seen) gives true cycle detection: a shared subobject
+ * reached twice by different routes is ordinary, and must not be reported as a
+ * self-reference.
+ */
+export function inspectShape(root: unknown): ShapeCensus {
+  let depth = 0;
+  let cyclic = false;
+  let capped = false;
+  const onPath = new Set<object>();
+  const stack: { node: object; children: unknown[]; next: number }[] = [];
+
+  const enter = (value: unknown, level: number): void => {
+    if (level > depth) depth = level;
+    if (value === null || typeof value !== "object") return;
+    if (onPath.has(value)) {
+      cyclic = true;
+      return;
+    }
+    if (level >= DEPTH_CAP) {
+      capped = true;
+      return;
+    }
+    onPath.add(value);
+    stack.push({ node: value, children: Array.isArray(value) ? value : Object.values(value), next: 0 });
+  };
+
+  enter(root, 1);
+  while (stack.length > 0) {
+    const frame = stack[stack.length - 1];
+    if (frame.next >= frame.children.length) {
+      onPath.delete(frame.node);
+      stack.pop();
+      continue;
+    }
+    // A frame at stack position n holds a value at level n; its children are n+1.
+    enter(frame.children[frame.next++], stack.length + 1);
+  }
+  return { depth, cyclic, capped };
+}
+
+/**
+ * Serialized size, or null when the value cannot be serialized at all.
+ *
+ * Null is itself a finding rather than a gap: `JSON.stringify` throws on a cycle
+ * and overflows on a deep enough value, which are the two conditions this file
+ * is looking for.
+ */
+export function serializedBytes(value: unknown): number | null {
+  try {
+    const json = JSON.stringify(value);
+    return json === undefined ? null : Buffer.byteLength(json);
+  } catch {
+    return null;
+  }
+}
+
+/** One conversation entry, measured. */
+interface EntryCensus extends ShapeCensus {
+  index: number;
+  role: string;
+  bytes: number | null;
+}
+
+function roleOf(entry: unknown): string {
+  const record = entry as { message?: { role?: unknown }; type?: unknown } | null;
+  const role = record?.message?.role;
+  if (typeof role === "string") return role;
+  return typeof record?.type === "string" ? record.type : "unknown";
+}
+
+function censusOfEntries(entries: readonly unknown[]): {
+  count: number;
+  bytes: number | null;
+  deepest: EntryCensus[];
+  largest: EntryCensus[];
+  cyclic: EntryCensus[];
+} {
+  const measured: EntryCensus[] = entries.map((entry, index) => ({
+    index,
+    role: roleOf(entry),
+    bytes: serializedBytes(entry),
+    ...inspectShape(entry),
+  }));
+  const byDepth = [...measured].sort((a, b) => b.depth - a.depth).slice(0, WORST_LISTED);
+  const byBytes = [...measured].sort((a, b) => (b.bytes ?? 0) - (a.bytes ?? 0)).slice(0, WORST_LISTED);
+  return {
+    count: measured.length,
+    bytes: measured.reduce<number | null>((total, one) => (total === null || one.bytes === null ? null : total + one.bytes), 0),
+    deepest: byDepth,
+    largest: byBytes,
+    cyclic: measured.filter((one) => one.cyclic),
+  };
+}
+
+/** The finished assistant message, reduced to what a post-mortem can use. */
+function censusOfTurn(message: unknown): Record<string, unknown> {
+  const record = (message ?? {}) as Record<string, unknown>;
+  const content = Array.isArray(record.content) ? record.content : [];
+  return {
+    provider: record.provider,
+    model: record.model,
+    api: record.api,
+    stopReason: record.stopReason,
+    rawStopReason: record.rawStopReason,
+    // Verbatim: on the providers that attach one this is the only object in the
+    // whole pipeline that ever carried a stack, and it must not be summarized.
+    diagnostics: record.diagnostics,
+    blocks: content.map((block: unknown) => {
+      const one = (block ?? {}) as Record<string, unknown>;
+      return {
+        type: one.type,
+        ...(typeof one.name === "string" ? { toolName: one.name } : {}),
+        bytes: serializedBytes(one),
+        ...inspectShape(one),
+      };
+    }),
+  };
+}
+
+/** Which red bubble the failure became, so a record can be matched to what was seen. */
+export type TurnFailureSource = "assistant" | "compaction" | "runtime" | "runtime_failed";
+
+export interface TurnFailureReport {
+  source: TurnFailureSource;
+  /** The text exactly as the browser will show it. */
+  message: string;
+  /** pi's finished assistant message, when the failure was a turn's own. */
+  assistantMessage?: unknown;
+  /** The active branch as it stood — the input the overflow is a function of. */
+  entries?: readonly unknown[];
+}
+
+/** Roll the log rather than let it grow without bound. */
+function rollIfLarge(file: string): void {
+  try {
+    if (fs.statSync(file).size < MAX_LOG_BYTES) return;
+    fs.renameSync(file, `${file}.1`);
+  } catch {
+    // No file yet, or a rename we lost a race on. Either way, append below.
+  }
+}
+
+/**
+ * Write one record, synchronously and best-effort.
+ *
+ * Synchronous on purpose: `runtime_failed` means the runtime is finished, and an
+ * async append scheduled behind it is an append that may never run. A diagnostic
+ * that loses the one occurrence it exists to capture is worse than none, and this
+ * only runs on a failure that is already rare.
+ */
+export function recordTurnFailure(agentDir: string, report: TurnFailureReport): void {
+  try {
+    writeRecord(agentDir, report);
+  } catch (error) {
+    // A diagnostic that takes down the event handler it runs in has cost more
+    // than it can ever return. The census is best-effort by construction.
+    console.error(`[pi-outpost] turn-failure census failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function writeRecord(agentDir: string, report: TurnFailureReport): void {
+  const record: Record<string, unknown> = {
+    at: new Date().toISOString(),
+    source: report.source,
+    message: report.message,
+    ...(report.assistantMessage === undefined ? {} : { turn: censusOfTurn(report.assistantMessage) }),
+    ...(report.entries === undefined ? {} : { context: censusOfEntries(report.entries) }),
+  };
+
+  const context = record.context as { count?: number; deepest?: EntryCensus[]; cyclic?: EntryCensus[] } | undefined;
+  const headline = [
+    `[pi-outpost] turn failed with stack exhaustion (${report.source})`,
+    context?.count === undefined ? "" : ` context=${context.count} entries`,
+    context?.deepest?.[0] === undefined ? "" : ` maxDepth=${context.deepest[0].depth}`,
+    context?.cyclic?.length ? ` SELF-REFERENCE in ${context.cyclic.length} entr${context.cyclic.length === 1 ? "y" : "ies"}` : "",
+  ].join("");
+  console.error(headline);
+
+  const file = path.join(agentDir, "turn-failures.jsonl");
+  try {
+    fs.mkdirSync(agentDir, { recursive: true });
+    rollIfLarge(file);
+    fs.appendFileSync(file, `${JSON.stringify(record)}\n`);
+    console.error(`[pi-outpost] wrote a full census to ${file}`);
+  } catch (error) {
+    // The census is worth more than the file: if nothing can be written, put it
+    // on stderr rather than lose the occurrence.
+    console.error(`[pi-outpost] could not write ${file}: ${error instanceof Error ? error.message : String(error)}`);
+    console.error(JSON.stringify(record));
+  }
+}

--- a/server/test/turnFailureLog.test.ts
+++ b/server/test/turnFailureLog.test.ts
@@ -1,0 +1,172 @@
+/**
+ * The census a stack-exhausted turn leaves behind.
+ *
+ * The point of these is the first test: the probe must survive an input deep
+ * enough to kill a recursive one, because that is the only input anybody will
+ * ever run it on. A depth measurement that overflows while measuring depth
+ * reports a crash instead of the number the investigation needs.
+ */
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { inspectShape, isStackExhaustion, recordTurnFailure, serializedBytes } from "../src/turnFailureLog.ts";
+
+/** Nested `{ next: { next: … } }`, built iteratively so the fixture is not the bug. */
+function deepChain(levels: number): unknown {
+  let node: Record<string, unknown> = {};
+  for (let i = 0; i < levels; i++) node = { next: node };
+  return node;
+}
+
+describe("isStackExhaustion", () => {
+  it("recognises what the provider actually puts in the bubble", () => {
+    // Verbatim V8, which is what survives `error.message` in every provider catch.
+    assert.equal(isStackExhaustion("Maximum call stack size exceeded"), true);
+    assert.equal(isStackExhaustion("Auto-compaction failed: Maximum call stack size exceeded"), true);
+    assert.equal(isStackExhaustion("RangeError: Maximum call stack size exceeded"), true);
+  });
+
+  it("stays narrow, so the common failures do not bury the rare one", () => {
+    for (const message of [
+      "429 rate limit reached; retry in 20s",
+      "Connection lost",
+      "The provider refused the request: context length exceeded",
+      "Anthropic stream ended without a stop reason",
+    ]) {
+      assert.equal(isStackExhaustion(message), false, message);
+    }
+  });
+});
+
+describe("inspectShape", () => {
+  it("measures a depth that would overflow a recursive probe", () => {
+    // 60k levels: comfortably past the ~11k frames V8 gives a simple recursion,
+    // so a recursive implementation of this function fails here and this one
+    // must not.
+    const census = inspectShape(deepChain(60_000));
+    assert.equal(census.capped, true);
+    assert.ok(census.depth >= 20_000, `expected the cap to be reached, got ${census.depth}`);
+    assert.equal(census.cyclic, false);
+  });
+
+  it("reports the depth of an ordinary payload exactly", () => {
+    // { a: [ { b: 1 } ] } — value 1, array 2, object 3, number 4.
+    assert.deepEqual(inspectShape({ a: [{ b: 1 }] }), { depth: 4, cyclic: false, capped: false });
+    assert.deepEqual(inspectShape("text"), { depth: 1, cyclic: false, capped: false });
+    assert.deepEqual(inspectShape(null), { depth: 1, cyclic: false, capped: false });
+  });
+
+  it("flags a self-reference, the shape that has already caused this failure here", () => {
+    // jiti's interop `default`, which pointed a schema at itself and sent
+    // TypeBox's compiler round forever. See structuredExchangeSchemaNode.ts.
+    const decorated: Record<string, unknown> = { $id: "urn:test", type: "object" };
+    decorated.default = decorated;
+    const census = inspectShape(decorated);
+    assert.equal(census.cyclic, true);
+    assert.equal(census.capped, false);
+  });
+
+  it("does not mistake a shared subobject for a cycle", () => {
+    // Reached twice by different routes is ordinary; reachable from itself is not.
+    const shared = { value: 1 };
+    const census = inspectShape({ left: shared, right: shared });
+    assert.equal(census.cyclic, false);
+    assert.equal(census.depth, 3);
+  });
+});
+
+describe("serializedBytes", () => {
+  it("measures what a payload weighs", () => {
+    assert.equal(serializedBytes({ a: 1 }), Buffer.byteLength(JSON.stringify({ a: 1 })));
+  });
+
+  it("returns null rather than throwing on the two shapes under investigation", () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    assert.equal(serializedBytes(cyclic), null);
+    assert.equal(serializedBytes(deepChain(200_000)), null);
+  });
+});
+
+describe("recordTurnFailure", () => {
+  const withAgentDir = (run: (dir: string) => void): void => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "turn-failure-"));
+    try {
+      run(dir);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  };
+
+  const readRecords = (dir: string): Record<string, unknown>[] =>
+    fs
+      .readFileSync(path.join(dir, "turn-failures.jsonl"), "utf8")
+      .split("\n")
+      .filter((line) => line !== "")
+      .map((line) => JSON.parse(line));
+
+  it("writes the message verbatim and names the deepest entry in the context", () => {
+    withAgentDir((dir) => {
+      recordTurnFailure(dir, {
+        source: "assistant",
+        message: "Maximum call stack size exceeded",
+        assistantMessage: { provider: "anthropic", model: "claude-sonnet-5", stopReason: "error", content: [] },
+        entries: [
+          { id: "a", message: { role: "user", content: "hi" } },
+          { id: "b", message: { role: "toolResult", content: deepChain(40) } },
+        ],
+      });
+
+      const [record] = readRecords(dir);
+      assert.equal(record.message, "Maximum call stack size exceeded");
+      assert.equal(record.source, "assistant");
+      assert.equal((record.turn as Record<string, unknown>).provider, "anthropic");
+      const context = record.context as { count: number; deepest: { index: number; role: string; depth: number }[] };
+      assert.equal(context.count, 2);
+      // The deep one must be the one the record puts first, by index and by role.
+      assert.equal(context.deepest[0].index, 1);
+      assert.equal(context.deepest[0].role, "toolResult");
+      assert.ok(context.deepest[0].depth > 40);
+    });
+  });
+
+  it("keeps a provider's diagnostics verbatim — the only place a stack ever survives", () => {
+    withAgentDir((dir) => {
+      const diagnostics = [{ type: "stream_error", error: { name: "RangeError", stack: "RangeError: Maximum call stack size exceeded\n    at parse" } }];
+      recordTurnFailure(dir, {
+        source: "assistant",
+        message: "Maximum call stack size exceeded",
+        assistantMessage: { provider: "pi", diagnostics, content: [] },
+      });
+      const [record] = readRecords(dir);
+      assert.deepEqual((record.turn as Record<string, unknown>).diagnostics, diagnostics);
+    });
+  });
+
+  it("records a self-referential context without hanging or throwing", () => {
+    withAgentDir((dir) => {
+      const entry: Record<string, unknown> = { id: "a", message: { role: "user" } };
+      entry.self = entry;
+      recordTurnFailure(dir, { source: "runtime", message: "Maximum call stack size exceeded", entries: [entry] });
+      const [record] = readRecords(dir);
+      const context = record.context as { bytes: number | null; cyclic: { index: number }[] };
+      assert.equal(context.cyclic.length, 1);
+      assert.equal(context.cyclic[0].index, 0);
+      // Unserializable is a finding, not a gap: it is what a cycle does to JSON.
+      assert.equal(context.bytes, null);
+    });
+  });
+
+  it("appends, so repeated occurrences can be compared against each other", () => {
+    withAgentDir((dir) => {
+      for (const source of ["assistant", "compaction"] as const) {
+        recordTurnFailure(dir, { source, message: "Maximum call stack size exceeded" });
+      }
+      const records = readRecords(dir);
+      assert.equal(records.length, 2);
+      assert.deepEqual(records.map((one) => one.source), ["assistant", "compaction"]);
+    });
+  });
+});

--- a/server/test/turnFailureLog.test.ts
+++ b/server/test/turnFailureLog.test.ts
@@ -11,7 +11,15 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, it } from "node:test";
-import { inspectShape, isStackExhaustion, recordTurnFailure, serializedBytes } from "../src/turnFailureLog.ts";
+import {
+  inspectShape,
+  isStackExhaustion,
+  noteCompaction,
+  noteToolOutcome,
+  noteTurnOutcome,
+  recordTurnFailure,
+  serializedBytes,
+} from "../src/turnFailureLog.ts";
 
 /** Nested `{ next: { next: … } }`, built iteratively so the fixture is not the bug. */
 function deepChain(levels: number): unknown {
@@ -156,6 +164,58 @@ describe("recordTurnFailure", () => {
       assert.equal(context.cyclic[0].index, 0);
       // Unserializable is a finding, not a gap: it is what a cycle does to JSON.
       assert.equal(context.bytes, null);
+    });
+  });
+
+  it("carries the run-up, which is where every reported occurrence actually starts", () => {
+    // The reported sequence, in order: a red tool card, a cut request, then the
+    // overflow. Only the last one matches isStackExhaustion, so a record of that
+    // one alone would throw away the two events that say what was going on.
+    withAgentDir((dir) => {
+      noteToolOutcome("bash", true, "command not found");
+      noteTurnOutcome({ provider: "openai-completions", model: "qwen3", stopReason: "aborted", errorMessage: "Request was aborted" });
+      recordTurnFailure(dir, { source: "assistant", message: "Maximum call stack size exceeded" });
+
+      const [record] = readRecords(dir);
+      const recent = record.recent as Record<string, unknown>[];
+      const tail = recent.slice(-2);
+      assert.deepEqual(
+        tail.map((one) => one.kind),
+        ["tool", "turn"],
+      );
+      assert.equal(tail[0].toolName, "bash");
+      assert.equal(tail[0].isError, true);
+      assert.equal(tail[1].errorMessage, "Request was aborted");
+      assert.equal(tail[1].provider, "openai-completions");
+    });
+  });
+
+  it("records a compaction in the run-up, since that is what runs after a turn fails", () => {
+    withAgentDir((dir) => {
+      noteCompaction("start");
+      noteCompaction("end", "Auto-compaction failed: upstream timed out");
+      recordTurnFailure(dir, { source: "assistant", message: "Maximum call stack size exceeded" });
+
+      const recent = (readRecords(dir)[0].recent as Record<string, unknown>[]).slice(-2);
+      assert.deepEqual(
+        recent.map((one) => [one.kind, one.phase]),
+        [
+          ["compaction", "start"],
+          ["compaction", "end"],
+        ],
+      );
+      assert.equal(recent[1].errorMessage, "Auto-compaction failed: upstream timed out");
+    });
+  });
+
+  it("ignores a turn that carried no error, so the run-up stays signal", () => {
+    withAgentDir((dir) => {
+      noteToolOutcome("read", false, "file contents");
+      noteTurnOutcome({ provider: "openai-completions", stopReason: "stop" });
+      recordTurnFailure(dir, { source: "assistant", message: "Maximum call stack size exceeded" });
+
+      const recent = readRecords(dir)[0].recent as Record<string, unknown>[];
+      assert.equal(recent[recent.length - 1].kind, "tool");
     });
   });
 


### PR DESCRIPTION
"Maximum call stack size exceeded" reaches the red bubble as eight words
with no frame, and that is not information pi-outpost is discarding.
Every provider's stream loop ends in the same catch:

  catch (error) { output.errorMessage = error instanceof Error
                                      ? error.message
                                      : JSON.stringify(error) }

The message is kept and the Error is dropped, so by the time the turn
crosses the runtime seam there is no `.stack` left anywhere in the
process to log. Only pi-messages and openai-codex-responses attach a
diagnostic that carries one; the Anthropic path does not.

A stack overflow is a deterministic function of its input, so record the
input. The number that decides it is depth: a recursive-descent parser
dies of nesting and is indifferent to length, so a census reporting
thousands names the culprit and one reporting tens clears every parser at
once. A self-reference gets its own flag, that being the shape which has
already caused this exact failure here — jiti's interop `default` pointing
a schema at itself, which sent TypeBox's compiler round forever.

The probe is iterative. A recursive one would overflow on precisely the
input worth measuring and report a crash instead of a number; the first
test pins that at 60k levels.

What is written is a census, not a transcript: counts, sizes, depths,
roles, block and tool names, to <agentDir>/turn-failures.jsonl. No message
text, no tool arguments, no file contents. The one verbatim field is the
provider's own diagnostics.

Wired to all four paths that reach a red bubble — a turn's own failure, a
failed compaction, a recoverable runtime error, and the fail-closed one,
which is written synchronously because nothing runs after it. The whole
record is wrapped: a diagnostic that takes down the handler it runs in has
cost more than it can return.

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014e9PiJ9yvqiNAZHoes5M5u