### PR TITLE
feat(ui): offer a way back to the latest message

### DIFF
--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -64,3 +64,124 @@ test("reports no console error while loading", async ({ page }) => {
 
   expect(errors).toEqual([]);
 });
+
+/**
+ * The return-to-latest control, in a conversation with something to scroll.
+ *
+ * On the seeded server rather than the default one: the offline workspace has an
+ * empty transcript, and a viewport with nothing above it can never leave the
+ * near-bottom region. Placement and stickiness are the two claims jsdom cannot
+ * make — it computes no layout, so a control that travelled with the transcript
+ * or resolved its position against the wrong box would look identical there.
+ */
+test.describe("the return-to-latest control", () => {
+  const CONTROL = "Scroll to the latest message";
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(process.env.PI_E2E_DIAGRAMS_URL!);
+    await expect(page.getByTitle("connected")).toBeVisible();
+    // The seeded transcript arrives over the socket; wait for it before scrolling.
+    await expect(page.locator("[data-item-index]").first()).toBeVisible();
+  });
+
+  const scroller = (page: import("@playwright/test").Page) => page.locator("main");
+
+  async function scrollTo(page: import("@playwright/test").Page, top: number) {
+    await scroller(page).evaluate((main, value) => {
+      main.scrollTop = value;
+    }, top);
+  }
+
+  // openlore: scenario=FixedAboveComposer spec=conversation-scroll-navigation
+  test("stays put above the composer while the transcript scrolls under it", async ({ page }) => {
+    await scrollTo(page, 0);
+    const control = page.getByRole("button", { name: CONTROL });
+    await expect(control).toBeVisible();
+
+    const before = (await control.boundingBox())!;
+    const composer = (await page.locator("footer").boundingBox())!;
+    expect(before.y + before.height).toBeLessThanOrEqual(composer.y);
+
+    await scrollTo(page, 600);
+    // A child of the scroller would have travelled 600px by now.
+    const after = (await control.boundingBox())!;
+    expect(after.y).toBeCloseTo(before.y, 0);
+    expect(after.x).toBeCloseTo(before.x, 0);
+  });
+
+  test("returns to the end of the transcript and takes itself away", async ({ page }) => {
+    await scrollTo(page, 0);
+    await page.getByRole("button", { name: CONTROL }).click();
+
+    await expect(page.getByRole("button", { name: CONTROL })).toHaveCount(0);
+    await expect
+      .poll(() =>
+        scroller(page).evaluate((main) => main.scrollHeight - main.scrollTop - main.clientHeight),
+      )
+      .toBeLessThan(120);
+  });
+
+  test("does not flicker back on through the frames of its own scroll", async ({ page }) => {
+    // The browser animates `behavior: "smooth"` over many frames, each emitting a
+    // scroll event that still reports a viewport far from the end. jsdom fires
+    // none of them, so this is the only place the flicker was ever visible.
+    await scrollTo(page, 0);
+    await page.getByRole("button", { name: CONTROL }).click();
+
+    const samples = await page.evaluate(async () => {
+      const seen: boolean[] = [];
+      for (let i = 0; i < 60; i++) {
+        seen.push(!!document.querySelector('button[aria-label="Scroll to the latest message"]'));
+        await new Promise((r) => requestAnimationFrame(r));
+      }
+      return seen;
+    });
+
+    // The first sample can still catch the frame the click landed on.
+    expect(samples.slice(1).some(Boolean)).toBe(false);
+  });
+
+  test("gives the scroll back to a reader who changes their mind mid-return", async ({ page }) => {
+    await scrollTo(page, 0);
+    await page.getByRole("button", { name: CONTROL }).click();
+    await page.evaluate(() => new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r))));
+
+    await page.locator("main").evaluate((main) => {
+      main.dispatchEvent(new WheelEvent("wheel", { deltaY: -400, bubbles: true }));
+      main.scrollTop = 100;
+    });
+
+    await expect(page.getByRole("button", { name: CONTROL })).toBeVisible();
+  });
+
+  // openlore: scenario=KeyboardActivation spec=conversation-scroll-navigation
+  test("answers the keyboard, not only the pointer", async ({ page }) => {
+    // jsdom dispatches no click from a keydown, so this is the only place the
+    // claim that the control is keyboard-operable is actually tested.
+    await scrollTo(page, 0);
+    const control = page.getByRole("button", { name: CONTROL });
+    await control.focus();
+    await page.keyboard.press("Enter");
+
+    await expect(control).toHaveCount(0);
+    await expect
+      .poll(() =>
+        scroller(page).evaluate((main) => main.scrollHeight - main.scrollTop - main.clientHeight),
+      )
+      .toBeLessThan(120);
+  });
+
+  // openlore: scenario=ComposerStaysUsable spec=conversation-scroll-navigation
+  test("leaves the composer usable underneath it", async ({ page }) => {
+    await scrollTo(page, 0);
+    await expect(page.getByRole("button", { name: CONTROL })).toBeVisible();
+
+    const box = page.getByRole("textbox", { name: /message/i });
+    await box.click();
+    await box.fill("typed past the control");
+
+    await expect(box).toHaveValue("typed past the control");
+    // Clicking into the composer is not a scroll: the control is still there.
+    await expect(page.getByRole("button", { name: CONTROL })).toBeVisible();
+  });
+});

--- a/openspec/changes/add-scroll-to-bottom-button/.openspec.yaml
+++ b/openspec/changes/add-scroll-to-bottom-button/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-30

