### PR TITLE
Open the interface in a window of its own

### DIFF
--- a/openspec/changes/open-the-interface-in-its-own-window/.openspec.yaml
+++ b/openspec/changes/open-the-interface-in-its-own-window/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-29

--- a/openspec/changes/open-the-interface-in-its-own-window/design.md
+++ b/openspec/changes/open-the-interface-in-its-own-window/design.md
@@ -1,0 +1,92 @@
+## Context
+
+See `proposal.md` for motivation and `specs/cli/spec.md` for the contract.
+
+`server/src/openBrowser.ts` already separates the three questions cleanly:
+`shouldOpenBrowser()` decides *whether*, `browsableUrl()` decides *where* — from
+the address actually bound, so a port chosen by the operating system is handled —
+and `openerFor()` decides *how*, today by handing the URL to the platform's own
+opener (`open`, `cmd /c start`, `xdg-open`). Only the third changes here.
+
+Its current comment states the principle being reversed: *"Nothing here parses a
+browser preference — the OS holds it."*
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One gesture from launching the server to an interface in a window of its own.
+- No regression anywhere the window cannot be presented.
+- The change confined to how the interface is opened.
+
+**Non-Goals:**
+
+- Changing whether a browser opens, which address it opens, or the behaviour when
+  opening fails.
+- Requiring the interface to be installed as a web app. A window of its own does
+  not depend on that, and must not start to.
+- Choosing a browser for the user. What is selected here is a browser *able to
+  present the window*, not a preferred one.
+- Any behaviour that differs between an interface opened this way and one opened
+  in a tab. It is the same interface, served by the same server.
+
+## Decisions
+
+### A window of its own becomes the default, with a fallback rather than a failure
+
+The alternative is opt-in configuration, which is safer and worse: it would leave
+the good behaviour behind a setting most people never find, and the case that
+needs it most — a double-clicked executable, which the specification already calls
+a whole application — is exactly the case where nobody is editing configuration.
+
+What makes the default defensible is that it degrades rather than fails. Where the
+window cannot be presented, the interface opens exactly as it does today, and the
+server says nothing about it. So the worst case of the new default is the current
+behaviour.
+
+### `openBrowser` keeps its meaning; a separate setting carries the shape
+
+`openBrowser` is a tri-state today — unset, true, false — and it answers *whether*.
+Overloading it with a third, non-boolean value would put two questions in one
+setting and make `false` ambiguous against a shape.
+
+So the shape is its own setting, and `openBrowser` still wins: asked not to open,
+nothing opens, whatever shape was configured. The command line mirrors it, since
+the requirement says the decision is overridable from both.
+
+### Naming browsers, deliberately, in one function
+
+Presenting a window without tabs means invoking a browser that can do it, which
+means naming browsers — the thing `openBrowser.ts` says it does not do. The
+reversal is real and is confined to `openerFor()`: a small ordered list of
+candidates per platform, the first that exists wins, and none found means the
+existing opener is used.
+
+What keeps this from becoming a browser-preference parser is that the list answers
+one question — *can this present a window of its own* — and never *which browser
+should the user have*. A machine with none simply gets today's behaviour.
+
+### Failure stays invisible
+
+The requirement already says a failed open is not a failed start. This adds a
+second way to fail — a browser that exists but refuses to present the window — and
+it is treated identically: the address is printed, the server runs. Nothing here
+is worth an error message that suggests the operator has something to fix.
+
+## Risks / Trade-offs
+
+- [A visible default change: someone who wanted a tab now gets a window] → The
+  setting restores it in both directions, and the fallback means the change is
+  invisible on machines that cannot present the window at all.
+- [A window without an address bar hides which server is being talked to, which
+  matters once several projects or several deployments exist] → The interface
+  already names its project and its branding in its own header; the address bar
+  was not what carried that.
+- [Naming browsers ages badly as they are renamed or repackaged] → The list is
+  ordered candidates with a fallback, so an entry that stops matching costs
+  today's behaviour rather than a failure, and the fallback is exercised as a
+  scenario rather than assumed.
+- [A window of its own on a machine where the interface was also installed as a
+  web app could present two different-looking windows for the same thing] → They
+  are the same window shape presented by the same browser; what differs is only
+  whether the browser also has an icon for it.

--- a/openspec/changes/open-the-interface-in-its-own-window/proposal.md
+++ b/openspec/changes/open-the-interface-in-its-own-window/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Starting the server opens the interface as a tab in whatever browser was already there, among that browser's other tabs, wearing its address bar. The interface is not a page someone is visiting — it is the application they launched, and it has just been made installable as one.
+
+Reaching that window today takes a second gesture: start the server, then find and click the installed app. Two clicks for one intention, and the second one is easy to miss — which leaves a user looking at a tab and wondering whether that is the application.
+
+## What Changes
+
+- Open the interface in a window of its own — no tabs, no address bar — where the machine has a browser that can present one.
+- **This becomes the default.** The interface has one address and one purpose, and every way of starting it benefits: a double-clicked executable most of all, since that is the case the specification already calls a whole application.
+- Fall back to opening the interface the way it opens today wherever a window of its own is not available. A machine whose browser cannot do this SHALL behave exactly as it does now.
+- Let the operator ask for the old behaviour explicitly, for anyone who would rather have a tab.
+- Change nothing about *whether* a browser opens, which address it opens, or what happens when opening fails. Those decisions stay where they are; this changes only the shape of the window.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `cli`: `StartingOpensTheInterface` currently requires the interface to open in the default browser. It gains the window's shape as part of the contract — its own window by default, the current behaviour as a fallback and as an explicit choice — while every other guarantee in that requirement stands unchanged.
+
+## Impact
+
+- The one function that decides how the interface is opened, and the configuration that selects it.
+- A documented decision is deliberately reversed: that code says today that it parses no browser preference because the operating system holds it. Presenting a window of its own requires naming a browser that can do it, so the reversal has to be written down rather than absorbed.
+- No change to the server, the protocol, the interface, or the widget.

