### PR TITLE
Publish a prerelease off the default tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,11 +181,18 @@ jobs:
       # entry that stopped covering dist/, both land here and nowhere earlier.
       - run: npm run check:cli
 
-      # Le publish peut se faire en Node 24 sans problème
+      # Le publish peut se faire en Node 24 sans problème.
+      #
+      # The dist-tag comes from the version, never from an input: a release that
+      # reached `beta`, or a beta that reached `latest`, would both be one forgotten
+      # checkbox away. And `latest` is the tag the update check reads, so moving it
+      # onto a prerelease offers that prerelease to every existing installation.
       - name: Publish
         run: |
+          channel=$(node scripts/release-channel.mjs "${GITHUB_REF_NAME#v}")
+          echo "publishing to the $channel channel"
           for pkg in ${{ steps.plan.outputs.publish }}; do
-            npm publish --workspace "$pkg"
+            npm publish --workspace "$pkg" --tag "$channel"
           done
 
   # Attached after publish, from the artifacts the matrix already proved runnable.
@@ -196,6 +203,9 @@ jobs:
     permissions:
       contents: write
     steps:
+      # This job downloads artifacts and nothing else, so it had no working copy —
+      # and the rule deciding whether this tag is a prerelease lives in one.
+      - uses: actions/checkout@v5
       - uses: actions/download-artifact@v8
         with:
           path: executables
@@ -204,11 +214,26 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # The same derivation as the npm channel, from the same version. Two
+          # independent decisions about one version is how a release ends up
+          # published as a prerelease and displayed as the current one.
+          channel=$(node scripts/release-channel.mjs "${GITHUB_REF_NAME#v}")
+          prerelease=""
+          if [ "$channel" != "latest" ]; then prerelease="--prerelease"; fi
           if ! gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
             gh release create "$GITHUB_REF_NAME" \
               --verify-tag \
               --generate-notes \
+              $prerelease \
               --title "$GITHUB_REF_NAME" \
               --repo "$GITHUB_REPOSITORY"