--- a/openspec/changes/add-scroll-to-bottom-button/design.md
+++ b/openspec/changes/add-scroll-to-bottom-button/design.md
@@ -1,0 +1,204 @@
+## Context
+
+See `proposal.md` — Why.
+
+The conversation viewport is the `<main>` element in `ui/src/App.tsx` (~line 698). Its scroll
+state is held in **a ref, not state**: `stickToBottom = useRef(true)` (App.tsx:385), recomputed
+in `handleScroll` as `main.scrollHeight - main.scrollTop - main.clientHeight < 120` (App.tsx:392),
+and read by the effect that follows streamed items (App.tsx:395-399). A ref was the right call
+for that job — scroll fires at frame rate and the effect only needs the latest value — but a ref
+change renders nothing, so it cannot drive a control's visibility on its own.
+
+Three other facts shape the approach:
+
+- `useConversationJump` (`ui/src/useConversationJump.ts`) receives the same ref and sets
+  `stickToBottom.current = false` when the analysis panel jumps to an item. Whatever replaces or
+  supplements the ref must keep that call working, or a jump gets yanked back to the bottom.
+- `<main>` already sits inside `<div className="relative z-0 flex min-h-0 flex-1 flex-col">`
+  (App.tsx:641), a stacking context that ends just above the `<footer>` holding the composer.
+  That div is the natural positioning parent: an absolutely-positioned child of it is fixed
+  relative to the viewport, not to the scrolling transcript.
+- jsdom implements no layout. `scrollHeight`, `clientHeight`, and `scrollTop` are all `0`, so the
+  near-bottom expression is `0 < 120` — always true. Any unit test of visibility must define
+  those three properties on the real `<main>` node before firing `scroll`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One source of truth for "is the reader near the bottom", read by both the auto-scroll effect
+  and the control's visibility, so the two can never disagree (spec: `ReturnToLatestControlVisibility`).
+- Keep the scroll handler allocation-free and re-render-free while the reader stays on one side
+  of the threshold.
+- Position the control without touching the transcript's DOM or the composer's layout.
+
+**Non-Goals:**
+
+- No unread-message counter, no "N new messages" badge, no jump-to-first-unread. This change
+  returns to the end; counting what was missed is a separate capability.
+- No change to the 120px threshold, and no configuration for it.
+- No persistence: visibility is derived from the live scroll position, never stored.
+- No new component library, animation library, or icon dependency.
+
+## Decisions
+
+### 1. Keep the ref, add state beside it, flip state only on threshold crossings
+
+`handleScroll` keeps writing `stickToBottom.current` exactly as today, and additionally calls
+`setAtBottom` — but only when the computed value differs from the ref's previous value.
+
+```
+const next = main.scrollHeight - main.scrollTop - main.clientHeight < THRESHOLD;
+if (next !== stickToBottom.current) setAtBottom(next);
+stickToBottom.current = next;
+```
+
+React bails out of an identical `useState` set, so an unconditional call would also be correct;
+the explicit comparison makes the intent legible and avoids the bail-out check on every scroll
+frame during streaming.
+
+*Why not replace the ref with state outright?* The effect at App.tsx:395 reads the value in the
+same tick it is set by a scroll during streaming; a state value read there would be one render
+stale and would follow content the reader had just scrolled away from. `useConversationJump` also
+writes the ref imperatively from inside an effect. The ref stays authoritative; state is a
+render-visible mirror.
+
+*Why not `useSyncExternalStore` or an IntersectionObserver on `bottomRef`?* An observer would be
+the idiomatic "is the end visible" primitive, but it answers a subtly different question than the
+120px threshold does, which would let the control and the auto-scroll decision disagree — the one
+thing the spec forbids. Keeping a single expression keeps them in lockstep.
+
+### 2. The jump reports, the conversation decides
+
+`useConversationJump` used to write `stickToBottom.current = false` itself. It now takes
+`onJump(target)` instead of the ref: the conversation owns both representations of the fact *and*
+the scroller's geometry, and the decision needs all three.
+
+The decision is not "the reader jumped, so stop following". Jumping to something already on screen
+at the end of the conversation scrolls nothing and emits no scroll event; suppressing the follow
+there strands a reader who is *at* the bottom with a transcript that no longer follows and no
+control offered, the control being hidden precisely because they are at the bottom. So the target's
+own box settles it: a jump is a departure when the target is off screen, or when the reader was
+already away from the end.
+
+Reading the target rather than waiting for the jump's first scroll frame also closes a window in
+which a streamed item arriving mid-jump pulls the reader back to the end and cancels the navigation
+they just asked for.
+
+### 3. Anchor the control to the existing `relative z-0` wrapper
+
+Render the button as the last child of `<div className="relative z-0 flex min-h-0 flex-1 flex-col">`
+(App.tsx:641), after `</main>`, positioned `absolute bottom-4 left-1/2 -translate-x-1/2 z-10`.
+
+*Why not inside `<main>`?* `<main>` is the scroller; a child of it scrolls with the transcript
+unless made `sticky`, and `sticky` inside a flex column whose content is a centered `max-w-3xl`
+div fights the existing layout. *Why not `position: fixed`?* The app also runs embedded in a host
+page (`@pi-outpost/embed`, shadow root, hostile host CSS); `fixed` resolves against the host's
+viewport, which is not the widget. Absolute inside a container the app owns is correct in both
+shapes. `z-10` keeps it above the transcript while staying inside the `z-0` stacking context, so
+it cannot rise above the header's menus.
+
+### 4. Restore the near-bottom state on activation, and ignore the animation's own frames
+
+The click handler scrolls `bottomRef` into view **and** sets both the ref and the state to `true`
+immediately, rather than waiting for the animation to settle.
+
+That alone is not enough, and the browser is the only place it shows: `scrollIntoView({behavior:
+"smooth"})` emits a scroll event per frame, and every one but the last reports a viewport still far
+from the end. Read naively they say the reader walked away — the control flickers back on for the
+length of the animation (observed directly in the bench), and the transcript stops following
+anything that streams in meanwhile. A `returning` guard therefore holds the last position seen while
+an app-initiated scroll is in flight, and swallows those frames.
+
+Three things release it, because none of them alone is enough:
+
+- **Arrival** — a frame that reaches the near-bottom region.
+- **Direction** — any position that moves *away* from the end. Nothing this app starts moves that
+  way, so that is the reader; it is the only signal a scrollbar drag gives.
+- **`scrollend`** — the backstop, and the only thing that catches a reader who drags *towards* the
+  end and lets go short of it: no gesture, and every position moving the way the animation was.
+
+The wheel, touch and key handlers on the scroller release it too, as the immediate path for the
+common case.
+
+The same guard wraps the automatic follow, for the same reason: a turn or tool card taller than the
+near-bottom region starts that animation from outside it.
+
+`prefers-reduced-motion: reduce` is read explicitly and turns the scroll into a jump — unlike a CSS
+transition, `behavior: "smooth"` is not softened by the preference on its own.
+
+### 5. Keep the control in `App.tsx`, not a new component file
+
+It is a single button with no state of its own and one callback. A separate component would need
+the same two props and add an import; the codebase keeps comparably-sized affordances inline.
+Revisit only if an unread counter arrives.
+
+### 6. Watch the geometry, and follow it rather than report it
+
+Scroll events are not the only way the end moves out of reach: a resized window, a composer that
+grew, tool cards revealed, a diagram or image that finishes laying out after its message arrived.
+None of them scroll. A `ResizeObserver` on the scroller and on the transcript inside it covers them.
+
+It must not simply re-evaluate, though. Content finishing its layout under a reader who is being
+followed is the end moving, not the reader leaving — reporting the new distance there files them as
+having walked away from a page they never touched, and (seen in the bench) cancels the scroll to the
+bottom on load. So while the conversation is following, the observer *follows*: it scrolls to the
+end. Only when it is not following does it re-evaluate, which is what takes the control away when
+the end comes back within reach.
+
+The observer is installed through a callback ref rather than by reading `mainRef` in an effect. The
+embed renders nothing until its branding request settles, so an effect looking at the ref on the
+first render finds null — and nothing in its dependencies changes when the real interface finally
+mounts, leaving the embedded widget with no observer at all.
+
+### 7. Test the threshold by defining layout on the real node
+
+Unit tests (`ui/src/App.test.tsx`) must `Object.defineProperty` `scrollHeight`, `clientHeight`,
+and `scrollTop` on the `<main>` element before `fireEvent.scroll`, since jsdom reports zero for
+all three. A test that skips this asserts nothing: the near-bottom expression is trivially true,
+so the button is never rendered and a "hidden at bottom" assertion passes for the wrong reason.
+Each visibility test therefore proves *both* directions — scrolled-up shows it, scrolled-down
+hides it — so a stub that never moves cannot pass.
+
+### 8. Prove placement, stacking and animation only in a browser
+
+`FixedAboveComposer` and `ComposerStaysUsable` are layout claims, `KeyboardActivation` needs a real
+key press (jsdom dispatches no click from a keydown), and the animation frames that the guard in
+decision 4 exists for are not emitted by jsdom at all. All of them get Playwright coverage against a
+real scroll container.
+
+The control also has to sit *below* the drawers that overlay the conversation. Session analysis and
+the work plan are both `z-10` and are rendered above it in the tree, so an equal level lets a
+control for the transcript paint over the panel covering the transcript — full width, on a narrow
+viewport. It is `z-0`: still above the transcript, which is not positioned at all. Its strip carries
+the same padding `<main>` takes beside an open drawer, so it centres on the conversation the reader
+can see.
+
+## Risks / Trade-offs
+
+- **Two representations of one fact (ref + state) can drift** → every write site goes through
+  `setStick`, which writes both; decision 2 removes the only site that wrote just one.
+- **The `returning` guard could swallow a reader's scroll indefinitely** → three independent
+  releases (decision 4), each with its own test, and it is armed only for a scroll that has further
+  to travel than the near-bottom region — from inside it there is nothing to guard, and arming there
+  would hold the guard for an animation that never ran.
+- **The observer could fight the follow, or loop** → decision 6 splits the two cases; scrolling
+  changes no box, so the callback cannot re-trigger itself. Confirmed in the bench with no
+  ResizeObserver loop warnings.
+- **A re-render per threshold crossing** → crossings are user-initiated and rare; the state does
+  not change while scrolling within one side of the threshold, so streaming does not re-render
+  `App` any more often than it does today.
+- **`scrollIntoView({behavior:"smooth"})` is a no-op under some reduced-motion settings and is
+  stubbed in jsdom** → activation sets the state itself (decision 4), so the observable outcome
+  does not depend on the animation completing. The unit test asserts the call plus the state
+  change; the browser test asserts the actual scroll position.
+- **The absolute button could overlay transcript content at narrow widths** → it sits in the
+  bottom gutter above the composer, centered, with the transcript's own `py-6` padding beneath
+  the last item; verified in the bench at a narrow viewport rather than assumed.
+- **The embed shape has a shadow root and host CSS** → decision 3 avoids `fixed` for this reason;
+  the bench (`npm run bench`, host page on 4321 with hostile CSS) is where that is confirmed.
+
+## Migration Plan
+
+None. Additive UI with no protocol, persistence, config, or dependency change. Rollback is
+reverting the commit; no state outlives it.

--- a/openspec/changes/add-scroll-to-bottom-button/proposal.md
+++ b/openspec/changes/add-scroll-to-bottom-button/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+When a reader moves up through a long or streaming conversation, returning to the newest message requires manually dragging or scrolling through the entire transcript. The application already knows when the reader has left its near-bottom region, so it can offer a direct return without changing the existing scrollback protection.
+
+## What Changes
+
+- Show a floating scroll-to-bottom control at the bottom of the conversation viewport whenever the reader is outside the existing near-bottom region.
+- Hide the control while the conversation is already near the bottom, including after activating it.
+- Scroll to the end of the current conversation when the control is activated, without sending, editing, or otherwise changing conversation content.
+- Keep the control reachable by keyboard and named for assistive technology.
+- Preserve the existing behavior that new streamed content auto-scrolls only while the reader remains near the bottom.
+
+## Capabilities
+
+### New Capabilities
+
+- `conversation-scroll-navigation`: Visibility, activation, accessibility, and interaction with existing conversation auto-scroll behavior for a direct return-to-latest control.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Conversation viewport ownership and scroll-state handling in `ui/src/App.tsx`.
+- UI component tests for scroll position, visibility, activation, and existing streaming behavior.
+- Running-app Playwright coverage for the real scroll container and fixed positioning above the composer.
+- No server, protocol, persistence, dependency, or compatibility changes.

