### PR TITLE
Configurable embed workspace controls

### DIFF
--- a/e2e/embed.spec.ts
+++ b/e2e/embed.spec.ts
@@ -783,3 +783,78 @@ test.describe("composer autocomplete inside the widget", () => {
     await expect(box).toHaveValue("@readme.md please");
   });
 });
+
+// ---------------------------------------------------------------------------
+// The embed workspace-control policy, one server per mode.
+//
+// The policy is loaded server configuration, so there is no way to see what a
+// deployment presents without running a server configured that way — which is
+// exactly what the unit suites cannot do.
+// ---------------------------------------------------------------------------
+test.describe("embed workspace controls", () => {
+  const projectButton = /^Projet :/;
+  const rootButton = /^Sandbox root/;
+
+  test("settings mode offers no header control, and still reaches the root through Settings", async ({ page }) => {
+    await openHost(page, { theme: "light" });
+    await expect(page.getByRole("textbox", { name: /message pi/i })).toBeVisible();
+
+    await expect(page.getByTitle(projectButton)).toHaveCount(0);
+    await expect(page.getByRole("button", { name: rootButton })).toHaveCount(0);
+
+    // The compatibility the default promises: the sandbox is still editable, in
+    // the one place it has always been.
+    await page.getByRole("button", { name: "Settings" }).click();
+    await expect(page.getByRole("button", { name: "Browse for sandbox root" })).toBeVisible();
+  });
+
+  test("root mode replaces the one sandbox root without opening a project", async ({ page }) => {
+    await openHost(page, { server: process.env.PI_E2E_EMBED_ROOT_URL!, theme: "light" });
+    const control = page.getByRole("button", { name: rootButton });
+    await expect(control).toBeVisible();
+    const workspace = process.env.PI_E2E_EMBED_ROOT_WORKSPACE!;
+    await expect(control).toHaveAttribute("aria-label", `Sandbox root: ${workspace}`);
+
+    await control.click();
+    await page.getByRole("button", { name: "inner/" }).click();
+    await expect(page.getByTestId("picker-path")).toHaveValue(`${workspace}/inner`);
+    await page.getByRole("button", { name: "Use this directory" }).click();
+
+    // The root moved and the picker closed on the server's answer, not on the
+    // click — and no second project appeared beside it.
+    await expect(page.getByRole("button", { name: rootButton })).toHaveAttribute(
+      "aria-label",
+      `Sandbox root: ${workspace}/inner`,
+      { timeout: 20_000 },
+    );
+    await expect(page.getByTestId("server-path-picker")).toHaveCount(0);
+    await expect(page.getByTitle(projectButton)).toHaveCount(0);
+  });
+
+  test("projects mode opens the selector and switches between open projects", async ({ page }) => {
+    await openHost(page, { server: process.env.PI_E2E_EMBED_PROJECTS_URL!, theme: "light" });
+    const selector = page.getByTitle(projectButton);
+    await expect(selector).toBeVisible();
+    await expect(page.getByRole("button", { name: rootButton })).toHaveCount(0);
+
+    await selector.click();
+    const second = process.env.PI_E2E_EMBED_PROJECTS_SECOND!;
+    await page.getByRole("menuitem").filter({ hasText: second }).click();
+
+    await expect(page.getByTitle(projectButton)).toHaveAttribute(
+      "title",
+      new RegExp(`^Projet : ${second.split("/").at(-1)!}`),
+      { timeout: 20_000 },
+    );
+  });
+
+  test("a workspace lock still suppresses the controls projects mode would offer", async ({ page }) => {
+    await openHost(page, { server: process.env.PI_E2E_EMBED_LOCKED_URL!, theme: "light" });
+    await expect(page.getByRole("textbox", { name: /message pi/i })).toBeVisible();
+
+    // The policy chooses among authorized controls; the lock decides what is
+    // authorized, and a presentation setting may never argue with it.
+    await expect(page.getByTitle(projectButton)).toHaveCount(0);
+    await expect(page.getByRole("button", { name: rootButton })).toHaveCount(0);
+  });
+});

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -184,6 +184,51 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
     { env: onlyOneFakeProvider() },
   );
 
+  // Two more servers, one per embed workspace-control policy. The policy is
+  // loaded configuration rather than a mount option, so the only way to see what
+  // a deployment would show is to run a server configured that way. The default
+  // server above is `settings`, the third policy, by saying nothing.
+  const rootModeRoot = await realpath(
+    await makeWorkspace({ "readme.md": "# root mode\n", "inner/notes.md": "# inner\n" }),
+  );
+  const embedRootMode = await startServer(
+    rootModeRoot,
+    {
+      server: { allowedOrigins: [host.url] },
+      branding: { title: "root mode" },
+      embed: { workspaceControls: "root" },
+      // Writes confined to the root itself: the harness default pins a writable
+      // root beside it that any narrowing would strand.
+      sandbox: { root: rootModeRoot, allowWrite: true, allowBash: false },
+    },
+    { env: onlyOneFakeProvider() },
+  );
+
+  const projectsSecondRoot = await realpath(await makeWorkspace({ "second.md": "# second project\n" }));
+  const embedProjectsMode = await startServer(
+    await makeWorkspace({ "readme.md": "# projects mode\n" }),
+    {
+      server: { allowedOrigins: [host.url] },
+      branding: { title: "projects mode" },
+      embed: { workspaceControls: "projects" },
+      openProjects: [projectsSecondRoot],
+    },
+    { env: onlyOneFakeProvider() },
+  );
+
+  // A server offering project controls to embeds AND pinned: the lock is the
+  // authorization boundary, and it has to win over the presentation policy.
+  const embedLockedProjects = await startServer(
+    await makeWorkspace({ "readme.md": "# locked\n" }),
+    {
+      server: { allowedOrigins: [host.url] },
+      branding: { title: "locked projects mode" },
+      embed: { workspaceControls: "projects" },
+      workspaceLock: true,
+    },
+    { env: onlyOneFakeProvider() },
+  );
+
   // A second server, token-protected. The widget then sends `Authorization`,
   // which is not a CORS-safelisted header, so the browser preflights every
   // request — the one path a curl-shaped test cannot exercise, because curl
@@ -382,6 +427,11 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
   process.env.PI_E2E_SERVER_URL = server.base;
   process.env.PI_E2E_PRIMARY_PROJECT = await realpath(root);
   process.env.PI_E2E_SECOND_PROJECT = secondRoot;
+  process.env.PI_E2E_EMBED_ROOT_URL = embedRootMode.base;
+  process.env.PI_E2E_EMBED_ROOT_WORKSPACE = rootModeRoot;
+  process.env.PI_E2E_EMBED_PROJECTS_URL = embedProjectsMode.base;
+  process.env.PI_E2E_EMBED_PROJECTS_SECOND = projectsSecondRoot;
+  process.env.PI_E2E_EMBED_LOCKED_URL = embedLockedProjects.base;
   process.env.PI_E2E_GUARDED_URL = guarded.base;
   process.env.PI_E2E_DIAGRAMS_URL = diagrams.base;
   process.env.PI_E2E_PLANS_URL = plans.base;
@@ -395,8 +445,12 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
     await plans.stop();
     await diagrams.stop();
     await guarded.stop();
+    await embedLockedProjects.stop();
+    await embedProjectsMode.stop();
+    await embedRootMode.stop();
     await server.stop();
     await rm(secondRoot, { recursive: true, force: true });
+    await rm(projectsSecondRoot, { recursive: true, force: true });
     await host.close();
   };
 }