--- a/openspec/changes/open-the-interface-in-its-own-window/scenario-coverage.md
+++ b/openspec/changes/open-the-interface-in-its-own-window/scenario-coverage.md
@@ -1,0 +1,54 @@
+Every `#### Scenario:` in this change's delta — the whole of `StartingOpensTheInterface`,
+since a MODIFIED requirement replaces its block — and what proves it. Built for task 5.1.
+Read the assertions, not the names: a scenario counts as **covered** only when the check
+would fail if the behaviour broke at the boundary the scenario describes.
+
+Files referenced:
+
+- `server/test/openBrowser.test.ts` (`ob`) — the three decisions the opener makes,
+  with the candidate list injected so the choice is testable on any machine
+- `server/test/open-browser-failure.test.mjs` (`fail`) — the wiring, over a real server
+- `server/test/config.test.ts` (`cfg`) · `server/test/cli.test.ts` (`cli`)
+- **live** — a real server on macOS, whose window was read back from inside it over CDP
+
+## cli — StartingOpensTheInterface (9)
+
+| Scenario | Status | Evidence |
+| --- | --- | --- |
+| StartingOnADesktopOpensTheInterface | covered | live: a real server opened Edge at its bound address, and the page reports connected, composer present, workspace visible — it is being served by the time it loads. ob "whether to open a browser" pins the desktop decision |
+| ItOpensInAWindowOfItsOwn | covered | live: that window reports `display-mode: standalone` and not `browser`, read from inside it. ob "every platform's candidates produce a command asking for the window" walks the production candidate list and requires each to produce `--app=<url>`, so a candidate that stops asking for the window fails here |
+| WhereNoOwnWindowIsPossible | covered | ob "a machine with no candidate gets no own-window opener" (every listed platform, plus one nothing is listed for, which must not throw) and "asking for a window on a machine that has none falls back to opening it at all" — the fallback reaches the platform opener, which is today's behaviour exactly |
+| TheOperatorCanAskForATab | covered | ob "asking for a tab uses the platform's own opener, even where a window was possible" asserts it on a machine where a candidate *is* present, which is the only case that can tell the two shapes apart; cfg and cli cover the setting and the flag that select it |
+| LaunchedWithoutATerminal | covered | pre-existing ob assertions on `shouldOpenBrowser`: the decision is a desktop session, never a terminal. Untouched by this change |
+| TheOpenedAddressIsTheBoundOne | covered | pre-existing ob assertions on `browsableUrl`, including a port chosen by the operating system. Untouched |
+| NothingOpensWhereNothingCanSeeIt | covered | pre-existing ob assertions. Untouched |
+| TheOperatorCanSaySoEitherWay | covered | pre-existing ob and cli assertions; cli "it says nothing about whether a browser opens at all" proves `--no-open --open-in window` does not contradict itself |
+| AFailedOpenIsNotAFailedStart | covered | ob proves a failed launch answers `false` rather than throwing, for the own-window path as well as the platform one; fail drives the same over a real server and asserts it keeps running |
+
+## Result
+
+All **9 scenarios are covered**. There are no partial or uncovered rows.
+
+## What no test here can establish
+
+The Windows entries in the candidate list are paths, and a test asserts the command
+built *from* a path — never that Edge or Chrome actually lives there on a Windows
+machine. Only running it on Windows can say that, and it is task 4.1/4.2, still open:
+the requester will check it against a beta build.
+
+The cost of those paths being wrong is bounded by design rather than by luck: no
+candidate found means no own-window opener, which means the platform opener, which is
+what this did before the change. A wrong path loses the feature on Windows and breaks
+nothing.
+
+## A near-miss worth recording
+
+The first attempt to read the window back launched Edge through Playwright with the
+same `--app=` flag, and the page reported `display-mode: browser`. The obvious reading
+was that the flag did not work. It was the harness: Playwright creates its own window
+and the flag never applied. Launching Edge directly, with its own profile and a
+debugging port, and attaching to *that* window gave `standalone: true`.
+
+The pattern is the one the project already knows: a driver that is kinder than reality.
+Here it was harsher instead, and would have cost a working feature rather than hidden a
+broken one.

--- a/openspec/changes/open-the-interface-in-its-own-window/scenario-coverage.md
+++ b/openspec/changes/open-the-interface-in-its-own-window/scenario-coverage.md
@@ -17,7 +17,7 @@ Files referenced:
 | --- | --- | --- |
 | StartingOnADesktopOpensTheInterface | covered | live: a real server opened Edge at its bound address, and the page reports connected, composer present, workspace visible — it is being served by the time it loads. ob "whether to open a browser" pins the desktop decision |
 | ItOpensInAWindowOfItsOwn | covered | live: that window reports `display-mode: standalone` and not `browser`, read from inside it. ob "every platform's candidates produce a command asking for the window" walks the production candidate list and requires each to produce `--app=<url>`, so a candidate that stops asking for the window fails here |
-| WhereNoOwnWindowIsPossible | covered | ob "a machine with no candidate gets no own-window opener" (every listed platform, plus one nothing is listed for, which must not throw) and "asking for a window on a machine that has none falls back to opening it at all" — the fallback reaches the platform opener, which is today's behaviour exactly |
+| WhereNoOwnWindowIsPossible | covered | ob "a machine with no candidate gets no own-window opener" (every listed platform, plus one nothing is listed for, which must not throw) and "asking for a window on a machine that has none falls back to what this always did", which asserts the chosen command is identical to the one a tab would have used |
 | TheOperatorCanAskForATab | covered | ob "asking for a tab uses the platform's own opener, even where a window was possible" asserts it on a machine where a candidate *is* present, which is the only case that can tell the two shapes apart; cfg and cli cover the setting and the flag that select it |
 | LaunchedWithoutATerminal | covered | pre-existing ob assertions on `shouldOpenBrowser`: the decision is a desktop session, never a terminal. Untouched by this change |
 | TheOpenedAddressIsTheBoundOne | covered | pre-existing ob assertions on `browsableUrl`, including a port chosen by the operating system. Untouched |
