### PR TITLE
fix(ui): let an extension toast expire while the app renders

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -323,16 +323,71 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
     { env: { ...onlyOneFakeProvider(), FAKE_PI_RPC_CONFIG: planFakeConfig } },
   );
 
+  // A fifth real app server, for the extension toast stack over that same Work
+  // Plan. Its own server because its `notify` fires on every prompt: sharing the
+  // plan server would drop a toast on top of the Work Plan spec's own clicks,
+  // which is precisely what this one is here to catch.
+  const notifyRoot = await makeWorkspace({ "readme.md": "# notifications\n" });
+  const notifySessionDir = path.join(notifyRoot, ".pi-agent", "sessions");
+  await mkdir(notifySessionDir, { recursive: true });
+  const notifySession = path.join(notifySessionDir, "2026-08-23T00-03-00-000Z_notify.jsonl");
+  await writeFile(notifySession, sessionText("notify", "Formatted work"));
+  const notifyPlan = {
+    version: 1,
+    id: "notified",
+    title: "Formatting plan",
+    updatedAt: "2026-08-23T00:00:03.000Z",
+    tasks: [{ id: "format", title: "Format the workspace", status: "in_progress", dependsOn: [], resources: [] }],
+  };
+  const notifyFakeConfig = path.join(notifyRoot, "fake-rpc.json");
+  await writeFile(notifyFakeConfig, JSON.stringify({
+    state: { sessionId: "notify", sessionFile: notifySession },
+    entries: [entry],
+    tree: [{ entry, children: [] }],
+    leafId: "user-1",
+    // One script for every prompt, not a list: the spec sends more than one and
+    // neither of them should depend on which spec ran before it.
+    commands_: {
+      prompt: {
+        replacement: { state: { isStreaming: false } },
+        writes: [{ path: `${notifySession}.work-plan.json`, content: `${JSON.stringify(notifyPlan, null, 2)}\n` }],
+        after: [
+          toolEnd(notifySession, notifyPlan, "notify-plan"),
+          // The real shape an extension's ui.notify() takes on the RPC wire.
+          {
+            type: "extension_ui_request",
+            id: "notify-1",
+            method: "notify",
+            message: "pi-Lens deferred format applied to 1 file(s): readme.md",
+            notifyType: "info",
+          },
+          { type: "agent_settled" },
+        ],
+      },
+    },
+  }));
+  const notifications = await startServer(
+    notifyRoot,
+    {
+      agentRuntime: { mode: "rpc", executable: process.execPath, args: [path.join(REPO, "server/test/fixtures/fake-pi-rpc.mjs")], startupTimeoutMs: 20_000 },
+      sandbox: undefined,
+    },
+    { env: { ...onlyOneFakeProvider(), FAKE_PI_RPC_CONFIG: notifyFakeConfig } },
+  );
+
+
   process.env.PI_E2E_HOST_URL = host.url;
   process.env.PI_E2E_SERVER_URL = server.base;
   process.env.PI_E2E_GUARDED_URL = guarded.base;
   process.env.PI_E2E_DIAGRAMS_URL = diagrams.base;
   process.env.PI_E2E_PLANS_URL = plans.base;