--- a/openspec/changes/add-scroll-to-bottom-button/specs/conversation-scroll-navigation/spec.md
+++ b/openspec/changes/add-scroll-to-bottom-button/specs/conversation-scroll-navigation/spec.md
@@ -1,0 +1,129 @@
+## Purpose
+
+Gives a reader who has moved up through the conversation a direct way back to the newest
+message, without disturbing the scrollback protection that keeps streamed output from
+yanking the viewport away while they read.
+
+## ADDED Requirements
+
+### Requirement: ReturnToLatestControlVisibility
+
+The conversation SHALL show a floating return-to-latest control whenever the reader's scroll
+position is outside the conversation's near-bottom region, and SHALL hide it whenever the
+position is inside that region. The near-bottom region is the same one that governs
+auto-scroll during streaming: the control's visibility and the auto-scroll decision SHALL
+never disagree.
+
+The control SHALL be evaluated against the live scroll position, so it appears without any
+further reader action once the position leaves the near-bottom region, and disappears once
+the position re-enters it — whether the position changed because the reader scrolled, because
+the control was activated, or because content was appended below.
+
+#### Scenario: HiddenAtBottom
+- **GIVEN** a conversation whose scroll position is inside the near-bottom region
+- **WHEN** the conversation is displayed
+- **THEN** no return-to-latest control is present
+
+#### Scenario: AppearsOnScrollUp
+- **GIVEN** a conversation long enough to scroll
+- **WHEN** the reader scrolls up so the position leaves the near-bottom region
+- **THEN** the return-to-latest control becomes visible
+
+#### Scenario: HidesOnScrollBackDown
+- **GIVEN** the return-to-latest control is visible
+- **WHEN** the reader scrolls back down into the near-bottom region
+- **THEN** the control is no longer present
+
+#### Scenario: NotShownWhenNothingToScroll
+- **GIVEN** a conversation shorter than the viewport, so there is no scrollback
+- **WHEN** the conversation is displayed
+- **THEN** no return-to-latest control is present
+
+### Requirement: ReturnToLatestActivation
+
+Activating the control SHALL scroll the conversation to the end of the current transcript and
+SHALL restore the near-bottom state, so that subsequent streamed content resumes auto-scrolling.
+Activation SHALL change nothing else: it SHALL NOT send, edit, retry, delete, or reorder any
+conversation content, SHALL NOT alter the composer draft or attachments, and SHALL NOT change
+which session, project, or file is open.
+
+#### Scenario: ScrollsToEnd
+- **GIVEN** the reader is scrolled up and the control is visible
+- **WHEN** the control is activated
+- **THEN** the conversation scrolls to the end of the transcript
+
+#### Scenario: HidesAfterActivation
+- **GIVEN** the reader is scrolled up and the control is visible
+- **WHEN** the control is activated and the scroll reaches the end
+- **THEN** the control is no longer present
+
+#### Scenario: ResumesAutoScroll
+- **GIVEN** the reader activated the control and is back at the end
+- **WHEN** new streamed content is appended
+- **THEN** the conversation follows that content, as it does for a reader who never scrolled up
+
+#### Scenario: SendsNothing
+- **GIVEN** a conversation with a draft in the composer and a scrolled-up viewport
+- **WHEN** the control is activated
+- **THEN** no message is sent, no item is added or removed from the conversation, and the draft is unchanged
+
+### Requirement: ReturnToLatestAccessibility
+
+The control SHALL be a button reachable by keyboard, activable with the standard activation
+keys, and SHALL carry an accessible name describing its action. It SHALL NOT trap focus, and
+SHALL NOT be present in the accessibility tree while the reader is in the near-bottom region.
+Its motion SHALL respect a reduced-motion preference.
+
+#### Scenario: NamedForAssistiveTech
+- **GIVEN** the control is visible
+- **WHEN** the accessibility tree is inspected
+- **THEN** the control is exposed as a button with a name describing a return to the latest message
+
+#### Scenario: KeyboardActivation
+- **GIVEN** the control is visible and focused
+- **WHEN** the reader presses Enter or Space
+- **THEN** the conversation scrolls to the end, as if the control had been clicked
+
+#### Scenario: AbsentFromTreeWhenHidden
+- **GIVEN** the reader is inside the near-bottom region
+- **WHEN** the accessibility tree is inspected
+- **THEN** no return-to-latest button is exposed
+
+#### Scenario: ReducedMotionJumps
+- **GIVEN** the reader's system asks for reduced motion
+- **WHEN** the control is activated
+- **THEN** the conversation arrives at the end without an animated scroll
+
+### Requirement: ScrollbackProtectionPreserved
+
+Introducing the control SHALL NOT change the existing behavior that new streamed content
+auto-scrolls the conversation only while the reader is inside the near-bottom region. A reader
+who is scrolled up SHALL keep their position while content streams below, whether or not the
+control is used.
+
+#### Scenario: NoYankWhileReadingScrollback
+- **GIVEN** the reader is scrolled up, outside the near-bottom region
+- **WHEN** the agent streams new content
+- **THEN** the scroll position is unchanged and the control remains visible
+
+#### Scenario: FollowsWhenNearBottom
+- **GIVEN** the reader is inside the near-bottom region
+- **WHEN** the agent streams new content
+- **THEN** the conversation follows the new content and no control appears
+
+### Requirement: ControlPlacement
+
+The control SHALL be positioned over the conversation viewport near its bottom edge, above the
+composer, and SHALL stay there as the conversation scrolls rather than moving with the
+transcript content. It SHALL NOT cover the composer, and SHALL NOT obscure the panels that
+overlay the conversation region.
+
+#### Scenario: FixedAboveComposer
+- **GIVEN** a scrolled-up conversation in the running application
+- **WHEN** the reader scrolls further
+- **THEN** the control stays anchored near the bottom of the conversation viewport, above the composer, and does not travel with the transcript
+
+#### Scenario: ComposerStaysUsable
+- **GIVEN** the control is visible
+- **WHEN** the reader clicks into the composer and types
+- **THEN** the composer receives the input; the control does not intercept it

--- a/openspec/changes/add-scroll-to-bottom-button/tasks.md
+++ b/openspec/changes/add-scroll-to-bottom-button/tasks.md
@@ -1,0 +1,33 @@
+## 1. Scroll state a render can read
+
+- [x] 1.1 In `ui/src/App.tsx`, add an `atBottom` state beside the existing `stickToBottom` ref and update it from `handleScroll` only when the computed near-bottom value differs from the ref's previous value (design decision 1); verify by adding a unit test in `ui/src/App.test.tsx` that defines `scrollHeight`, `clientHeight`, and `scrollTop` on the `<main>` node and asserts the near-bottom expression drives a visible change in both directions — scrolled-up and scrolled-back-down.
+- [x] 1.2 Extract the 120px threshold into a single named constant read by the auto-scroll effect and the visibility computation, so the two cannot diverge; verify by `rg -n '120' ui/src/App.tsx` returning no second literal for this threshold.
+- [x] 1.3 Give `useConversationJump` a way to report its `stickToBottom.current = false` write to the state mirror (design decision 2), keeping the hook's existing signature additive; verify `ui/src/useConversationJump.test.tsx` still passes and add a case asserting the callback fires on a jump.
+
+## 2. The control
+
+- [x] 2.1 Render the return-to-latest button as the last child of the `relative z-0` wrapper at `ui/src/App.tsx:641`, after `</main>`, positioned `absolute bottom-4 left-1/2 -translate-x-1/2 z-10`, rendered only while `atBottom` is false (design decision 3); verify with unit tests covering `HiddenAtBottom`, `AppearsOnScrollUp`, `HidesOnScrollBackDown`, and `AbsentFromTreeWhenHidden` via `getByRole("button", { name: ... })` / `queryByRole`.
+- [x] 2.2 Give the button an accessible name describing a return to the latest message, keyboard reachability as a native `<button type="button">`, and a `motion-reduce:` variant on any transition; verify with unit tests covering `NamedForAssistiveTech` and `KeyboardActivation` (`fireEvent.keyDown`/`click` on the focused button reaching the same handler).
+- [x] 2.3 Style it to match the app's existing floating affordances in both themes and both shells; verify by reading it back in the bench (task 4.1), not by inspecting the class string.
+
+## 3. Activation
+
+- [x] 3.1 On activation, scroll `bottomRef` into view and set both the ref and the state to near-bottom immediately rather than waiting for the animation to settle (design decision 4); verify with unit tests covering `ScrollsToEnd` (`scrollIntoView` called on the bottom anchor) and `HidesAfterActivation` (the button is gone from the tree after the click).
+- [x] 3.2 Add a unit test for `ResumesAutoScroll`: scroll up, activate the control, then append an item to `state.items` and assert the auto-scroll effect follows it.
+- [x] 3.3 Add a unit test for `SendsNothing`: with a composer draft and a scrolled-up viewport, activate the control and assert the agent API's send/edit/abort mocks were not called, the item count is unchanged, and the draft still reads back from the composer.
+- [x] 3.4 Add a unit test for `ScrollbackProtectionPreserved`: with the viewport outside the near-bottom region, append a streamed item and assert `scrollIntoView` was not called and the button is still present; then repeat inside the region and assert it is called and no button appears (`NoYankWhileReadingScrollback`, `FollowsWhenNearBottom`).
+- [x] 3.5 Add a unit test for `NotShownWhenNothingToScroll`: geometry where `scrollHeight === clientHeight`, and assert no button is exposed.
+- [x] 3.6 Add a unit test guarding the ref/state seam: jump to an item via the analysis panel, assert the control appears, then activate it and assert it disappears (design risk 1).
+
+## 4. Prove it in a browser
+
+- [x] 4.1 Rebuild in order — `web`, then `@pi-outpost/embed`, then `npm run build:e2e-host` — run `npm run bench`, and drive the real widget at `127.0.0.1:4323` (seeded transcript): scroll up, read back that the button is in the DOM, click it, and read back `scrollTop` at the end of the scroller and the button gone. Record what was observed; a screenshot is not a check.
+- [x] 4.2 Repeat 4.1 in the embedded shell on the host page (`127.0.0.1:4321`, hostile host CSS, shadow root) and confirm the control is positioned against the widget rather than the host viewport (design decision 3).
+- [x] 4.3 Add a Playwright test to `e2e/app.spec.ts` covering `FixedAboveComposer` and `ComposerStaysUsable`: in a scrolled conversation, assert the control's bounding box stays put across a further scroll and sits above the composer's box, and that clicking into the composer and typing reaches the textbox.
+- [x] 4.4 Check the control at a narrow viewport in the bench and confirm it does not overlay the last transcript item (design risk 4).
+
+## 5. Close the change
+
+- [x] 5.1 Run `npm run test --workspace ui`, `npm run typecheck`, `npm run lint`, and `npm run test:e2e`; all green.
+- [x] 5.2 Produce the scenario-to-test matrix for `openspec/changes/add-scroll-to-bottom-button/specs/conversation-scroll-navigation/spec.md` — enumerate with `rg '^#### Scenario:'`, classify each as covered/partial/uncovered, and name the test file and test title for each; every scenario must be `covered`.
+- [x] 5.3 Run `openspec validate add-scroll-to-bottom-button --strict` and `npx openlore check_spec_drift`; both clean.

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -990,3 +990,562 @@ describe("one listing, one picker", () => {
     expect(api.browseServerDirectory).toHaveBeenLastCalledWith("/srv/alpha");
   });
 });