@@ -40,6 +40,14 @@ The cost of those paths being wrong is bounded by design rather than by luck: no
 candidate found means no own-window opener, which means the platform opener, which is
 what this did before the change. A wrong path loses the feature on Windows and breaks
 nothing.
+
+## A second near-miss, caught by CI
+
+The first version of the two shape tests drove `openBrowser` and asserted on whether
+the spawn succeeded. That measures what the machine running the test happens to have
+installed: it passed on a laptop with no `xdg-open` and failed on a Linux runner that
+has one. Both tests now assert the command *chosen*, which is the same everywhere and
+is the only thing this change controls.
 
 ## A near-miss worth recording
 

--- a/openspec/changes/open-the-interface-in-its-own-window/specs/cli/spec.md
+++ b/openspec/changes/open-the-interface-in-its-own-window/specs/cli/spec.md
@@ -1,0 +1,74 @@
+## MODIFIED Requirements
+
+### Requirement: StartingOpensTheInterface
+
+However the server was started — from a package runner, from an installed binary, or
+from a standalone executable — starting it for a person SHALL open the interface at
+the address the server is actually listening on, once it is listening and not before.
+Anyone who starts this reads the address off the terminal and pastes it into a
+browser; the software can do that itself.
+
+It SHALL be opened in a window of its own — without tabs or an address bar — where
+the machine can present one. This is what the interface is: an application that was
+launched, not a page that was visited. Where no such window can be presented, it
+SHALL open in the default browser, exactly as it does otherwise; the shape of the
+window SHALL be overridable from the command line and from configuration, in both
+directions.
+
+The address SHALL be the one bound, not the one requested: where the port was chosen
+by the operating system, the opened address SHALL be the port it chose.
+
+Whether to open SHALL be decided by whether a browser can be shown at all — a
+desktop session exists — and not by whether a terminal is attached: an executable
+launched from a file manager has no terminal and is exactly the case that most needs
+opening. It SHALL be suppressed where a browser is the wrong answer: no desktop
+session, a container or a service, or a server that exists to back an interface
+hosted elsewhere. The decision SHALL be overridable in both directions from the
+command line and from configuration.
+
+A failure to open SHALL NOT be a failure to start: the server SHALL keep running and
+SHALL print the address, which is what the operator would have read anyway. This
+SHALL hold for a window of its own exactly as it holds for a browser tab, and failing
+to present one SHALL NOT be reported as an error the operator must act on.
+
+#### Scenario: StartingOnADesktopOpensTheInterface
+- **GIVEN** a machine with a desktop session
+- **WHEN** the operator starts the server
+- **THEN** the interface opens, and it is being served by the time the page loads
+
+#### Scenario: ItOpensInAWindowOfItsOwn
+- **GIVEN** a machine that can present a window without tabs or an address bar
+- **WHEN** the server is started for a person
+- **THEN** the interface appears in such a window
+
+#### Scenario: WhereNoOwnWindowIsPossible
+- **GIVEN** a machine whose browser cannot present a window of its own
+- **WHEN** the server is started for a person
+- **THEN** the interface opens in the default browser, as it does today
+- **AND** the server reports no error for it
+
+#### Scenario: TheOperatorCanAskForATab
+- **WHEN** the operator asks for the interface in the default browser rather than its own window
+- **THEN** it opens in the default browser, on a machine that could have presented its own window
+
+#### Scenario: LaunchedWithoutATerminal
+- **GIVEN** a standalone executable launched from a file manager, with no terminal attached
+- **THEN** the interface still opens — the absence of a terminal is not the absence of a person
+
+#### Scenario: TheOpenedAddressIsTheBoundOne
+- **GIVEN** a configuration that lets the operating system choose the port
+- **WHEN** the interface is opened
+- **THEN** the address it opens is the one the server bound, not the one configured
+
+#### Scenario: NothingOpensWhereNothingCanSeeIt
+- **WHEN** the server runs with no desktop session available
+- **THEN** nothing is launched, and the address is printed as usual
+
+#### Scenario: TheOperatorCanSaySoEitherWay
+- **WHEN** the operator asks for no browser, or asks for one where it would not have opened
+- **THEN** the request is honoured
+
+#### Scenario: AFailedOpenIsNotAFailedStart
+- **GIVEN** a machine where launching a browser fails
+- **WHEN** the server starts
+- **THEN** it is running and serving, and the address is printed

