### PR TITLE
Split the multi-project suite before it takes a release

### DIFF
--- a/server/test/multiProjectHarness.mjs
+++ b/server/test/multiProjectHarness.mjs
@@ -1,0 +1,86 @@
+/**
+ * What both multi-project suites need: a scriptable RPC server, a second project,
+ * and the session seeding that makes one project's history distinguishable from
+ * another's.
+ *
+ * Extracted when the single file crossed the per-file test timeout on a loaded
+ * runner — 26 tests, each starting a real server. Two files get two budgets, and
+ * the runner executes them in parallel, so the wall clock falls as well.
+ */
+import assert from "node:assert/strict";
+import { readFile, realpath, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
+import { connect, makeWorkspace, startServer } from "./harness.mjs";
+
+/**
+ * Seed a saved session for one project in the store the server reads.
+ *
+ * Both projects' sessions live in the SAME store — the server's agent directory —
+ * and are told apart by the cwd recorded in them. That is precisely what makes
+ * the scoping worth testing: the filter is the only thing keeping one project's
+ * conversations out of another's list.
+ */
+export function seedSession(cwd, sessionsDir, exchanges) {
+  const manager = SessionManager.create(cwd, sessionsDir);
+  for (const [role, text] of exchanges) manager.appendMessage({ role, content: [{ type: "text", text }] });
+  return manager.getSessionFile();
+}
+
+/** Where the harness puts the agent directory: sessions for every project land here. */
+export const sessionsDirOf = (serverRoot) => path.join(serverRoot, ".pi-agent", "sessions");
+
+/** A scriptable stand-in for `pi --mode rpc`, so a turn can actually stream here. */
+export const FAKE = fileURLToPath(new URL("./fixtures/fake-pi-rpc.mjs", import.meta.url));
+
+/**
+ * A server whose workspaces each run a scripted agent.
+ *
+ * One script serves both children — which is what the isolation tests need:
+ * the two projects behave identically, so anything that tells them apart is the
+ * routing under test rather than the fixture.
+ */
+export async function startScriptedServer(root, openProjects, script, extraConfig = {}) {
+  const fakeConfig = path.join(root, "fake-rpc.json");
+  await writeFile(fakeConfig, JSON.stringify(script));
+  return startServer(
+    root,
+    {
+      openProjects,
+      ...extraConfig,
+      // A sandbox cannot be enforced on a child that builds its own tools, so the
+      // pairing is refused at config load — see config.ts. Each workspace is still
+      // rooted at its own directory, which is what the browser confinement below
+      // actually rides on.
+      sandbox: undefined,
+      agentRuntime: { mode: "rpc", executable: process.execPath, args: [FAKE], startupTimeoutMs: 10_000 },
+    },
+    { env: { FAKE_PI_RPC_CONFIG: fakeConfig } },
+  );
+}
+
+/**
+ * The NEXT frame of a type, not the first one already received.
+ *
+ * `waitFor` scans what has arrived as well as what is coming, so asking for
+ * `sessions` twice hands back the first answer both times — which quietly turns
+ * a scoping assertion into a re-read of the listing it was meant to contrast with.
+ */
+export function next(client, predicate) {
+  const seen = client.received.filter(predicate).length;
+  return client.waitFor((m) => predicate(m) && client.received.filter(predicate).length > seen);
+}
+
+/** A second project directory, alongside the server's own. */
+export async function secondProject(name = "beta") {
+  // Resolved: the server reports realpath'd roots (on macOS /var/… is a link to
+  // /private/var/…), and a client must address a project by the root the server
+  // gave it rather than one it built itself.
+  return realpath(await makeWorkspace({ [`${name}.md`]: `# ${name}\n` }));
+}
+
+/** Long enough for at least two sweeps at the configured timeout. */
+export const RETIREMENT_TIMEOUT_MS = 2_000;
+export const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));