+
+// ---------------------------------------------------------------------------
+// conversation-scroll-navigation — the return-to-latest control
+// ---------------------------------------------------------------------------
+describe("ReturnToLatest", () => {
+  const CONTROL = "Scroll to the latest message";
+
+  /**
+   * Gives the conversation scroller a layout jsdom will not.
+   *
+   * jsdom implements none, so `scrollHeight`, `clientHeight` and `scrollTop` all
+   * read 0 and the near-bottom expression is `0 < 120` — always true. A test that
+   * skipped this would find the control never rendered and would pass its
+   * "hidden at the bottom" assertion for entirely the wrong reason. Every test
+   * below therefore drives both directions.
+   */
+  function layout(main: HTMLElement, geometry: { scrollHeight: number; clientHeight: number; scrollTop: number }) {
+    for (const [name, value] of Object.entries(geometry)) {
+      Object.defineProperty(main, name, { value, writable: true, configurable: true });
+    }
+  }
+
+  const scroller = () => document.querySelector("main")!;
+
+  /** Puts the reader far above the end and lets the app notice. */
+  function scrollUp(main = scroller()) {
+    layout(main, { scrollHeight: 4000, clientHeight: 600, scrollTop: 0 });
+    fireEvent.scroll(main);
+  }
+
+  /** Puts the reader back inside the near-bottom region and lets the app notice. */
+  function scrollDown(main = scroller()) {
+    layout(main, { scrollHeight: 4000, clientHeight: 600, scrollTop: 3400 });
+    fireEvent.scroll(main);
+  }
+
+  const control = () => screen.queryByRole("button", { name: CONTROL });
+
+  /** Where the transcript's bottom anchor lives: the scroller's last leaf. */
+  function bottomAnchor() {
+    const inner = scroller().firstElementChild!;
+    return inner.lastElementChild!;
+  }
+
+  let scrolledInto: Element[];
+
+  function mount(overrides: Record<string, unknown> = {}) {
+    const api = agentApi(agentState({ items: [{ kind: "user", text: "go" }] as ChatItem[], ...overrides }));
+    mockUseAgent.mockReturnValue(api);
+    return { api, view: render(<App />) };
+  }
+
+  beforeEach(() => {
+    scrolledInto = [];
+    Element.prototype.scrollIntoView = vi.fn(function (this: Element) {
+      scrolledInto.push(this);
+    });
+  });
+
+  // openlore: scenario=HiddenAtBottom spec=conversation-scroll-navigation
+  it("shows nothing while the reader is already at the bottom", () => {
+    mount();
+    scrollDown();
+    expect(control()).toBeNull();
+  });
+
+  // openlore: scenario=AppearsOnScrollUp spec=conversation-scroll-navigation
+  it("appears once the reader scrolls out of the near-bottom region", () => {
+    mount();
+    scrollDown();
+    expect(control()).toBeNull();
+
+    scrollUp();
+    expect(control()).toBeInTheDocument();
+  });
+
+  // openlore: scenario=HidesOnScrollBackDown spec=conversation-scroll-navigation
+  it("disappears once the reader scrolls back into it", () => {
+    mount();
+    scrollUp();
+    expect(control()).toBeInTheDocument();
+
+    scrollDown();
+    expect(control()).toBeNull();
+  });
+
+  // openlore: scenario=NotShownWhenNothingToScroll spec=conversation-scroll-navigation
+  it("stays away when the conversation is shorter than the viewport", () => {
+    mount();
+    const main = scroller();
+    layout(main, { scrollHeight: 400, clientHeight: 400, scrollTop: 0 });
+    fireEvent.scroll(main);
+    expect(control()).toBeNull();
+  });
+
+  // openlore: scenario=AbsentFromTreeWhenHidden spec=conversation-scroll-navigation
+  it("exposes no button at all to assistive technology while hidden", () => {
+    mount();
+    scrollUp();
+    expect(screen.getAllByRole("button", { name: CONTROL })).toHaveLength(1);
+
+    scrollDown();
+    // Not merely invisible: gone from the tree, so it is never a focus stop.
+    expect(screen.queryAllByRole("button", { name: CONTROL })).toHaveLength(0);
+  });
+
+  // openlore: scenario=NamedForAssistiveTech spec=conversation-scroll-navigation
+  it("is a named button, not an unlabelled decoration", () => {
+    mount();
+    scrollUp();
+    const button = screen.getByRole("button", { name: CONTROL });
+    // A native button is what makes Enter and Space work; the browser test
+    // presses them for real (e2e/app.spec.ts).
+    expect(button.tagName).toBe("BUTTON");
+    expect(button).toHaveAttribute("type", "button");
+    expect(button).not.toBeDisabled();
+  });
+
+  // openlore: scenario=ScrollsToEnd spec=conversation-scroll-navigation
+  it("scrolls to the end of the transcript when activated", () => {
+    mount();
+    scrollUp();
+    scrolledInto = [];
+
+    fireEvent.click(screen.getByRole("button", { name: CONTROL }));
+
+    expect(scrolledInto).toContain(bottomAnchor());
+  });
+
+  // openlore: scenario=ReducedMotionJumps spec=conversation-scroll-navigation
+  it("jumps rather than animates for a reader who asked for less motion", () => {
+    // `behavior: "smooth"` is not softened by the preference the way a CSS
+    // transition is: the browser animates it either way unless asked not to.
+    const matchMedia = vi.fn((query: string) => ({ matches: query.includes("reduce"), media: query }));
+    vi.stubGlobal("matchMedia", matchMedia);
+    const behaviors: (string | undefined)[] = [];
+    Element.prototype.scrollIntoView = vi.fn(function (this: Element, options?: ScrollIntoViewOptions | boolean) {
+      scrolledInto.push(this);
+      behaviors.push(typeof options === "object" ? options.behavior : undefined);
+    });
+
+    mount();
+    scrollUp();
+    behaviors.length = 0;
+    fireEvent.click(screen.getByRole("button", { name: CONTROL }));
+
+    expect(behaviors).toContain("auto");
+    expect(behaviors).not.toContain("smooth");
+    vi.unstubAllGlobals();
+  });
+
+  it("animates for everyone else", () => {
+    vi.stubGlobal("matchMedia", vi.fn((query: string) => ({ matches: false, media: query })));
+    const behaviors: (string | undefined)[] = [];
+    Element.prototype.scrollIntoView = vi.fn(function (this: Element, options?: ScrollIntoViewOptions | boolean) {
+      behaviors.push(typeof options === "object" ? options.behavior : undefined);
+    });
+
+    mount();
+    scrollUp();
+    behaviors.length = 0;
+    fireEvent.click(screen.getByRole("button", { name: CONTROL }));
+
+    expect(behaviors).toContain("smooth");
+    vi.unstubAllGlobals();
+  });
+
+  // openlore: scenario=HidesAfterActivation spec=conversation-scroll-navigation
+  it("takes itself away once it has done its job", () => {
+    mount();
+    scrollUp();
+    fireEvent.click(screen.getByRole("button", { name: CONTROL }));
+
+    // Not waiting for the smooth scroll to settle: a reduced-motion jump may
+    // never emit the settling event that would otherwise hide it.
+    expect(control()).toBeNull();
+  });
+
+  // openlore: scenario=ResumesAutoScroll spec=conversation-scroll-navigation
+  it("puts the reader back in the path of streamed content", () => {
+    let api = agentApi(agentState({ items: [{ kind: "user", text: "go" }] as ChatItem[] }));
+    mockUseAgent.mockImplementation(() => api);
+    const view = render(<App />);
+
+    scrollUp();
+    fireEvent.click(screen.getByRole("button", { name: CONTROL }));
+    scrolledInto = [];
+
+    api = agentApi(
+      agentState({ items: [{ kind: "user", text: "go" }, { kind: "user", text: "and on" }] as ChatItem[] }),
+    );
+    view.rerender(<App />);
+
+    expect(scrolledInto).toContain(bottomAnchor());
+  });
+
+  // openlore: scenario=SendsNothing spec=conversation-scroll-navigation
+  it("changes nothing but the scroll position", () => {
+    const { api } = mount();
+    const box = screen.getByPlaceholderText(/message/i);
+    fireEvent.change(box, { target: { value: "still writing this" } });
+    const itemsBefore = document.querySelectorAll("[data-item-index]").length;
+
+    scrollUp();
+    fireEvent.click(screen.getByRole("button", { name: CONTROL }));
+
+    expect(api.prompt).not.toHaveBeenCalled();
+    expect(api.editPrompt).not.toHaveBeenCalled();
+    expect(api.abort).not.toHaveBeenCalled();
+    expect(document.querySelectorAll("[data-item-index]")).toHaveLength(itemsBefore);
+    expect(box).toHaveValue("still writing this");
+  });
+
+  // openlore: scenario=NoYankWhileReadingScrollback spec=conversation-scroll-navigation
+  it("leaves a reader in the scrollback where they are while content streams", () => {
+    let api = agentApi(agentState({ items: [{ kind: "user", text: "go" }] as ChatItem[] }));
+    mockUseAgent.mockImplementation(() => api);
+    const view = render(<App />);
+
+    scrollUp();
+    scrolledInto = [];
+
+    api = agentApi(
+      agentState({ items: [{ kind: "user", text: "go" }, { kind: "user", text: "and on" }] as ChatItem[] }),
+    );
+    view.rerender(<App />);
+
+    expect(scrolledInto).toHaveLength(0);
+    expect(control()).toBeInTheDocument();
+  });
+
+  // openlore: scenario=FollowsWhenNearBottom spec=conversation-scroll-navigation
+  it("follows streamed content for a reader who never left the bottom", () => {
+    let api = agentApi(agentState({ items: [{ kind: "user", text: "go" }] as ChatItem[] }));
+    mockUseAgent.mockImplementation(() => api);
+    const view = render(<App />);
+
+    scrollDown();
+    scrolledInto = [];
+
+    api = agentApi(
+      agentState({ items: [{ kind: "user", text: "go" }, { kind: "user", text: "and on" }] as ChatItem[] }),
+    );
+    view.rerender(<App />);
+
+    expect(scrolledInto).toContain(bottomAnchor());
+    expect(control()).toBeNull();
+  });
+
+  it("stays away through the frames of its own animation", () => {
+    // A smooth scroll emits a scroll event per frame, and all but the last report
+    // a viewport still far from the end. Read naively they flicker the control
+    // back on for the length of the animation — observed in the browser before
+    // this guard existed — and stop streamed content being followed meanwhile.
+    mount();
+    scrollUp();
+    fireEvent.click(screen.getByRole("button", { name: CONTROL }));
+
+    const main = scroller();
+    for (const scrollTop of [400, 1200, 2400, 3400]) {
+      layout(main, { scrollHeight: 4000, clientHeight: 600, scrollTop });
+      fireEvent.scroll(main);
+      expect(control()).toBeNull();
+    }
+  });
+
+  it("hands control straight back to a reader who scrolls during the return", () => {
+    mount();
+    scrollUp();
+    fireEvent.click(screen.getByRole("button", { name: CONTROL }));
+
+    const main = scroller();
+    fireEvent.wheel(main);
+    layout(main, { scrollHeight: 4000, clientHeight: 600, scrollTop: 200 });
+    fireEvent.scroll(main);
+
+    // Their gesture, not our animation: the button comes back and the transcript
+    // stops following, which is the whole point of the scrollback protection.
+    expect(control()).toBeInTheDocument();
+  });
+
+  it("hands control back to a drag that emits no gesture of its own", () => {
+    // A scrollbar drag fires scroll events and nothing else. The only thing that
+    // separates it from the animation is the direction: nothing this app starts
+    // moves away from the end.
+    mount();
+    const main = scroller();
+    layout(main, { scrollHeight: 4000, clientHeight: 600, scrollTop: 2000 });
+    fireEvent.scroll(main);
+    expect(control()).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: CONTROL }));
+    expect(control()).toBeNull();
+
+    layout(main, { scrollHeight: 4000, clientHeight: 600, scrollTop: 1500 });
+    fireEvent.scroll(main);
+
+    expect(control()).toBeInTheDocument();
+  });
+
+  it("lets go of the guard when the scroll settles short of the end", () => {
+    // A reader who drags the scrollbar towards the end and releases early emits
+    // no gesture, and every position they pass through moves the same way the
+    // animation was going. `scrollend` is the only thing that separates them.
+    mount();
+    const main = scroller();
+    layout(main, { scrollHeight: 4000, clientHeight: 600, scrollTop: 2000 });
+    fireEvent.scroll(main);
+    fireEvent.click(screen.getByRole("button", { name: CONTROL }));
+    expect(control()).toBeNull();
+
+    layout(main, { scrollHeight: 4000, clientHeight: 600, scrollTop: 2600 });
+    fireEvent.scroll(main);
+    expect(control()).toBeNull(); // indistinguishable from the animation, so far
+
+    fireEvent(main, new Event("scrollend"));
+
+    // Settled, and not at the end: the reader is reading scrollback again.
+    expect(control()).toBeInTheDocument();
+  });
+
+  describe("the end moving without a scroll", () => {
+    /** A ResizeObserver whose notifications this test fires by hand. */
+    function stubResizeObserver() {
+      const callbacks: (() => void)[] = [];
+      vi.stubGlobal(
+        "ResizeObserver",
+        class {
+          constructor(callback: () => void) {
+            callbacks.push(callback);
+          }
+          observe() {}
+          disconnect() {}
+        },
+      );
+      return () => act(() => {
+        for (const notify of callbacks) notify();
+      });
+    }
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("goes with content that finishes rendering under a reader it is following", () => {
+      // A diagram or image that lays out after its message arrived grows the
+      // transcript with no item to trigger the effect that follows it. Reading the
+      // new distance back would file a reader who never touched the page as having
+      // walked away from it — and strand them there, no control offered.
+      const resize = stubResizeObserver();
+      mount();
+      scrollDown();
+      scrolledInto = [];
+
+      layout(scroller(), { scrollHeight: 4000, clientHeight: 600, scrollTop: 1000 });
+      resize();
+
+      expect(scrolledInto).toContain(bottomAnchor());
+      expect(control()).toBeNull();
+    });
+
+    it("takes the control away when the end comes back within reach", () => {
+      // The other direction, and the one no scroll event reports: a window that
+      // grew, or a transcript that shrank, can put the end back inside the region
+      // without the reader moving at all.
+      const resize = stubResizeObserver();
+      mount();
+      scrollUp();
+      expect(control()).toBeInTheDocument();
+
+      layout(scroller(), { scrollHeight: 640, clientHeight: 600, scrollTop: 0 });
+      resize();
+
+      expect(control()).toBeNull();
+    });
+  });
+
+  it("watches the scroller an embed mounts only once its branding has settled", () => {
+    // The embed paints nothing until the branding request returns. An effect that
+    // reached for the scroller on the first render found null, and nothing in its
+    // dependencies changed when the real interface arrived — so the embedded
+    // widget got no observer at all.
+    const callbacks: (() => void)[] = [];
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        constructor(callback: () => void) {
+          callbacks.push(callback);
+        }
+        observe() {}
+        disconnect() {}
+      },
+    );
+
+    let api = agentApi(agentState({ brandingReady: false, items: [] as ChatItem[] }));
+    mockUseAgent.mockImplementation(() => api);
+    const view = render(<App rootElement={document.createElement("div")} />);
+    expect(document.querySelector("main")).toBeNull(); // nothing painted yet
+
+    api = agentApi(agentState({ brandingReady: true, items: [{ kind: "user", text: "go" }] as ChatItem[] }));
+    view.rerender(<App rootElement={document.createElement("div")} />);
+
+    expect(callbacks.length).toBeGreaterThan(0);
+    vi.unstubAllGlobals();
+  });
+
+  it("does not let a stream cancel a jump that has only just set off", () => {
+    // The jump is a smooth scroll: for its first frames the reader is still
+    // inside the near-bottom region. Waiting for one of them to prove they left
+    // leaves a window in which a streamed item pulls them back to the end and
+    // undoes the navigation they asked for.
+    const items: ChatItem[] = [
+      { kind: "user", text: "go" },
+      { kind: "assistant", blocks: [{ type: "text", text: "first" }], usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2 } },
+      { kind: "user", text: "more" },
+      { kind: "assistant", blocks: [{ type: "text", text: "second" }], usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2 } },
+    ];
+    let api = agentApi(agentState({ items }));
+    mockUseAgent.mockImplementation(() => api);
+    const view = render(<App />);
+    scrollDown();
+
+    // The target sits above the viewport: jsdom gives every box zeros, so the
+    // one fact this turns on has to be stated.
+    const main = scroller();
+    main.getBoundingClientRect = () => ({ top: 0, bottom: 600, left: 0, right: 800, width: 800, height: 600, x: 0, y: 0, toJSON: () => ({}) });
+    const target = document.querySelector('[data-item-index="1"]')!;
+    target.getBoundingClientRect = () => ({ top: -900, bottom: -700, left: 0, right: 800, width: 800, height: 200, x: 0, y: -900, toJSON: () => ({}) });
+
+    fireEvent.click(screen.getByTitle(/turns? ·/));
+    fireEvent.click(screen.getAllByRole("button", { name: /^Turn 1:/ })[0]);
+
+    scrolledInto = [];
+    api = agentApi(agentState({ items: [...items, { kind: "user", text: "and on" }] as ChatItem[] }));
+    view.rerender(<App />);
+
+    // The stream did not drag them back to the end.
+    expect(scrolledInto).not.toContain(bottomAnchor());
+  });
+
+  it("keeps following a stream whose own catch-up scroll starts far from the end", () => {
+    // A turn or tool card taller than the near-bottom region starts the automatic
+    // scroll from outside it. Its intermediate frames report a viewport far from
+    // the end, and read as a departure they would show the control and stop the
+    // follow midway through the stream.
+    let api = agentApi(agentState({ items: [{ kind: "user", text: "go" }] as ChatItem[] }));
+    mockUseAgent.mockImplementation(() => api);
+    const view = render(<App />);
+    scrollDown();
+
+    const main = scroller();
+    // The tall card has landed: the end is now far below the viewport.
+    layout(main, { scrollHeight: 4000, clientHeight: 600, scrollTop: 1000 });
+    api = agentApi(
+      agentState({ items: [{ kind: "user", text: "go" }, { kind: "user", text: "a tall one" }] as ChatItem[] }),
+    );
+    view.rerender(<App />);
+
+    for (const scrollTop of [1600, 2600, 3400]) {
+      layout(main, { scrollHeight: 4000, clientHeight: 600, scrollTop });
+      fireEvent.scroll(main);
+      expect(control()).toBeNull();
+    }
+
+    // And still following: another item arrives and the transcript goes with it.
+    scrolledInto = [];
+    api = agentApi(
+      agentState({
+        items: [
+          { kind: "user", text: "go" },
+          { kind: "user", text: "a tall one" },
+          { kind: "user", text: "and another" },
+        ] as ChatItem[],
+      }),
+    );
+    view.rerender(<App />);
+    expect(scrolledInto).toContain(bottomAnchor());
+  });
+
+  it("goes away when the transcript is replaced by one with nothing to scroll", () => {
+    // The scroller survives a session switch. A reader parked at the top of a
+    // long conversation who switches to a short one keeps scrollTop 0 — now the
+    // bottom — and the browser emits no scroll event to say so.
+    let api = agentApi(agentState({ items: [{ kind: "user", text: "go" }] as ChatItem[] }));
+    mockUseAgent.mockImplementation(() => api);
+    const view = render(<App />);
+
+    scrollUp();
+    expect(control()).toBeInTheDocument();
+
+    layout(scroller(), { scrollHeight: 400, clientHeight: 400, scrollTop: 0 });
+    api = agentApi(agentState({ sessionId: "sess_2", items: [] as ChatItem[] }));
+    view.rerender(<App />);
+
+    expect(control()).toBeNull();
+  });
+
+  it("keeps out from under the panels that overlay the conversation", () => {
+    // Analysis and Work Plan are drawers at z-10, full width on a narrow
+    // viewport. This control is rendered after them, so an equal level would
+    // paint a transcript affordance on top of the panel covering the transcript.
+    mockUseAgent.mockReturnValue(agentApi(agentState({ items: [{ kind: "user", text: "go" }] as ChatItem[] })));
+    render(<App />);
+    scrollUp();
+
+    const strip = screen.getByRole("button", { name: CONTROL }).parentElement!;
+    expect(strip.className).toContain("z-0");
+    expect(strip.className).not.toContain("z-10");
+  });
+
+  describe("an analysis jump", () => {
+    const items: ChatItem[] = [
+      { kind: "user", text: "go" },
+      { kind: "assistant", blocks: [{ type: "text", text: "first" }], usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2 } },
+      { kind: "user", text: "more" },
+      { kind: "assistant", blocks: [{ type: "text", text: "second" }], usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2 } },
+    ];
+
+    function jumpToFirstTurn() {
+      fireEvent.click(screen.getByTitle(/turns? ·/));
+      fireEvent.click(screen.getAllByRole("button", { name: /^Turn 1:/ })[0]);
+    }
+
+    beforeEach(() => {
+      mockUseAgent.mockReturnValue(agentApi(agentState({ items })));
+      render(<App />);
+    });
+
+    it("offers the way back once it has taken the reader out of the region", () => {
+      scrollDown();
+      jumpToFirstTurn();
+      // What the browser does next, and jsdom does not: the jump's own scroll.
+      scrollUp();
+
+      expect(control()).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: CONTROL }));
+      expect(control()).toBeNull();
+    });
+
+    it("leaves a reader at the bottom alone when it moves them nowhere", () => {
+      // Jumping to something already on screen at the end scrolls nothing and
+      // emits no scroll event. Treating that as a departure would strand the
+      // reader: the transcript stops following, and the control that would fix
+      // it is hidden precisely because they are at the bottom.
+      scrollDown();
+      jumpToFirstTurn();
+
+      expect(control()).toBeNull();
+
+      // Still followed: the point of not having called it a departure.
+      scrolledInto = [];
+      const main = scroller();
+      layout(main, { scrollHeight: 4000, clientHeight: 600, scrollTop: 3400 });
+      fireEvent.scroll(main);
+      expect(control()).toBeNull();
+    });
+  });
+});

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -66,6 +66,15 @@ interface AppProps {
   workspace?: string;
 }
 