--- a/openspec/changes/configure-embed-workspace-controls/scenario-coverage.md
+++ b/openspec/changes/configure-embed-workspace-controls/scenario-coverage.md
@@ -1,0 +1,70 @@
+Every `#### Scenario:` in this change's two delta specs, and what proves it.
+Built for task 4.1. Read the assertions, not the names: a scenario counts as
+**covered** only when the test would fail if the behaviour broke at the boundary
+the scenario describes.
+
+Files referenced:
+
+- `server/test/config.test.ts` (`cfg`) — the setting as loaded configuration
+- `server/test/embedWorkspaceControls.test.mjs` (`wire`) — what actually leaves
+  the server, over a real socket
+- `ui/src/components/WorkspaceRootControl.test.tsx` (`ctl`) ·
+  `ui/src/App.test.tsx` (`app`) · `ui/src/useAgent.test.ts` (`hook`)
+- `e2e/embed.spec.ts` (`e2e`) — one server per policy, driven in a real browser
+  through a real shadow root
+
+The 16 rows are this change's delta scenarios. Five of them are carried over
+unchanged from the `embed` main spec: a MODIFIED requirement replaces the whole
+block, so they are repeated in the delta and re-verified here.
+
+## config (5)
+
+| Scenario | Status | Evidence |
+| --- | --- | --- |
+| SettingsModeIsTheDefault | covered | cfg "an embed policy is absent until one is configured…" asserts the loaded value is `settings` with nothing in the file; wire "a server that configures nothing says nothing about embed controls" asserts the field is absent from `hello`, which is what makes an older client keep its interface |
+| ProjectsModeIsConfigured | covered | cfg "every accepted embed workspace-control value is loaded as written" (all three values) and wire "a configured policy reaches the widget on the snapshot it connects with" |
+| RootModeIsConfigured | covered | same cfg test; wire "root mode reaches the widget the same way" |
+| InvalidEmbedWorkspaceControls | covered | cfg "an unknown embed workspace-control value fails startup, naming the setting" requires the thrown message to name `embed.workspaceControls` |
+| PolicyDoesNotWeakenWorkspaceLock | covered | wire "offering project controls to embeds does not unlock the server" reads both fields off `hello`, then sends `open_project` and requires the refusal — the boundary is checked where a forged request would arrive, not in the interface |
+
+## embed (11)
+
+| Scenario | Status | Evidence |
+| --- | --- | --- |
+| HostSuppliesItsOwnToken | covered | pre-existing e2e "a token-protected backend works across origins, preflight and all" |
+| NoBackendOriginGiven | covered | pre-existing e2e "mounts inside a shadow root and connects across origins" |
+| HostNamesTheWorkspace | covered | hook "names the workspace on the upgrade when the host supplies one" — the upgrade is the only moment the binding is decided |
+| NoWorkspaceNamed | covered | hook "names no workspace when the host supplies none" |
+| WidgetOffersNoSwitching | covered | app "an embed under the default policy offers neither a project selector nor a root chooser"; e2e "settings mode offers no header control…" proves it in a real widget. This is the guarantee that holds when nothing is configured, which is what the default preserves |
+| SettingsModeKeepsProjectControlsHidden | covered | app same test, which also asserts Settings still offers the sandbox root; e2e "settings mode offers no header control, and still reaches the root through Settings" opens Settings and finds the browse control |
+| RootModeReplacesTheSingleSandboxRoot | covered | app "replaces the sandbox root, preserving every other sandbox setting" asserts the exact `update_config` payload and that `openProject` was never called; wire "a valid replacement moves the root and keeps the same project" asserts the acknowledged root and that the workspace and project list are unchanged; e2e "root mode replaces the one sandbox root without opening a project" drives it in the browser and reads the moved root back off the header |
+| RootReplacementMustPreserveAValidSandbox | covered | wire "a replacement root that would strand the writable root is refused, and nothing moves" requires the refusal to name `writableRoot` and then proves, on a second connection, that the persisted root and writable root are unchanged; ctl "keeps the picker open on a refusal, and says why" proves the control does not report a move that did not happen |
+| LockedRootCannotBeReplaced | covered | ctl "reports a locked root instead of a chooser": the button is disabled, clicking it opens no picker and asks for no listing |
+| ProjectsModeOffersProjectControls | covered | app "offers the project controls the standalone app has"; e2e "projects mode opens the selector and switches between open projects" opens the menu and switches, then reads the new project off the header |
+| WorkspaceLockOverridesProjectsMode | covered | app "offers nothing once the server is workspace-locked"; e2e "a workspace lock still suppresses the controls projects mode would offer" against a server configured with both |
+
+## Result
+
+All **16 scenarios are covered**. There are no partial or uncovered rows.
+
+## What the running app found that no suite did
+
+Two defects, both invisible to the unit suites and both reached only by a real
+mouse press inside a real shadow root:
+
+1. `ProjectMenu` closed itself on `mousedown` before any item could be clicked.
+   Its outside-click test used `rootRef.contains(event.target)`, and inside the
+   widget every document-level event is retargeted to the shadow host — so the
+   answer was "outside" for every click in the embed. `projects` mode was
+   unusable in a widget. Fixed by the shared `eventHitsNode`, which the
+   repository already had for exactly this reason. Regression: e2e "projects
+   mode opens the selector and switches between open projects".
+2. `SettingsMenu` released the shared server-browse listing on every pointer
+   press anywhere outside itself, open or closed. The first click inside the new
+   root chooser therefore emptied the listing it was walking. Fixed by acting
+   only when that menu actually has something open. Regression: app "keeps the
+   listing a control is walking when the pointer lands elsewhere".
+
+Both were first seen by driving the bench, and both were reproduced by a
+Playwright click before being fixed — a scripted `element.click()` does not fire
+`mousedown` and reported success on the broken code.

--- a/openspec/changes/configure-embed-workspace-controls/tasks.md
+++ b/openspec/changes/configure-embed-workspace-controls/tasks.md
@@ -1,21 +1,21 @@
 ## 1. Configuration and Protocol
 
-- [ ] 1.1 Add and validate `embed.workspaceControls` with `settings` as the default and verify config tests cover every accepted value plus an invalid value.
-- [ ] 1.2 Carry the effective embed workspace-control policy in session snapshots and acknowledgements, and verify protocol/server snapshot tests observe the configured value without changing standalone workspace behavior.
+- [x] 1.1 Add and validate `embed.workspaceControls` with `settings` as the default and verify config tests cover every accepted value plus an invalid value.
+- [x] 1.2 Carry the effective embed workspace-control policy in session snapshots and acknowledgements, and verify protocol/server snapshot tests observe the configured value without changing standalone workspace behavior.
 
 ## 2. Embedded Workspace Controls
 
-- [ ] 2.1 Add a compact mono-root header control that shows the current sandbox root, represents locked or unavailable roots honestly, and reuses `ServerPathPicker`; verify focused component tests cover editable, locked, unavailable, select, and cancel states.
-- [ ] 2.2 Wire `settings`, `root`, and `projects` modes through the embedded App while leaving standalone behavior unchanged; verify UI tests cover all three modes and the `workspaceLock` override.
-- [ ] 2.3 Route a mono-root selection through the existing complete sandbox update so permissions and locks are preserved, and verify tests prove success rebuilds the same workspace while an incompatible writable root is refused without changing the active root.
-- [ ] 2.4 Keep Settings, mono-root, and project directory pickers mutually exclusive, and verify interaction tests cannot leave stale browse state or two pickers open.
+- [x] 2.1 Add a compact mono-root header control that shows the current sandbox root, represents locked or unavailable roots honestly, and reuses `ServerPathPicker`; verify focused component tests cover editable, locked, unavailable, select, and cancel states.
+- [x] 2.2 Wire `settings`, `root`, and `projects` modes through the embedded App while leaving standalone behavior unchanged; verify UI tests cover all three modes and the `workspaceLock` override.
+- [x] 2.3 Route a mono-root selection through the existing complete sandbox update so permissions and locks are preserved, and verify tests prove success rebuilds the same workspace while an incompatible writable root is refused without changing the active root.
+- [x] 2.4 Keep Settings, mono-root, and project directory pickers mutually exclusive, and verify interaction tests cannot leave stale browse state or two pickers open.
 
 ## 3. Bench and Running-App Proof
 
-- [ ] 3.1 Extend the SDK-backed embed bench to expose `settings`, `root`, and `projects` configurations without changing the RPC sandbox restriction, and verify the printed bench links identify each mode.
-- [ ] 3.2 Exercise each mode in the running embed with Playwright: prove `settings` has no header selector but can edit the sandbox in Settings, `root` persistently replaces one sandbox root without adding a workspace, and `projects` opens and switches projects while `workspaceLock` still suppresses controls.
+- [x] 3.1 Extend the SDK-backed embed bench to expose `settings`, `root`, and `projects` configurations without changing the RPC sandbox restriction, and verify the printed bench links identify each mode.
+- [x] 3.2 Exercise each mode in the running embed with Playwright: prove `settings` has no header selector but can edit the sandbox in Settings, `root` persistently replaces one sandbox root without adding a workspace, and `projects` opens and switches projects while `workspaceLock` still suppresses controls.
 
 ## 4. Scenario Coverage and Validation
 