--- a/server/test/multiProjectLifecycle.test.mjs
+++ b/server/test/multiProjectLifecycle.test.mjs
@@ -1,0 +1,360 @@
+/**
+ * The life of a project: opened, listed, persisted, retired, closed, refused.
+ *
+ * Everything here is about the *set* of open projects and what the server does to it —
+ * the counterpart to `multiProjectWorkspaces.test.mjs`, which is about what a single
+ * connection sees once that set exists.
+ */
+
+import assert from "node:assert/strict";
+import { readFile, realpath, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { connect, makeWorkspace, startServer } from "./harness.mjs";
+import {
+  RETIREMENT_TIMEOUT_MS,
+  next,
+  secondProject,
+  seedSession,
+  sessionsDirOf,
+  startScriptedServer,
+  wait,
+} from "./multiProjectHarness.mjs";
+
+test("a persisted project is listed but has no session until it is opened", async (t) => {
+  const beta = await secondProject();
+  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
+  const server = await startServer(root, { openProjects: [beta] });
+  t.after(() => server.stop());
+
+  const client = connect(server.wsUrl());
+  t.after(() => client.close());
+  const hello = await client.waitFor((m) => m.type === "hello");
+
+  assert.equal(hello.workspaces.length, 2, "both projects are listed");
+  const restored = hello.workspaces.find((w) => w.root === beta);
+  // Startup must not grow with the number of open projects: the session is built
+  // on first use, not at boot.
+  assert.equal(restored.activity, "stopped", "the restored project has no session yet");
+  assert.equal(hello.workspace.root, root, "the connection is bound to the server's own project");
+});
+
+test("closing a project is refused while its agent is streaming", async (t) => {
+  const beta = await secondProject();
+  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
+  const server = await startScriptedServer(root, [beta], {
+    state: { sessionId: "scripted", isStreaming: false },
+    commands_: { prompt: { after: [{ type: "agent_start" }] } },
+  });
+  t.after(() => server.stop());
+
+  const client = connect(server.wsUrl());
+  t.after(() => client.close());
+  await client.waitFor((m) => m.type === "hello");
+
+  client.send({ type: "switch_workspace", root: beta });
+  await client.waitFor((m) => m.type === "workspace_switched");
+  client.send({ type: "prompt", text: "go" });
+  await client.waitFor((m) => m.type === "agent_start" || m.type === "streaming");
+
+  // Refused rather than queued: cancelling someone's work to satisfy a close is
+  // worse than asking them to stop it first.
+  client.send({ type: "close_project", root: beta });
+  const refused = await client.waitFor((m) => m.type === "workspace_error");
+  assert.match(refused.message, /working/i);
+
+  // And the workspace is still there, still running.
+  const second = connect(server.wsUrl());
+  t.after(() => second.close());
+  const hello = await second.waitFor((m) => m.type === "hello");
+  assert.ok(hello.workspaces.some((w) => w.root === beta), "the project was not closed");
+});
+
+test("an unwatched project is retired, stays listed, and comes back with its history", async (t) => {
+  const beta = await secondProject();
+  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
+  const server = await startServer(root, { openProjects: [beta], workspaceIdleTimeoutMs: RETIREMENT_TIMEOUT_MS });
+  t.after(() => server.stop());
+
+  const client = connect(server.wsUrl());
+  t.after(() => client.close());
+  await client.waitFor((m) => m.type === "hello");
+
+  client.send({ type: "switch_workspace", root: beta });
+  const started = await client.waitFor((m) => m.type === "workspace_switched");
+  const sessionId = started.sessionId;
+
+  // Nobody is watching beta any more: the idle clock starts when the last client
+  // leaves it, not at the next sweep.
+  client.send({ type: "switch_workspace", root });
+  await client.waitFor((m) => m.type === "workspace_switched" && m.workspace.root === root);
+  await wait(RETIREMENT_TIMEOUT_MS * 3);
+
+  const retired = await client.waitFor(
+    (m) => m.type === "workspace_activity" && m.workspaces.some((w) => w.root === beta && w.activity === "stopped"),
+  );
+  // Retiring is not closing: the project is still open, it simply holds no session.
+  assert.ok(retired.workspaces.some((w) => w.root === beta), "the retired project is still listed as open");
+
+  client.send({ type: "switch_workspace", root: beta });
+  const rebuilt = await client.waitFor((m) => m.type === "workspace_switched" && m.workspace.root === beta);
+  assert.equal(rebuilt.sessionId, sessionId, "the rebuilt workspace resumes the session it was retired with");
+});
+
+test("a project whose agent is streaming outlives any idle period", async (t) => {
+  const beta = await secondProject();
+  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
+  const server = await startScriptedServer(
+    root,
+    [beta],
+    {
+      state: { sessionId: "scripted", isStreaming: false },
+      commands_: { prompt: { after: [{ type: "agent_start" }] } },
+    },
+    { workspaceIdleTimeoutMs: RETIREMENT_TIMEOUT_MS },
+  );
+  t.after(() => server.stop());
+
+  const client = connect(server.wsUrl());
+  t.after(() => client.close());
+  await client.waitFor((m) => m.type === "hello");
+
+  client.send({ type: "switch_workspace", root: beta });
+  await client.waitFor((m) => m.type === "workspace_switched" && m.workspace.root === beta);
+  client.send({ type: "prompt", text: "a long one" });
+  await client.waitFor((m) => m.type === "agent_start" || m.type === "streaming");
+
+  // Left alone with the turn still running, well past the timeout. This is the
+  // line that makes "unused" mean unused rather than unwatched.
+  client.send({ type: "switch_workspace", root });
+  await client.waitFor((m) => m.type === "workspace_switched" && m.workspace.root === root);
+  await wait(RETIREMENT_TIMEOUT_MS * 3);
+
+  const second = connect(server.wsUrl());
+  t.after(() => second.close());
+  const hello = await second.waitFor((m) => m.type === "hello");
+  assert.equal(hello.workspaces.find((w) => w.root === beta).activity, "working", "the turn kept its project alive");
+});
+
+test("closing a project releases it, moves whoever was watching, and leaves its history on disk", async (t) => {
+  const beta = await secondProject();
+  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
+  // A conversation worth losing: the point of the close is that it does not.
+  const betaSession = seedSession(beta, sessionsDirOf(root), [
+    ["user", "what did we decide?"],
+    ["assistant", "we decided to keep it."],
+  ]);
+  const server = await startServer(root, { openProjects: [beta] });
+  t.after(() => server.stop());
+
+  const client = connect(server.wsUrl());
+  t.after(() => client.close());
+  await client.waitFor((m) => m.type === "hello");
+
+  client.send({ type: "switch_workspace", root: beta });
+  await client.waitFor((m) => m.type === "workspace_switched" && m.workspace?.root === beta);
+
+  client.send({ type: "close_project", root: beta });
+  // Bound to the project that just went: a client left there would reach a
+  // workspace with no runtime on its next message. Back down to one project the
+  // snapshot advertises none at all, which is the single-project rule.
+  const moved = await next(client, (m) => m.type === "workspace_switched");
+  assert.ok(!moved.workspaces || !moved.workspaces.some((w) => w.root === beta), "the project is no longer listed");
+
+  // Closing is not deleting. A new session is fair — the workspace was stopped,
+  // not suspended — but what was said in that project has to still be there.
+  client.send({ type: "open_project", root: beta });
+  await next(client, (m) => m.type === "workspace_switched" && m.workspace?.root === beta);
+  client.send({ type: "list_sessions" });
+  const reopened = await next(client, (m) => m.type === "sessions");
+  assert.ok(reopened.sessions.some((session) => session.path === betaSession), "the earlier conversation survived the close");
+});
+
+test("the open set is written before the project is opened, and survives a restart", async (t) => {
+  const beta = await secondProject();
+  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
+  const server = await startServer(root);
+  t.after(() => server.stop());
+
+  const client = connect(server.wsUrl());
+  t.after(() => client.close());
+  await client.waitFor((m) => m.type === "hello");
+
+  client.send({ type: "open_project", root: beta });
+  await client.waitFor((m) => m.type === "workspace_switched" && m.workspace.root === beta);
+
+  // Persistence is the server's own doing, not something hand-authored: a project
+  // the user watched appear has to still be there at the next start.
+  const persisted = JSON.parse(await readFile(server.configFile, "utf8"));
+  assert.ok(persisted.openProjects.includes(beta), `the config records ${beta}, got ${JSON.stringify(persisted.openProjects)}`);
+
+  const restarted = await startServer(await realpath(await makeWorkspace({ "a.md": "alpha\n" })), {
+    openProjects: persisted.openProjects,
+  });
+  t.after(() => restarted.stop());
+  const afterRestart = connect(restarted.wsUrl());
+  t.after(() => afterRestart.close());
+  const hello = await afterRestart.waitFor((m) => m.type === "hello");
+  assert.ok(hello.workspaces.some((w) => w.root === beta), "the project is open again after a restart");
+});
+
+test("a project opened with no settings of its own inherits the server's sandbox", async (t) => {
+  const beta = await secondProject();
+  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
+  // Read-only server. The inherited settings are rooted at the new project, but
+  // everything else about them — writing off, in particular — comes along: a
+  // project opened through the picker must not be a way around the sandbox.
+  const server = await startServer(root, {
+    openProjects: [beta],
+    sandbox: { root, allowWrite: false, allowBash: false },
+  });
+  t.after(() => server.stop());
+
+  const client = connect(server.wsUrl());
+  t.after(() => client.close());
+  await client.waitFor((m) => m.type === "hello");
+
+  client.send({ type: "switch_workspace", root: beta });
+  await client.waitFor((m) => m.type === "workspace_switched" && m.workspace?.root === beta);
+
+  client.send({ type: "write_file", path: "beta.md", content: "rewritten\n", expectedMtimeMs: 0, force: true, requestId: "write:beta" });
+  const refused = await client.waitFor((m) => m.requestId === "write:beta");
+  assert.equal(refused.type, "file_browser_error", "writing in the new project is refused, as it is in the first");
+
+  // Rooted at ITS OWN directory, though: the read is served, and it is beta's file.
+  client.send({ type: "read_file", path: "beta.md", requestId: "read:beta" });
+  const read = await client.waitFor((m) => m.requestId === "read:beta");
+  assert.equal(read.type, "file_content", "the project is sandboxed at its own root, not the server's");
+});
+
+test("a client that leaves while its project is starting does not keep it alive", async (t) => {
+  const beta = await secondProject();
+  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
+  const server = await startServer(root, { openProjects: [beta], workspaceIdleTimeoutMs: RETIREMENT_TIMEOUT_MS });
+  t.after(() => server.stop());
+
+  // Bound by name to a project with no session yet, then gone before it is built.
+  // The close handler has already forgotten this socket by the time the build
+  // finishes; a bind that ran anyway would leave a dead client watching beta, and
+  // a workspace nobody is looking at would count as watched forever.
+  const leaving = connect(`${server.wsUrl()}?workspace=${encodeURIComponent(beta)}`);
+  // Open first — closing a socket mid-handshake is a different race, and not the
+  // one this is about — then leave immediately, while the session is still being
+  // built behind the upgrade.
+  await leaving.open();
+  leaving.close();
+
+  const client = connect(server.wsUrl());
+  t.after(() => client.close());
+  await client.waitFor((m) => m.type === "hello");
+  await wait(RETIREMENT_TIMEOUT_MS * 3);
+
+  const retired = await client.waitFor(
+    (m) => m.type === "workspace_activity" && m.workspaces.some((w) => w.root === beta && w.activity === "stopped"),
+    20_000,
+  );
+  assert.ok(retired, "the project the departed client started was retired");
+});
+
+test("the last project cannot be closed", async (t) => {
+  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
+  const server = await startServer(root);
+  t.after(() => server.stop());
+
+  const client = connect(server.wsUrl());
+  t.after(() => client.close());
+  await client.waitFor((m) => m.type === "hello");
+
+  client.send({ type: "close_project", root });
+  const error = await client.waitFor((m) => m.type === "workspace_error");
+  assert.match(error.message, /last open project/i);
+});
+
+test("a pinned server refuses to open, close or switch", async (t) => {
+  const beta = await secondProject();
+  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
+  const server = await startServer(root, { openProjects: [beta], workspaceLock: true });
+  t.after(() => server.stop());
+
+  const client = connect(server.wsUrl());
+  t.after(() => client.close());
+  const hello = await client.waitFor((m) => m.type === "hello");
+  assert.equal(hello.workspaceLocked, true, "the client is told, so it can hide the affordance");
+
+  client.send({ type: "switch_workspace", root: beta });
+  const refusedSwitch = await client.waitFor((m) => m.type === "workspace_error");
+  assert.match(refusedSwitch.message, /pinned/i);
+
+  client.send({ type: "open_project", root: beta });
+  const refusedOpen = await client.waitFor(
+    (m) => m.type === "workspace_error" && m !== refusedSwitch,
+  );
+  assert.match(refusedOpen.message, /pinned/i);
+});
+
+test("opening an unreadable path fails and opens nothing", async (t) => {
+  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
+  const server = await startServer(root);
+  t.after(() => server.stop());
+
+  const client = connect(server.wsUrl());
+  t.after(() => client.close());
+  await client.waitFor((m) => m.type === "hello");
+
+  client.send({ type: "open_project", root: path.join(root, "does-not-exist") });
+  const error = await client.waitFor((m) => m.type === "workspace_error");
+  assert.match(error.message, /cannot open/i);
+
+  // Nothing was added: the set is still one project long.
+  client.send({ type: "list_sessions" });
+  await client.waitFor((m) => m.type === "sessions");
+  const second = connect(server.wsUrl());
+  t.after(() => second.close());
+  const hello = await second.waitFor((m) => m.type === "hello");
+  // The set is still one long. Asserted on the list rather than on its absence:
+  // the snapshot now always carries it, so "nothing was added" is a length.
+  assert.deepEqual(hello.workspaces.map((w) => w.root), [root], "still a single-project server");
+});
+
+test("opening a directory that is already open reuses it", async (t) => {
+  const beta = await secondProject();
+  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
+  const server = await startServer(root, { openProjects: [beta] });
+  t.after(() => server.stop());
+
+  const client = connect(server.wsUrl());
+  t.after(() => client.close());
+  const hello = await client.waitFor((m) => m.type === "hello");
+
+  client.send({ type: "open_project", root: beta });
+  const switched = await client.waitFor((m) => m.type === "workspace_switched");
+
+  assert.equal(switched.workspace.root, beta);
+  // Two workspaces on one root would be two writers on one session store.
+  assert.equal(switched.workspaces.length, hello.workspaces.length, "no duplicate project");
+});
+
+test("a persisted set that cannot be written leaves the server untouched", async (t) => {
+  const beta = await secondProject();
+  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
+  const server = await startServer(root);
+  t.after(() => server.stop());
+
+  const client = connect(server.wsUrl());
+  t.after(() => client.close());
+  await client.waitFor((m) => m.type === "hello");
+
+  // Persist-first is the rule: a set that cannot be saved must not be applied.
+  // Removing the configured source is deterministic on every platform and makes
+  // the persistence transaction fail before it can produce a replacement file.
+  await unlink(server.configFile);
+
+  client.send({ type: "open_project", root: beta });
+  const error = await client.waitFor((m) => m.type === "workspace_error");
+  assert.match(error.message, /cannot read|cannot save|could not save/i);
+
+  const second = connect(server.wsUrl());
+  t.after(() => second.close());
+  const hello = await second.waitFor((m) => m.type === "hello");
+  assert.deepEqual(hello.workspaces.map((w) => w.root), [root], "the project was not opened");
+});

--- a/server/test/multiProjectWorkspaces.test.mjs
+++ b/server/test/multiProjectWorkspaces.test.mjs
@@ -1,88 +1,30 @@
 /**
- * Multi-project workspaces, over the real server and the real WebSocket.
+ * What one connection sees, over the real server and the real WebSocket.
  *
- * These check the boundaries that the feature is only worth having if it holds:
- * a project's sessions belong to that project, a client watching one hears about
- * the others' activity but not their content, the last project cannot be closed,
- * and a persisted set that cannot be written leaves the server untouched.
+ * A project's sessions belong to that project, a client watching one hears about the
+ * others' activity but not their content, and a file, a session or a tool call cannot
+ * cross from one project into another.
  *
- * Everything here is scoped to what a single test process can prove. Whether the
- * switch *looks* right — the cross-fade, the badge, the draft — is the bench's
- * job, not this file's.
+ * The lifecycle of a project — opening it, closing it, persisting the set, retiring
+ * it, pinning the server — lives in `multiProjectLifecycle.test.mjs`. Split because
+ * one file of 26 tests, each starting a real server, crossed the per-file timeout on
+ * a loaded runner and took a release with it.
  */
+
 import assert from "node:assert/strict";
 import { readFile, realpath, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import test from "node:test";
-import { SessionManager } from "@earendil-works/pi-coding-agent";
 import { connect, makeWorkspace, startServer } from "./harness.mjs";
-
-/**
- * Seed a saved session for one project in the store the server reads.
- *
- * Both projects' sessions live in the SAME store — the server's agent directory —
- * and are told apart by the cwd recorded in them. That is precisely what makes
- * the scoping worth testing: the filter is the only thing keeping one project's
- * conversations out of another's list.
- */
-function seedSession(cwd, sessionsDir, exchanges) {
-  const manager = SessionManager.create(cwd, sessionsDir);
-  for (const [role, text] of exchanges) manager.appendMessage({ role, content: [{ type: "text", text }] });
-  return manager.getSessionFile();
-}
-
-/** Where the harness puts the agent directory: sessions for every project land here. */
-const sessionsDirOf = (serverRoot) => path.join(serverRoot, ".pi-agent", "sessions");
-
-/** A scriptable stand-in for `pi --mode rpc`, so a turn can actually stream here. */
-const FAKE = fileURLToPath(new URL("./fixtures/fake-pi-rpc.mjs", import.meta.url));
-
-/**
- * A server whose workspaces each run a scripted agent.
- *
- * One script serves both children — which is what the isolation tests need:
- * the two projects behave identically, so anything that tells them apart is the
- * routing under test rather than the fixture.
- */
-async function startScriptedServer(root, openProjects, script, extraConfig = {}) {
-  const fakeConfig = path.join(root, "fake-rpc.json");
-  await writeFile(fakeConfig, JSON.stringify(script));
-  return startServer(
-    root,
-    {
-      openProjects,
-      ...extraConfig,
-      // A sandbox cannot be enforced on a child that builds its own tools, so the
-      // pairing is refused at config load — see config.ts. Each workspace is still
-      // rooted at its own directory, which is what the browser confinement below
-      // actually rides on.
-      sandbox: undefined,
-      agentRuntime: { mode: "rpc", executable: process.execPath, args: [FAKE], startupTimeoutMs: 10_000 },
-    },
-    { env: { FAKE_PI_RPC_CONFIG: fakeConfig } },
-  );
-}
-
-/**
- * The NEXT frame of a type, not the first one already received.
- *
- * `waitFor` scans what has arrived as well as what is coming, so asking for
- * `sessions` twice hands back the first answer both times — which quietly turns
- * a scoping assertion into a re-read of the listing it was meant to contrast with.
- */
-function next(client, predicate) {
-  const seen = client.received.filter(predicate).length;
-  return client.waitFor((m) => predicate(m) && client.received.filter(predicate).length > seen);
-}
-
-/** A second project directory, alongside the server's own. */
-async function secondProject(name = "beta") {
-  // Resolved: the server reports realpath'd roots (on macOS /var/… is a link to
-  // /private/var/…), and a client must address a project by the root the server
-  // gave it rather than one it built itself.
-  return realpath(await makeWorkspace({ [`${name}.md`]: `# ${name}\n` }));
-}
+import {
+  RETIREMENT_TIMEOUT_MS,
+  next,
+  secondProject,
+  seedSession,
+  sessionsDirOf,
+  startScriptedServer,
+  wait,
+} from "./multiProjectHarness.mjs";
 
 // openlore: scenario=ASingleProjectIsStillDescribed spec=api
 test("a single-project server still says which project it is serving", async (t) => {
@@ -105,24 +47,6 @@ test("a single-project server still says which project it is serving", async (t)
   );
   assert.ok(hello.workspace.name, "a project the interface can name");
   assert.ok(hello.workspace.activity, "with the state the control shows beside it");
-});
-
-test("a persisted project is listed but has no session until it is opened", async (t) => {
-  const beta = await secondProject();
-  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
-  const server = await startServer(root, { openProjects: [beta] });
-  t.after(() => server.stop());
-
-  const client = connect(server.wsUrl());
-  t.after(() => client.close());
-  const hello = await client.waitFor((m) => m.type === "hello");
-
-  assert.equal(hello.workspaces.length, 2, "both projects are listed");
-  const restored = hello.workspaces.find((w) => w.root === beta);
-  // Startup must not grow with the number of open projects: the session is built
-  // on first use, not at boot.
-  assert.equal(restored.activity, "stopped", "the restored project has no session yet");
-  assert.equal(hello.workspace.root, root, "the connection is bound to the server's own project");
 });
 
 test("switching builds the other project's session and keeps its history apart", async (t) => {
@@ -266,37 +190,6 @@ test("a streaming turn reaches its own project's clients and no others", async (
   );
 });
 
-test("closing a project is refused while its agent is streaming", async (t) => {
-  const beta = await secondProject();
-  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
-  const server = await startScriptedServer(root, [beta], {
-    state: { sessionId: "scripted", isStreaming: false },
-    commands_: { prompt: { after: [{ type: "agent_start" }] } },
-  });
-  t.after(() => server.stop());
-
-  const client = connect(server.wsUrl());
-  t.after(() => client.close());
-  await client.waitFor((m) => m.type === "hello");
-
-  client.send({ type: "switch_workspace", root: beta });
-  await client.waitFor((m) => m.type === "workspace_switched");
-  client.send({ type: "prompt", text: "go" });
-  await client.waitFor((m) => m.type === "agent_start" || m.type === "streaming");
-
-  // Refused rather than queued: cancelling someone's work to satisfy a close is
-  // worse than asking them to stop it first.
-  client.send({ type: "close_project", root: beta });
-  const refused = await client.waitFor((m) => m.type === "workspace_error");
-  assert.match(refused.message, /working/i);
-
-  // And the workspace is still there, still running.
-  const second = connect(server.wsUrl());
-  t.after(() => second.close());
-  const hello = await second.waitFor((m) => m.type === "hello");
-  assert.ok(hello.workspaces.some((w) => w.root === beta), "the project was not closed");
-});
-
 test("a connection cannot read a file belonging to another project", async (t) => {
   const beta = await realpath(await makeWorkspace({ "secret.md": "beta's own\n" }));
   const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
@@ -323,76 +216,6 @@ test("a connection cannot read a file belonging to another project", async (t) =
   client.send({ type: "read_file", path: "secret.md", requestId: "read:own" });
   const own = await client.waitFor((m) => m.requestId === "read:own");
   assert.equal(own.type, "file_content", "its own project's file is readable");
-});
-
-/** Long enough for at least two sweeps at the configured timeout. */
-const RETIREMENT_TIMEOUT_MS = 2_000;
-const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-
-test("an unwatched project is retired, stays listed, and comes back with its history", async (t) => {
-  const beta = await secondProject();
-  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
-  const server = await startServer(root, { openProjects: [beta], workspaceIdleTimeoutMs: RETIREMENT_TIMEOUT_MS });
-  t.after(() => server.stop());
-
-  const client = connect(server.wsUrl());
-  t.after(() => client.close());
-  await client.waitFor((m) => m.type === "hello");
-
-  client.send({ type: "switch_workspace", root: beta });
-  const started = await client.waitFor((m) => m.type === "workspace_switched");
-  const sessionId = started.sessionId;
-
-  // Nobody is watching beta any more: the idle clock starts when the last client
-  // leaves it, not at the next sweep.
-  client.send({ type: "switch_workspace", root });
-  await client.waitFor((m) => m.type === "workspace_switched" && m.workspace.root === root);
-  await wait(RETIREMENT_TIMEOUT_MS * 3);
-
-  const retired = await client.waitFor(
-    (m) => m.type === "workspace_activity" && m.workspaces.some((w) => w.root === beta && w.activity === "stopped"),
-  );
-  // Retiring is not closing: the project is still open, it simply holds no session.
-  assert.ok(retired.workspaces.some((w) => w.root === beta), "the retired project is still listed as open");
-
-  client.send({ type: "switch_workspace", root: beta });
-  const rebuilt = await client.waitFor((m) => m.type === "workspace_switched" && m.workspace.root === beta);
-  assert.equal(rebuilt.sessionId, sessionId, "the rebuilt workspace resumes the session it was retired with");
-});
-
-test("a project whose agent is streaming outlives any idle period", async (t) => {
-  const beta = await secondProject();
-  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
-  const server = await startScriptedServer(
-    root,
-    [beta],
-    {
-      state: { sessionId: "scripted", isStreaming: false },
-      commands_: { prompt: { after: [{ type: "agent_start" }] } },
-    },
-    { workspaceIdleTimeoutMs: RETIREMENT_TIMEOUT_MS },
-  );
-  t.after(() => server.stop());
-
-  const client = connect(server.wsUrl());
-  t.after(() => client.close());
-  await client.waitFor((m) => m.type === "hello");
-
-  client.send({ type: "switch_workspace", root: beta });
-  await client.waitFor((m) => m.type === "workspace_switched" && m.workspace.root === beta);
-  client.send({ type: "prompt", text: "a long one" });
-  await client.waitFor((m) => m.type === "agent_start" || m.type === "streaming");
-
-  // Left alone with the turn still running, well past the timeout. This is the
-  // line that makes "unused" mean unused rather than unwatched.
-  client.send({ type: "switch_workspace", root });
-  await client.waitFor((m) => m.type === "workspace_switched" && m.workspace.root === root);
-  await wait(RETIREMENT_TIMEOUT_MS * 3);
-
-  const second = connect(server.wsUrl());
-  t.after(() => second.close());
-  const hello = await second.waitFor((m) => m.type === "hello");
-  assert.equal(hello.workspaces.find((w) => w.root === beta).activity, "working", "the turn kept its project alive");
 });
 
 test("a turn started before a switch finishes in the project it belongs to", async (t) => {
@@ -423,40 +246,6 @@ test("a turn started before a switch finishes in the project it belongs to", asy
     (m) => m.type === "workspace_activity" && m.workspaces.some((w) => w.root === beta && w.activity === "idle"),
   );
   assert.ok(finished, "the turn ran to completion in a project nobody was watching");
-});
-
-test("closing a project releases it, moves whoever was watching, and leaves its history on disk", async (t) => {
-  const beta = await secondProject();
-  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
-  // A conversation worth losing: the point of the close is that it does not.
-  const betaSession = seedSession(beta, sessionsDirOf(root), [
-    ["user", "what did we decide?"],
-    ["assistant", "we decided to keep it."],
-  ]);
-  const server = await startServer(root, { openProjects: [beta] });
-  t.after(() => server.stop());
-
-  const client = connect(server.wsUrl());
-  t.after(() => client.close());
-  await client.waitFor((m) => m.type === "hello");
-
-  client.send({ type: "switch_workspace", root: beta });
-  await client.waitFor((m) => m.type === "workspace_switched" && m.workspace?.root === beta);
-
-  client.send({ type: "close_project", root: beta });
-  // Bound to the project that just went: a client left there would reach a
-  // workspace with no runtime on its next message. Back down to one project the
-  // snapshot advertises none at all, which is the single-project rule.
-  const moved = await next(client, (m) => m.type === "workspace_switched");
-  assert.ok(!moved.workspaces || !moved.workspaces.some((w) => w.root === beta), "the project is no longer listed");
-
-  // Closing is not deleting. A new session is fair — the workspace was stopped,
-  // not suspended — but what was said in that project has to still be there.
-  client.send({ type: "open_project", root: beta });
-  await next(client, (m) => m.type === "workspace_switched" && m.workspace?.root === beta);
-  client.send({ type: "list_sessions" });
-  const reopened = await next(client, (m) => m.type === "sessions");
-  assert.ok(reopened.sessions.some((session) => session.path === betaSession), "the earlier conversation survived the close");
 });
 
 test("a session belonging to another project cannot be opened", async (t) => {
@@ -492,63 +281,6 @@ test("a session belonging to another project cannot be opened", async (t) => {
   client.send({ type: "list_sessions" });
   const onBeta = await next(client, (m) => m.type === "sessions");
   assert.ok(onBeta.sessions.some((s) => s.path === betaSession), "its own project lists it");
-});
-
-test("the open set is written before the project is opened, and survives a restart", async (t) => {
-  const beta = await secondProject();
-  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
-  const server = await startServer(root);
-  t.after(() => server.stop());
-
-  const client = connect(server.wsUrl());
-  t.after(() => client.close());
-  await client.waitFor((m) => m.type === "hello");
-
-  client.send({ type: "open_project", root: beta });
-  await client.waitFor((m) => m.type === "workspace_switched" && m.workspace.root === beta);
-
-  // Persistence is the server's own doing, not something hand-authored: a project
-  // the user watched appear has to still be there at the next start.
-  const persisted = JSON.parse(await readFile(server.configFile, "utf8"));
-  assert.ok(persisted.openProjects.includes(beta), `the config records ${beta}, got ${JSON.stringify(persisted.openProjects)}`);
-
-  const restarted = await startServer(await realpath(await makeWorkspace({ "a.md": "alpha\n" })), {
-    openProjects: persisted.openProjects,
-  });
-  t.after(() => restarted.stop());
-  const afterRestart = connect(restarted.wsUrl());
-  t.after(() => afterRestart.close());
-  const hello = await afterRestart.waitFor((m) => m.type === "hello");
-  assert.ok(hello.workspaces.some((w) => w.root === beta), "the project is open again after a restart");
-});
-
-test("a project opened with no settings of its own inherits the server's sandbox", async (t) => {
-  const beta = await secondProject();
-  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
-  // Read-only server. The inherited settings are rooted at the new project, but
-  // everything else about them — writing off, in particular — comes along: a
-  // project opened through the picker must not be a way around the sandbox.
-  const server = await startServer(root, {
-    openProjects: [beta],
-    sandbox: { root, allowWrite: false, allowBash: false },
-  });
-  t.after(() => server.stop());
-
-  const client = connect(server.wsUrl());
-  t.after(() => client.close());
-  await client.waitFor((m) => m.type === "hello");
-
-  client.send({ type: "switch_workspace", root: beta });
-  await client.waitFor((m) => m.type === "workspace_switched" && m.workspace?.root === beta);
-
-  client.send({ type: "write_file", path: "beta.md", content: "rewritten\n", expectedMtimeMs: 0, force: true, requestId: "write:beta" });
-  const refused = await client.waitFor((m) => m.requestId === "write:beta");
-  assert.equal(refused.type, "file_browser_error", "writing in the new project is refused, as it is in the first");
-
-  // Rooted at ITS OWN directory, though: the read is served, and it is beta's file.
-  client.send({ type: "read_file", path: "beta.md", requestId: "read:beta" });
-  const read = await client.waitFor((m) => m.requestId === "read:beta");
-  assert.equal(read.type, "file_content", "the project is sandboxed at its own root, not the server's");
 });
 
 test("a question raised in a background project waits there, and can be answered on return", async (t) => {
@@ -646,138 +378,6 @@ test("a client moved to a waiting project is shown what it is waiting for", asyn
   displaced.send({ type: "close_project", root: gamma });
   const moved = await next(displaced, (m) => m.type === "workspace_switched");
   assert.equal(moved.workspace?.root ?? root, root, "the displaced client landed on the default project");
-});
-
-test("a client that leaves while its project is starting does not keep it alive", async (t) => {
-  const beta = await secondProject();
-  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
-  const server = await startServer(root, { openProjects: [beta], workspaceIdleTimeoutMs: RETIREMENT_TIMEOUT_MS });
-  t.after(() => server.stop());
-
-  // Bound by name to a project with no session yet, then gone before it is built.
-  // The close handler has already forgotten this socket by the time the build
-  // finishes; a bind that ran anyway would leave a dead client watching beta, and
-  // a workspace nobody is looking at would count as watched forever.
-  const leaving = connect(`${server.wsUrl()}?workspace=${encodeURIComponent(beta)}`);
-  // Open first — closing a socket mid-handshake is a different race, and not the
-  // one this is about — then leave immediately, while the session is still being
-  // built behind the upgrade.
-  await leaving.open();
-  leaving.close();
-
-  const client = connect(server.wsUrl());
-  t.after(() => client.close());
-  await client.waitFor((m) => m.type === "hello");
-  await wait(RETIREMENT_TIMEOUT_MS * 3);
-
-  const retired = await client.waitFor(
-    (m) => m.type === "workspace_activity" && m.workspaces.some((w) => w.root === beta && w.activity === "stopped"),
-    20_000,
-  );
-  assert.ok(retired, "the project the departed client started was retired");
-});
-
-test("the last project cannot be closed", async (t) => {
-  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
-  const server = await startServer(root);
-  t.after(() => server.stop());
-
-  const client = connect(server.wsUrl());
-  t.after(() => client.close());
-  await client.waitFor((m) => m.type === "hello");
-
-  client.send({ type: "close_project", root });
-  const error = await client.waitFor((m) => m.type === "workspace_error");
-  assert.match(error.message, /last open project/i);
-});
-
-test("a pinned server refuses to open, close or switch", async (t) => {
-  const beta = await secondProject();
-  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
-  const server = await startServer(root, { openProjects: [beta], workspaceLock: true });
-  t.after(() => server.stop());
-
-  const client = connect(server.wsUrl());
-  t.after(() => client.close());
-  const hello = await client.waitFor((m) => m.type === "hello");
-  assert.equal(hello.workspaceLocked, true, "the client is told, so it can hide the affordance");
-
-  client.send({ type: "switch_workspace", root: beta });
-  const refusedSwitch = await client.waitFor((m) => m.type === "workspace_error");
-  assert.match(refusedSwitch.message, /pinned/i);
-
-  client.send({ type: "open_project", root: beta });
-  const refusedOpen = await client.waitFor(
-    (m) => m.type === "workspace_error" && m !== refusedSwitch,
-  );
-  assert.match(refusedOpen.message, /pinned/i);
-});
-
-test("opening an unreadable path fails and opens nothing", async (t) => {
-  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
-  const server = await startServer(root);
-  t.after(() => server.stop());
-
-  const client = connect(server.wsUrl());
-  t.after(() => client.close());
-  await client.waitFor((m) => m.type === "hello");
-
-  client.send({ type: "open_project", root: path.join(root, "does-not-exist") });
-  const error = await client.waitFor((m) => m.type === "workspace_error");
-  assert.match(error.message, /cannot open/i);
-
-  // Nothing was added: the set is still one project long.
-  client.send({ type: "list_sessions" });
-  await client.waitFor((m) => m.type === "sessions");
-  const second = connect(server.wsUrl());
-  t.after(() => second.close());
-  const hello = await second.waitFor((m) => m.type === "hello");
-  // The set is still one long. Asserted on the list rather than on its absence:
-  // the snapshot now always carries it, so "nothing was added" is a length.
-  assert.deepEqual(hello.workspaces.map((w) => w.root), [root], "still a single-project server");
-});
-
-test("opening a directory that is already open reuses it", async (t) => {
-  const beta = await secondProject();
-  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
-  const server = await startServer(root, { openProjects: [beta] });
-  t.after(() => server.stop());
-
-  const client = connect(server.wsUrl());
-  t.after(() => client.close());
-  const hello = await client.waitFor((m) => m.type === "hello");
-
-  client.send({ type: "open_project", root: beta });
-  const switched = await client.waitFor((m) => m.type === "workspace_switched");
-
-  assert.equal(switched.workspace.root, beta);
-  // Two workspaces on one root would be two writers on one session store.
-  assert.equal(switched.workspaces.length, hello.workspaces.length, "no duplicate project");
-});
-
-test("a persisted set that cannot be written leaves the server untouched", async (t) => {
-  const beta = await secondProject();
-  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
-  const server = await startServer(root);
-  t.after(() => server.stop());
-
-  const client = connect(server.wsUrl());
-  t.after(() => client.close());
-  await client.waitFor((m) => m.type === "hello");
-
-  // Persist-first is the rule: a set that cannot be saved must not be applied.
-  // Removing the configured source is deterministic on every platform and makes
-  // the persistence transaction fail before it can produce a replacement file.
-  await unlink(server.configFile);
-
-  client.send({ type: "open_project", root: beta });
-  const error = await client.waitFor((m) => m.type === "workspace_error");
-  assert.match(error.message, /cannot read|cannot save|could not save/i);
-
-  const second = connect(server.wsUrl());
-  t.after(() => second.close());
-  const hello = await second.waitFor((m) => m.type === "hello");
-  assert.deepEqual(hello.workspaces.map((w) => w.root), [root], "the project was not opened");
 });
 
 // openlore: scenario=OneProjectIsStillNamed spec=multi-project-workspaces


### PR DESCRIPTION
The `0.17.0-beta.1` release failed on `test timed out after 300000ms` with `# fail 0` — nothing red, one file out of time and cancelled. Nothing was published; `latest` never moved.

`multiProjectWorkspaces.test.mjs` had grown to 26 tests, each starting a real server: **139s here**, and past the per-file limit on a runner already busy from the executables matrix. The two branch CIs before it passed on the same file, which is what being at the edge looks like.

## The split

By what each half is about, not by size:

- **`multiProjectWorkspaces`** — what one connection sees: a project's sessions are its own, a client hears about other projects' activity and not their content, and a file, a session or a tool call cannot cross between projects.
- **`multiProjectLifecycle`** — the set of open projects and what the server does to it: opening, closing, persisting, retiring, pinning, refusing.
- **`multiProjectHarness.mjs`** — what both need: a scriptable RPC server, a second project, the session seeding that makes one project's history distinguishable from another's.

Two files get two budgets, and the runner takes them in parallel: **55s and 79s**, four to five times under the limit rather than twice.

Same 26 tests. None changed — this moves them and nothing else.

server 1,599 passed, nothing skipped, 202s for the whole suite. Lint clean, Codex found nothing.

## After this merges

The `v0.17.0-beta.1` tag points at the commit whose release failed, and will be moved onto the new `main`. That is safe here for one reason: **nothing was published**, so no version number was burned and nobody has consumed the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198kLx3nUiNf1C14ZXHHsBm