+/**
+ * How close to the end counts as "at the bottom", in pixels.
+ *
+ * One number, two readers: the effect that follows streamed content, and the
+ * return-to-latest control's visibility. A second literal would let the button
+ * claim the reader is away while the transcript keeps scrolling under them.
+ */
+const NEAR_BOTTOM_PX = 120;
+
 const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootElement, initialTheme, token, workspace }, ref) {
   const embedded = rootElement !== undefined;
   const accentTarget = rootElement ?? document.documentElement;
@@ -380,23 +389,185 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
     initialTheme,
   );
   useImperativeHandle(ref, () => ({ setTheme }), [setTheme]);
-  const mainRef = useRef<HTMLElement>(null);
+  const mainRef = useRef<HTMLElement | null>(null);
+  /**
+   * The scroller, as state as well as a ref.
+   *
+   * The embed renders nothing until its branding request settles, so an effect
+   * that reached for the ref on the first render found null — and nothing in its
+   * dependencies changed when the real interface finally mounted, so it never
+   * looked again. A callback ref reports the mount itself.
+   */
+  const [scrollerElement, setScrollerElement] = useState<HTMLElement | null>(null);
+  const attachScroller = useCallback((node: HTMLElement | null) => {
+    mainRef.current = node;
+    setScrollerElement(node);
+  }, []);
   const bottomRef = useRef<HTMLDivElement>(null);
   const stickToBottom = useRef(true);