+  process.env.PI_E2E_NOTIFY_URL = notifications.base;
   process.env.PI_E2E_PLAN_SOURCE = sourceSession;
   process.env.PI_E2E_PLAN_FORK = forkSession;
   process.env.PI_E2E_TOKEN = E2E_TOKEN;
 
   return async () => {
+    await notifications.stop();
     await plans.stop();
     await diagrams.stop();
     await guarded.stop();

--- a/e2e/notifications.spec.ts
+++ b/e2e/notifications.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * An extension toast is an overlay: it sits at the top right, over the Work Plan
+ * panel, above everything. That is affordable only because it leaves on its own.
+ *
+ * It did not. The six-second timer was keyed on the dismiss callback, which the
+ * app rebuilds on every render, so each render tore the timer down and started a
+ * new one — and a session that renders more often than once every six seconds
+ * (any answer, any plan update, any click) kept the toast alive indefinitely,
+ * parked on top of the plan it was covering.
+ *
+ * Timers under render pressure are exactly the class of bug a unit test agrees
+ * with and a browser refutes, so this runs against the real app.
+ */
+test("an extension toast leaves the Work Plan alone again", async ({ page }) => {
+  await page.goto(process.env.PI_E2E_NOTIFY_URL!);
+  await expect(page.getByTitle("connected")).toBeVisible();
+
+  const composer = page.getByRole("textbox", { name: /message pi/i });
+  await expect(composer).toBeEnabled();
+  await composer.fill("Format the workspace");
+  await composer.press("Enter");
+
+  const panel = page.getByRole("complementary", { name: "Work Plan" });
+  await expect(panel).toBeVisible();
+  const toast = page.getByRole("status").filter({ hasText: "pi-Lens deferred format applied" });
+  await expect(toast).toBeVisible();
+
+  // Why any of this matters: the toast really does land on the panel.
+  const overlay = await toast.boundingBox();
+  const plan = await panel.boundingBox();
+  expect(overlay).not.toBeNull();
+  expect(plan).not.toBeNull();
+  expect(overlay!.x < plan!.x + plan!.width && plan!.x < overlay!.x + overlay!.width).toBe(true);
+  expect(overlay!.y < plan!.y + plan!.height && plan!.y < overlay!.y + overlay!.height).toBe(true);
+
+  // The escape hatch, first: a reader who does not want to wait can close it.
+  await toast.getByRole("button", { name: "Dismiss notification" }).click();
+  await expect(toast).toHaveCount(0);
+
+  // And now the timer itself, under the render pressure that used to freeze it.
+  // The sidebar toggle is app-level state well clear of the toast, so every
+  // iteration re-renders the tree the toast hangs from without clicking through
+  // the overlay under test.
+  await composer.fill("Format the workspace again");
+  await composer.press("Enter");
+  await expect(toast).toBeVisible();
+
+  const sessions = page.getByRole("button", { name: "sessions" });
+  const deadline = Date.now() + 8000;
+  while (Date.now() < deadline && (await toast.count()) > 0) {
+    await sessions.click();
+    await sessions.click();
+    await page.waitForTimeout(150);
+  }
+  // Read once, with no retry. A polling assertion passes on the broken build
+  // too: the loop stops, the app goes quiet, the last timer anyone started runs
+  // out six seconds later and the toast finally goes. What is under test is that
+  // it left *while* the renders were coming.
+  expect(await toast.count(), "the toast was still up after 8s of re-renders").toBe(0);
+});

--- a/openspec/specs/components/spec.md
+++ b/openspec/specs/components/spec.md
@@ -199,7 +199,10 @@ The History width SHALL use a local browser-storage preference distinct from the
 The component layer SHALL provide distinct surfaces for extension dialogs, notifications, and
 widgets. `ExtensionDialog` SHALL render a supplied dialog request and report a dialog response.
 Notification and widget components SHALL render the corresponding extension state supplied by the
-application.
+application. A notification is an overlay above the rest of the interface, so `ExtensionNotifications`
+SHALL report each notification's dismissal a fixed interval after that notification arrived — measured
+from its arrival and unaffected by how often the application around it re-renders — and SHALL also
+offer a dismiss control on each notification.
 
 #### Scenario: RespondToExtensionDialog
 - **GIVEN** a dialog request supplied to `ExtensionDialog`
@@ -210,6 +213,16 @@ application.
 - **GIVEN** extension notification state supplied by the application
 - **WHEN** `ExtensionNotifications` renders
 - **THEN** the notifications are presented by the dedicated extension surface
+
+#### Scenario: DismissExtensionNotificationsOnSchedule
+- **GIVEN** a notification presented by `ExtensionNotifications`
+- **WHEN** the application around it re-renders repeatedly while the dismissal interval runs
+- **THEN** the component reports that notification's dismissal once the interval has elapsed since it arrived
+
+#### Scenario: DismissExtensionNotificationOnDemand
+- **GIVEN** a notification presented by `ExtensionNotifications`
+- **WHEN** the user activates that notification's dismiss control
+- **THEN** the component reports that notification's dismissal
 
 #### Scenario: RenderExtensionWidgets
 - **GIVEN** extension widget state supplied by the application

--- a/ui/src/components/ExtensionNotifications.test.tsx
+++ b/ui/src/components/ExtensionNotifications.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { ExtensionNotifications } from "./ExtensionNotifications";
 import type { ExtensionNotification } from "../useAgent";
 
@@ -43,5 +43,33 @@ describe("ExtensionNotifications", () => {
     vi.advanceTimersByTime(6000);
     expect(onDismiss).toHaveBeenCalledWith("1");
     vi.useRealTimers();
+  });
+
+  // The bug this guards: the parent re-creates `onDismiss` on every render, so an
+  // effect keyed on the callback restarted the six-second timer each time. A
+  // streaming answer re-renders far faster than that, and the toast became
+  // permanent — sitting on top of the Work Plan panel.
+  it("auto-dismisses on schedule even while the parent keeps re-rendering", () => {
+    vi.useFakeTimers();
+    try {
+      const onDismiss = vi.fn();
+      const notifications: ExtensionNotification[] = [{ id: "1", message: "Auto", notifyType: "info" }];
+      const { rerender } = render(<ExtensionNotifications notifications={notifications} onDismiss={onDismiss} />);
+      // A fresh inline callback per render, exactly as App passes one down.
+      for (let elapsed = 0; elapsed < 6000; elapsed += 100) {
+        vi.advanceTimersByTime(100);
+        rerender(<ExtensionNotifications notifications={notifications} onDismiss={(id) => onDismiss(id)} />);
+      }
+      expect(onDismiss).toHaveBeenCalledWith("1");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("dismisses on demand from the close button", () => {
+    const onDismiss = vi.fn();
+    render(<ExtensionNotifications notifications={[{ id: "1", message: "Manual", notifyType: "info" }]} onDismiss={onDismiss} />);
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss notification" }));
+    expect(onDismiss).toHaveBeenCalledWith("1");
   });
 });

--- a/ui/src/components/ExtensionNotifications.tsx
+++ b/ui/src/components/ExtensionNotifications.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import type { ExtensionNotification } from "../useAgent";
 
 const STYLES: Record<NonNullable<ExtensionNotification["notifyType"]>, string> = {
@@ -7,15 +7,42 @@ const STYLES: Record<NonNullable<ExtensionNotification["notifyType"]>, string> =
   error: "border-red-300 bg-red-50 text-red-800 dark:border-red-900 dark:bg-red-950/60 dark:text-red-200",
 };
 
+const DISMISS_AFTER_MS = 6000;
+
 function NotificationToast({ notification, onDismiss }: { notification: ExtensionNotification; onDismiss: () => void }) {
+  // The callback lives in a ref, and the timer depends on the notification's id
+  // alone. Depending on the callback looks equivalent and is not: the parent
+  // hands down a fresh closure on every render, so the effect used to tear its
+  // timer down and start a new one each time anything above it re-rendered.
+  // Under a streaming answer — or any Work Plan update — that happens far more
+  // often than once every six seconds, and the toast never expired: it sat over
+  // the Work Plan panel until the page was reloaded.
+  const dismiss = useRef(onDismiss);
   useEffect(() => {
-    const timer = setTimeout(onDismiss, 6000);
+    dismiss.current = onDismiss;
+  });
+
+  useEffect(() => {
+    const timer = setTimeout(() => dismiss.current(), DISMISS_AFTER_MS);
     return () => clearTimeout(timer);
-  }, [onDismiss]);
+  }, [notification.id]);
 
   return (
-    <div className={`rounded-lg border px-3 py-2 text-sm shadow-lg ${STYLES[notification.notifyType ?? "info"]}`}>
-      {notification.message}
+    <div
+      role="status"
+      className={`flex items-start gap-2 rounded-lg border px-3 py-2 text-sm shadow-lg ${STYLES[notification.notifyType ?? "info"]}`}
+    >
+      <span className="min-w-0 flex-1 break-words">{notification.message}</span>
+      {/* The escape hatch: whatever else goes wrong, a toast covering the panel
+          behind it is one click away from gone. */}
+      <button
+        type="button"
+        aria-label="Dismiss notification"
+        onClick={() => dismiss.current()}
+        className="-mr-1 shrink-0 rounded px-1 leading-5 opacity-60 transition-opacity hover:opacity-100 focus-visible:opacity-100"
+      >
+        ×
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
The six-second dismissal timer was keyed on the dismiss callback, which
the application rebuilds on every render. Each render therefore cleared
the timer and started a new one, so any session that renders more often
than once every six seconds — a streaming answer, a Work Plan update, a
click — kept the toast alive for good. It parked at the top right, over
the Work Plan panel's own title, until the page was reloaded.

The callback now lives in a ref and the timer depends on the
notification's id, so it runs once from the moment the notification
arrives. Each toast also carries a close button: whatever else goes
wrong, an overlay covering the panel behind it is one click away.

Covered by a unit test that re-renders the parent with a fresh callback
across the whole interval, and by a browser test against the real app —
a scripted `notify` over a live Work Plan, asserted with no retry so the
old build cannot pass by going quiet and letting the last timer run out.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015NCvxiNZr3LbJQmnpd3HML