+          fi
+          # This job is rerun to repair a release, and a rerun skips the create above —
+          # so the flag would never reach a release that already exists and is marked
+          # wrongly. Stated every time instead of only at creation.
+          if [ -n "$prerelease" ]; then
+            gh release edit "$GITHUB_REF_NAME" --prerelease --repo "$GITHUB_REPOSITORY"
+          else
+            gh release edit "$GITHUB_REF_NAME" --prerelease=false --latest --repo "$GITHUB_REPOSITORY"
           fi
           gh release upload "$GITHUB_REF_NAME" executables/* --clobber --repo "$GITHUB_REPOSITORY"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-outpost",
-  "version": "0.16.4",
+  "version": "0.17.0-beta.1",
   "type": "module",
   "description": "A web interface for the pi coding agent: a browser chat UI you run with npx — no clone, no build.",
   "license": "MIT",

--- a/embed/package.json
+++ b/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-outpost/embed",
-  "version": "0.16.4",
+  "version": "0.17.0-beta.1",
   "type": "module",
   "description": "Mount pi-outpost as a Shadow-DOM-isolated widget inside another web app.",
   "license": "MIT",

--- a/openspec/changes/publish-prereleases-off-the-default-tag/.openspec.yaml
+++ b/openspec/changes/publish-prereleases-off-the-default-tag/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-29

--- a/openspec/changes/publish-prereleases-off-the-default-tag/design.md
+++ b/openspec/changes/publish-prereleases-off-the-default-tag/design.md
@@ -1,0 +1,67 @@
+## Context
+
+See `proposal.md` for motivation and `specs/update/spec.md` for the contract.
+
+Two lines produce the current behaviour, both in `.github/workflows/release.yml`:
+
+```yaml
+npm publish --workspace "$pkg"        # no --tag, so npm moves `latest`
+gh release create "$GITHUB_REF_NAME"  # no --prerelease, so GitHub calls it the newest
+```
+
+The client side already does the right thing: `fetchLatestVersion` asks
+`${registry}/pi-outpost/latest`, so it reads the default dist-tag rather than the
+highest version number. Nothing there changes.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A prerelease reachable by name and invisible to an update check.
+- The choice made by the version string, not by a hand-set input.
+
+**Non-Goals:**
+
+- A prerelease channel in the update command — asking for one is `npm install
+  pi-outpost@beta`, which needs nothing from us.
+- Changing what a release does.
+- Deciding a release cadence, or what belongs in a prerelease.
+
+## Decisions
+
+### The dist-tag is derived from the version, and derived in a module
+
+A workflow input would let a release be published to `beta`, or a beta to `latest`, on
+the day someone leaves the box at its default. The version already says which it is —
+semver reserves the hyphen for exactly this — so the version is the input.
+
+It lives in a small module rather than an expression inside the YAML, because a rule
+embedded in a workflow can only be tested by matching strings against the workflow
+file, and that tests the text rather than the decision. A module can be given
+`0.17.0-beta.1` and asked what it answers.
+
+### The channel is the prerelease's own identifier
+
+`0.17.0-beta.1` publishes to `beta`, `0.18.0-rc.1` to `rc`. Hardcoding `beta` would
+put a release candidate on the beta channel, which is a lie told to whoever asked for
+one or the other.
+
+A prerelease with no identifier — `0.17.0-1`, which semver allows — has no name to
+use, and takes `next`: a channel that is not `latest`, which is the property that
+matters.
+
+### GitHub's flag comes from the same answer
+
+`--prerelease` is set from the same derivation, so the npm channel and the GitHub
+listing cannot disagree. Two independent decisions about the same version is how a
+release ends up published as a beta and displayed as the current one.
+
+## Risks / Trade-offs
+
+- [A version published to a channel nobody knows about is invisible] → It is announced
+  as a prerelease on the release page, which is where the executables already are.
+- [`latest` is never moved back by a prerelease, so a beta published after a release
+  stays behind it for anyone not asking] → That is the requirement, not a side effect.
+- [A workflow change is only exercised by tagging] → The decision is unit-tested, and
+  what remains untested is the two flags being passed, which the existing
+  workflow-shape test covers the way it covers the rest of that file.

--- a/openspec/changes/publish-prereleases-off-the-default-tag/proposal.md
+++ b/openspec/changes/publish-prereleases-off-the-default-tag/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+The release pipeline can only publish one way: `npm publish` with no tag, which moves
+`latest`, and `gh release create` with no flag, which marks the release as the newest.
+There is no way to put a version in front of a few people without putting it in front
+of everyone.
+
+That matters because the update check asks the registry for the `latest` dist-tag. A
+prerelease published the way this pipeline publishes would become what every existing
+installation is told to upgrade to.
+
+## What Changes
+
+- Publish a prerelease under its own npm dist-tag, derived from the version itself
+  rather than chosen at release time — `0.17.0-beta.1` goes to `beta`, and a release
+  version still goes to `latest`.
+- Mark a prerelease as such on GitHub, so the release page does not present it as the
+  current one.
+- Change nothing about a release version: same tag, same page, same executables.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `update`: the update check reads the registry's default tag, and nothing says what a
+  prerelease does to it. It gains the guarantee it depends on — a prerelease is not
+  what an installation is offered.
+
+## Impact
+
+- The release workflow's publish and release-creation steps.
+- A small module deciding the dist-tag from a version, so the rule is a tested function
+  rather than an expression inside a YAML file nobody can run.
+- No change to the client: the update check already asks for `latest`, which is exactly
+  the behaviour this preserves.

--- a/openspec/changes/publish-prereleases-off-the-default-tag/scenario-coverage.md
+++ b/openspec/changes/publish-prereleases-off-the-default-tag/scenario-coverage.md
@@ -1,0 +1,49 @@
+Every `#### Scenario:` in this change's delta, and what proves it. Built for task 4.1.
+Read the assertions, not the names: a scenario counts as **covered** only when the
+check would fail if the behaviour broke at the boundary the scenario describes.
+
+Files referenced:
+
+- `server/test/releaseChannel.test.mjs` (`ch`) — the rule itself, asked directly
+- `server/test/release-workflow.test.mjs` (`wf`) — that the pipeline uses that rule,
+  for both answers
+- `server/test/update.test.ts` (`upd`) — what the update check reads, unchanged here
+
+## update (5)
+
+| Scenario | Status | Evidence |
+| --- | --- | --- |
+| APrereleaseDoesNotMoveTheDefaultChannel | covered | ch "a prerelease never takes it" requires `channelFor` to return something other than `latest` for every prerelease shape, and wf requires the publish step to pass that channel as `--tag`. The other half is pre-existing and untouched: `fetchLatestVersion` asks `${registry}/pi-outpost/latest`, so a version that never reaches that tag is never offered |
+| AReleaseStillMovesIt | covered | ch "a release takes the default channel" over four release versions; wf proves the same derived value is what `--tag` receives, so a release publishes to `latest` exactly as before |
+| TheChannelComesFromTheVersion | covered | ch is the whole file — the answer is a function of the version and nothing else. wf "one derivation feeds both the npm channel and the release listing" requires the workflow to call that module in both jobs, and requires the publish step *not* to match the old tagless form |
+| APrereleaseIsListedAsOne | covered | wf requires `--prerelease` to be set from the same `$channel` and passed to `gh release create`, and requires the attach job to check out the module it runs — it previously had no working copy, so the rule would have been unreachable there |
+| AskingForItInstallsIt | covered | ch "a prerelease publishes under its own identifier" pins that `0.17.0-beta.1` → `beta`, which is the name `npm install pi-outpost@beta` resolves. Nothing in this repository implements that resolution: it is npm's, and what this change owes it is a channel with the name an operator would ask for |
+
+## Result
+
+All **5 scenarios are covered**. There are no partial or uncovered rows.
+
+## Two defects review caught, both on the guarantee itself
+
+- **A prerelease may name the default channel.** `1.2.3-latest.1` is a valid version
+  whose identifier *is* `latest`, and the rule returned it: the workflow would then
+  move npm's default tag and create an ordinary release. Not through a mistake — through
+  the front door, since the identifier is what becomes the channel. It is now refused,
+  loudly, which stops the job rather than the installations.
+- **A rerun could not correct a release already marked wrongly.** The attach job exists
+  partly to repair a release, and a repair skips the create — so a flag passed only at
+  creation would never reach it. The derived state is now stated on every run, in both
+  directions.
+
+## What is asserted here and what is not
+
+The rule is a module so that it can be asked rather than pattern-matched. Given
+`0.17.0-beta.1` it answers `beta`; given `v0.17.0` it throws rather than guessing,
+because guessing means treating it as a release and taking `latest` with it — the one
+mistake on this path that reaches every installation.
+
+What remains matched against the YAML is that the workflow *calls* it, in both places,
+and passes both flags. That is the same form the file's existing test already uses, and
+the part that only a real tag can exercise. The first prerelease is therefore also the
+proof: if `latest` moves, it moves visibly, and `npm dist-tag ls pi-outpost` says so
+before anyone's update check does.

--- a/openspec/changes/publish-prereleases-off-the-default-tag/specs/update/spec.md
+++ b/openspec/changes/publish-prereleases-off-the-default-tag/specs/update/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: PrereleasesAreNotWhatAnInstallationIsOffered
+
+A prerelease SHALL be published so that it does not become what an update check
+offers, and SHALL be marked as a prerelease wherever releases are listed. Which
+channel a version is published to SHALL be derived from the version itself, so that a
+release cannot reach the default channel by a prerelease's route, or the reverse,
+through anyone forgetting to say which it is.
+
+An operator SHALL be able to install a prerelease deliberately, by asking for it.
+
+#### Scenario: APrereleaseDoesNotMoveTheDefaultChannel
+- **GIVEN** a published prerelease newer than every release
+- **WHEN** an existing installation checks for an update
+- **THEN** it is told it is on the newest published version
+- **AND** the prerelease is not offered
+
+#### Scenario: AReleaseStillMovesIt
+- **GIVEN** a published release newer than every other
+- **WHEN** an existing installation checks for an update
+- **THEN** the release is offered
+
+#### Scenario: TheChannelComesFromTheVersion
+- **WHEN** a version is published
+- **THEN** the channel it goes to is decided by whether that version is a prerelease, not by a separate instruction that could disagree with it
+
+#### Scenario: APrereleaseIsListedAsOne
+- **WHEN** a prerelease is published
+- **THEN** it is marked as a prerelease where releases are listed, rather than shown as the current one
+
+#### Scenario: AskingForItInstallsIt
+- **GIVEN** a published prerelease
+- **WHEN** an operator asks for that channel by name
+- **THEN** the prerelease is what they install

--- a/openspec/changes/publish-prereleases-off-the-default-tag/tasks.md
+++ b/openspec/changes/publish-prereleases-off-the-default-tag/tasks.md
@@ -1,0 +1,17 @@
+## 1. The rule
+
+- [x] 1.1 Add a module that answers, for a version, whether it is a prerelease and which npm dist-tag it belongs to; verify unit tests cover a release, a beta, a release candidate, a prerelease with no identifier, and a version the module should refuse rather than guess at.
+
+## 2. The pipeline
+
+- [x] 2.1 Publish each package with the dist-tag that module returns; verify the workflow-shape test asserts the publish step passes a derived tag rather than none.
+- [x] 2.2 Create the GitHub release with `--prerelease` from the same answer; verify the workflow-shape test asserts both flags come from one derivation, so the npm channel and the release listing cannot disagree.
+
+## 3. The version being released
+
+- [x] 3.1 Set `cli` and `embed` to `0.17.0-beta.1`, the two packages the release job publishes; verify the packages agree with the tag that will be pushed, which is what the pipeline already refuses to publish without.
+
+## 4. Scenario coverage and validation
+
+- [x] 4.1 Enumerate every `#### Scenario:` in the delta and write the scenario-to-test matrix with assertion-level evidence, naming what would fail if each broke; leave no scenario partial or uncovered — `scenario-coverage.md`, 5/5 covered, and explicit about what only a real tag can exercise
+- [x] 4.2 Run the focused tests, then the relevant full suites and `openspec validate publish-prereleases-off-the-default-tag --strict` — typecheck passed; lint passed; `check:cli` passed against the bumped package; server 1,598 passed with nothing skipped; UI 1,346 passed; strict validation passed

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "cli": {
       "name": "pi-outpost",
-      "version": "0.16.4",
+      "version": "0.17.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "^0.84.3",
@@ -42,7 +42,7 @@
     },
     "embed": {
       "name": "@pi-outpost/embed",
-      "version": "0.16.4",
+      "version": "0.17.0-beta.1",
       "license": "MIT",
       "devDependencies": {
         "@microsoft/api-extractor": "^7.58.9",

--- a/scripts/release-channel.mjs
+++ b/scripts/release-channel.mjs
@@ -1,0 +1,69 @@
+/**
+ * Which channel a version belongs to.
+ *
+ * The release workflow publishes with `npm publish --tag <channel>` and creates the
+ * GitHub Release with or without `--prerelease`. Both answers come from here, from the
+ * version alone, so they cannot disagree: a version published to a prerelease channel
+ * and displayed as the current release is the failure this exists to prevent.
+ *
+ * Derived rather than configured. A workflow input would let a release go to `beta`,
+ * or a beta to `latest`, on the day someone leaves the box at its default — and moving
+ * `latest` to a prerelease is what makes every existing installation offer it, since
+ * the update check reads that tag and not the highest version number.
+ *
+ *   node scripts/release-channel.mjs 0.17.0-beta.1   # → beta
+ *   node scripts/release-channel.mjs 0.17.0          # → latest
+ */
+
+/** semver, reduced to the two things this has to tell apart. */
+const VERSION = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/;
+
+/** The channel a release goes to, and the only one an update check reads. */
+export const DEFAULT_CHANNEL = "latest";
+/** A prerelease whose identifier is only a number has no name to use; it takes this. */
+export const UNNAMED_PRERELEASE_CHANNEL = "next";
+
+export class VersionError extends Error {}
+
+/**
+ * The npm dist-tag for a version.
+ *
+ * A prerelease publishes under its own identifier — `beta`, `rc`, `alpha` — rather
+ * than a single hardcoded name: putting a release candidate on the beta channel is a
+ * lie told to whoever asked for one or the other.
+ *
+ * Refuses what it cannot read, and what it must not answer. A version this does not
+ * recognise would otherwise be treated as a release and take `latest` with it, which
+ * is the one mistake that reaches every installation — and a prerelease that *names*
+ * itself `latest` would reach it through the front door, since the identifier is what
+ * becomes the channel.
+ */
+export function channelFor(version) {
+  const match = VERSION.exec(String(version).trim());
+  if (!match) throw new VersionError(`not a version this can classify: "${version}"`);
+  const prerelease = match[4];
+  if (prerelease === undefined) return DEFAULT_CHANNEL;
+  const identifier = prerelease.split(".")[0];
+  if (identifier.toLowerCase() === DEFAULT_CHANNEL) {
+    throw new VersionError(
+      `"${version}" is a prerelease naming the default channel: publishing it would move "${DEFAULT_CHANNEL}" onto a prerelease`,
+    );
+  }
+  return /^\d+$/.test(identifier) ? UNNAMED_PRERELEASE_CHANNEL : identifier;
+}
+
+/** Whether this version is a prerelease, by the same reading. */
+export function isPrerelease(version) {
+  return channelFor(version) !== DEFAULT_CHANNEL;
+}
+
+// Called by the workflow: prints the channel, or fails loudly enough to stop the job.
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, "/").split("/").pop())) {
+  const version = process.argv[2];
+  try {
+    process.stdout.write(channelFor(version));
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exit(1);
+  }
+}