+  /**
+   * The same fact as `stickToBottom`, in a form a render can read.
+   *
+   * The ref stays authoritative: the effect below reads it in the tick a scroll
+   * writes it, where state would still be one render behind and would follow
+   * content the reader had just scrolled away from. This mirror exists only so
+   * the return-to-latest control can appear and disappear, and it is written
+   * everywhere the ref is — see `setStick` and `useConversationJump`.
+   */
+  const [atBottom, setAtBottom] = useState(true);
+
+  /** Writes both representations of the near-bottom fact, so they cannot drift. */
+  const setStick = useCallback((next: boolean) => {
+    if (next !== stickToBottom.current) setAtBottom(next);
+    stickToBottom.current = next;
+  }, []);
+
+  /** Reads the near-bottom fact off the scroller's current geometry. */
+  const syncStick = useCallback(() => {
+    const main = mainRef.current;
+    if (!main) return;
+    setStick(main.scrollHeight - main.scrollTop - main.clientHeight < NEAR_BOTTOM_PX);
+  }, [setStick]);
+
+  /**
+   * True while a return-to-latest animation is still on its way to the end.
+   *
+   * A smooth scroll emits a scroll event per frame, and every one of them but the
+   * last reports a viewport still far from the end. Read naively they say the
+   * reader has gone back to the scrollback, which flickers the control on again
+   * for the length of the animation and — worse — stops the transcript following
+   * anything that streams in while it runs.
+   */
+  const returning = useRef<number | null>(null);
+
+  /**
+   * Arms the guard for a scroll this app is about to start towards the end.
+   *
+   * Only when that scroll has somewhere to travel. From inside the near-bottom
+   * region it covers less ground than the region itself, so none of its frames
+   * can read as a departure — and arming there would leave the guard held by an
+   * animation that never ran, swallowing the reader's next scroll instead.
+   */
+  const beginReturn = useCallback(() => {
+    const main = mainRef.current;
+    if (!main) return;
+    if (main.scrollHeight - main.scrollTop - main.clientHeight < NEAR_BOTTOM_PX) return;
+    returning.current = main.scrollTop;
+  }, []);
 
   // Track whether the user is reading scrollback: only auto-scroll when
   // already near the bottom (avoids yanking during streaming).