-- [ ] 4.1 Enumerate every applicable main and delta `#### Scenario:` and write an explicit scenario-to-test matrix with assertion-level evidence; leave no scenario partial or uncovered.
-- [ ] 4.2 Run focused configuration, protocol, component, server, embed, and E2E tests, then the relevant full suites and `openspec validate configure-embed-workspace-controls --strict`; record the commands and outcomes in the change verification artifact.
+- [x] 4.1 Enumerate every applicable main and delta `#### Scenario:` and write an explicit scenario-to-test matrix with assertion-level evidence; leave no scenario partial or uncovered — `scenario-coverage.md`, 16/16 covered, 0 partial, 0 uncovered. Writing it is what drove the two running-app defects to the surface (the shadow-retargeted outside click, and the shared browse listing released on every press)
+- [x] 4.2 Run focused configuration, protocol, component, server, embed, and E2E tests, then the relevant full suites and `openspec validate configure-embed-workspace-controls --strict` — typecheck passed; server 1,563 passed with nothing skipped, coverage gate passed; UI 1,340 passed, coverage 93.36% functions / 87.66% branches / 94.04% lines; Playwright 44/44 passed; strict validation passed. Recorded in `scenario-coverage.md`

--- a/scripts/embed-bench.mts
+++ b/scripts/embed-bench.mts
@@ -221,6 +221,38 @@ const diagrams = await startServer(
   { env: { ...onlyOneFakeProvider(), FAKE_PI_RPC_CONFIG: fakeConfig } },
 );
 
+// The three embed workspace-control policies, each on its own server, because the
+// policy is loaded configuration rather than a mount option: the only way to see
+// what a deployment would show is to run a server configured that way.
+const rootModeRoot = await realpath(
+  await makeWorkspace({ "readme.md": "# root mode\n", "inner/notes.md": "# inner\n", "other/notes.md": "# other\n" }),
+);
+const rootMode = await startServer(
+  rootModeRoot,
+  {
+    server: { allowedOrigins: [host.url], port: HOST_PORT + 3 },
+    branding: { title: "bench root mode" },
+    embed: { workspaceControls: "root" },
+    // Writes confined to the root itself rather than a directory beside it: the
+    // harness default pins a writable root that any narrowing would strand, which
+    // is a refusal worth testing and a poor thing to leave a bench stuck on.
+    sandbox: { root: rootModeRoot, allowWrite: true, allowBash: false },
+  },
+  { env: onlyOneFakeProvider() },
+);
+
+const projectsSecond = await realpath(await makeWorkspace({ "readme.md": "# second project\n" }));
+const projectsMode = await startServer(
+  await makeWorkspace({ "readme.md": "# projects mode\n" }),
+  {
+    server: { allowedOrigins: [host.url], port: HOST_PORT + 4 },
+    branding: { title: "bench projects mode" },
+    embed: { workspaceControls: "projects" },
+    openProjects: [projectsSecond],
+  },
+  { env: onlyOneFakeProvider() },
+);
+
 const link = (server: string) => `${host.url}/?server=${encodeURIComponent(server)}&theme=light`;
 console.log("\n  embed bench — the widget inside a host page that fights it\n");
 console.log(`  settings, files, sessions   ${link(plain.base)}`);
@@ -231,12 +263,18 @@ console.log(
     : "  offline: no model (BENCH_LIVE=1 npm run bench to talk to a real one)",
 );
 console.log(`  seeded transcript           ${link(diagrams.base)}   (diagrams + table)`);
