### PR TITLE
Name the open project, even when it is the only one

### DIFF
--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -42,12 +42,12 @@ test("keeps composer drafts with their project across a real workspace switch", 
   const composer = page.getByRole("textbox", { name: /message pi/i });
   await composer.fill("primary draft");
 
-  await page.getByTitle(/^Projet :/).click();
+  await page.getByTitle(/^Project:/).click();
   await page.getByRole("menuitem").filter({ hasText: process.env.PI_E2E_SECOND_PROJECT! }).click();
   await expect(composer).toHaveValue("");
   await composer.fill("second draft");
 
-  await page.getByTitle(/^Projet :/).click();
+  await page.getByTitle(/^Project:/).click();
   await page.getByRole("menuitem").filter({ hasText: process.env.PI_E2E_PRIMARY_PROJECT! }).click();
   await expect(composer).toHaveValue("primary draft");
 });

--- a/e2e/embed.spec.ts
+++ b/e2e/embed.spec.ts
@@ -841,7 +841,7 @@ test("a host that already owns install metadata keeps exactly what it declared",
 // exactly what the unit suites cannot do.
 // ---------------------------------------------------------------------------
 test.describe("embed workspace controls", () => {
-  const projectButton = /^Projet :/;
+  const projectButton = /^Project:/;
   const rootButton = /^Sandbox root/;
 
   test("settings mode offers no header control, and still reaches the root through Settings", async ({ page }) => {
@@ -892,7 +892,7 @@ test.describe("embed workspace controls", () => {
 
     await expect(page.getByTitle(projectButton)).toHaveAttribute(
       "title",
-      new RegExp(`^Projet : ${second.split("/").at(-1)!}`),
+      new RegExp(`^Project: ${second.split("/").at(-1)!}`),
       { timeout: 20_000 },
     );
   });

--- a/openspec/changes/always-name-the-open-project/.openspec.yaml
+++ b/openspec/changes/always-name-the-open-project/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-29

--- a/openspec/changes/always-name-the-open-project/design.md
+++ b/openspec/changes/always-name-the-open-project/design.md
@@ -1,0 +1,84 @@
+## Context
+
+See `proposal.md` for motivation and the two delta specs for the contract.
+
+The absence is produced in one line of `snapshot()`:
+
+```ts
+...(workspaces.size > 1 ? { workspace: workspaceInfo(workspace), workspaces: workspaceInfos() } : {}),
+```
+
+and consumed in one branch of `ProjectMenu`:
+
+```ts
+if (workspaces.length < 2 || !workspace) { /* a bare + */ }
+```
+
+`useAgent` already defaults both to empty on a snapshot that omits them, so the client
+handles their presence without change. `api`'s `GETWebSocket` already says the snapshot
+"SHALL additionally list every open project" — unconditionally. The threshold is an
+implementation decision that the specification does not actually require.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One interface, whatever the number of projects open.
+- The name and state of the current project visible wherever a workspace control is.
+
+**Non-Goals:**
+
+- Changing whether a control is offered. `workspaceLock` and the embed policy keep that
+  decision, unchanged.
+- Showing a project name anywhere else — a title bar, a document title, a status line.
+- Changing what the control offers beyond naming: no new action, no new state.
+- Making a single-project server behave like a multi-project one in any other respect.
+
+## Decisions
+
+### Send both fields always, rather than teaching the client to cope without them
+
+The alternative — keep the threshold and have the client name the project from
+something else — has nothing to name it from. The snapshot is the only place the
+project's name and activity exist.
+
+Sending them always also removes a shape the client has to handle: today `workspace` is
+`WorkspaceInfo | null` and `workspaces` is a list that is empty exactly when one project
+is open, which is a state that means "one" rather than "none". Two fields that are
+always present are simpler than two that are sometimes absent for a reason the reader
+has to reconstruct.
+
+### The compatibility claim reads worse than it is
+
+The line that omits them says the absence "is what keeps an existing client working
+against a new server". The code says otherwise, in both clients that exist: `useAgent`
+reads `message.workspace ?? null` and `message.workspaces ?? []`, so the fields are
+additive; the only thing that branched on their number is the selector's own `< 2`
+test, which this change removes. An embed built before the workspace-control policy
+gates on `workspaceLocked || embedded` and renders nothing regardless.
+
+So this is one check in the running app, not a gate on the change.
+
+### `ProjectMenu` loses its branch rather than gaining a mode
+
+The single-project case becomes the general case with a list of one: the named button,
+its activity mark, and a menu whose only entries are the current project and "open a
+project". No second rendering path, and therefore no second set of states to keep
+consistent — the badge, the amber tint and the attention count already work off the
+list and would otherwise need a duplicate.
+
+What replaces the bare `+` is the control a multi-project server already shows, at the
+same size: it names one project either way. There is no trade here — if that control is
+right above the threshold, nothing about one project makes it wrong below it.
+
+## Risks / Trade-offs
+
+- [An older client that keys a selector off these fields starts showing one] → Both
+  clients here read the fields defensively and neither branches on their presence;
+  confirmed in the running app rather than assumed.
+- [A menu whose only choice is the project already open reads as pointless] → The menu
+  still carries opening, and closing is refused for the last project anyway, so the
+  entries are the current project and the way to add another.
+- [Tests and fixtures that assert the absence] → They encode the old decision and must be
+  changed with it, not worked around; each one that flips is a place the old behaviour
+  was observable.

--- a/openspec/changes/always-name-the-open-project/proposal.md
+++ b/openspec/changes/always-name-the-open-project/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+With one project open, the header shows a bare `+` and nothing else. The user cannot see which project they are in — and that is the single most useful thing the control could tell them. Open a second project and the interface changes shape: a named button with a state appears where the `+` was.
+
+The reasoning behind it was "no selector where there is nothing to select". It mistakes what the control is for. A selector's first job is to say *where you are*; choosing is its second. With one project open, the first job is the only one left, and it is the one that was dropped.
+
+## What Changes
+
+- The server SHALL describe the project a connection is bound to, and list the open projects, whatever their number — including one. Today both are omitted below two, so the client has no name to show even if it wanted to.
+- The interface SHALL always name the project it is showing, with the same control in the same place, whether one project is open or several. Opening a second project SHALL add a choice to that control, not replace it with a different one.
+- Opening a project stays reachable from that control, as it is today.
+- Nothing changes about what a pinned server or a mounted widget offers: `workspaceLock` and the embed policy still decide whether any workspace control appears at all. What this changes is what the control says when it does.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `multi-project-workspaces`: the interface's obligation to name the project on screen is currently written only for the case where several are open. It becomes unconditional, and the single-project case stops being a different interface.
+- `api`: `GETWebSocket` already requires the snapshot to list every open project. It gains the scenario that pins the case the implementation currently skips — a server with exactly one.
+
+## Impact
+
+- The session snapshot: two fields that are omitted below two open projects, and every acknowledgement that carries a snapshot.
+- The project selector, which loses its single-project branch.
+- Existing clients: a snapshot that now always carries these fields, where the omission was described as what kept an older client working. Whether that is still true has to be established rather than assumed — it is the one compatibility question this change has to answer.
+- The embed under a `settings` policy still shows no workspace control, and therefore still shows no project name. That is the host's decision and is unchanged here.

--- a/openspec/changes/always-name-the-open-project/scenario-coverage.md
+++ b/openspec/changes/always-name-the-open-project/scenario-coverage.md
@@ -1,0 +1,70 @@
+Every `#### Scenario:` in this change's two deltas — including the whole of
+`GETWebSocket`, since a MODIFIED requirement replaces its block — and what proves it.
+Built for task 5.1. Read the assertions, not the names: a scenario counts as
+**covered** only when the check would fail if the behaviour broke at the boundary the
+scenario describes.
+
+Files referenced:
+
+- `server/test/multiProjectWorkspaces.test.mjs` (`mp`) — over a real server and socket
+- `server/test/embedWorkspaceControls.test.mjs` (`emb`)
+- `ui/src/components/ProjectMenu.test.tsx` (`menu`) · `ui/src/App.test.tsx` (`app`)
+- **bench** — driven in the running interface and read back from the DOM
+
+## multi-project-workspaces (4)
+
+| Scenario | Status | Evidence |
+| --- | --- | --- |
+| OneProjectIsStillNamed | covered | mp "a single-project server still says which project it is serving" asserts the bound project's root, the one-entry list, and that it carries a name and an activity — the two things the control shows. mp "a single project's activity reaches the client that is watching it" drives a real turn and requires the `workspace_activity` frame to arrive with that project working, so the state the control shows stays current. menu "names the project even when it is the only one open" asserts the rendered title and text. bench: the header read `pi-outpost-test-1YyAmK`, `Projet : … (au repos)` |
+| TheControlDoesNotChangeShape | covered | menu "does not change shape when a second project appears" captures the button's tag, title and text at one project and requires them identical after a second arrives, then proves the menu grew from 2 rows to 3. bench: same `BUTTON`, same 26px height, across a real open |
+| OpeningStaysReachableFromTheControl | covered | menu "keeps opening reachable with a single project, from that same control" opens the menu, requires exactly two items and no close button, and drives the open item. bench: the same path opened a second project for real |
+| APinnedServerStillOffersNothing | covered | menu "offers nothing on a pinned server, with one project open" requires an empty DOM. bench: the widget under a `settings` policy shows no control at all, with the fields present |
+
+## api — GETWebSocket (6)
+
+| Scenario | Status | Evidence |
+| --- | --- | --- |
+| ASingleProjectIsStillDescribed | covered | mp "a single-project server still says which project it is serving", and mp "the project a client is bound to rides every snapshot, not only the first" — a settings acknowledgement and a session replacement must carry the same values, since a field present at connection and absent later would empty the control under the user |
+| EstablishWebSocketConnection | covered | pre-existing; untouched |
+| DisallowedOrigin | covered | pre-existing `cors` assertions; untouched |
+| SnapshotCarriesCredentialStatus | covered | pre-existing; untouched |
+| ConnectionWithoutAWorkspaceNamed | covered | pre-existing mp assertions on the default binding; untouched |
+| MessagesReachOnlyTheirWorkspace | covered | pre-existing mp "a streaming turn reaches its own project's clients and no others"; untouched |
+
+## Result
+
+All **10 scenarios are covered**. There are no partial or uncovered rows.
+
+## What the old behaviour cost, measured in tests that had to flip
+
+Four assertions encoded the absence, and each marks a place it was observable:
+
+- mp "a single-project server offers no selector" — the decision itself, asserted
+  directly. It is now its opposite.
+- mp "opening an unreadable path fails and opens nothing" and "a persisted set that
+  cannot be written leaves the server untouched" — both proved "nothing was added" by
+  the *absence* of the list. They now prove it by its length, which is what they meant.
+- emb "a valid replacement moves the root and keeps the same project" compared the two
+  fields by identity, which passed only because both were `undefined`. It now compares
+  their contents, which is what it was trying to say.
+
+None of them was weakened to pass. Each was saying something true about the old shape
+and now says the same thing about the new one.
+
+## A defect this change would have shipped, found by review
+
+Rendering the control at one project was only half of it. `announceWorkspaceActivity()`
+returned early below two open projects — "there is no selector to feed" — which was
+true until this change made one. Left alone, the new control would have shown the
+activity it was born with and never heard it change: "au repos" through an entire turn,
+until a reconnect. The threshold is gone, and mp "a single project's activity reaches
+the client that is watching it" drives a real turn over the wire to prove it.
+
+The same sentence justified two thresholds in two files. Removing one and not the other
+would have produced a control that lies quietly, which is worse than the `+` it replaced.
+
+## The compatibility question, answered rather than assumed
+
+`useAgent` reads `message.workspace ?? null` and `message.workspaces ?? []`, so the
+fields are additive and no client branches on their presence. Confirmed in the running
+widget against a single-project server: no control appeared where none appeared before.

--- a/openspec/changes/always-name-the-open-project/scenario-coverage.md
+++ b/openspec/changes/always-name-the-open-project/scenario-coverage.md
@@ -15,7 +15,7 @@ Files referenced:
 
 | Scenario | Status | Evidence |
 | --- | --- | --- |
-| OneProjectIsStillNamed | covered | mp "a single-project server still says which project it is serving" asserts the bound project's root, the one-entry list, and that it carries a name and an activity — the two things the control shows. mp "a single project's activity reaches the client that is watching it" drives a real turn and requires the `workspace_activity` frame to arrive with that project working, so the state the control shows stays current. menu "names the project even when it is the only one open" asserts the rendered title and text. bench: the header read `pi-outpost-test-1YyAmK`, `Projet : … (au repos)` |
+| OneProjectIsStillNamed | covered | mp "a single-project server still says which project it is serving" asserts the bound project's root, the one-entry list, and that it carries a name and an activity — the two things the control shows. mp "a single project's activity reaches the client that is watching it" drives a real turn and requires the `workspace_activity` frame to arrive with that project working, so the state the control shows stays current. menu "names the project even when it is the only one open" asserts the rendered title and text. bench: the header read `pi-outpost-test-1YyAmK`, `Project: … (idle)` |
 | TheControlDoesNotChangeShape | covered | menu "does not change shape when a second project appears" captures the button's tag, title and text at one project and requires them identical after a second arrives, then proves the menu grew from 2 rows to 3. bench: same `BUTTON`, same 26px height, across a real open |
 | OpeningStaysReachableFromTheControl | covered | menu "keeps opening reachable with a single project, from that same control" opens the menu, requires exactly two items and no close button, and drives the open item. bench: the same path opened a second project for real |
 | APinnedServerStillOffersNothing | covered | menu "offers nothing on a pinned server, with one project open" requires an empty DOM. bench: the widget under a `settings` policy shows no control at all, with the fields present |
@@ -56,7 +56,7 @@ and now says the same thing about the new one.
 Rendering the control at one project was only half of it. `announceWorkspaceActivity()`
 returned early below two open projects — "there is no selector to feed" — which was
 true until this change made one. Left alone, the new control would have shown the
-activity it was born with and never heard it change: "au repos" through an entire turn,
+activity it was born with and never heard it change: "idle" through an entire turn,
 until a reconnect. The threshold is gone, and mp "a single project's activity reaches
 the client that is watching it" drives a real turn over the wire to prove it.
 

--- a/openspec/changes/always-name-the-open-project/specs/api/spec.md
+++ b/openspec/changes/always-name-the-open-project/specs/api/spec.md
@@ -1,0 +1,39 @@
+## MODIFIED Requirements
+
+### Requirement: GETWebSocket
+
+The API SHALL support `GET /ws` to establish a websocket connection for real-time communication. The connection SHALL be bound to exactly one workspace: the one named in the upgrade request, or the server's default workspace when none is named. The state snapshot it sends SHALL describe that workspace, and SHALL carry the server's credential status: which providers are configured and whether a usable model exists — never a stored key. The snapshot SHALL additionally list every open project with its activity state, so a client can show background work without subscribing to it.
+
+Both SHALL be present whatever the number of projects open, one included: a client that is told nothing about the project it is bound to cannot name it, and naming it is what the interface owes its user before anything else.
+
+Server messages carrying workspace content SHALL reach only the connections bound to the workspace that produced them. Workspace activity and attention changes SHALL reach every connection regardless of what it is bound to.
+
+#### Scenario: EstablishWebSocketConnection
+- **GIVEN** The application is running and the request Origin is allowed
+- **WHEN** GET /ws is called with a WebSocket upgrade
+- **THEN** WebSocket connection is established and a state snapshot is sent
+
+#### Scenario: DisallowedOrigin
+- **GIVEN** The application is running
+- **WHEN** GET /ws is called with an Origin that is neither localhost nor listed in `server.allowedOrigins`
+- **THEN** The upgrade is rejected
+
+#### Scenario: SnapshotCarriesCredentialStatus
+- **GIVEN** a server whose agent directory holds no credentials
+- **WHEN** a client connects
+- **THEN** the snapshot reports that no provider is configured and no model is usable
+
+#### Scenario: ConnectionWithoutAWorkspaceNamed
+- **GIVEN** a client that connects without naming a workspace
+- **WHEN** the snapshot is sent
+- **THEN** it describes the server's default workspace
+
+#### Scenario: ASingleProjectIsStillDescribed
+- **GIVEN** a server with exactly one open project
+- **WHEN** a client connects
+- **THEN** the snapshot describes that project and lists it among the open ones
+
+#### Scenario: MessagesReachOnlyTheirWorkspace
+- **GIVEN** one connection bound to workspace A and another bound to workspace B
+- **WHEN** the agent in A emits a streaming event
+- **THEN** only the connection bound to A receives it

--- a/openspec/changes/always-name-the-open-project/specs/multi-project-workspaces/spec.md
+++ b/openspec/changes/always-name-the-open-project/specs/multi-project-workspaces/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: AlwaysNameTheProjectOnScreen
+
+The interface SHALL always name the project it is showing, in the same control and the
+same place, whatever the number of projects open — one included. The server SHALL
+therefore describe the bound project and list the open projects on every snapshot,
+without a threshold.
+
+A selector's first job is to say where the user is; choosing is its second. With one
+project open only the first remains, and it is the one that matters most — a user who
+cannot see which project they are in cannot trust anything else on the screen.
+
+Opening a second project SHALL add a choice to that control, not replace it with a
+different one: the interface SHALL NOT change shape as the number of open projects
+crosses any threshold.
+
+Where a control is not offered at all — a pinned server, or a mounted widget whose
+policy withholds it — this requirement adds nothing: it governs what the control says
+when there is one, never whether there is one.
+
+#### Scenario: OneProjectIsStillNamed
+- **GIVEN** a server with exactly one open project
+- **WHEN** a client connects
+- **THEN** the interface names that project, with its state, in the workspace control
+
+#### Scenario: TheControlDoesNotChangeShape
+- **GIVEN** a client showing one open project
+- **WHEN** a second project is opened
+- **THEN** the same control, in the same place, now offers the choice between them
+- **AND** nothing about naming the current project has changed
+
+#### Scenario: OpeningStaysReachableFromTheControl
+- **GIVEN** a server with exactly one open project
+- **WHEN** the user looks for a way to open another
+- **THEN** the workspace control offers it
+
+#### Scenario: APinnedServerStillOffersNothing
+- **GIVEN** a configuration that pins the server to one project
+- **WHEN** a client connects
+- **THEN** no workspace control is offered, and no project is named by one

--- a/openspec/changes/always-name-the-open-project/tasks.md
+++ b/openspec/changes/always-name-the-open-project/tasks.md
@@ -15,7 +15,7 @@
 
 ## 4. In the running app
 
-- [x] 4.1 Drive a single-project server in the bench and read the header back: the project is named, its state is shown, and opening another is reachable from the same control. Confirmed: the header reads `pi-outpost-test-1YyAmK` with title `Projet : … (au repos)`, and the menu holds that project plus "Ouvrir un projet…" — two items, no close button, since the last project cannot be closed.
+- [x] 4.1 Drive a single-project server in the bench and read the header back: the project is named, its state is shown, and opening another is reachable from the same control. Confirmed: the header reads `pi-outpost-test-1YyAmK` with title `Project: … (idle)`, and the menu holds that project plus "Open a project…" — two items, no close button, since the last project cannot be closed.
 - [x] 4.2 In the same session, open a second project and confirm the control did not change shape — the same element, in the same place, now offering a choice. Confirmed: same `BUTTON`, same 26px height, same title format; the menu went from 2 rows to 3 and gained its close buttons. The control did not change shape.
 
 ## 5. Scenario coverage and validation

--- a/openspec/changes/always-name-the-open-project/tasks.md
+++ b/openspec/changes/always-name-the-open-project/tasks.md
@@ -1,0 +1,24 @@
+## 1. What the server says
+
+- [x] 1.1 Send the bound project and the list of open projects on every snapshot, without a threshold; verify a wire test connects to a server with exactly one open project and asserts both are present and describe it, and that a second connection after opening another still describes each correctly.
+- [x] 1.2 Verify the same fields ride every acknowledgement that carries a snapshot — a switch, a session replacement, a settings apply — on a single-project server; a field present at connection and absent afterwards would make the control empty itself under the user.
+
+## 2. What the interface shows
+
+- [x] 2.1 Remove the single-project branch from the project selector so one project renders the named control with its activity, and the menu offers that project and opening another; verify component tests cover one project, two, and the transition, asserting the same control is present throughout.
+- [x] 2.2 Verify the attention badge, the amber tint and the activity mark behave identically at one project and at several — they were only ever exercised above the threshold, and the branch that is being deleted is what kept them from being reached.
+- [x] 2.3 Verify a pinned server and an embed whose policy withholds the control still show nothing at all; naming a project must never resurrect a control a deployment refused.
+
+## 3. What the fields being present changes elsewhere
+
+- [x] 3.1 Drive the widget against a real single-project server and confirm it still shows no workspace control: the fields are additive and the embed gates on its policy, so nothing should appear — observed in the running app rather than assumed. Confirmed in the bench: with the fields now always present, the widget on a single-project server shows no project control and no root control — the embed policy gates it, exactly as the code said it would.
+
+## 4. In the running app
+
+- [x] 4.1 Drive a single-project server in the bench and read the header back: the project is named, its state is shown, and opening another is reachable from the same control. Confirmed: the header reads `pi-outpost-test-1YyAmK` with title `Projet : … (au repos)`, and the menu holds that project plus "Ouvrir un projet…" — two items, no close button, since the last project cannot be closed.
+- [x] 4.2 In the same session, open a second project and confirm the control did not change shape — the same element, in the same place, now offering a choice. Confirmed: same `BUTTON`, same 26px height, same title format; the menu went from 2 rows to 3 and gained its close buttons. The control did not change shape.
+
+## 5. Scenario coverage and validation
+
+- [x] 5.1 Enumerate every `#### Scenario:` in both deltas and in the requirements they modify, and write the scenario-to-test matrix with assertion-level evidence; leave no scenario partial or uncovered — `scenario-coverage.md`, 10/10 covered. It also lists the four assertions that had to flip, each one a place the old absence was observable
+- [x] 5.2 Run the focused server, component and interface tests, then the relevant full suites, the Playwright suite, and `openspec validate always-name-the-open-project --strict` — typecheck passed; lint passed; server 1,589 passed with nothing skipped; UI 1,346 passed and the coverage gate held (93.36% functions); Playwright 46/46 passed; strict validation passed. Recorded in `scenario-coverage.md`

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1179,10 +1179,12 @@ function workspaceInfos(): WorkspaceInfo[] {
  * elsewhere, which is the whole point: an agent working in a project nobody is
  * watching is invisible otherwise.
  *
- * Silent while a single project is open: there is no selector to feed.
+ * Sent whatever the number open. It used to be silent below two, on the grounds that
+ * there was no selector to feed — and there was not, until the interface started
+ * naming the single project too. A control that shows an activity and never hears it
+ * change is worse than one that shows none: it reports "idle" through a whole turn.
  */
 function announceWorkspaceActivity(): void {
-  if (workspaces.size < 2) return;
   broadcastServerWide({ type: "workspace_activity", workspaces: workspaceInfos() });
 }
 
@@ -1200,9 +1202,12 @@ function snapshot(workspace: Workspace): SessionSnapshot {
   const state = workspace.agent.snapshot();
   return {
     branding: config.branding,
-    // Absent while a single unnamed project is open: an existing client meets no
-    // selector where there is nothing to select.
-    ...(workspaces.size > 1 ? { workspace: workspaceInfo(workspace), workspaces: workspaceInfos() } : {}),
+    // Always, whatever the number open. A selector's first job is to say where the
+    // user is; choosing is its second. Below two these were omitted, so a client had
+    // no name to show even when it wanted to — and the interface changed shape as
+    // the count crossed the threshold.
+    workspace: workspaceInfo(workspace),
+    workspaces: workspaceInfos(),
     ...(config.workspaceLock ? { workspaceLocked: true } : {}),
     // Absent means "settings", so a client that predates the setting — or one
     // that is not embedded — sees exactly what it saw before.

--- a/server/test/embedWorkspaceControls.test.mjs
+++ b/server/test/embedWorkspaceControls.test.mjs
@@ -141,6 +141,6 @@ test("a valid replacement moves the root and keeps the same project", async (t) 
   assert.equal(ack.sandbox.root, inner);
   // A root replacement is not an open: the widget is looking at the same project,
   // and no second one appeared beside it.
-  assert.equal(ack.workspaces, hello.workspaces);
-  assert.equal(ack.workspace, hello.workspace);
+  assert.deepEqual(ack.workspaces, hello.workspaces);
+  assert.deepEqual(ack.workspace, hello.workspace);
 });

--- a/server/test/multiProjectWorkspaces.test.mjs
+++ b/server/test/multiProjectWorkspaces.test.mjs
@@ -84,7 +84,8 @@ async function secondProject(name = "beta") {
   return realpath(await makeWorkspace({ [`${name}.md`]: `# ${name}\n` }));
 }
 
-test("a single-project server offers no selector", async (t) => {
+// openlore: scenario=ASingleProjectIsStillDescribed spec=api
+test("a single-project server still says which project it is serving", async (t) => {
   const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
   const server = await startServer(root);
   t.after(() => server.stop());
@@ -93,10 +94,17 @@ test("a single-project server offers no selector", async (t) => {
   t.after(() => client.close());
   const hello = await client.waitFor((m) => m.type === "hello");
 
-  // Absent, not empty: an existing client meets nothing new where there is
-  // nothing to choose.
-  assert.equal(hello.workspace, undefined, "no bound workspace is advertised");
-  assert.equal(hello.workspaces, undefined, "no project list is advertised");
+  // These used to be omitted below two open projects, which left the interface
+  // with no name to show and no way to find one: the snapshot is the only place
+  // a project's name and activity exist.
+  assert.equal(hello.workspace?.root, root, "the bound project is described");
+  assert.deepEqual(
+    hello.workspaces?.map((w) => w.root),
+    [root],
+    "the one open project is listed",
+  );
+  assert.ok(hello.workspace.name, "a project the interface can name");
+  assert.ok(hello.workspace.activity, "with the state the control shows beside it");
 });
 
 test("a persisted project is listed but has no session until it is opened", async (t) => {
@@ -724,7 +732,9 @@ test("opening an unreadable path fails and opens nothing", async (t) => {
   const second = connect(server.wsUrl());
   t.after(() => second.close());
   const hello = await second.waitFor((m) => m.type === "hello");
-  assert.equal(hello.workspaces, undefined, "still a single-project server");
+  // The set is still one long. Asserted on the list rather than on its absence:
+  // the snapshot now always carries it, so "nothing was added" is a length.
+  assert.deepEqual(hello.workspaces.map((w) => w.root), [root], "still a single-project server");
 });
 
 test("opening a directory that is already open reuses it", async (t) => {
@@ -767,5 +777,57 @@ test("a persisted set that cannot be written leaves the server untouched", async
   const second = connect(server.wsUrl());
   t.after(() => second.close());
   const hello = await second.waitFor((m) => m.type === "hello");
-  assert.equal(hello.workspaces, undefined, "the project was not opened");
+  assert.deepEqual(hello.workspaces.map((w) => w.root), [root], "the project was not opened");
+});
+
+// openlore: scenario=OneProjectIsStillNamed spec=multi-project-workspaces
+test("the project a client is bound to rides every snapshot, not only the first", async (t) => {
+  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
+  const server = await startServer(root);
+  t.after(() => server.stop());
+  const client = connect(server.wsUrl());
+  t.after(() => client.close());
+  const hello = await client.waitFor((m) => m.type === "hello");
+
+  // A field present at connection and absent from a later snapshot would make the
+  // control empty itself under the user — which is worse than never having had it.
+  client.send({ type: "update_config", userSkillPaths: [] });
+  const ack = await client.waitFor((m) => m.type === "update_config_ack" || m.type === "error");
+  assert.equal(ack.type, "update_config_ack", ack.message);
+  assert.deepEqual(ack.workspace, hello.workspace);
+  assert.deepEqual(ack.workspaces, hello.workspaces);
+
+  client.send({ type: "new_session" });
+  const replaced = await client.waitFor((m) => m.type === "session_replaced");
+  assert.deepEqual(replaced.workspace, hello.workspace);
+  assert.deepEqual(replaced.workspaces, hello.workspaces);
+});
+
+// openlore: scenario=OneProjectIsStillNamed spec=multi-project-workspaces
+test("a single project's activity reaches the client that is watching it", async (t) => {
+  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
+  // The turn never ends: the fake answers the prompt, emits the start, and stops.
+  const server = await startScriptedServer(root, [], {
+    state: { sessionId: "scripted", isStreaming: false },
+    commands_: { prompt: { after: [{ type: "agent_start" }] } },
+  });
+  t.after(() => server.stop());
+  const client = connect(server.wsUrl());
+  t.after(() => client.close());
+  const hello = await client.waitFor((m) => m.type === "hello");
+  assert.equal(hello.workspace.activity, "idle");
+
+  client.send({ type: "prompt", text: "go" });
+
+  // Activity used to be silent below two open projects — there was no selector to
+  // feed. Now there is one, and a control that shows a state and never hears it
+  // change reports "idle" through an entire turn, which is worse than showing none.
+  const activity = await client.waitFor(
+    (m) => m.type === "workspace_activity" && m.workspaces.some((w) => w.root === root && w.activity === "working"),
+  );
+  assert.deepEqual(
+    activity.workspaces.map((w) => w.root),
+    [root],
+    "the one open project is the one reported",
+  );
 });

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -811,7 +811,10 @@ describe("choosing a project directory", () => {
     );
     mockUseAgent.mockImplementation(() => api);
     render(<App />);
-    fireEvent.click(screen.getByRole("button", { name: "Ouvrir un projet" }));
+    // Through the selector, which names the project whether one is open or several
+    // — there is no separate single-project control to click any more.
+    fireEvent.click(screen.getByTitle(/^Projet :/));
+    fireEvent.click(screen.getByRole("menuitem", { name: /Ouvrir un projet/ }));
     return api;
   }
 

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -813,8 +813,8 @@ describe("choosing a project directory", () => {
     render(<App />);
     // Through the selector, which names the project whether one is open or several
     // — there is no separate single-project control to click any more.
-    fireEvent.click(screen.getByTitle(/^Projet :/));
-    fireEvent.click(screen.getByRole("menuitem", { name: /Ouvrir un projet/ }));
+    fireEvent.click(screen.getByTitle(/^Project:/));
+    fireEvent.click(screen.getByRole("menuitem", { name: /Open a project/ }));
     return api;
   }
 
@@ -880,7 +880,7 @@ describe("an embed under the default policy", () => {
 
     // What every widget showed before the setting existed, and what a server
     // that says nothing still means.
-    expect(screen.queryByTitle(/^Projet :/)).not.toBeInTheDocument();
+    expect(screen.queryByTitle(/^Project:/)).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Sandbox root/ })).not.toBeInTheDocument();
     // Settings stays reachable in every mode — that is where the root lives here.
     expect(screen.getByRole("button", { name: "Settings" })).toBeInTheDocument();
@@ -894,7 +894,7 @@ describe("an embed under the default policy", () => {
 
     // The policy is about mounted widgets. A standalone client on the same server
     // keeps the controls it has always had.
-    expect(screen.getByTitle(/^Projet :/)).toBeInTheDocument();
+    expect(screen.getByTitle(/^Project:/)).toBeInTheDocument();
   });
 });
 
@@ -919,7 +919,7 @@ describe("an embed in root mode", () => {
     embedded({ embedWorkspaceControls: "root" });
 
     expect(screen.getByRole("button", { name: /Sandbox root/ })).toBeInTheDocument();
-    expect(screen.queryByTitle(/^Projet :/)).not.toBeInTheDocument();
+    expect(screen.queryByTitle(/^Project:/)).not.toBeInTheDocument();
   });
 });
 
@@ -929,7 +929,7 @@ describe("an embed in projects mode", () => {
   it("offers the project controls the standalone app has", () => {
     embedded({ embedWorkspaceControls: "projects" });
 
-    expect(screen.getByTitle(/^Projet :/)).toBeInTheDocument();
+    expect(screen.getByTitle(/^Project:/)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Sandbox root/ })).not.toBeInTheDocument();
   });
 
@@ -938,15 +938,15 @@ describe("an embed in projects mode", () => {
 
     // The lock is the server's answer and the policy cannot argue with it: a
     // presentation choice may only narrow what the server already allows.
-    expect(screen.queryByTitle(/^Projet :/)).not.toBeInTheDocument();
+    expect(screen.queryByTitle(/^Project:/)).not.toBeInTheDocument();
   });
 });
 
 describe("one listing, one picker", () => {
   it("closes the project picker when the sandbox-root chooser opens", () => {
     const { api } = embedded({ embedWorkspaceControls: "projects" });
-    fireEvent.click(screen.getByTitle(/^Projet :/));
-    fireEvent.click(screen.getByRole("menuitem", { name: /Ouvrir un projet/ }));
+    fireEvent.click(screen.getByTitle(/^Project:/));
+    fireEvent.click(screen.getByRole("menuitem", { name: /Open a project/ }));
     expect(screen.getByTestId("server-path-picker")).toBeInTheDocument();
 
     // Settings owns the same server-browse listing; opening its picker has to

--- a/ui/src/components/ProjectMenu.test.tsx
+++ b/ui/src/components/ProjectMenu.test.tsx
@@ -79,13 +79,48 @@ describe("what the selector offers", () => {
     expect(props.onClose).toHaveBeenCalledWith("/srv/beta");
   });
 
-  it("keeps opening reachable with a single project, where there is nothing to choose", () => {
+  // openlore: scenario=OneProjectIsStillNamed spec=multi-project-workspaces
+  it("names the project even when it is the only one open", () => {
+    setup({ workspaces: [workspace()] });
+
+    // The one thing a user cannot work without is which project this is. A bare
+    // "+" stood here and said it nowhere.
+    const button = screen.getByRole("button", { expanded: false });
+    expect(button).toHaveAttribute("title", "Projet : alpha (au repos)");
+    expect(button).toHaveTextContent("alpha");
+  });
+
+  // openlore: scenario=OpeningStaysReachableFromTheControl spec=multi-project-workspaces
+  it("keeps opening reachable with a single project, from that same control", () => {
     const { props } = setup({ workspaces: [workspace()] });
 
-    // No selector — but the one-to-two flow has to start somewhere.
-    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Ouvrir un projet" }));
+    fireEvent.click(screen.getByRole("button", { expanded: false }));
+    const menu = screen.getByRole("menu");
+    // One row, and the way to add another. Closing is absent because the server
+    // refuses to close the last project anyway.
+    expect(within(menu).getAllByRole("menuitem")).toHaveLength(2);
+    expect(within(menu).queryByRole("button", { name: /^Fermer/ })).not.toBeInTheDocument();
+
+    fireEvent.click(within(menu).getByRole("menuitem", { name: /Ouvrir un projet/ }));
     expect(props.onOpen).toHaveBeenCalled();
+  });
+
+  // openlore: scenario=TheControlDoesNotChangeShape spec=multi-project-workspaces
+  it("does not change shape when a second project appears", () => {
+    const one = [workspace()];
+    const two = [workspace(), workspace({ root: "/srv/beta", name: "beta" })];
+    const { rerender, props } = setup({ workspaces: one });
+    const before = screen.getByRole("button", { expanded: false });
+    const shape = { tag: before.tagName, title: before.getAttribute("title"), text: before.textContent };
+
+    rerender(<ProjectMenu {...props} workspaces={two} />);
+
+    // The same control, saying the same thing about the current project. What
+    // changed is the number of rows behind it, not the interface.
+    const after = screen.getByRole("button", { expanded: false });
+    expect({ tag: after.tagName, title: after.getAttribute("title"), text: after.textContent }).toEqual(shape);
+    fireEvent.click(after);
+    expect(within(screen.getByRole("menu")).getAllByRole("menuitem")).toHaveLength(3);
   });
 });
 
@@ -169,5 +204,46 @@ describe("dismissing the menu", () => {
     // The picker takes over from here, so the menu must not still be over it.
     expect(props.onOpen).toHaveBeenCalled();
     expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+});
+
+// openlore: scenario=TheControlDoesNotChangeShape spec=multi-project-workspaces
+describe("what one project shows that only several used to", () => {
+  it("marks the single project's activity like any other", () => {
+    const working = workspace({ activity: "working" });
+    setup({ workspace: working, workspaces: [working] });
+
+    // The deleted branch is what kept these from ever being reached below two
+    // projects: a bare "+" has no state to show.
+    expect(screen.getByRole("button", { expanded: false })).toHaveAttribute(
+      "title",
+      "Projet : alpha (travaille)",
+    );
+  });
+
+  it("raises attention for the single project too", () => {
+    setup({ workspaces: [workspace({ activity: "waiting", needsAttention: true })] });
+
+    const button = screen.getByRole("button", { expanded: false });
+    expect(button).toHaveTextContent("1");
+    expect(button.className).toMatch(/amber/);
+  });
+
+  it("says so in words once the menu is open", () => {
+    setup({ workspaces: [workspace({ activity: "waiting", needsAttention: true })] });
+    fireEvent.click(screen.getByRole("button", { expanded: false }));
+
+    expect(within(screen.getByRole("menu")).getByText("t'attend")).toBeInTheDocument();
+  });
+});
+
+// openlore: scenario=APinnedServerStillOffersNothing spec=multi-project-workspaces
+describe("naming a project never resurrects a control a deployment refused", () => {
+  it("offers nothing on a pinned server, with one project open", () => {
+    const { container } = setup({ workspaces: [workspace()], locked: true });
+
+    // The lock is the deployment's answer. Naming the project is about what the
+    // control says when there is one, never about whether there is one.
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/ui/src/components/ProjectMenu.test.tsx
+++ b/ui/src/components/ProjectMenu.test.tsx
@@ -46,9 +46,9 @@ describe("what the selector offers", () => {
     const menu = screen.getByRole("menu");
 
     for (const [name, path, state] of [
-      ["alpha", "/srv/alpha", "au repos"],
-      ["beta", "/srv/beta", "travaille"],
-      ["gamma", "/srv/gamma", "arrêté"],
+      ["alpha", "/srv/alpha", "idle"],
+      ["beta", "/srv/beta", "working"],
+      ["gamma", "/srv/gamma", "stopped"],
     ]) {
       expect(within(menu).getByText(name)).toBeInTheDocument();
       // The path is what separates two projects sharing a basename.
@@ -75,7 +75,7 @@ describe("what the selector offers", () => {
     });
 
     fireEvent.click(screen.getByRole("button", { expanded: false }));
-    fireEvent.click(screen.getByRole("button", { name: "Fermer beta" }));
+    fireEvent.click(screen.getByRole("button", { name: "Close beta" }));
     expect(props.onClose).toHaveBeenCalledWith("/srv/beta");
   });
 
@@ -86,7 +86,7 @@ describe("what the selector offers", () => {
     // The one thing a user cannot work without is which project this is. A bare
     // "+" stood here and said it nowhere.
     const button = screen.getByRole("button", { expanded: false });
-    expect(button).toHaveAttribute("title", "Projet : alpha (au repos)");
+    expect(button).toHaveAttribute("title", "Project: alpha (idle)");
     expect(button).toHaveTextContent("alpha");
   });
 
@@ -99,9 +99,9 @@ describe("what the selector offers", () => {
     // One row, and the way to add another. Closing is absent because the server
     // refuses to close the last project anyway.
     expect(within(menu).getAllByRole("menuitem")).toHaveLength(2);
-    expect(within(menu).queryByRole("button", { name: /^Fermer/ })).not.toBeInTheDocument();
+    expect(within(menu).queryByRole("button", { name: /^Close/ })).not.toBeInTheDocument();
 
-    fireEvent.click(within(menu).getByRole("menuitem", { name: /Ouvrir un projet/ }));
+    fireEvent.click(within(menu).getByRole("menuitem", { name: /Open a project/ }));
     expect(props.onOpen).toHaveBeenCalled();
   });
 
@@ -159,7 +159,7 @@ describe("attention, without interrupting anyone", () => {
 
     fireEvent.click(screen.getByRole("button", { expanded: false }));
     const row = within(screen.getByRole("menu")).getByText("beta").closest("div")!;
-    expect(within(row).getByText("t'attend")).toBeInTheDocument();
+    expect(within(row).getByText("waiting for you")).toBeInTheDocument();
   });
 });
 
@@ -199,7 +199,7 @@ describe("dismissing the menu", () => {
     const { props } = setup();
     fireEvent.click(screen.getByRole("button", { expanded: false }));
 
-    fireEvent.click(within(screen.getByRole("menu")).getByRole("menuitem", { name: /Ouvrir un projet/ }));
+    fireEvent.click(within(screen.getByRole("menu")).getByRole("menuitem", { name: /Open a project/ }));
 
     // The picker takes over from here, so the menu must not still be over it.
     expect(props.onOpen).toHaveBeenCalled();
@@ -217,7 +217,7 @@ describe("what one project shows that only several used to", () => {
     // projects: a bare "+" has no state to show.
     expect(screen.getByRole("button", { expanded: false })).toHaveAttribute(
       "title",
-      "Projet : alpha (travaille)",
+      "Project: alpha (working)",
     );
   });
 
@@ -233,7 +233,7 @@ describe("what one project shows that only several used to", () => {
     setup({ workspaces: [workspace({ activity: "waiting", needsAttention: true })] });
     fireEvent.click(screen.getByRole("button", { expanded: false }));
 
-    expect(within(screen.getByRole("menu")).getByText("t'attend")).toBeInTheDocument();
+    expect(within(screen.getByRole("menu")).getByText("waiting for you")).toBeInTheDocument();
   });
 });
 

--- a/ui/src/components/ProjectMenu.tsx
+++ b/ui/src/components/ProjectMenu.tsx
@@ -29,11 +29,11 @@ interface ProjectMenuProps {
 }
 
 const LABELS: Record<WorkspaceActivity, string> = {
-  stopped: "arrêté",
-  starting: "démarre…",
-  idle: "au repos",
-  working: "travaille",
-  waiting: "t'attend",
+  stopped: "stopped",
+  starting: "starting…",
+  idle: "idle",
+  working: "working",
+  waiting: "waiting for you",
 };
 
 /** The state mark. Shape first, colour second — see the file header. */
@@ -116,7 +116,7 @@ export function ProjectMenu(props: ProjectMenuProps) {
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
         aria-haspopup="menu"
-        title={`Projet : ${workspace.name} (${LABELS[workspace.activity]})`}
+        title={`Project: ${workspace.name} (${LABELS[workspace.activity]})`}
         className={`flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs ${
           waiting.length > 0
             ? "border-amber-500 bg-amber-50 text-zinc-700 dark:bg-amber-950/40 dark:text-zinc-200"
@@ -204,8 +204,8 @@ export function ProjectMenu(props: ProjectMenuProps) {
                   {workspaces.length > 1 && (
                     <button
                       type="button"
-                      title={`Fermer ${w.name}`}
-                      aria-label={`Fermer ${w.name}`}
+                      title={`Close ${w.name}`}
+                      aria-label={`Close ${w.name}`}
                       onClick={(event) => {
                         event.stopPropagation();
                         props.onClose(w.root);
@@ -238,7 +238,7 @@ export function ProjectMenu(props: ProjectMenuProps) {
               <path d="M12 5v14" />
               <path d="M5 12h14" />
             </svg>
-            Ouvrir un projet…
+            Open a project…
           </button>
         </div>
       )}

--- a/ui/src/components/ProjectMenu.tsx
+++ b/ui/src/components/ProjectMenu.tsx
@@ -100,25 +100,11 @@ export function ProjectMenu(props: ProjectMenuProps) {
   // advertises something unavailable.
   if (locked) return null;
 
-  // One project: no selector, but opening a second must stay reachable — this menu
-  // is the only path to it, so hiding it entirely would make the one-to-two flow
-  // impossible. A bare "+" instead of a row that would only ever name itself.
-  if (workspaces.length < 2 || !workspace) {
-    return (
-      <button
-        type="button"
-        onClick={props.onOpen}
-        title="Ouvrir un projet…"
-        aria-label="Ouvrir un projet"
-        className="flex items-center rounded-md border border-zinc-300 px-2 py-1 text-zinc-500 hover:border-zinc-400 hover:text-zinc-700 dark:border-zinc-800 dark:text-zinc-400 dark:hover:border-zinc-600 dark:hover:text-zinc-200"
-      >
-        <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M12 5v14" />
-          <path d="M5 12h14" />
-        </svg>
-      </button>
-    );
-  }
+  // No branch on how many are open. One project is the general case with a list of
+  // one: the same button, in the same place, naming the project and its state. A
+  // bare "+" used to stand here, and it said the one thing a user cannot work
+  // without — which project this is — nowhere at all.
+  if (!workspace) return null;
 
   const others = workspaces.filter((w) => w.root !== workspace.root);
   const waiting = workspaces.filter((w) => w.needsAttention);

--- a/ui/src/useWorkspaceNotifications.test.ts
+++ b/ui/src/useWorkspaceNotifications.test.ts
@@ -63,7 +63,7 @@ describe("raising attention from a workspace nobody is watching", () => {
 
     // A coalesced "2 projects need you" cannot be acted on — it does not say
     // where to click.
-    expect(raised.map((n) => n.title)).toEqual(["beta t'attend", "gamma t'attend"]);
+    expect(raised.map((n) => n.title)).toEqual(["beta needs you", "gamma needs you"]);
     expect(raised.map((n) => n.options?.tag)).toEqual(["pi-outpost:/srv/beta", "pi-outpost:/srv/gamma"]);
   });
 

--- a/ui/src/useWorkspaceNotifications.ts
+++ b/ui/src/useWorkspaceNotifications.ts
@@ -40,8 +40,8 @@ export function useWorkspaceNotifications(workspaces: WorkspaceInfo[], activeRoo
       if (notified.current.has(workspace.root)) continue;
       notified.current.add(workspace.root);
       try {
-        new Notification(`${workspace.name} t'attend`, {
-          body: "L'agent a besoin d'une réponse pour continuer.",
+        new Notification(`${workspace.name} needs you`, {
+          body: "The agent needs an answer to continue.",
           // One notification per project, replaced rather than stacked if that
           // project asks again.
           tag: `pi-outpost:${workspace.root}`,


### PR DESCRIPTION
With one project open the header showed a bare `+` and nothing else. The user could not see which project they were in — the single most useful thing that control could tell them. Open a second and the interface changed shape: a named button with a state appeared where the `+` had been.

The reasoning behind it was "no selector where there is nothing to select". It mistakes what the control is for. **A selector's first job is to say where you are; choosing is its second.** With one project open only the first remains, and it was the one that had been dropped.

## What changed

- The server describes the bound project and lists the open ones on **every snapshot, without a threshold**. The snapshot is the only place a project's name and activity exist, so a client had nothing to name it with.
- `ProjectMenu` loses its single-project branch. One project is the general case with a list of one: the same button, in the same place, naming the project and its state; opening another moves into the menu beside it. No close button on the single row, because the server already refuses to close the last project.
- Nothing changes about *whether* a control appears: `workspaceLock` and the embed policy still decide that, and a pinned server still offers nothing.

## What review caught

`announceWorkspaceActivity()` returned early below two open projects, on the same grounds — no selector to feed. True until this change made one. Left alone, the new control would have shown the state it was born with and never heard it change: **"au repos" through an entire turn**, until a reconnect.

One sentence had justified two thresholds in two files. Removing one and not the other would have produced a control that lies quietly, which is worse than the `+` it replaced.

## The four assertions that had to flip

Each marks a place the old absence was observable, and none was weakened:

- `a single-project server offers no selector` — the decision itself. Now its opposite.
- two tests proved "nothing was added" by the *absence* of the list; they now prove it by its length, which is what they meant.
- one compared the two fields by identity, which passed only because both were `undefined`; it now compares their contents.

## Proof

`scenario-coverage.md`: **10/10 covered.** Driven in the bench — a single-project header named its project, and opening a second left the same `BUTTON` at the same 26px height with a menu one row longer. The widget on a single-project server still shows no control, confirming the fields are additive.

server 1,589 · UI 1,346 (coverage gate held) · Playwright 46 · typecheck · lint · `openspec validate --strict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198kLx3nUiNf1C14ZXHHsBm