-  function handleScroll() {
+  const evaluatePosition = useCallback(() => {
     const main = mainRef.current;
     if (!main) return;
-    stickToBottom.current = main.scrollHeight - main.scrollTop - main.clientHeight < 120;
+    const near = main.scrollHeight - main.scrollTop - main.clientHeight < NEAR_BOTTOM_PX;
+    const from = returning.current;
+    if (from !== null) {
+      if (main.scrollTop < from) {
+        // Away from the end: nothing this app started moves that way, so this is
+        // the reader — with the scrollbar, say, which emits no gesture of its own.
+        returning.current = null;
+      } else {
+        returning.current = near ? null : main.scrollTop;
+        // Still on its way. Reporting the position it is passing through would
+        // say the reader had left the bottom, which shows the control mid-flight
+        // and stops the transcript following anything that streams in meanwhile.
+        if (!near) return;
+      }
+    }
+    setStick(near);
+  }, [setStick]);
+
+  /** A scroll the reader started: whatever we were animating towards, they own it now. */
+  function handleScrollGesture() {
+    returning.current = null;
   }
+
+  /**
+   * Two things the scroll handler alone would miss.
+   *
+   * `scrollend` is what finally ends a guarded return, whatever ended it: the
+   * animation arriving, or a reader dragging the scrollbar *towards* the end and
+   * letting go short of it — a drag that emits no gesture and only ever moves the
+   * way the animation was going, so nothing else can tell it apart.
+   *
+   * The observer covers the geometry moving under a scroll position that did not:
+   * a resized window, a composer that grew, tool cards revealed. None of those
+   * scroll, and all of them can put the end out of reach without a word.
+   */
+  useEffect(() => {
+    const main = scrollerElement;
+    if (!main) return;
+    const settle = () => {
+      returning.current = null;
+      evaluatePosition();
+    };
+    main.addEventListener("scrollend", settle);
+    let observer: ResizeObserver | undefined;
+    if (typeof ResizeObserver !== "undefined") {
+      observer = new ResizeObserver(() => {
+        if (stickToBottom.current) {
+          // A reader being followed has not gone anywhere: the end moved. Content
+          // that finishes rendering after it arrived — a diagram, an image — grows
+          // the transcript with no item to trigger the effect that follows it, and
+          // reporting the new distance would file the reader as having walked away
+          // from a page they never touched.
+          beginReturn();
+          bottomRef.current?.scrollIntoView({ behavior: "auto" });
+          return;
+        }
+        evaluatePosition();
+      });
+      observer.observe(main);
+      // The transcript's own box: its height is what tool cards and streamed
+      // content change, and the scroller's own box never moves for either.
+      if (main.firstElementChild) observer.observe(main.firstElementChild);
+    }
+    return () => {
+      main.removeEventListener("scrollend", settle);
+      observer?.disconnect();
+    };
+  }, [scrollerElement, evaluatePosition, beginReturn]);
+
+  /**
+   * Return to the newest message.
+   *
+   * The near-bottom state is restored here rather than left to the scroll events
+   * the animation emits: a smooth scroll that a reduced-motion setting turns into
+   * a jump may never emit a settling event, which would strand the button on
+   * screen and leave streamed content unfollowed.
+   */
+  const scrollToLatest = useCallback(() => {
+    setStick(true);
+    beginReturn();
+    // `smooth` is not softened by a reduced-motion preference the way a CSS
+    // transition is — the browser animates it regardless — so the preference is
+    // read here and the scroll becomes a jump when it is set.
+    const reduced = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+    bottomRef.current?.scrollIntoView({ behavior: reduced ? "auto" : "smooth" });
+  }, [setStick, beginReturn]);
 
   useEffect(() => {
     if (stickToBottom.current) {
+      // Guarded like the explicit return, and for the same reason: a turn or a
+      // tool card taller than the near-bottom region starts this animation from
+      // outside it, and its own intermediate frames would otherwise read as the
+      // reader walking away — ending the follow midway through a stream.
+      beginReturn();
       bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+      return;
     }
-  }, [state.items]);
+    /**
+     * The transcript changed under a reader who is not at the end.
+     *
+     * `<main>` survives a session switch, so a reader parked at the top of a long
+     * conversation who switches to a short or empty one keeps `scrollTop = 0` —
+     * a position that is now the bottom, with no scroll event to say so. Reading
+     * the geometry back is the only thing that notices, and it is safe here
+     * precisely because the reader is not being followed: nothing moves.
+     */
+    syncStick();
+  }, [state.items, syncStick, beginReturn]);
 
   // Recomputed only when the transcript itself changes, not on every unrelated
   // render of a component this tall.
@@ -429,12 +600,40 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
     [readFile, fetchGitFileHistory, searchFiles],
   );
   const showTools = useCallback(() => setHideTools(false), []);