--- a/server/test/release-workflow.test.mjs
+++ b/server/test/release-workflow.test.mjs
@@ -27,3 +27,28 @@ test("EveryReleaseCarriesThem: a missing GitHub Release is created before assets
   assert.match(attachJob, /if ! gh release view[\s\S]+then[\s\S]+gh release create/);
   assert.match(attachJob, /gh release upload[^\n]+--clobber/);
 });
+
+// openlore: scenario=TheChannelComesFromTheVersion spec=update
+test("PrereleasesAreNotWhatAnInstallationIsOffered: one derivation feeds both the npm channel and the release listing", () => {
+  const publishJob = workflow.slice(workflow.indexOf("\n  publish:"), workflow.indexOf("\n  attach:"));
+  const attachJob = workflow.slice(workflow.indexOf("\n  attach:"));
+
+  // Publishing with no tag moves `latest`, which is the tag the update check reads —
+  // so a prerelease published that way is offered to every existing installation.
+  assert.doesNotMatch(publishJob, /npm publish --workspace "\$pkg"\s*$/m, "publishing with no dist-tag moves latest");
+  assert.match(publishJob, /npm publish --workspace "\$pkg" --tag "\$channel"/);
+  assert.match(publishJob, /channel=\$\(node scripts\/release-channel\.mjs/, "the channel must come from the version");
+
+  // openlore: scenario=APrereleaseIsListedAsOne spec=update
+  assert.match(attachJob, /channel=\$\(node scripts\/release-channel\.mjs/, "the same rule decides the listing");
+  assert.match(attachJob, /if \[ "\$channel" != "latest" \]; then prerelease="--prerelease"; fi/);
+  assert.match(attachJob, /gh release create[\s\S]{0,200}\$prerelease/);
+
+  // The rule lives in a working copy, and this job had none.
+  assert.match(attachJob, /actions\/checkout/, "the attach job must check out the rule it runs");
+
+  // A rerun repairs an existing release and skips the create, so a flag passed only
+  // at creation never reaches a release that is already marked wrongly.
+  assert.match(attachJob, /gh release edit "\$GITHUB_REF_NAME" --prerelease --repo/);
+  assert.match(attachJob, /gh release edit "\$GITHUB_REF_NAME" --prerelease=false --latest --repo/);
+});

--- a/server/test/releaseChannel.test.mjs
+++ b/server/test/releaseChannel.test.mjs
@@ -1,0 +1,76 @@
+/**
+ * Which channel a version publishes to.
+ *
+ * The whole point of this rule living in a module is that it can be asked. Inside the
+ * workflow it could only be checked by matching strings against a YAML file, which
+ * tests the text and not the decision — and the decision is the one that, made wrong,
+ * moves `latest` onto a prerelease and offers it to every existing installation.
+ */
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import {
+  DEFAULT_CHANNEL,
+  UNNAMED_PRERELEASE_CHANNEL,
+  VersionError,
+  channelFor,
+  isPrerelease,
+} from "../../scripts/release-channel.mjs";
+
+// openlore: scenario=TheChannelComesFromTheVersion spec=update
+describe("the channel comes from the version", () => {
+  test("a release takes the default channel", () => {
+    for (const version of ["0.17.0", "1.0.0", "0.16.4", "10.20.30"]) {
+      assert.equal(channelFor(version), DEFAULT_CHANNEL, version);
+      assert.equal(isPrerelease(version), false, version);
+    }
+  });
+
+  // openlore: scenario=APrereleaseDoesNotMoveTheDefaultChannel spec=update
+  test("a prerelease never takes it", () => {
+    for (const version of ["0.17.0-beta.1", "0.18.0-rc.2", "1.0.0-alpha", "0.17.0-1"]) {
+      assert.notEqual(channelFor(version), DEFAULT_CHANNEL, version);
+      assert.equal(isPrerelease(version), true, version);
+    }
+  });
+
+  test("a prerelease publishes under its own identifier, not one name for all of them", () => {
+    // A release candidate on the beta channel is a lie told to whoever asked for one
+    // or the other.
+    assert.equal(channelFor("0.17.0-beta.1"), "beta");
+    assert.equal(channelFor("0.18.0-rc.2"), "rc");
+    assert.equal(channelFor("1.0.0-alpha.3"), "alpha");
+    assert.equal(channelFor("1.0.0-alpha"), "alpha");
+  });
+
+  test("a prerelease with only a number has no name to use, and takes one that is not the default", () => {
+    assert.equal(channelFor("0.17.0-1"), UNNAMED_PRERELEASE_CHANNEL);
+    assert.notEqual(UNNAMED_PRERELEASE_CHANNEL, DEFAULT_CHANNEL);
+  });
+
+  test("build metadata is not a prerelease", () => {
+    // `+sha` says how it was built, never that it is unfinished.
+    assert.equal(channelFor("0.17.0+abc123"), DEFAULT_CHANNEL);
+    assert.equal(channelFor("0.17.0-beta.1+abc123"), "beta");
+  });
+
+  test("what it cannot read, it refuses rather than guesses", () => {
+    // Guessing means treating it as a release, which takes `latest` with it — the one
+    // mistake here that reaches every installation.
+    for (const bad of ["v0.17.0", "0.17", "", "latest", "0.17.0.1", "beta"]) {
+      assert.throws(() => channelFor(bad), VersionError, `"${bad}" should be refused`);
+    }
+  });
+
+  test("a prerelease may not name the default channel", () => {
+    // `1.2.3-latest.1` is a valid version whose identifier is the one name that must
+    // never be answered: it would move the tag every update check reads, through the
+    // front door rather than by a mistake.
+    for (const named of ["1.2.3-latest.1", "1.2.3-latest", "1.2.3-LATEST.2"]) {
+      assert.throws(() => channelFor(named), VersionError, named);
+    }
+  });
+
+  test("the version the release is being cut at goes where it should", () => {
+    assert.equal(channelFor("0.17.0-beta.1"), "beta");
+  });
+});


### PR DESCRIPTION
Prepares the `0.17.0-beta.1` release. The pipeline could only publish one way: `npm publish` with no tag, which moves `latest`, and `gh release create` with no flag, which marks the release as the newest.

`latest` is the tag the update check reads (`fetchLatestVersion` asks `${registry}/pi-outpost/latest`), so **a prerelease published that way is offered to every existing installation**.

## What changed

The channel comes from the version, in a module rather than an expression inside the YAML:

```
node scripts/release-channel.mjs 0.17.0-beta.1   # → beta
node scripts/release-channel.mjs 0.17.0          # → latest
node scripts/release-channel.mjs 0.18.0-rc.2     # → rc
```

**Derived, not configured** — a workflow input would let a release reach `beta`, or a beta reach `latest`, on the day someone leaves the box at its default. And **its own identifier**, not one hardcoded name: putting a release candidate on the beta channel is a lie told to whoever asked for either.

`--prerelease` for the GitHub Release comes from the same answer, so the npm channel and the release listing cannot disagree. The attach job gains a checkout — it had no working copy to run the rule from.

It lives in a module so it can be *asked*, not pattern-matched: a rule inside a workflow can only be tested by matching strings against the workflow file, which tests the text rather than the decision.

## Two defects review caught, both on the guarantee itself

- **`1.2.3-latest.1`** is a valid version whose prerelease identifier *is* `latest`. The rule returned it, so the workflow would have moved npm's default tag and created an ordinary release — not through a mistake, through the front door. Refused now, loudly, which stops the job rather than the installations.
- **A rerun could not correct a release already marked wrongly.** The attach job exists partly to repair a release, and a repair skips the create, so a flag passed only at creation never reached it. The derived state is stated on every run, in both directions.

## Proof

`scenario-coverage.md`: **5/5 covered**, and explicit about what only a real tag can exercise — the first prerelease is also the proof, and `npm dist-tag ls pi-outpost` says so before anyone's update check does.

Sets `cli` and `embed` to `0.17.0-beta.1`, which is what the tag will claim; the pipeline already refuses to publish a tag its packages disagree with.

server 1,598 · UI 1,346 · typecheck · lint · `check:cli` against the bumped package · `openspec validate --strict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198kLx3nUiNf1C14ZXHHsBm