--- a/openspec/changes/open-the-interface-in-its-own-window/tasks.md
+++ b/openspec/changes/open-the-interface-in-its-own-window/tasks.md
@@ -1,0 +1,25 @@
+## 1. Choosing the shape
+
+- [x] 1.1 Add the setting that selects how the interface is opened, defaulting to its own window, and the command-line flag that overrides it in both directions; verify configuration tests cover the default, each accepted value, an invalid value naming the setting, and that a request not to open at all still wins over any shape.
+
+## 2. Presenting the window
+
+- [x] 2.1 Extend the one function that decides how to open so it can present a window of its own, from an ordered list of candidates per platform; verify unit tests assert the command and arguments produced for each supported platform, driven off that list rather than a copy kept in the test.
+- [x] 2.2 Fall back to the existing opener when no candidate is present; verify a test proves the fallback returns exactly what is produced today, so a machine that cannot present the window is provably unchanged.
+- [x] 2.3 Keep a failure invisible: a browser that exists but refuses to present the window leaves the server running and the address printed; verify a test drives that path and asserts the server neither fails nor reports an error for it.
+
+## 3. Proving it opens what it should
+
+- [x] 3.1 Verify the address opened is still the bound one, including where the operating system chose the port, and that suppression still works — this change must not disturb *whether* or *where*; verify the existing scenarios still pass unmodified. Done: the existing opener and failure suites pass unmodified (15 tests), and neither `shouldOpenBrowser` nor `browsableUrl` was touched.
+- [x] 3.2 Launch a real server on this machine and confirm the interface appears in a window with no tabs and no address bar, and that it is the interface — connected, serving, showing the workspace. A screenshot is not a check: read the window back. Done: a real server opened Edge with `open -na "/Applications/Microsoft Edge.app" --args --app=<bound url>`, and that window, read back over CDP, reports `display-mode: standalone`, title "pi", connected, composer present, workspace visible.
+- [x] 3.3 Start the same server with the setting asking for a tab, and confirm it opens in the default browser instead. Done at the boundary that decides it: with a candidate browser present, asking for a tab reaches the platform opener rather than the own-window one. The visible tab was not driven on this machine — the default browser is the user's, and that path is the one that has shipped since the beginning.
+
+## 4. On Windows, where this is for
+
+- [ ] 4.1 Double-click the standalone executable on a Windows machine and confirm it lands in a window of its own with a single gesture, with no second click on an installed app; record what appears, including whether the console window behaves as before.
+- [ ] 4.2 On the same machine, confirm the fallback: with no candidate browser available, the interface still opens as it does today and the server reports nothing.
+
+## 5. Scenario coverage and validation
+
+- [x] 5.1 Enumerate every `#### Scenario:` in the delta and in the requirement it modifies, and write the scenario-to-test matrix with assertion-level evidence; leave no scenario partial or uncovered — `scenario-coverage.md`, 9/9 covered. It also records the one thing no test here can establish: that the Windows candidate paths are where those browsers actually live, which is tasks 4.1/4.2
+- [x] 5.2 Run the focused configuration and opener tests, then the relevant full suites and `openspec validate open-the-interface-in-its-own-window --strict` — typecheck passed; lint passed; server 1,588 passed with nothing skipped; UI 1,340 passed; strict validation passed. Recorded in `scenario-coverage.md`. Tasks 4.1/4.2 remain open: the Windows check is the requester's, against a beta build

--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -9,6 +9,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { parseArgs } from "node:util";
 import { type CliOptions, userConfigDir } from "./config.ts";
+import { OPEN_SHAPES, type OpenShape } from "./openBrowser.ts";
 
 /**
  * Config written by `pi-outpost init` — deliberately the safe end of every choice.
@@ -65,6 +66,7 @@ Options
   --offline          never fetch remote model catalogs (air-gapped hosts)
   --open             open the interface in your browser once the server is listening
   --no-open          do not (the default wherever no desktop session exists)
+  --open-in <shape>  window (its own window, the default) or browser (a tab)
   -h, --help         show this help
   -v, --version      show the version
 
@@ -165,6 +167,8 @@ export interface ParsedCli {
   update: { check: boolean };
   /** undefined when neither --open nor --no-open was given, so config still decides. */
   open?: boolean;
+  /** undefined when --open-in was not given, so config still decides the shape. */
+  openIn?: OpenShape;
 }
 
 type Command = "init" | "config" | "login" | "build-exe" | "update";
@@ -200,6 +204,7 @@ export function parseCli(argv: string[]): ParsedCli {
         check: { type: "boolean", default: false },
         open: { type: "boolean", default: false },
         "no-open": { type: "boolean", default: false },
+        "open-in": { type: "string" },
         help: { type: "boolean", short: "h", default: false },
         version: { type: "boolean", short: "v", default: false },
       },
@@ -234,6 +239,10 @@ export function parseCli(argv: string[]): ParsedCli {
   if (values.global && command !== "init") {
     throw new CliError('"--global" belongs to "pi-outpost init" — see "pi-outpost --help"');
   }
+  const openIn = values["open-in"] as string | undefined;
+  if (openIn !== undefined && !OPEN_SHAPES.includes(openIn as OpenShape)) {
+    throw new CliError(`"--open-in" must be one of ${OPEN_SHAPES.join(", ")} (got "${openIn}") — see "pi-outpost --help"`);
+  }
   if (values.open && values["no-open"]) {
     throw new CliError('"--open" and "--no-open" contradict each other — see "pi-outpost --help"');
   }
@@ -259,6 +268,7 @@ export function parseCli(argv: string[]): ParsedCli {
     update: { check: values.check },
     // Left undefined unless asked for, so configuration still has its say.
     ...(values.open ? { open: true } : values["no-open"] ? { open: false } : {}),
+    ...(openIn === undefined ? {} : { openIn: openIn as OpenShape }),
   };
 }
 

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -24,6 +24,7 @@ import os from "node:os";
 import path from "node:path";
 import { THEMES, type Theme } from "@pi-outpost/shared";
 import { STRUCTURED_EXCHANGE_BYTES_CEILING } from "@pi-outpost/shared/structured-exchange/bounds";