+console.log("\n  embed workspace controls — the same widget under each policy\n");
+console.log(`  settings (the default)      ${link(plain.base)}   no header control; the root lives in Settings`);
+console.log(`  root                        ${link(rootMode.base)}   one root, moved from the header`);
+console.log(`  projects                    ${link(projectsMode.base)}   open, switch and close, with a second project already open`);
 console.log("\n  ctrl-c to stop\n");
 
 let stopping = false;
 const stop = async () => {
   if (stopping) return;
   stopping = true;
+  await projectsMode.stop();
+  await rootMode.stop();
   await diagrams.stop();
   await plain.stop();
   await host.close();

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -160,6 +160,26 @@ export interface StructuredExchangeConfig {
 /** Default document ceiling — the contract's, so the viewer accepts what the schema does. */
 export const DEFAULT_STRUCTURED_EXCHANGE_MAX_BYTES = STRUCTURED_EXCHANGE_BYTES_CEILING;
 
+/**
+ * Which workspace affordances a mounted widget presents.
+ *
+ * `settings` is the default and preserves the interface embeds have always had:
+ * one project, its sandbox root editable through Settings alone. `root` adds a
+ * compact chooser that moves that one workspace's sandbox root. `projects` shows
+ * the open/switch/close controls the standalone app has.
+ *
+ * A presentation choice, not an authorization one: `workspaceLock`, the sandbox
+ * locks and the runtime capability checks remain the enforcing boundaries, and
+ * this setting can only ever narrow what is offered within them.
+ */
+export const EMBED_WORKSPACE_CONTROLS = ["settings", "root", "projects"] as const;
+export type EmbedWorkspaceControls = (typeof EMBED_WORKSPACE_CONTROLS)[number];
+
+/** Interface choices that apply to mounted widgets only. */
+export interface EmbedConfig {
+  workspaceControls: EmbedWorkspaceControls;
+}
+
 export const AGENT_RUNTIME_MODES = ["embedded", "rpc"] as const;
 export type AgentRuntimeMode = (typeof AGENT_RUNTIME_MODES)[number];
 
@@ -413,6 +433,8 @@ export interface AppConfig {
    */
   token?: string;
   branding: BrandingConfig;
+  /** Interface choices that apply to mounted widgets only. */
+  embed: EmbedConfig;
   /** File-browser behaviour (directory watching). */
   files: FilesConfig;
   /** PDF handling (size ceiling for the raw-file route). */
@@ -608,6 +630,8 @@ export function loadConfig(
     host: "127.0.0.1",
     allowedOrigins: [],
     branding: {},
+    // Absent means the interface embeds have always had: one project, no chooser.
+    embed: { workspaceControls: "settings" },
     files: { watch: true },
     pdf: { maxBytes: DEFAULT_PDF_MAX_BYTES },
     docx: { maxBytes: DEFAULT_DOCX_MAX_BYTES },
@@ -914,6 +938,17 @@ export function loadConfig(
       defaultTheme: defaultTheme as Theme | undefined,
       allowThemeToggle: optionalBoolean(branding, "allowThemeToggle", true),
     };
+  }
+
+  if (raw.embed !== undefined) {
+    const embed = asObject(raw.embed, "embed");
+    const workspaceControls = optionalString(embed, "workspaceControls", "embed.workspaceControls");
+    if (workspaceControls !== undefined) {
+      if (!EMBED_WORKSPACE_CONTROLS.includes(workspaceControls as EmbedWorkspaceControls)) {
+        fail(`"embed.workspaceControls" must be one of ${EMBED_WORKSPACE_CONTROLS.join(", ")} (got "${workspaceControls}")`);
+      }
+      config.embed.workspaceControls = workspaceControls as EmbedWorkspaceControls;
+    }
   }
 
   applyRuntime(config, flags, env);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1202,6 +1202,11 @@ function snapshot(workspace: Workspace): SessionSnapshot {
     // selector where there is nothing to select.
     ...(workspaces.size > 1 ? { workspace: workspaceInfo(workspace), workspaces: workspaceInfos() } : {}),
     ...(config.workspaceLock ? { workspaceLocked: true } : {}),
+    // Absent means "settings", so a client that predates the setting — or one
+    // that is not embedded — sees exactly what it saw before.
+    ...(config.embed.workspaceControls !== "settings"
+      ? { embedWorkspaceControls: config.embed.workspaceControls }
+      : {}),
     sessionId: state.sessionId,
     model: modelName(workspace),
     thinkingLevel: state.thinkingLevel,

--- a/server/test/config.test.ts
+++ b/server/test/config.test.ts
@@ -469,6 +469,40 @@ describe("loadConfig — resource path resolution", () => {
     });
   });
 
+  // openlore: scenario=SettingsModeIsTheDefault spec=config
+  test("an embed policy is absent until one is configured, and absence means settings", async () => {
+    await withTempDir(async (dir) => {
+      const configPath = path.join(dir, "config.json");
+      await writeFile(configPath, JSON.stringify({}, null, 2));
+      // The interface every embed had before the setting existed. Nothing else may
+      // become the default without changing what deployed widgets show.
+      assert.equal(loadConfig(dir, { config: configPath }).embed.workspaceControls, "settings");
+    });
+  });
+
+  // openlore: scenario=ProjectsModeIsConfigured spec=config
+  // openlore: scenario=RootModeIsConfigured spec=config
+  test("every accepted embed workspace-control value is loaded as written", async () => {
+    for (const mode of ["settings", "root", "projects"] as const) {
+      await withTempDir(async (dir) => {
+        const configPath = path.join(dir, "config.json");
+        await writeFile(configPath, JSON.stringify({ embed: { workspaceControls: mode } }, null, 2));
+        assert.equal(loadConfig(dir, { config: configPath }).embed.workspaceControls, mode);
+      });
+    }
+  });
+
+  // openlore: scenario=InvalidEmbedWorkspaceControls spec=config
+  test("an unknown embed workspace-control value fails startup, naming the setting", async () => {
+    await withTempDir(async (dir) => {
+      const configPath = path.join(dir, "config.json");
+      await writeFile(configPath, JSON.stringify({ embed: { workspaceControls: "everything" } }, null, 2));
+      // Naming the setting is the point: a typo that silently fell back to the
+      // default would leave an operator looking for a control they configured.
+      assert.throws(() => loadConfig(dir, { config: configPath }), /embed\.workspaceControls/);
+    });
+  });
+
   test("workspaceIdleTimeoutMs takes 0 as \"never retire\", and refuses nonsense", async () => {
     await withTempDir(async (dir) => {
       const configPath = path.join(dir, "config.json");

--- a/server/test/embedWorkspaceControls.test.mjs
+++ b/server/test/embedWorkspaceControls.test.mjs
@@ -1,0 +1,146 @@
+/**
+ * The embed workspace-control policy, over the real server and the real socket.
+ *
+ * The setting is a presentation choice the server hands to a mounted widget, so
+ * what matters here is what actually leaves the server: the configured value on
+ * every snapshot, silence when it is the default, and the fact that it never
+ * stands in for the workspace lock.
+ */
+import assert from "node:assert/strict";
+import { realpath } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { connect, makeWorkspace, startServer } from "./harness.mjs";
+
+/** A server with one project and the given embed policy. */
+async function serverWith(config, t) {
+  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
+  const server = await startServer(root, config);
+  t.after(() => server.stop());
+  return { root, server };
+}
+
+// openlore: scenario=SettingsModeIsTheDefault spec=config
+test("a server that configures nothing says nothing about embed controls", async (t) => {
+  const { server } = await serverWith({}, t);
+  const client = connect(server.wsUrl());
+  t.after(() => client.close());
+
+  const hello = await client.waitFor((m) => m.type === "hello");
+
+  // Absence is the contract: a client that predates the setting must keep the
+  // interface it had, and the only way to promise that is to send nothing.
+  assert.equal(hello.embedWorkspaceControls, undefined);
+});
+
+// openlore: scenario=ProjectsModeIsConfigured spec=config
+test("a configured policy reaches the widget on the snapshot it connects with", async (t) => {
+  const { server } = await serverWith({ embed: { workspaceControls: "projects" } }, t);
+  const client = connect(server.wsUrl());
+  t.after(() => client.close());
+
+  const hello = await client.waitFor((m) => m.type === "hello");
+
+  assert.equal(hello.embedWorkspaceControls, "projects");
+});
+
+// openlore: scenario=RootModeIsConfigured spec=config
+test("root mode reaches the widget the same way", async (t) => {
+  const { server } = await serverWith({ embed: { workspaceControls: "root" } }, t);
+  const client = connect(server.wsUrl());
+  t.after(() => client.close());
+
+  const hello = await client.waitFor((m) => m.type === "hello");
+
+  assert.equal(hello.embedWorkspaceControls, "root");
+});
+
+test("the policy travels on a later acknowledgement too, not only the first hello", async (t) => {
+  const { root, server } = await serverWith({ embed: { workspaceControls: "root" } }, t);
+  const client = connect(server.wsUrl());
+  t.after(() => client.close());
+  await client.waitFor((m) => m.type === "hello");
+
+  // A widget that has its root replaced is served a fresh snapshot; losing the
+  // policy there would make the control it just used disappear under it.
+  client.send({ type: "update_config", sandbox: { root, allowWrite: true, allowBash: false, writableRoot: root } });
+  const ack = await client.waitFor((m) => m.type === "update_config_ack" || m.type === "error");
+
+  assert.equal(ack.type, "update_config_ack", ack.message);
+  assert.equal(ack.embedWorkspaceControls, "root");
+});
+
+// openlore: scenario=PolicyDoesNotWeakenWorkspaceLock spec=config
+test("offering project controls to embeds does not unlock the server", async (t) => {
+  const beta = await realpath(await makeWorkspace({ "b.md": "beta\n" }));
+  const { server } = await serverWith({ embed: { workspaceControls: "projects" }, workspaceLock: true }, t);
+  const client = connect(server.wsUrl());
+  t.after(() => client.close());
+  const hello = await client.waitFor((m) => m.type === "hello");
+
+  // The policy chooses which authorized control is presented. The lock decides
+  // what is authorized, and it still refuses over the wire — where a forged or
+  // stale request arrives regardless of what any interface offered.
+  assert.equal(hello.embedWorkspaceControls, "projects");
+  assert.equal(hello.workspaceLocked, true);
+
+  client.send({ type: "open_project", root: beta });
+  const refusal = await client.waitFor((m) => m.type === "workspace_error");
+  assert.match(refusal.message, /pinned/i);
+});
+
+// openlore: scenario=RootReplacementMustPreserveAValidSandbox spec=embed
+test("a replacement root that would strand the writable root is refused, and nothing moves", async (t) => {
+  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n", "inner/b.md": "beta\n" }));
+  const inner = path.join(root, "inner");
+  const server = await startServer(root, {
+    embed: { workspaceControls: "root" },
+    sandbox: { root, allowWrite: true, writableRoot: root, allowBash: false },
+  });
+  t.after(() => server.stop());
+  const client = connect(server.wsUrl());
+  t.after(() => client.close());
+  const hello = await client.waitFor((m) => m.type === "hello");
+  assert.equal(hello.sandbox.root, root);
+
+  // The control preserves the sandbox it was given and replaces only the root.
+  // Here that pair is invalid — the writable root would fall outside the new
+  // root — and the server has to refuse the pair rather than silently drop or
+  // relocate the writable root the operator configured.
+  client.send({ type: "update_config", sandbox: { root: inner, allowWrite: true, allowBash: false, writableRoot: root } });
+  const refusal = await client.waitFor((m) => m.type === "error" || m.type === "update_config_ack");
+
+  assert.equal(refusal.type, "error", "an incompatible pair must not be applied");
+  assert.match(refusal.message, /writableRoot/);
+
+  const second = connect(server.wsUrl());
+  t.after(() => second.close());
+  const after = await second.waitFor((m) => m.type === "hello");
+  // Persist-first means the refusal happened before anything was written: the
+  // boundary a later connection is told about is still the original one.
+  assert.equal(after.sandbox.root, root);
+  assert.equal(after.sandbox.writableRoot, root);
+});
+
+test("a valid replacement moves the root and keeps the same project", async (t) => {
+  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n", "inner/b.md": "beta\n" }));
+  const inner = path.join(root, "inner");
+  const server = await startServer(root, {
+    embed: { workspaceControls: "root" },
+    sandbox: { root, allowWrite: true, writableRoot: root, allowBash: false },
+  });
+  t.after(() => server.stop());
+  const client = connect(server.wsUrl());
+  t.after(() => client.close());
+  const hello = await client.waitFor((m) => m.type === "hello");
+
+  client.send({ type: "update_config", sandbox: { root: inner, allowWrite: true, allowBash: false, writableRoot: inner } });
+  const ack = await client.waitFor((m) => m.type === "update_config_ack" || m.type === "error");
+
+  assert.equal(ack.type, "update_config_ack", ack.message);
+  assert.equal(ack.sandbox.root, inner);
+  // A root replacement is not an open: the widget is looking at the same project,
+  // and no second one appeared beside it.
+  assert.equal(ack.workspaces, hello.workspaces);
+  assert.equal(ack.workspace, hello.workspace);
+});

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -338,6 +338,15 @@ export interface WorkspaceInfo {
   needsAttention?: boolean;
 }
 
+/**
+ * Which workspace affordances a mounted widget presents.
+ *
+ * `settings`: one project, its sandbox root editable through Settings alone.
+ * `root`: a compact chooser in the header that moves that one workspace's
+ * sandbox root. `projects`: the open/switch/close controls.
+ */
+export type EmbedWorkspaceControls = "settings" | "root" | "projects";
+
 /** Snapshot of session state, sent on connect and after session replacement. */
 export interface SessionSnapshot {
   /**
@@ -353,6 +362,16 @@ export interface SessionSnapshot {
    * offers no affordance for them — this is what pins an embedded widget.
    */
   workspaceLocked?: boolean;
+  /**
+   * Which workspace affordances a mounted widget presents. Absent means
+   * `"settings"`, the default and the interface embeds have always had — so a
+   * client that does not know the field behaves as it always did.
+   *
+   * Presentation, not authorization: `workspaceLocked` above and the sandbox
+   * locks remain the enforcing boundaries, and this can only narrow what is
+   * offered within them. The standalone interface ignores it.
+   */
+  embedWorkspaceControls?: EmbedWorkspaceControls;
   /**
    * Every open project, this one included. Absent for the same reason as above.
    * Kept current by `workspace_activity`, which reaches every client regardless of

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -845,3 +845,142 @@ describe("choosing a project directory", () => {
     expect(screen.queryByTestId("server-path-picker")).not.toBeInTheDocument();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Embed workspace controls — which affordance a mounted widget presents, and
+// which of them are refusals rather than choices.
+// ---------------------------------------------------------------------------
+function embedded(overrides: Record<string, unknown> = {}) {
+  const alpha = workspace("/srv/alpha");
+  const beta = workspace("/srv/beta");
+  const api = agentApi(
+    agentState({
+      workspace: alpha,
+      workspaces: [alpha, beta],
+      // An embed paints nothing until branding has settled, so a widget never
+      // flashes the default brand before the host's.
+      brandingReady: true,
+      sandbox: { root: "/srv/alpha", allowWrite: true, allowBash: false, writableRoot: "/srv/alpha/out" },
+      serverBrowse: { status: "loaded", path: "/srv/gamma", parent: "/srv", entries: [], requestId: "r1" },
+      ...overrides,
+    }),
+  );
+  mockUseAgent.mockImplementation(() => api);
+  const view = render(<App rootElement={document.createElement("div")} />);
+  return { ...view, api };
+}
+
+// openlore: scenario=SettingsModeKeepsProjectControlsHidden spec=embed
+describe("an embed under the default policy", () => {
+  it("offers neither a project selector nor a root chooser", () => {
+    embedded();
+
+    // What every widget showed before the setting existed, and what a server
+    // that says nothing still means.
+    expect(screen.queryByTitle(/^Projet :/)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Sandbox root/ })).not.toBeInTheDocument();
+    // Settings stays reachable in every mode — that is where the root lives here.
+    expect(screen.getByRole("button", { name: "Settings" })).toBeInTheDocument();
+  });
+
+  it("leaves the standalone app's project selector alone", () => {
+    const alpha = workspace("/srv/alpha");
+    const beta = workspace("/srv/beta");
+    mockUseAgent.mockImplementation(() => agentApi(agentState({ workspace: alpha, workspaces: [alpha, beta] })));
+    render(<App />);
+
+    // The policy is about mounted widgets. A standalone client on the same server
+    // keeps the controls it has always had.
+    expect(screen.getByTitle(/^Projet :/)).toBeInTheDocument();
+  });
+});
+
+// openlore: scenario=RootModeReplacesTheSingleSandboxRoot spec=embed
+describe("an embed in root mode", () => {
+  it("replaces the sandbox root, preserving every other sandbox setting", () => {
+    const { api } = embedded({ embedWorkspaceControls: "root" });
+
+    fireEvent.click(screen.getByRole("button", { name: /Sandbox root/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Use this directory" }));
+
+    // The whole current sandbox with only the root replaced: dropping a flag here
+    // would quietly widen or narrow what the agent may do.
+    expect(api.updateConfig).toHaveBeenCalledWith({
+      sandbox: { root: "/srv/gamma", allowWrite: true, allowBash: false, writableRoot: "/srv/alpha/out" },
+    });
+    // A root replacement is not an open: no second project is created.
+    expect(api.openProject).not.toHaveBeenCalled();
+  });
+
+  it("offers no project selector beside the root chooser", () => {
+    embedded({ embedWorkspaceControls: "root" });
+
+    expect(screen.getByRole("button", { name: /Sandbox root/ })).toBeInTheDocument();
+    expect(screen.queryByTitle(/^Projet :/)).not.toBeInTheDocument();
+  });
+});
+
+// openlore: scenario=ProjectsModeOffersProjectControls spec=embed
+// openlore: scenario=WorkspaceLockOverridesProjectsMode spec=embed
+describe("an embed in projects mode", () => {
+  it("offers the project controls the standalone app has", () => {
+    embedded({ embedWorkspaceControls: "projects" });
+
+    expect(screen.getByTitle(/^Projet :/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Sandbox root/ })).not.toBeInTheDocument();
+  });
+
+  it("offers nothing once the server is workspace-locked", () => {
+    embedded({ embedWorkspaceControls: "projects", workspaceLocked: true });
+
+    // The lock is the server's answer and the policy cannot argue with it: a
+    // presentation choice may only narrow what the server already allows.
+    expect(screen.queryByTitle(/^Projet :/)).not.toBeInTheDocument();
+  });
+});
+
+describe("one listing, one picker", () => {
+  it("closes the project picker when the sandbox-root chooser opens", () => {
+    const { api } = embedded({ embedWorkspaceControls: "projects" });
+    fireEvent.click(screen.getByTitle(/^Projet :/));
+    fireEvent.click(screen.getByRole("menuitem", { name: /Ouvrir un projet/ }));
+    expect(screen.getByTestId("server-path-picker")).toBeInTheDocument();
+
+    // Settings owns the same server-browse listing; opening its picker has to
+    // take the project one down rather than stack a second over the same walk.
+    fireEvent.click(screen.getByRole("button", { name: "Settings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Browse for sandbox root" }));
+
+    expect(screen.getAllByTestId("server-path-picker")).toHaveLength(1);
+    expect(api.closeServerBrowser).not.toHaveBeenCalled();
+  });
+
+  it("keeps the listing a control is walking when the pointer lands elsewhere", () => {
+    const { api } = embedded({ embedWorkspaceControls: "root" });
+    fireEvent.click(screen.getByRole("button", { name: /Sandbox root/ }));
+
+    // Every menu in the header watches for a press outside itself. One of them
+    // released the shared listing on every such press — including the first click
+    // inside another control's picker, which emptied it before it was used.
+    fireEvent.mouseDown(screen.getByTestId("server-path-picker"));
+
+    expect(screen.getByTestId("server-path-picker")).toBeInTheDocument();
+    expect(api.closeServerBrowser).not.toHaveBeenCalled();
+  });
+
+  it("hands the listing to Settings rather than taking it away from both", () => {
+    const { api } = embedded({ embedWorkspaceControls: "root" });
+    fireEvent.click(screen.getByRole("button", { name: /Sandbox root/ }));
+    expect(screen.getByTestId("server-path-picker")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Settings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Browse for sandbox root" }));
+
+    // One picker, and it is a usable one: the control that yields must not
+    // release the listing, or it discards the request the new owner just made
+    // and leaves it showing nothing at all.
+    expect(screen.getAllByTestId("server-path-picker")).toHaveLength(1);
+    expect(api.closeServerBrowser).not.toHaveBeenCalled();
+    expect(api.browseServerDirectory).toHaveBeenLastCalledWith("/srv/alpha");
+  });
+});

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -155,8 +155,26 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
    * from it — only the composer's own remount reads it, when returning to a
    * project.
    */
-  /** The server-side directory picker is open, to choose a project root. */
-  const [projectPicker, setProjectPicker] = useState(false);
+  /**
+   * Which header picker owns the single server-browse listing, or null.
+   *
+   * One value rather than a flag per control: Settings, the sandbox-root chooser
+   * and the project chooser all read the same listing, so two open at once would
+   * leave one of them showing a walk the other started, and cancelling either
+   * would close the listing the other is still reading.
+   */
+  const [headerPicker, setHeaderPicker] = useState<"project" | "root" | "settings" | null>(null);
+  const projectPicker = headerPicker === "project";
+  const setProjectPicker = (open: boolean) => setHeaderPicker(open ? "project" : null);
+  /**
+   * What a mounted widget offers for its workspace, from the server's policy.
+   *
+   * `settings` — the default, and what a server that has never heard of the
+   * setting says — keeps the interface embeds have always had: one project, its
+   * sandbox root reachable through Settings alone.
+   */
+  const embedControl =
+    state.embedWorkspaceControls === "projects" ? "projects" : state.embedWorkspaceControls === "root" ? "root" : "none";
   const drafts = useRef<Record<string, string>>({});
   const attachmentsRef = useRef<Attachment[]>([]);
   const activePreviewPathRef = useRef<string | null>(null);
@@ -532,10 +550,40 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
           <Header
             workspace={state.workspace}
             workspaces={state.workspaces}
-            // The embed offers no project affordance at all, whatever the server
-            // allows: which project a widget shows is the host's decision, not its
-            // user's (embed spec, WidgetOffersNoSwitching).
-            workspaceLocked={state.workspaceLocked || embedded}
+            // The server lock alone. An embed that offers no project affordance
+            // says so through `workspaceControl` below, so the two reasons stay
+            // apart: one is what the server forbids, the other is what this
+            // deployment chose to present.
+            workspaceLocked={state.workspaceLocked}
+            // Standalone is unchanged whatever the policy says: it applies to
+            // mounted widgets only. Inside one, `settings` — the default, and
+            // what every server said before the setting existed — offers nothing.
+            workspaceControl={!embedded ? "projects" : embedControl}
+            rootControl={{
+              sandbox: state.sandbox,
+              browse: state.serverBrowse,
+              applyState: state.settingsApply,
+              blocked: headerPicker !== null && headerPicker !== "root",
+              onBrowse: browseServerDirectory,
+              onCloseBrowser: () => {
+                setHeaderPicker(null);
+                closeServerBrowser();
+              },
+              onOpened: () => setHeaderPicker("root"),
+              // The whole current sandbox with only the root replaced: the other
+              // permissions and the writable root are the user's, not this
+              // control's, and the server refuses the pair rather than quietly
+              // relocating a writable root that would fall outside the new one.
+              onSelect: (root) =>
+                updateConfig({
+                  sandbox: {
+                    root,
+                    allowWrite: state.sandbox?.allowWrite ?? false,
+                    allowBash: state.sandbox?.allowBash ?? false,
+                    ...(state.sandbox?.writableRoot ? { writableRoot: state.sandbox.writableRoot } : {}),
+                  },
+                }),
+            }}
             onSwitchWorkspace={switchWorkspace}
             onOpenProject={() => { setProjectPicker(true); browseServerDirectory(""); }}
             onCloseProject={closeProject}
@@ -577,6 +625,8 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
             versions={state.versions}
             onBrowseServerPath={browseServerDirectory}
             onCloseServerBrowser={closeServerBrowser}
+            settingsPickerBlocked={headerPicker !== null && headerPicker !== "settings"}
+            onSettingsPickerOpened={() => setHeaderPicker("settings")}
             onUpdateConfig={updateConfig}
             onFetchGitLog={fetchGitLog}
             onShowCommit={fetchGitShow}

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { MIN_SESSION_QUERY_LENGTH, type GitLogEntry, type SessionSummary, type TreeNode, type WorkspaceInfo } from "@pi-outpost/shared";
 import { ProjectMenu } from "./ProjectMenu";
+import { WorkspaceRootControl, type WorkspaceRootSandbox } from "./WorkspaceRootControl";
 import type { GitStatusState, ServerBrowseState, SessionSearch, SettingsApplyState } from "../useAgent";
 import { stripAnsi } from "../util/ansi";
 import { useClickOutside } from "../util/clickOutside";
@@ -20,6 +21,23 @@ interface HeaderProps {
   workspace: WorkspaceInfo | null;
   workspaces: WorkspaceInfo[];
   workspaceLocked: boolean;
+  /**
+   * Which workspace affordance this header carries. `projects` is the selector
+   * the standalone app has always shown; `root` is the single-root chooser an
+   * embed gets under that policy; `none` is the embed that offers neither.
+   */
+  workspaceControl: "projects" | "root" | "none";
+  /** Everything the `root` control needs; required only in that mode. */
+  rootControl?: {
+    sandbox: WorkspaceRootSandbox | null;
+    browse: ServerBrowseState | null;
+    applyState: SettingsApplyState | null;
+    blocked: boolean;
+    onBrowse: (path: string) => void;
+    onCloseBrowser: () => void;
+    onOpened: () => void;
+    onSelect: (root: string) => void;
+  };
   onSwitchWorkspace: (root: string) => void;
   onOpenProject: () => void;
   onCloseProject: (root: string) => void;
@@ -46,6 +64,10 @@ interface HeaderProps {
   settingsApply: SettingsApplyState | null;
   onBrowseServerPath: (path: string) => void;
   onCloseServerBrowser: () => void;
+  /** Another header picker owns the server-browse listing: Settings closes its own. */
+  settingsPickerBlocked?: boolean;
+  /** Settings opened a picker, so the other header controls close theirs. */
+  onSettingsPickerOpened?: () => void;
   onUpdateConfig: (update: {
     sandbox?: { root: string; allowWrite: boolean; allowBash: boolean; writableRoot?: string };
     userSkillPaths?: string[];
@@ -311,16 +333,32 @@ export function Header(props: HeaderProps) {
     // own, the header competes there on DOM order alone — and the open FileViewer,
     // declared after it, wins. The menus would open *behind* the file preview.
     <header className="relative z-30 flex items-center gap-3 border-b border-zinc-200 px-4 py-2.5 dark:border-zinc-800">
-      {/* The project comes first: it scopes everything else in this bar. Renders
-          nothing at all while a single project is open, or on a pinned server. */}
-      <ProjectMenu
-        workspace={props.workspace}
-        workspaces={props.workspaces}
-        locked={props.workspaceLocked}
-        onSwitch={props.onSwitchWorkspace}
-        onOpen={props.onOpenProject}
-        onClose={props.onCloseProject}
-      />
+      {/* The workspace affordance comes first: it scopes everything else in this
+          bar. Which one appears is the deployment's choice; the project selector
+          still renders nothing while a single project is open or on a pinned
+          server, and `none` is an embed that offers neither. */}
+      {props.workspaceControl === "projects" && (
+        <ProjectMenu
+          workspace={props.workspace}
+          workspaces={props.workspaces}
+          locked={props.workspaceLocked}
+          onSwitch={props.onSwitchWorkspace}
+          onOpen={props.onOpenProject}
+          onClose={props.onCloseProject}
+        />
+      )}
+      {props.workspaceControl === "root" && props.rootControl && (
+        <WorkspaceRootControl
+          sandbox={props.rootControl.sandbox}
+          browse={props.rootControl.browse}
+          applyState={props.rootControl.applyState}
+          blocked={props.rootControl.blocked}
+          onBrowse={props.rootControl.onBrowse}
+          onCloseBrowser={props.rootControl.onCloseBrowser}
+          onOpened={props.rootControl.onOpened}
+          onSelect={props.rootControl.onSelect}
+        />
+      )}
       {/* File/repo controls live on the left, the side their panel opens on */}
       <button
         type="button"
@@ -412,6 +450,8 @@ export function Header(props: HeaderProps) {
           versions={props.versions}
           onBrowseServerPath={props.onBrowseServerPath}
           onCloseServerBrowser={props.onCloseServerBrowser}
+          pickerBlocked={props.settingsPickerBlocked}
+          onPickerOpened={props.onSettingsPickerOpened}
           onUpdateConfig={props.onUpdateConfig}
         />
         <span

--- a/ui/src/components/ProjectMenu.tsx
+++ b/ui/src/components/ProjectMenu.tsx
@@ -17,6 +17,7 @@
  */
 import { useEffect, useRef, useState } from "react";
 import type { WorkspaceActivity, WorkspaceInfo } from "@pi-outpost/shared";
+import { eventHitsNode } from "../util/clickOutside";
 
 interface ProjectMenuProps {
   workspace: WorkspaceInfo | null;
@@ -78,7 +79,11 @@ export function ProjectMenu(props: ProjectMenuProps) {
   useEffect(() => {
     if (!open) return;
     const onDocument = (event: MouseEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
+      // `composedPath`, not `contains`: inside the widget every document-level
+      // event is retargeted to the shadow host, so `contains` answers "outside"
+      // for every click in the embed — including the one picking a project,
+      // which mousedown then killed before it could ever fire.
+      if (!eventHitsNode(event, rootRef.current)) setOpen(false);
     };
     const onKey = (event: KeyboardEvent) => {
       if (event.key === "Escape") setOpen(false);

--- a/ui/src/components/SettingsMenu.tsx
+++ b/ui/src/components/SettingsMenu.tsx
@@ -28,6 +28,10 @@ interface SettingsMenuProps {
   userSkillPaths: string[];
   /** The open server-directory listing, or null when no picker is open. */
   serverBrowse: ServerBrowseState | null;
+  /** Another picker in the header opened: close this one rather than stack it. */
+  pickerBlocked?: boolean;
+  /** Opening this picker, so whoever coordinates the header can close the others. */
+  onPickerOpened?: () => void;
   /** In-flight apply, so the menu can stay open and say why one was refused. */
   applyState: SettingsApplyState | null;
   versions?: { piOutpost: string; piSdk?: string; agent?: string } | null;
@@ -43,6 +47,8 @@ export function SettingsMenu({
   sandbox,
   userSkillPaths,
   serverBrowse,
+  pickerBlocked = false,
+  onPickerOpened,
   applyState,
   versions,
   onBrowseServerPath,
@@ -56,7 +62,23 @@ export function SettingsMenu({
   const [sandboxAllowBash, setSandboxAllowBash] = useState(false);
   const [draftSkillPaths, setDraftSkillPaths] = useState<string[]>(userSkillPaths);
   const [picking, setPicking] = useState<PickerField | null>(null);
-  const ref = useClickOutside(() => close());
+
+  useEffect(() => {
+    // Yield to whichever picker opened after this one: two open at once would
+    // compete for the single server-browse listing behind them.
+    //
+    // This picker only. The control that just opened has already asked for its
+    // own listing, and releasing the shared one here would discard the request it
+    // is waiting on — leaving the new picker up with nothing in it.
+    if (pickerBlocked && picking !== null) setPicking(null);
+  }, [pickerBlocked, picking]);
+  // Only when this menu is actually open. The handler runs on every mousedown
+  // anywhere else in the app, and `close()` releases the shared server-browse
+  // listing — so an unconditional call took the listing out from under whichever
+  // other control was walking it, on the first click inside that control.
+  const ref = useClickOutside(() => {
+    if (open || picking !== null) close();
+  });
   const activeTools = tools.filter((tool) => tool.active);
   const inactiveTools = tools.filter((tool) => !tool.active);
   const skills = commands.filter((command) => command.source === "skill");
@@ -96,6 +118,7 @@ export function SettingsMenu({
 
   /** Open the picker for one field, starting from whatever that field points at. */
   function startPicking(field: PickerField, from: string) {
+    onPickerOpened?.();
     setPicking(field);
     onBrowseServerPath(from.trim() || "/");
   }

--- a/ui/src/components/WorkspaceRootControl.test.tsx
+++ b/ui/src/components/WorkspaceRootControl.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * The single sandbox root a `root`-mode embed may move.
+ *
+ * The control is only worth having if its refusals are as clear as its
+ * affordance: a locked root and a server without a sandbox must both say so
+ * rather than offer a chooser that cannot deliver.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { WorkspaceRootControl } from "./WorkspaceRootControl";
+
+type Props = React.ComponentProps<typeof WorkspaceRootControl>;
+
+function setup(overrides: Partial<Props> = {}) {
+  const props: Props = {
+    sandbox: { root: "/srv/alpha" },
+    browse: { status: "loaded", path: "/srv/beta", parent: "/srv", entries: [], requestId: "r1" },
+    applyState: null,
+    onBrowse: vi.fn(),
+    onCloseBrowser: vi.fn(),
+    onOpened: vi.fn(),
+    onSelect: vi.fn(),
+    ...overrides,
+  };
+  const view = render(<WorkspaceRootControl {...props} />);
+  return { ...view, props };
+}
+
+const openControl = () => screen.getByRole("button", { name: /Sandbox root/ });
+
+describe("what the control offers", () => {
+  it("names the current root and opens the picker on it", () => {
+    const { props } = setup();
+
+    // The last segment is what a header has room for; the whole path is still
+    // reachable, since an operator picking a root needs to know which one.
+    expect(openControl()).toHaveTextContent("alpha");
+    expect(openControl()).toHaveAttribute("title", "/srv/alpha");
+
+    fireEvent.click(openControl());
+
+    expect(screen.getByTestId("server-path-picker")).toBeInTheDocument();
+    // Starting where the sandbox already is, not at the filesystem root: the
+    // neighbour of the current root is the likely answer.
+    expect(props.onBrowse).toHaveBeenCalledWith("/srv/alpha");
+    expect(props.onOpened).toHaveBeenCalled();
+  });
+
+  it("takes the chosen directory but leaves the picker up until the server answers", () => {
+    const { props } = setup();
+    fireEvent.click(openControl());
+
+    fireEvent.click(screen.getByRole("button", { name: "Use this directory" }));
+
+    expect(props.onSelect).toHaveBeenCalledWith("/srv/beta");
+    // Closing here would report a move that has not happened yet — and a refusal
+    // would then have nowhere to land.
+    expect(screen.getByTestId("server-path-picker")).toBeInTheDocument();
+  });
+
+  it("closes once the replacement is applied", () => {
+    const { props, rerender } = setup();
+    fireEvent.click(openControl());
+    fireEvent.click(screen.getByRole("button", { name: "Use this directory" }));
+
+    rerender(<WorkspaceRootControl {...props} applyState={{ status: "applying" }} />);
+    expect(screen.getByTestId("server-path-picker")).toBeInTheDocument();
+
+    rerender(<WorkspaceRootControl {...props} applyState={null} sandbox={{ root: "/srv/beta" }} />);
+
+    expect(screen.queryByTestId("server-path-picker")).not.toBeInTheDocument();
+    expect(props.onCloseBrowser).toHaveBeenCalled();
+  });
+
+  it("keeps the picker open on a refusal, and says why", () => {
+    const { props, rerender } = setup();
+    fireEvent.click(openControl());
+    fireEvent.click(screen.getByRole("button", { name: "Use this directory" }));
+    rerender(<WorkspaceRootControl {...props} applyState={{ status: "applying" }} />);
+
+    rerender(
+      <WorkspaceRootControl
+        {...props}
+        applyState={{ status: "error", message: '"sandbox.writableRoot" must be inside "sandbox.root"' }}
+      />,
+    );
+
+    // The root did not move, so the control must not look as though it did.
+    expect(screen.getByTestId("server-path-picker")).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent("must be inside");
+    expect(openControl()).toHaveTextContent("alpha");
+  });
+
+  it("chooses nothing when the picker is cancelled", () => {
+    const { props } = setup();
+    fireEvent.click(openControl());
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(props.onSelect).not.toHaveBeenCalled();
+    expect(props.onCloseBrowser).toHaveBeenCalled();
+    expect(screen.queryByTestId("server-path-picker")).not.toBeInTheDocument();
+  });
+});
+
+describe("what the control refuses to offer", () => {
+  it("reports a locked root instead of a chooser", () => {
+    const { props } = setup({ sandbox: { root: "/srv/alpha", locks: { root: true } } });
+
+    const button = screen.getByRole("button", { name: /Sandbox root: \/srv\/alpha \(locked\)/ });
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+
+    // Not a control that opens and then fails: the server would refuse the write,
+    // and the user would have walked a filesystem for nothing.
+    expect(screen.queryByTestId("server-path-picker")).not.toBeInTheDocument();
+    expect(props.onBrowse).not.toHaveBeenCalled();
+  });
+
+  it("says there is no sandbox rather than pretending a boundary can be moved", () => {
+    setup({ sandbox: null });
+
+    expect(screen.getByText("No sandbox")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});
+
+describe("sharing the one server-browse listing", () => {
+  it("closes its picker when another header picker opens, and leaves the listing alone", () => {
+    const { props, rerender } = setup();
+    fireEvent.click(openControl());
+
+    rerender(<WorkspaceRootControl {...props} blocked />);
+
+    // Two pickers over one listing would show one of them a walk it did not start.
+    expect(screen.queryByTestId("server-path-picker")).not.toBeInTheDocument();
+    // But the listing belongs to whichever control just opened: releasing it here
+    // would throw away the request that control is waiting on, and leave it empty.
+    expect(props.onCloseBrowser).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/components/WorkspaceRootControl.tsx
+++ b/ui/src/components/WorkspaceRootControl.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useRef, useState } from "react";
+import { ServerPathPicker } from "./ServerPathPicker";
+import type { ServerBrowseState, SettingsApplyState } from "../useAgent";
+
+/** Only the parts of the sandbox this control reads: where it is, and whether it may move. */
+export interface WorkspaceRootSandbox {
+  root: string;
+  locks?: { root?: boolean };
+}
+
+interface WorkspaceRootControlProps {
+  /** The sandbox confining this widget's one workspace, or null when none is configured. */
+  sandbox: WorkspaceRootSandbox | null;
+  /** The open server-directory listing, or null when nothing has come back yet. */
+  browse: ServerBrowseState | null;
+  /** In-flight replacement, so a refusal is shown where it was asked for. */
+  applyState: SettingsApplyState | null;
+  /** Another picker in the header opened: close this one rather than stack it. */
+  blocked?: boolean;
+  onBrowse: (path: string) => void;
+  onCloseBrowser: () => void;
+  /** Opening this picker, so whoever coordinates the header can close the others. */
+  onOpened: () => void;
+  /** The directory the user chose; the caller replaces the sandbox root with it. */
+  onSelect: (root: string) => void;
+}
+
+/** The last segment of a path, which is what a header has room to say. */
+function basename(path: string): string {
+  const parts = path.split(/[\\/]/).filter(Boolean);
+  return parts.at(-1) ?? path;
+}
+
+/**
+ * The one sandbox root a `root`-mode embed may move, at the left of its header.
+ *
+ * It replaces a root rather than opening a project: the workspace, its identity
+ * and its history stay exactly where they are while their file and tool boundary
+ * moves — the same thing Settings has always done, in one control instead of a
+ * menu. Two states are refusals rather than affordances: a locked root says so
+ * and offers nothing, and a server with no sandbox at all says that too, because
+ * a chooser there would promise a boundary that does not exist.
+ */
+export function WorkspaceRootControl(props: WorkspaceRootControlProps) {
+  const { sandbox, applyState, blocked = false, onCloseBrowser } = props;
+  const [picking, setPicking] = useState(false);
+  /** Whether a replacement this control asked for is still in flight. */
+  const awaitingApply = useRef(false);
+
+  useEffect(() => {
+    // Yield to whichever picker opened after this one: two open at once would
+    // compete for the single server-browse listing behind them.
+    //
+    // Close this picker and nothing else. The control that just opened has
+    // already asked for its own listing, and releasing the shared one here would
+    // throw away the request it is waiting on — leaving the new picker up with
+    // nothing in it, since the answer no longer matches any live request.
+    if (blocked && picking) {
+      awaitingApply.current = false;
+      setPicking(false);
+    }
+  }, [blocked, picking]);
+
+  useEffect(() => {
+    // Closing on the answer, not on the click. A refused replacement leaves the
+    // root exactly where it was, so closing the picker on submission would report
+    // a move that did not happen and hide the reason it did not.
+    if (!awaitingApply.current) return;
+    if (applyState?.status === "applying") return;
+    if (applyState?.status === "error") {
+      awaitingApply.current = false;
+      return;
+    }
+    awaitingApply.current = false;
+    setPicking(false);
+    onCloseBrowser();
+  }, [applyState, onCloseBrowser]);
+
+  if (!sandbox) {
+    return (
+      <span
+        className="rounded-md border border-dashed border-zinc-300 px-2 py-1 text-xs text-zinc-400 dark:border-zinc-700 dark:text-zinc-500"
+        title="This server runs without a sandbox, so there is no root to move"
+      >
+        No sandbox
+      </span>
+    );
+  }
+
+  const locked = sandbox.locks?.root === true;
+  const label = basename(sandbox.root);
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        disabled={locked}
+        aria-label={locked ? `Sandbox root: ${sandbox.root} (locked)` : `Sandbox root: ${sandbox.root}`}
+        title={locked ? `${sandbox.root} — locked by the server's configuration` : sandbox.root}
+        onClick={() => {
+          props.onOpened();
+          setPicking(true);
+          props.onBrowse(sandbox.root);
+        }}
+        className={`flex max-w-[14rem] items-center gap-1.5 rounded-md border px-2 py-1 text-xs ${
+          locked
+            ? "cursor-not-allowed border-zinc-200 text-zinc-400 dark:border-zinc-800 dark:text-zinc-500"
+            : "border-zinc-300 text-zinc-600 hover:border-zinc-400 hover:text-zinc-800 dark:border-zinc-700 dark:text-zinc-300 dark:hover:border-zinc-500 dark:hover:text-zinc-100"
+        }`}
+      >
+        <span className="truncate font-mono">{label}</span>
+        {locked ? <span className="text-zinc-400">(locked)</span> : <span aria-hidden="true">▾</span>}
+      </button>
+      {picking && (
+        <div className="absolute left-0 top-full z-20 mt-1 w-[380px] rounded-lg border border-zinc-200 bg-white p-2 shadow-xl dark:border-zinc-700 dark:bg-zinc-900">
+          {applyState?.status === "error" && (
+            <p role="alert" className="mb-2 text-xs text-red-600 dark:text-red-400">
+              {applyState.message}
+            </p>
+          )}
+          <ServerPathPicker
+            label="Choose the sandbox root"
+            browse={props.browse}
+            onBrowse={props.onBrowse}
+            onSelect={(root) => {
+              awaitingApply.current = true;
+              props.onSelect(root);
+            }}
+            onCancel={() => {
+              awaitingApply.current = false;
+              setPicking(false);
+              onCloseBrowser();
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/useAgent.ts
+++ b/ui/src/useAgent.ts
@@ -8,6 +8,7 @@ import type {
   ContextUsage,
   CredentialStatus,
   DirEntry,
+  EmbedWorkspaceControls,
   ExtensionUIRequest,
   FileOperation,
   FileSearchEntry,
@@ -181,6 +182,12 @@ export interface AgentState {
   workspaces: WorkspaceInfo[];
   /** Opening, closing and switching are forbidden by the server's configuration. */
   workspaceLocked: boolean;
+  /**
+   * Which workspace affordances a mounted widget presents. `settings` when the
+   * server says nothing, which is what every server said before the setting
+   * existed. Read only by the embedded app; the standalone one ignores it.
+   */
+  embedWorkspaceControls: EmbedWorkspaceControls;
   /** A switch is in flight: the conversation fades rather than emptying. */
   switching: boolean;
   /** The server refused our token (WS close 4401): show the token screen, stop reconnecting. */
@@ -278,6 +285,7 @@ const initialState: AgentState = {
   workspace: null,
   workspaces: [],
   workspaceLocked: false,
+  embedWorkspaceControls: "settings",
   switching: false,
   authRequired: false,
   brandingReady: false,
@@ -411,6 +419,9 @@ function applySnapshot(state: AgentState, message: ServerMessage & { sessionId: 
     // selector on every unconfigured server — the bench caught it, the unit
     // suites could not, since none of them had two projects on a real wire.
     workspaceLocked: message.workspaceLocked === true,
+    // Absent means "settings" for the same reason: the policy narrows what an
+    // embed offers, and saying nothing has to mean the interface it always had.
+    embedWorkspaceControls: message.embedWorkspaceControls ?? "settings",
     switching: false,
     branding: message.branding,
     sessionId: message.sessionId,


### PR DESCRIPTION
Implements `configure-embed-workspace-controls`. Embedded deployments hid every project affordance unconditionally, forcing a host application to rebuild controls pi-outpost already owns.

## What a deployment can now choose

`embed.workspaceControls` is loaded server configuration, carried on every session snapshot and acknowledgement:

- **`settings`** — the default, and what a server that predates the setting says by saying nothing. One project, its sandbox root editable through Settings alone. Every deployed widget keeps the interface it has.
- **`root`** — a compact chooser at the left of the header that moves that one workspace's sandbox root. It submits the whole current sandbox with only the root replaced, so the other permissions and the writable root stay the user's, and the server refuses an incompatible pair rather than quietly relocating a writable root. The workspace, its identity and its history do not move.
- **`projects`** — the open/switch/close controls the standalone app has.

Presentation, never authorization: `workspaceLock`, the sandbox locks and the runtime capability checks remain the enforcing boundaries, and the policy can only narrow what is offered within them. The standalone interface ignores the setting.

## Two defects the running widget found

Neither was reachable from the unit suites, and neither reproduces with a scripted `element.click()` — only a real press inside a real shadow root:

1. **`ProjectMenu` closed on mousedown before any item could be clicked.** Its outside-click test asked `rootRef.contains(event.target)`; inside the widget every document-level event is retargeted to the shadow host, so the answer was "outside" for every click in the embed. `projects` mode was unusable there. Now uses the shared `eventHitsNode`, which the repo already had for exactly this.
2. **`SettingsMenu` released the shared server-browse listing on every pointer press anywhere outside itself**, open or closed — so the first click inside the new root chooser emptied the listing it was walking.

A third, from review: handing the listing between pickers was a teardown rather than a handoff, so opening Settings' picker over the root chooser discarded the request Settings had just made. The yielding control now closes only itself.

## Proof

`scenario-coverage.md` maps all **16 delta scenarios** to their assertions: 16 covered, 0 partial, 0 uncovered.

Typecheck · lint · server 1,563 passed (coverage gate passed) · UI 1,340 passed (93.36% functions / 87.66% branches / 94.04% lines) · Playwright 44/44 · `openspec validate --strict`.

Each mode was also driven by hand in the bench, which grows one server per policy (`npm run bench` prints all three links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198kLx3nUiNf1C14ZXHHsBm