+  /**
+   * Stop following the bottom, because a jump has taken the reader elsewhere.
+   *
+   * Unless it has not. Jumping to something already on screen at the end of the
+   * conversation moves nothing and emits no scroll event, so suppressing the
+   * follow there would strand a reader who is *at* the bottom with a transcript
+   * that no longer follows and no control offered to fix it — the control being
+   * hidden precisely because they are at the bottom.
+   *
+   * The target's own box is what settles it, not the scroll position alone: a
+   * jump from the bottom to something far above does move the reader, and waiting
+   * for its first frame to prove that leaves a window in which a streamed item
+   * pulls them straight back and cancels the navigation they just asked for.
+   */
+  const handleJump = useCallback(
+    (target: Element) => {
+      const main = mainRef.current;
+      if (main) {
+        const view = main.getBoundingClientRect();
+        const box = target.getBoundingClientRect();
+        const onScreen = box.top >= view.top && box.bottom <= view.bottom;
+        const near = main.scrollHeight - main.scrollTop - main.clientHeight < NEAR_BOTTOM_PX;
+        if (onScreen && near) return;
+      }
+      setStick(false);
+    },
+    [setStick],
+  );
   const { jumpToItem, highlightIndex } = useConversationJump({
     items: state.items,
     scrollerRef: mainRef,
     hideTools,
     onShowTools: showTools,
-    stickToBottom,
+    onJump: handleJump,
   });
 
   useEffect(() => {
@@ -696,8 +895,13 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
           {/* The drawer overlays the right side; padding keeps the conversation
               beside it rather than behind it, so a jump lands somewhere visible. */}
           <main
-            ref={mainRef}
-            onScroll={handleScroll}
+            ref={attachScroller}
+            onScroll={evaluatePosition}
+            // A gesture beats an animation: whichever of these the reader makes,
+            // the return we were still animating stops being what they asked for.
+            onWheel={handleScrollGesture}
+            onTouchStart={handleScrollGesture}
+            onKeyDown={handleScrollGesture}
             /* During a switch the outgoing conversation fades and holds rather than
                emptying: a blank pane makes a switch read as a page reload, which is
                the one thing this transition exists to avoid. No skeleton — the old
@@ -833,6 +1037,35 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
               <div ref={bottomRef} />
             </div>
           </main>
+          {/* Outside <main> on purpose: a child of the scroller travels with the
+              transcript. Absolute against the `relative z-0` wrapper rather than
+              `fixed`, which would resolve against the host page's viewport when
+              this widget is embedded in one, not against the widget.
+
+              `z-0` rather than `z-10`: the drawers that overlay the conversation
+              sit at `z-10` and are rendered above this in the tree, so an equal
+              level would let a control for the transcript paint over the panel
+              covering it — full-width, on a narrow viewport. Still above the
+              transcript, which is not positioned at all.
+
+              The strip carries the same padding <main> takes beside an open
+              drawer, so the button centres on the conversation the reader can
+              see rather than on the region the drawer is sitting in. */}
+          <div
+            className={`pointer-events-none absolute inset-x-0 bottom-4 z-0 flex justify-center ${analysisOpen ? "md:pr-[26rem]" : state.workPlan && workPlanOpen ? "md:pr-[23rem]" : ""}`}
+          >
+          {!atBottom && (
+            <button
+              type="button"
+              onClick={scrollToLatest}
+              aria-label="Scroll to the latest message"
+              className="pointer-events-auto flex items-center gap-1.5 rounded-full border border-zinc-300 bg-white/95 px-3 py-1.5 text-xs text-zinc-600 shadow-lg backdrop-blur transition-colors hover:bg-zinc-50 motion-reduce:transition-none dark:border-zinc-700 dark:bg-zinc-900/95 dark:text-zinc-300 dark:hover:bg-zinc-800"
+            >
+              <span aria-hidden>↓</span>
+              Latest
+            </button>
+          )}
+          </div>
           </div>
 
           <footer className="border-t border-zinc-200 px-4 py-3 dark:border-zinc-800">

--- a/ui/src/useConversationJump.test.tsx
+++ b/ui/src/useConversationJump.test.tsx
@@ -11,7 +11,7 @@ const items: ChatItem[] = [
 ];
 
 /** Stands in for the conversation: same anchors, same hideTools filter. */
-function Conversation({ startHidden = false }: { startHidden?: boolean }) {
+function Conversation({ startHidden = false, onStick }: { startHidden?: boolean; onStick?: (next: boolean) => void }) {
   const scrollerRef = useRef<HTMLDivElement>(null);
   const stickToBottom = useRef(true);
   const [hideTools, setHideTools] = useState(startHidden);
@@ -20,7 +20,10 @@ function Conversation({ startHidden = false }: { startHidden?: boolean }) {
     scrollerRef,
     hideTools,
     onShowTools: () => setHideTools(false),
-    stickToBottom,
+    onJump: () => {
+      stickToBottom.current = false;
+      onStick?.(false);
+    },
   });
 
   return (
@@ -96,6 +99,19 @@ describe("useConversationJump", () => {
       screen.getByText("jump to turn").click();
     });
     expect(screen.getByTestId("stick").textContent).toBe("false");
+  });
+
+  it("reports the jump to its owner rather than writing the fact itself", () => {
+    // The conversation keeps a second, render-visible copy of this fact and knows
+    // the scroller's geometry. A hook that wrote the ref directly could reach only
+    // one of the two, and could not tell a jump that moved the reader from one
+    // that changed nothing.
+    const onStick = vi.fn();
+    render(<Conversation onStick={onStick} />);
+    act(() => {
+      screen.getByText("jump to turn").click();
+    });
+    expect(onStick).toHaveBeenCalledWith(false);
   });
 
   it("does nothing for an index outside the conversation", () => {

--- a/ui/src/useConversationJump.ts
+++ b/ui/src/useConversationJump.ts
@@ -9,8 +9,18 @@ interface JumpOptions {
   hideTools: boolean;
   /** Reveals tool cards; called before jumping to one that is filtered out. */
   onShowTools: () => void;
-  /** Set to false on a jump so the stick-to-bottom effect does not yank it back. */
-  stickToBottom: React.MutableRefObject<boolean>;
+  /**
+   * Called once the jump has been issued, so the conversation can stop following
+   * the bottom and not yank the arrival back to the end.
+   *
+   * A report rather than the `stickToBottom` ref this used to take: the
+   * conversation now keeps a second, render-visible copy of that fact and knows
+   * the scroller's geometry, both of which it must weigh before deciding. A hook
+   * that wrote the ref directly could reach only one of the two, and could not
+   * tell a jump that moved the reader from one that changed nothing. The target
+   * goes with the report because that question is answered from its box.
+   */
+  onJump: (target: Element) => void;
 }
 
 /** How long the target stays marked after arrival. */
@@ -25,7 +35,7 @@ const HIGHLIGHT_MS = 2000;
  * revealed first — scrolling to an unrendered node would make the click a
  * silent no-op, the worst outcome for a navigation affordance.
  */
-export function useConversationJump({ items, scrollerRef, hideTools, onShowTools, stickToBottom }: JumpOptions) {
+export function useConversationJump({ items, scrollerRef, hideTools, onShowTools, onJump }: JumpOptions) {
   const [highlightIndex, setHighlightIndex] = useState<number | null>(null);
   const pending = useRef<number | null>(null);
   // Bumped per jump so a second jump to the same item still scrolls.
@@ -55,12 +65,12 @@ export function useConversationJump({ items, scrollerRef, hideTools, onShowTools
     pending.current = null;
     const target = scrollerRef.current?.querySelector(`[data-item-index="${index}"]`);
     if (!target) return;
-    stickToBottom.current = false;
+    onJump(target);
     target.scrollIntoView?.({ behavior: "smooth", block: "center" });
     setHighlightIndex(index);
     if (timer.current) clearTimeout(timer.current);
     timer.current = setTimeout(() => setHighlightIndex(null), HIGHLIGHT_MS);
-  }, [nonce, hideTools, scrollerRef, stickToBottom]);
+  }, [nonce, hideTools, scrollerRef, onJump]);
 
   return { jumpToItem, highlightIndex };
 }


### PR DESCRIPTION
> **Re-opening #127 against `main`.** #127 targeted `feat/user-extension-paths`, and #126 merged
> that branch into `main` *before* #127 landed on it — so `main`'s tip (`810ea6d`) has `b161d83` as
> its parent and this commit never came along. Same commit (`4764cbc`), same diff, now based on
> `main`, whose history already contains everything it sat on top of.

A reader who has moved up through a long or streaming conversation had no way back to the newest
message but to drag the scrollbar the whole way. The application already knew when they had left its
near-bottom region — that is what stops streamed output yanking the viewport away while you read — it
just never offered to act on it.

A small pill — `↓ Latest` — centred above the composer, present only while the reader is outside the
near-bottom region.

## What it does

- Appears when the reader leaves the near-bottom region, disappears when they re-enter it — whether
  they scrolled, activated the control, or content arrived below them.
- Returns to the end and puts the reader back in the path of streamed content.
- Sends, edits and changes nothing else. Composer draft, attachments, open session and file are
  untouched.
- Native `<button>`, named for assistive technology, absent from the tree while hidden, and a jump
  rather than an animation under `prefers-reduced-motion`.
- Leaves the existing scrollback protection exactly as it was.

Spec: `openspec/changes/add-scroll-to-bottom-button/specs/conversation-scroll-navigation/spec.md`.

## How

One fact, two representations. `stickToBottom` stays the ref the auto-scroll effect reads in the
same tick a scroll writes it — state there would be one render stale and would follow content the
reader had just scrolled away from. `atBottom` mirrors it for the render. Every write goes through
`setStick`, and the 120px threshold is one named constant both readers share, so the control's
visibility and the auto-scroll decision cannot disagree.

**Most of the work is about a scroll that lies.** `scrollIntoView({behavior: "smooth"})` emits an
event per frame, and every one but the last reports a viewport still far from the end. Read naively
they say the reader walked away: the control flickers back on for the length of the animation, and
the transcript stops following anything streaming in meanwhile. A guard holds the last position seen
while an app-initiated scroll is in flight and swallows those frames. Three things release it,
because none alone is enough:

| release | catches |
|---|---|
| arrival | the animation finishing |
| a position moving *away* from the end | the reader — all a scrollbar drag gives you |
| `scrollend` | a drag *towards* the end, released short of it: no gesture, and every position moving the way the animation was |

The same guard wraps the automatic follow, which has the identical problem whenever a turn or tool
card is taller than the near-bottom region.

**Scroll events are not the only way the end moves out of reach.** A resized window, a composer that
grew, tool cards revealed, a diagram that finishes laying out after its message arrived — none of
them scroll. A `ResizeObserver` covers them, and it *follows* rather than reports: content settling
under a reader who is being followed is the end moving, not the reader leaving. Reporting it filed
them as having walked away from a page they never touched, and cancelled the scroll to the bottom on
load. It installs through a callback ref, because the embed renders nothing until its branding
request settles and an effect reaching for `mainRef` on the first render finds `null` — with nothing
in its dependencies to make it look again.

**The analysis panel's jump reports its target** instead of writing the ref itself. Jumping to
something already on screen at the end scrolls nothing and emits no event; calling that a departure
stranded a reader *at* the bottom with a transcript that no longer followed and no control offered —
the control being hidden precisely because they were at the bottom. Reading the target rather than
waiting for the jump's first frame also closes a window in which a streamed item pulled them back
and cancelled the navigation they had just asked for.

**Placement.** Absolute against the `relative z-0` wrapper, not `fixed` — `fixed` resolves against
the host page's viewport when the widget is embedded in one, not against the widget. `z-0`, not
`z-10`: the session-analysis and work-plan drawers are `z-10` and rendered above it in the tree, so
an equal level painted a control for the transcript over the panel covering the transcript, full
width on a narrow viewport. Its strip carries the same padding `<main>` takes beside an open drawer,
so it centres on the conversation the reader can actually see.

## Testing

`ui` 1382 passed · typecheck ok · lint ok · e2e 54 passed · `openspec validate --strict` valid.

Sixteen scenarios, sixteen tests, each annotated `// openlore: scenario=… spec=…`. Thirteen in
`ui/src/App.test.tsx`, three in `e2e/app.spec.ts` — layout claims, a real key press (jsdom dispatches
no click from a keydown), and the animation frames jsdom does not emit at all.

jsdom reports `0` for `scrollHeight`, `clientHeight` and `scrollTop`, which makes the near-bottom
expression `0 < 120` — trivially true. A test that skipped the geometry stub would find the control
never rendered and pass its "hidden at the bottom" assertion for entirely the wrong reason, so every
visibility test drives **both** directions. Each behaviour was mutation-checked: forcing the control
hidden fails 10 tests, forcing it always shown fails 8, and every fix below fails its own test when
reverted.

It was also driven by hand in the running app — standalone and embedded, light and dark, down to
380px — reading back the DOM and the scroll position rather than looking at a screenshot.

## Review

Five Codex passes, six findings, **every one confirmed real and fixed**; clean on the sixth.

1. **Stale state after a transcript replacement** — switch from a long session to a short one and the
   control stayed with nothing to scroll. `<main>` survives the switch and `scrollTop` never moves,
   so no scroll event says so.
2. **Painted over the drawers** — the `z-10` collision above.
3. **P1 — the animation's own frames.** I had sampled the settled state and called it done;
   frame-by-frame in the browser read `shown,gone,gone,gone,shown,shown…`.
4. **Jump suppression too eager** — the stranding described above.
5. **The guard could hold forever** — the scrollbar drag released early; `scrollend` closes it.
6. **Observers never installed in the embed** — the callback ref.

On the last: my earlier "embed verified" runs had been reading a **stale host bundle** — I skipped
`build:e2e-host`, which is what the bench's host page actually serves. The freshness gate in
`e2e/global-setup.ts` catches this; the bench does not.

## Not in this PR

Six `openlore drift` gaps in `useAgent.ts`, `Header.tsx`, `SettingsMenu.tsx`, `server/src/index.ts`,
`config.ts` and `protocol.ts` — all pre-existing on the base branch, none in files this change
touches.

The OpenSpec change is left unarchived: archiving belongs on `main`, after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApVH3xC7mrGRnqbkCc8uVM
