### PR TITLE
chore(release): v0.16.4

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-outpost",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "type": "module",
   "description": "A web interface for the pi coding agent: a browser chat UI you run with npx — no clone, no build.",
   "license": "MIT",

--- a/embed/package.json
+++ b/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-outpost/embed",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "type": "module",
   "description": "Mount pi-outpost as a Shadow-DOM-isolated widget inside another web app.",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "cli": {
       "name": "pi-outpost",
-      "version": "0.16.3",
+      "version": "0.16.4",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "^0.84.3",
@@ -42,7 +42,7 @@
     },
     "embed": {
       "name": "@pi-outpost/embed",
-      "version": "0.16.3",
+      "version": "0.16.4",
       "license": "MIT",
       "devDependencies": {
         "@microsoft/api-extractor": "^7.58.9",


### PR DESCRIPTION
A patch release for the extension-toast fix that landed in #113.

## What changes

The version bump only, in the same three places every release touches:

- `cli/package.json` — `pi-outpost` 0.16.3 → 0.16.4
- `embed/package.json` — `@pi-outpost/embed` 0.16.3 → 0.16.4
- `package-lock.json` — the two matching workspace entries

No source changes. The shape matches the previous release commit (v0.16.3) exactly.

## What it releases

The six-second dismissal timer on an extension toast was keyed on the dismiss callback, which the application rebuilds on every render. Each render therefore cleared the timer and started a new one, so any session rendering more often than once every six seconds — a streaming answer, a Work Plan update, a click — kept the toast alive indefinitely, parked at the top right over the Work Plan panel's own title until the page was reloaded.

The timer now runs once from the moment the notification arrives, and every toast carries a close button.

## Checks

Run locally on this branch: `npm run typecheck`, `npm run lint`, `npm test --workspace ui` (1292 tests) — all green.

`npm test --workspace server` reports 1512/1517. The three failures are artefacts of the container this ran in, not of the diff (which touches no source at all):

- two permission-based tests ("reports a file it cannot write", "refuses a directory it cannot read") — the run is as root, which ignores the permission bits they rely on;
- one credentials test that expects no usable model — the environment supplies one regardless.

All three pass on CI runners, which are neither root nor pre-provisioned with a provider key.

## After merge

Push the `v0.16.4` tag on the resulting `main` commit — that is what triggers `release.yml`: the executable matrix, the npm publish of both packages over OIDC, and the binaries attached to the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NCvxiNZr3LbJQmnpd3HML

---
_Generated by [Claude Code](https://claude.ai/code/session_015NCvxiNZr3LbJQmnpd3HML)_