+import { OPEN_SHAPES, type OpenShape } from "./openBrowser.ts";
 
 export interface BrandingConfig {
   /** Header title. Default: "π". */
@@ -402,6 +403,16 @@ export interface AppConfig {
    */
   openBrowser?: boolean;
   /**
+   * How the interface is presented once it is opened: in a window of its own, or
+   * in the default browser as a tab.
+   *
+   * Separate from `openBrowser` on purpose. That one answers *whether* and is
+   * tri-state; folding a shape into it would put two questions in one setting and
+   * make `false` ambiguous against a shape. `openBrowser` still wins: asked not to
+   * open, nothing opens, whatever shape was configured.
+   */
+  openIn: OpenShape;
+  /**
    * Whether update checking may make a request. Tri-state on purpose.
    *
    * Left undefined it follows `offline`, which is the sensible default both ways: a
@@ -457,6 +468,8 @@ export interface CliOptions {
   port?: number;
   host?: string;
   offline?: boolean;
+  /** Set by --open-in; leave it out and configuration decides the shape. */
+  openIn?: OpenShape;
 }
 
 /** Thrown when no config file exists anywhere: the CLI turns it into `init` advice. */
@@ -627,6 +640,10 @@ export function loadConfig(
     webContext: true,
     offline: false,
     port: 3141,
+    // A window of its own by default: the interface is an application that was
+    // launched, not a page that was visited. Where no browser on the machine can
+    // present one, opening falls back to what it always did.
+    openIn: "window",
     host: "127.0.0.1",
     allowedOrigins: [],
     branding: {},
@@ -814,6 +831,13 @@ export function loadConfig(
   config.webContext = optionalBoolean(raw, "webContext", true);
   config.offline = optionalBoolean(raw, "offline", false);
   if (raw.openBrowser !== undefined) config.openBrowser = optionalBoolean(raw, "openBrowser", true);
+  const openIn = optionalString(raw, "openIn", "openIn");
+  if (openIn !== undefined) {
+    if (!OPEN_SHAPES.includes(openIn as OpenShape)) {
+      fail(`"openIn" must be one of ${OPEN_SHAPES.join(", ")} (got "${openIn}")`);
+    }
+    config.openIn = openIn as OpenShape;
+  }
   // Read only when present, or the tri-state collapses: a stored `false` is
   // indistinguishable from "not mentioned", and "not mentioned" is what lets
   // `offline` decide.
@@ -1045,6 +1069,7 @@ export function applyRuntime(config: AppConfig, flags: CliOptions, env: NodeJS.P
     config.token = token;
   }
 
+  if (flags.openIn !== undefined) config.openIn = flags.openIn;
   if (flags.port !== undefined) config.port = flags.port;
   if (flags.host !== undefined) config.host = flags.host;
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -753,7 +753,7 @@ await app.listen({ port: PORT, host: HOST });
   if (servesTheInterface && shouldOpenBrowser({ explicit: cli.open, configured: config.openBrowser })) {
     // Not awaited for its outcome beyond a line of output: a browser that will not
     // start is not a reason for a server to stop.
-    void openBrowser(url).then((opened) => {
+    void openBrowser(url, process.platform, config.openIn).then((opened) => {
       if (!opened) console.log(`[server] could not open a browser — open ${url} yourself`);
     });
   }

--- a/server/src/openBrowser.ts
+++ b/server/src/openBrowser.ts
@@ -7,6 +7,19 @@
  * from at all.
  */
 import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * How the interface is presented once it is opened.
+ *
+ * `window` is a window of its own — no tabs, no address bar — which is what the
+ * interface is: an application that was launched, not a page that was visited.
+ * `browser` is what this always did, and is what a machine that cannot present
+ * such a window falls back to.
+ */
+export const OPEN_SHAPES = ["window", "browser"] as const;
+export type OpenShape = (typeof OPEN_SHAPES)[number];
 
 export interface OpenDecision {
   /** Set by --open / --no-open, which win over everything. */
@@ -59,6 +72,68 @@ export function browsableUrl(address: { address: string; port: number; family?: 
   return `http://${authority}:${address.port}/`;
 }
 
+/**
+ * Browsers that can present a window of its own, in the order they are tried.
+ *
+ * This is the one place that names a browser, and it reverses what the rest of
+ * this file says: the operating system holds the user's preference, and asking it
+ * to open a URL is how that preference is honoured. Presenting a window without
+ * tabs cannot go through that door — it needs a browser invoked directly, with the
+ * flag that asks for the window.
+ *
+ * What keeps this from becoming a browser-preference parser is the question it
+ * answers. Not "which browser should this user have" but "can this one present the
+ * window at all". A machine where none is found gets the ordinary opener, which is
+ * exactly today's behaviour.
+ *
+ * Paths, not names, so the answer is a file that either exists or does not — and
+ * so a test can decide what exists without a machine that has any of them.
+ */
+export const OWN_WINDOW_BROWSERS: Record<string, readonly string[]> = {
+  darwin: [
+    "/Applications/Microsoft Edge.app",
+    "/Applications/Google Chrome.app",
+    "/Applications/Chromium.app",
+    "/Applications/Brave Browser.app",
+  ],
+  win32: [
+    "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe",
+    "C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe",
+    "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+    "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
+  ],
+  linux: ["microsoft-edge", "google-chrome", "chromium", "chromium-browser"],
+};
+
+/** Whether a candidate is present. Injected so the choice can be tested anywhere. */
+export type ExistsProbe = (candidate: string) => boolean;
+
+/** Real answer: an absolute path is a file, a bare name is looked up on PATH. */
+const existsOnThisMachine: ExistsProbe = (candidate) => {
+  if (path.isAbsolute(candidate)) return fs.existsSync(candidate);
+  const entries = (process.env.PATH ?? "").split(path.delimiter).filter(Boolean);
+  return entries.some((entry) => fs.existsSync(path.join(entry, candidate)));
+};
+
+/**
+ * How to present the interface in a window of its own, or undefined where nothing
+ * on this machine can.
+ *
+ * On macOS the browser is still launched through `open`, because an application
+ * bundle is not an executable to spawn; `-n` asks for a new instance so an already
+ * running browser does not simply raise its own window instead.
+ */
+export function ownWindowOpenerFor(
+  platform: NodeJS.Platform,
+  url: string,
+  exists: ExistsProbe = existsOnThisMachine,
+): { command: string; args: string[] } | undefined {
+  const candidate = (OWN_WINDOW_BROWSERS[platform] ?? []).find((entry) => exists(entry));
+  if (candidate === undefined) return undefined;
+  if (platform === "darwin") return { command: "open", args: ["-na", candidate, "--args", `--app=${url}`] };
+  return { command: candidate, args: [`--app=${url}`] };
+}
+
 /** The platform's own opener. Nothing here parses a browser preference — the OS holds it. */
 function openerFor(platform: NodeJS.Platform, url: string): { command: string; args: string[] } {
   if (platform === "darwin") return { command: "open", args: [url] };
@@ -75,8 +150,16 @@ function openerFor(platform: NodeJS.Platform, url: string): { command: string; a
  * exit non-zero: the address is printed either way, which is what the operator would
  * have used before this existed.
  */
-export function openBrowser(url: string, platform: NodeJS.Platform = process.platform): Promise<boolean> {
-  const { command, args } = openerFor(platform, url);
+export function openBrowser(
+  url: string,
+  platform: NodeJS.Platform = process.platform,
+  shape: OpenShape = "window",
+  exists?: ExistsProbe,
+): Promise<boolean> {
+  // Falling back rather than failing is what makes a window of its own safe as the
+  // default: the worst case is exactly what this did before.
+  const own = shape === "window" ? ownWindowOpenerFor(platform, url, exists) : undefined;
+  const { command, args } = own ?? openerFor(platform, url);
   return new Promise((resolve) => {
     try {
       const child = spawn(command, args, { detached: true, stdio: "ignore" });

--- a/server/src/openBrowser.ts
+++ b/server/src/openBrowser.ts
@@ -150,16 +150,25 @@ function openerFor(platform: NodeJS.Platform, url: string): { command: string; a
  * exit non-zero: the address is printed either way, which is what the operator would
  * have used before this existed.
  */
+export function chooseOpener(
+  platform: NodeJS.Platform,
+  url: string,
+  shape: OpenShape,
+  exists?: ExistsProbe,
+): { command: string; args: string[] } {
+  // Falling back rather than failing is what makes a window of its own safe as the
+  // default: the worst case is exactly what this did before.
+  const own = shape === "window" ? ownWindowOpenerFor(platform, url, exists) : undefined;
+  return own ?? openerFor(platform, url);
+}
+
 export function openBrowser(
   url: string,
   platform: NodeJS.Platform = process.platform,
   shape: OpenShape = "window",
   exists?: ExistsProbe,
 ): Promise<boolean> {
-  // Falling back rather than failing is what makes a window of its own safe as the
-  // default: the worst case is exactly what this did before.
-  const own = shape === "window" ? ownWindowOpenerFor(platform, url, exists) : undefined;
-  const { command, args } = own ?? openerFor(platform, url);
+  const { command, args } = chooseOpener(platform, url, shape, exists);
   return new Promise((resolve) => {
     try {
       const child = spawn(command, args, { detached: true, stdio: "ignore" });

--- a/server/test/cli.test.ts
+++ b/server/test/cli.test.ts
@@ -289,3 +289,28 @@ describe("build-exe and the browser flags", () => {
     assert.equal(parseCli(["--no-open"]).open, false);
   });
 });
+
+describe("--open-in", () => {
+  test("names the shape the interface opens in", () => {
+    assert.equal(parseCli(["--open-in", "browser"]).openIn, "browser");
+    assert.equal(parseCli(["--open-in", "window"]).openIn, "window");
+  });
+
+  test("left out, configuration still decides", () => {
+    // Undefined rather than a default here: a flag that always had a value would
+    // silently override whatever the file said.
+    assert.equal(parseCli([]).openIn, undefined);
+  });
+
+  test("an unknown shape is refused, naming the flag and what it accepts", () => {
+    assert.throws(() => parseCli(["--open-in", "kiosk"]), /--open-in.*window.*browser/s);
+  });
+
+  test("it says nothing about whether a browser opens at all", () => {
+    // Two questions, two flags. Asking for a shape must not be read as asking to
+    // open, or `--no-open --open-in window` would contradict itself.
+    const flags = parseCli(["--no-open", "--open-in", "window"]);
+    assert.equal(flags.open, false);
+    assert.equal(flags.openIn, "window");
+  });
+});

--- a/server/test/config.test.ts
+++ b/server/test/config.test.ts
@@ -867,3 +867,71 @@ describe("loadConfig — resource path resolution", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// How the interface is presented once it opens.
+// ---------------------------------------------------------------------------
+describe("loadConfig — the shape the interface opens in", () => {
+  async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+    const dir = await mkdtemp(path.join(tmpdir(), "pi-outpost-openin-test-"));
+    try {
+      return await fn(dir);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }
+
+  async function load(dir: string, raw: Record<string, unknown>) {
+    const configPath = path.join(dir, "config.json");
+    await writeFile(configPath, JSON.stringify(raw, null, 2));
+    return loadConfig(dir, { config: configPath });
+  }
+
+  // openlore: scenario=ItOpensInAWindowOfItsOwn spec=cli
+  test("a window of its own is what an unconfigured server opens", async () => {
+    await withTempDir(async (dir) => {
+      // The default is the whole point: the case that needs it most is a
+      // double-clicked executable, where nobody is editing a configuration file.
+      assert.equal((await load(dir, {})).openIn, "window");
+    });
+  });
+
+  // openlore: scenario=TheOperatorCanAskForATab spec=cli
+  test("every accepted shape is loaded as written", async () => {
+    for (const shape of ["window", "browser"] as const) {
+      await withTempDir(async (dir) => {
+        assert.equal((await load(dir, { openIn: shape })).openIn, shape);
+      });
+    }
+  });
+
+  test("an unknown shape fails startup, naming the setting", async () => {
+    await withTempDir(async (dir) => {
+      const configPath = path.join(dir, "config.json");
+      await writeFile(configPath, JSON.stringify({ openIn: "kiosk" }, null, 2));
+      await assert.rejects(
+        async () => loadConfig(dir, { config: configPath }),
+        /openIn/,
+        "a typo that silently fell back would leave an operator hunting a window that never appears",
+      );
+    });
+  });
+
+  test("the shape says nothing about whether anything opens", async () => {
+    await withTempDir(async (dir) => {
+      // Two settings, two questions. `openBrowser` still decides whether, and a
+      // shape must never be read as a request to open.
+      const config = await load(dir, { openBrowser: false, openIn: "window" });
+      assert.equal(config.openBrowser, false);
+      assert.equal(config.openIn, "window");
+    });
+  });
+
+  test("the command line overrides the file", async () => {
+    await withTempDir(async (dir) => {
+      const configPath = path.join(dir, "config.json");
+      await writeFile(configPath, JSON.stringify({ openIn: "window" }, null, 2));
+      assert.equal(loadConfig(dir, { config: configPath, openIn: "browser" }).openIn, "browser");
+    });
+  });
+});

--- a/server/test/openBrowser.test.ts
+++ b/server/test/openBrowser.test.ts
@@ -7,7 +7,14 @@
  */
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
-import { OWN_WINDOW_BROWSERS, browsableUrl, openBrowser, ownWindowOpenerFor, shouldOpenBrowser } from "../src/openBrowser.ts";
+import {
+  OWN_WINDOW_BROWSERS,
+  browsableUrl,
+  chooseOpener,
+  openBrowser,
+  ownWindowOpenerFor,
+  shouldOpenBrowser,
+} from "../src/openBrowser.ts";
 
 describe("whether to open a browser", () => {
   test("a desktop platform opens by default", () => {
@@ -127,28 +134,34 @@ describe("presenting the interface in a window of its own", () => {
   });
 
   // openlore: scenario=TheOperatorCanAskForATab spec=cli
-  test("asking for a tab uses the platform's own opener, even where a window was possible", async () => {
-    // The whole difference between the two shapes is which command runs. Asserting
-    // it here is the real boundary: a machine that could present the window must
-    // still hand the URL to the operating system when a tab was asked for.
+  test("asking for a tab uses the platform's own opener, even where a window was possible", () => {
+    // The whole difference between the two shapes is which command is chosen, so
+    // that is what this asserts. Driving `openBrowser` instead would measure
+    // whether a spawn succeeded, which depends on what the machine running the
+    // test happens to have installed — green on a runner with xdg-open, red on a
+    // laptop without it, and about nothing this change controls either way.
     const present = () => true;
     for (const platform of ["darwin", "win32", "linux"] as const) {
       const own = ownWindowOpenerFor(platform, URL, present);
       assert.ok(own, `${platform}: expected a window opener to be possible`);
-      // With shape "browser" the own-window opener is not consulted at all, which
-      // is what `openBrowser` proves by reaching a platform opener that cannot run.
-      const opened = await openBrowser(URL, "aix", "browser", present);
-      assert.equal(opened, false, "the platform opener ran, not the own-window one");
+      const chosen = chooseOpener(platform, URL, "browser", present);
+      assert.notDeepEqual(chosen, own, `${platform}: a tab was asked for and the window opener was chosen`);
+      assert.ok(
+        !chosen.args.some((arg) => arg.startsWith("--app=")),
+        `${platform}: the chosen command still asks for a window of its own`,
+      );
     }
   });
 
-  test("asking for a window on a machine that has none falls back to opening it at all", async () => {
+  test("asking for a window on a machine that has none falls back to what this always did", () => {
     // The fallback is what makes a window of its own safe as the default: the
-    // worst case is exactly what this did before. `absentHere` stands in for a
-    // platform opener that cannot start, so a false answer proves the fallback
-    // ran rather than the own-window path.
-    const absent: NodeJS.Platform = process.platform === "win32" ? "linux" : "win32";
-    const opened = await openBrowser(URL, absent, "window", () => false);
-    assert.equal(opened, false);
+    // worst case is exactly what this did before. Asserted as the command chosen,
+    // which is the same on every machine, rather than as a spawn that succeeds or
+    // fails depending on what is installed where the test runs.
+    for (const platform of ["darwin", "win32", "linux"] as const) {
+      const withNone = chooseOpener(platform, URL, "window", () => false);
+      const asATab = chooseOpener(platform, URL, "browser", () => false);
+      assert.deepEqual(withNone, asATab, `${platform}: the fallback is not the platform opener`);
+    }
   });
 });

--- a/server/test/openBrowser.test.ts
+++ b/server/test/openBrowser.test.ts
@@ -7,7 +7,7 @@
  */
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
-import { browsableUrl, openBrowser, shouldOpenBrowser } from "../src/openBrowser.ts";
+import { OWN_WINDOW_BROWSERS, browsableUrl, openBrowser, ownWindowOpenerFor, shouldOpenBrowser } from "../src/openBrowser.ts";
 
 describe("whether to open a browser", () => {
   test("a desktop platform opens by default", () => {
@@ -71,6 +71,84 @@ describe("launching it", () => {
     // and the open would succeed.
     const absentHere: NodeJS.Platform = process.platform === "win32" ? "linux" : "win32";
     const opened = await openBrowser("http://127.0.0.1:3141/", absentHere);
+    assert.equal(opened, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// A window of its own — and what happens where none can be presented.
+// ---------------------------------------------------------------------------
+describe("presenting the interface in a window of its own", () => {
+  /** A machine where exactly these candidates exist. */
+  const machineWith = (...present: string[]) => (candidate: string) => present.includes(candidate);
+  const NOTHING = () => false;
+  const URL = "http://127.0.0.1:3141/";
+
+  // openlore: scenario=ItOpensInAWindowOfItsOwn spec=cli
+  test("every platform's candidates produce a command asking for the window", () => {
+    // Driven off the production list: a candidate removed there fails here rather
+    // than passing against a copy this test kept.
+    for (const [platform, candidates] of Object.entries(OWN_WINDOW_BROWSERS)) {
+      for (const candidate of candidates) {
+        const opener = ownWindowOpenerFor(platform as NodeJS.Platform, URL, machineWith(candidate));
+        assert.ok(opener, `${platform}: ${candidate} produced no opener`);
+        assert.ok(
+          opener.args.includes(`--app=${URL}`),
+          `${platform}: ${candidate} does not ask for a window of its own`,
+        );
+      }
+    }
+  });
+
+  test("the first candidate present is the one used", () => {
+    const candidates = OWN_WINDOW_BROWSERS.win32;
+    // Both present: the order in the list is the answer, not whichever the
+    // filesystem happened to return first.
+    const opener = ownWindowOpenerFor("win32", URL, machineWith(candidates[0], candidates[1]));
+    assert.equal(opener?.command, candidates[0]);
+  });
+
+  test("macOS goes through `open`, since an app bundle is not a program to spawn", () => {
+    const bundle = OWN_WINDOW_BROWSERS.darwin[0];
+    const opener = ownWindowOpenerFor("darwin", URL, machineWith(bundle));
+    assert.equal(opener?.command, "open");
+    // `-n` asks for a new instance: an already-running browser would otherwise
+    // raise its own window and ignore the request.
+    assert.deepEqual(opener?.args, ["-na", bundle, "--args", `--app=${URL}`]);
+  });
+
+  // openlore: scenario=WhereNoOwnWindowIsPossible spec=cli
+  test("a machine with no candidate gets no own-window opener", () => {
+    for (const platform of Object.keys(OWN_WINDOW_BROWSERS)) {
+      assert.equal(ownWindowOpenerFor(platform as NodeJS.Platform, URL, NOTHING), undefined);
+    }
+    // And a platform nothing is listed for, which must not throw.
+    assert.equal(ownWindowOpenerFor("aix", URL, NOTHING), undefined);
+  });
+
+  // openlore: scenario=TheOperatorCanAskForATab spec=cli
+  test("asking for a tab uses the platform's own opener, even where a window was possible", async () => {
+    // The whole difference between the two shapes is which command runs. Asserting
+    // it here is the real boundary: a machine that could present the window must
+    // still hand the URL to the operating system when a tab was asked for.
+    const present = () => true;
+    for (const platform of ["darwin", "win32", "linux"] as const) {
+      const own = ownWindowOpenerFor(platform, URL, present);
+      assert.ok(own, `${platform}: expected a window opener to be possible`);
+      // With shape "browser" the own-window opener is not consulted at all, which
+      // is what `openBrowser` proves by reaching a platform opener that cannot run.
+      const opened = await openBrowser(URL, "aix", "browser", present);
+      assert.equal(opened, false, "the platform opener ran, not the own-window one");
+    }
+  });
+
+  test("asking for a window on a machine that has none falls back to opening it at all", async () => {
+    // The fallback is what makes a window of its own safe as the default: the
+    // worst case is exactly what this did before. `absentHere` stands in for a
+    // platform opener that cannot start, so a false answer proves the fallback
+    // ran rather than the own-window path.
+    const absent: NodeJS.Platform = process.platform === "win32" ? "linux" : "win32";
+    const opened = await openBrowser(URL, absent, "window", () => false);
     assert.equal(opened, false);
   });
 });


### PR DESCRIPTION
Implements `open-the-interface-in-its-own-window`. Starting the server opened the interface as a tab, among that browser's other tabs, wearing its address bar. Reaching the app window took a second gesture — start the server, then find and click the installed app.

## What changed

The interface now opens **without tabs or an address bar** wherever the machine has a browser that can present such a window, and that is the default. The case that needs it most is a double-clicked executable, which is exactly where nobody is editing a configuration file — putting it behind a setting would have left the good behaviour where it is never found.

What makes the default safe is that it **degrades rather than fails**: where no candidate browser is present, the interface opens exactly as it did before and the server says nothing about it. The worst case of the new default is the old behaviour.

- `openIn` (`window` | `browser`) and `--open-in` select the shape, in both directions.
- `openBrowser` still decides *whether* anything opens, and still wins — `--no-open --open-in window` does not contradict itself.
- Nothing changes about which address is opened, or what happens when opening fails.

## A documented decision, deliberately reversed

`openBrowser.ts` says today that it parses no browser preference, because the operating system holds it. Presenting a window without tabs cannot go through that door — it needs a browser invoked directly with the flag that asks for the window. The reversal is confined to one function, and the question that list answers is *can this present the window*, never *which browser should this user have*.

## Proof

Verified on a real server: the Edge window it opened reports `display-mode: standalone`, connected, composer present, workspace visible — read back from inside that window over CDP.

The first attempt read `browser` instead, because Playwright creates its own window and the `--app=` flag never applied. That near-miss is recorded in the coverage matrix: a driver harsher than reality, which would have cost a working feature rather than hidden a broken one.

`scenario-coverage.md`: **9/9 scenarios covered** — the whole of `StartingOpensTheInterface`, since a MODIFIED requirement replaces its block.

typecheck · lint · server 1,588 · UI 1,340 · `openspec validate --strict`.

## Still open

The Windows candidate paths are the one thing no test here can establish: a test asserts the command built *from* a path, never that Edge lives there on a Windows machine. Tasks 4.1 and 4.2 remain unchecked — the author will run them against a beta build.

That gap is bounded by design rather than by luck: no candidate found means the platform opener, which is what this did before. A wrong path loses the feature on Windows and breaks nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198kLx3nUiNf1C14ZXHHsBm