### PR TITLE
Say why the server could not start

### DIFF
--- a/openspec/changes/say-why-the-server-could-not-start/.openspec.yaml
+++ b/openspec/changes/say-why-the-server-could-not-start/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-30

--- a/openspec/changes/say-why-the-server-could-not-start/design.md
+++ b/openspec/changes/say-why-the-server-could-not-start/design.md
@@ -1,0 +1,114 @@
+## Context
+
+See proposal.md — Why. Two facts about the code shape the approach.
+
+`server/src/index.ts` is a top-level module with top-level `await`. `await app.listen({
+port: PORT, host: HOST })` sits at line 733 with nothing around it, so its rejection is an
+unhandled rejection: Node prints a trace and exits. Every other failure in the same file
+already has a house style — `complain(error)` at line 148, which prints one line and
+prefixes it `[pi]` unless the message brings its own bracket, followed by `process.exit`.
+`init` and `build-exe` both use it. This change joins that path; it does not invent one.
+
+The second fact is about where the message lands. A process started from a file manager on
+Windows *owns* its console window: the window exists because the process does, and it
+closes when the process exits. There is no scrollback to go back to and no terminal that
+outlives it. A process started from a shell borrows a console that belongs to the shell,
+and its output survives it. The same `console.error` call is therefore permanent in one
+case and a flash in the other, and nothing in the message itself can tell the difference.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A failure to bind reads like every other startup failure this binary has.
+- The message reaches an operator who has no terminal — the case the own-window change
+  created and the reason this is worth doing now.
+- The decision about whether to hold the console is a value a test can compute, not a
+  behaviour a test has to observe through a keypress.
+
+**Non-Goals:**
+
+- Recovering from the failure — retrying, scanning for a free port, or joining a server
+  already running. See proposal.md — Out of scope.
+- Anything on the success path. A server that binds must not gain a line of output, a
+  prompt, or a millisecond.
+- Failures after `listen` succeeds. A stalled extension binding leaves the process alive
+  and is a different change.
+
+## Decisions
+
+**Catch at the call, not with a global handler.** An `unhandledRejection` handler would
+also catch a failure this file has not thought about, and would report it as if it had.
+The point of the message is that it knows what failed; a `try`/`catch` around the one
+statement keeps that true. Alternative considered: a process-wide handler, which is fewer
+lines and turns every future unknown failure into a confident sentence about the wrong
+thing.
+
+**Two pure functions and one impure edge.** The message is a function of the error, the
+host and the port. Whether to hold the console is a function of the platform, the
+environment, and who the parent process is. Both are exported and tested directly; only
+the keypress wait touches the terminal. This mirrors `openBrowser.ts`, where
+`shouldOpenBrowser` and `browsableUrl` are pure and the spawn is the thin part — the same
+shape, for the same reason: the interesting question is the decision, and a decision is
+cheap to test everywhere and expensive to test through its effect.
+
+**Ask who the parent is, rather than whether a terminal is attached.** `process.stdin.isTTY`
+is true both for a double-clicked window and for a shell, so it cannot separate the two
+cases; it only says a person could type. The question that matters is whether this console
+dies with this process, and that is answered by the parent: a console spawned by the file
+manager has `explorer.exe` above it, a shell has the shell. On Windows the parent's image
+name comes from `tasklist /FI "PID eq <ppid>" /FO CSV /NH`, run once, only on the failure
+path, and only there — the success path never pays for it, and a fatal error can afford a
+process spawn. `/FO CSV /NH` because `tasklist`'s headers are localised and its default
+layout is column-aligned; the image name itself is not localised.
+
+Alternative considered and rejected: hold whenever `stdin` is a TTY and `CI` is unset, with
+a timeout so a wrong guess cannot hang. Five lines instead of thirty, no spawn, no parsing.
+Rejected because it makes an interactive shell user press a key on an error they can
+already read, and because the timeout is a second guess layered on the first — if the
+signal were right, no bound would be needed.
+
+**Hold only on a confident yes.** The probe answers `explorer.exe`, something else, or
+nothing at all — no parent, a probe that failed, a platform with no `tasklist`. Only the
+first holds the console. Everything else exits immediately, which is exactly today's
+behaviour, so a probe that cannot answer degrades to what already happens rather than to a
+process that hangs. `CI` is checked first and never holds, on the same reasoning
+`shouldOpenBrowser` already applies to it: a runner has no one watching.
+
+**Wait for a key, not for a timeout.** Once the answer is a confident yes, the window is
+the operator's only copy of the message and there is no honest number of seconds after
+which it should be thrown away. `setRawMode(true)` and the first byte on `stdin` ends it.
+Where raw mode is unavailable the wait is skipped rather than degraded into a hang.
+
+**Exit non-zero, with the code the file already uses.** `1`, as `init` and `build-exe`
+use for their failures. `2` is taken by argument parsing and means "you typed something
+wrong", which this is not.
+
+## Risks / Trade-offs
+
+**A wrong parent probe holds a window nobody is watching** → It can only hold when the
+parent is `explorer.exe`, and a process whose parent is the file manager has, by
+construction, a console of its own that would otherwise vanish. A wrong answer in the other
+direction — failing to recognise a launch that owns its console — loses the message, which
+is today's behaviour and not a regression.
+
+**`tasklist` is absent or restricted on a hardened Windows** → The probe returns no answer,
+the process exits immediately, and the operator is exactly where this change found them.
+No path treats a failed probe as a yes.
+
+**A spawn on the failure path costs time** → Only on the path that ends in `exit`, and only
+on Windows. Nothing measures a process that is already dead.
+
+**The occupied-port test binds a real port** → Bind port 0 first, read back what the
+operating system chose, and start the server against that. Never a fixed number: a test
+that hard-codes 3141 fails on the machine of anyone who has the interface open, which is
+everyone working on this.
+
+## Migration Plan
+
+None. No configuration key, no flag, no stored state, no protocol message. The change is
+visible only on a path that previously ended in a stack trace.
+
+## Open Questions
+
+None.

--- a/openspec/changes/say-why-the-server-could-not-start/proposal.md
+++ b/openspec/changes/say-why-the-server-could-not-start/proposal.md
@@ -1,0 +1,61 @@
+## Why
+
+A server that cannot bind its port dies on an unhandled rejection. `await app.listen(...)`
+is the one startup step in `server/src/index.ts` that no one catches, while every other
+failure in that file — a bad flag, a failed `init`, a refused `build-exe` — goes through
+`complain()` and an exit code. The operator gets a stack trace where every neighbouring
+failure gets a sentence.
+
+Opening the interface in a window of its own made this worse, and now. That change made
+the double-click the intended way in on Windows, and a double-clicked process owns its
+console: when it exits, the window closes and takes the message with it. The interface
+never opens either, so there is no second place to look. Observed on a real Windows
+machine this week — a second instance started while a first held port 3141 died silently,
+and the browser window in front of the operator belonged to the *older* server, so the new
+build was judged on the old one's state.
+
+## What Changes
+
+- Catch a failure to listen and report it the way this file reports every other startup
+  failure: a line, not a stack, and a non-zero exit.
+- Name the common case for what it is. A port already in use SHALL say so, name the host
+  and port that were refused, and name `--port`, which is the way out.
+- Hold the console open when the process owns it, so the line can be read. A shell, a
+  script and CI SHALL NOT be made to wait — only the launch that has nowhere else to
+  print.
+- No change to a server that starts: this is entirely on the path where it does not.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `cli`: adds a requirement covering what the binary does when it cannot start. The spec
+  says today what starting does — it opens the interface, at the bound address, and a
+  failure to open is not a failure to start. It says nothing about failing to start,
+  which is the case this change is about.
+
+## Impact
+
+- `server/src/index.ts` — the unguarded `await app.listen(...)`, and the `complain()`
+  path it should be joining.
+- Nothing else at runtime. No configuration key, no flag, no protocol message: the
+  behaviour is on a path that ends in `process.exit`.
+- Tests: the server harness starts real servers on real ports, so the occupied-port case
+  is reachable without a mock. Whether the console is held is a decision, and the decision
+  is what gets tested — not a keypress.
+
+## Out of scope, deliberately
+
+- **Single-instance rendezvous**: a second launch joining the server already running
+  instead of starting one. That is the better answer to the Windows case and it is a
+  larger change, with a state file, a liveness probe and a key that keeps two legitimate
+  projects apart.
+- **Ephemeral ports**: letting the operating system choose, now that nobody types the
+  address. Viable, and it costs bookmarks and embedded widgets pinned to 3141.
+- **Extension failures surfaced in the interface**: `bindExtensions` never settling leaves
+  the interface unconnectable and says so only on the console. Same family, different
+  change.

--- a/openspec/changes/say-why-the-server-could-not-start/scenario-coverage.md
+++ b/openspec/changes/say-why-the-server-could-not-start/scenario-coverage.md
@@ -1,0 +1,24 @@
+# Scenario coverage
+
+Every `#### Scenario:` in `specs/cli/spec.md`, with the assertion that would fail if the
+contract broke. Enumerated with `rg '^#### Scenario:' openspec/changes/say-why-the-server-could-not-start/`.
+
+| Scenario | Status | Where | What would fail |
+|---|---|---|---|
+| ThePortIsAlreadyTaken | covered | `server/test/startup-failure.test.mjs` — "exits non-zero with one readable line and no stack trace"; `server/test/startupFailure.test.ts` — "an occupied port names the address refused and the flag that moves it" | The integration test holds a real port (bound at 0, read back), starts a real server against it, and asserts the exit code is non-zero, that stderr names `127.0.0.1:<that port>`, says "already in use", names `--port`, carries no `at ` stack frame, no `unhandled`, and exactly one `cannot start` line. Remove the `try`/`catch` at `server/src/index.ts:742` and every one of those fails. |
+| TheBindFailsForSomeOtherReason | covered | `server/test/startupFailure.test.ts` — "another reason still gets a sentence", "an unknown reason carries the reason, and never a stack" | Asserts EACCES and EADDRNOTAVAIL each name the address and the flag that applies (`--port`, `--host`); that EACCES on a high port does not blame privilege, which a reserved range or a security product can cause; that a literal IPv6 host keeps its brackets so `[::1]:3141` still names a port; and that an unrecognised code still yields a sentence carrying the underlying message and never the stack. Reached at the wire only through a port the machine refuses, which is not portable to assert; the message is the whole of what changes between codes, and it is asserted directly. |
+| TheMessageOutlivesTheWindow | partial | `server/test/startupFailure.test.ts` — "a file manager above us on Windows owns the window", "a key ends the wait and hands the terminal back"; task 4.1 | The decision is asserted in full: `explorer.exe` above us on Windows is the only yes, in three spellings. The wait is driven through a supplied stream and asserts raw mode goes on and back off and the stream is paused. What no test here can establish is that a double-clicked executable on Windows really does have `explorer.exe` as its parent and really does own its window — that is task 4.1, on the requester's machine. |
+| NobodyElseIsMadeToWait | covered | `server/test/startupFailure.test.ts` — "a shell borrows a console that outlives us", "no answer is not a yes", "elsewhere the terminal outlives the process", "a runner is never made to wait"; `server/test/startup-failure.test.mjs` — the same test as row 1 | Four shells answer no, an absent or empty parent answers no, macOS and Linux answer no whatever the parent, and `CI` answers no even with `explorer.exe` above. At the wire, the integration test asserts stderr never says "press any key" — it runs from a test runner, which is exactly this case, and it would hang rather than fail if the decision went the other way. |
+| AServerThatStartsIsUnchanged | covered | `server/test/startup-failure.test.mjs` — "says what it always said, waits for nothing, and serves" | Starts a real server through the harness, which only resolves once `/health` answers — so a process that stopped to be dismissed fails by timing out. Then asserts the `[server] http://127.0.0.1:<port>/` line is printed as before and that the log contains neither "press any key" nor "cannot start". |
+
+## What no test here establishes
+
+The parent-process probe answers a real question only on Windows. `parentImageName()` is
+asserted not to throw on every platform and to answer `undefined` off Windows, and
+`parseTasklistImageName` is asserted against real `tasklist` CSV output and against its
+polite refusal ("INFO: No tasks are running..."), which exits zero. That the string
+`tasklist` actually prints for an Explorer-launched process is `explorer.exe` is what task
+4.1 checks, on a machine that has one.
+
+Task 4.2 is the other direction on the same machine: the same failing start from
+PowerShell, exiting immediately with the same line and no prompt.

--- a/openspec/changes/say-why-the-server-could-not-start/specs/cli/spec.md
+++ b/openspec/changes/say-why-the-server-could-not-start/specs/cli/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: AFailureToStartIsSaidOutLoud
+
+A server that cannot begin listening SHALL report why in the same voice as every other
+failure this binary can have: one line naming what went wrong, and a non-zero exit. It
+SHALL NOT exit on an unhandled error, and it SHALL NOT print a stack trace as its
+explanation — a stack is where the code was, not what the operator must do.
+
+An address already in use SHALL be named for what it is. The message SHALL carry the host
+and port that were refused, and SHALL name the way to move it, so that reading the line is
+enough to act on it. Any other reason a bind fails SHALL still produce a readable line
+rather than a trace.
+
+The message SHALL survive the console it was printed on. Where the process owns that
+console — a standalone executable started from a file manager, which is how the interface
+is meant to be opened and which has no terminal behind it — the process SHALL hold it open
+until the operator dismisses it, because exiting would close the window and take the only
+copy of the message with it. Where the console belongs to something else — a shell, a
+script, a continuous integration runner — the process SHALL exit immediately and wait for
+no one.
+
+A server that starts SHALL be unaffected: nothing added to its output, and nothing to
+dismiss.
+
+#### Scenario: ThePortIsAlreadyTaken
+- **GIVEN** something is already listening on the host and port the server was asked to bind
+- **WHEN** the operator starts the server
+- **THEN** it exits non-zero having printed a single line that names that host and port and the flag that moves it
+- **AND** no stack trace is printed
+
+#### Scenario: TheBindFailsForSomeOtherReason
+- **GIVEN** an address the machine will not let this process bind
+- **WHEN** the operator starts the server
+- **THEN** it exits non-zero having printed a readable line naming the failure, not a stack trace
+
+#### Scenario: TheMessageOutlivesTheWindow
+- **GIVEN** a launch that owns its console, with no terminal behind it
+- **WHEN** the server fails to start
+- **THEN** the process holds the console open until the operator dismisses it, so the message can be read
+
+#### Scenario: NobodyElseIsMadeToWait
+- **GIVEN** a launch from a shell, a script, or a continuous integration runner
+- **WHEN** the server fails to start
+- **THEN** it exits immediately, waiting for no input
+
+#### Scenario: AServerThatStartsIsUnchanged
+- **WHEN** the server binds successfully
+- **THEN** it prints what it prints today, waits for nothing, and keeps running

--- a/openspec/changes/say-why-the-server-could-not-start/tasks.md
+++ b/openspec/changes/say-why-the-server-could-not-start/tasks.md
@@ -1,0 +1,23 @@
+## 1. The message
+
+- [x] 1.1 Add the function that turns a failed bind into the line an operator reads, from the error, the host and the port; verify unit tests assert the occupied-port case names both the address refused and the flag that moves it, that another bind failure still produces a readable line, and that neither carries a stack.
+
+## 2. The decision to hold the console
+
+- [x] 2.1 Add the function that decides whether this process owns the console it printed on, from the platform, the environment and the parent's identity, with the parent supplied rather than looked up; verify unit tests assert a confident yes only for a file-manager parent on Windows, and no for a shell parent, an unknown parent, a probe that answered nothing, a non-Windows platform, and a continuous integration runner — the last taking precedence over everything else.
+- [x] 2.2 Add the real parent probe behind that injection point, reading the parent's image name once and only when asked; verify a test proves a probe that fails or finds nothing returns no answer rather than throwing, so the decision degrades to "do not hold".
+
+## 3. Joining the failure path
+
+- [x] 3.1 Guard the one unguarded `await app.listen(...)` so a failure goes through the file's existing `complain()` and exits non-zero, and hold the console before exiting where the decision says to; verify a test starts a server on a port already bound — bound at port 0 and read back, never a fixed number — and asserts the exit code, the single line on stderr, and the absence of a stack trace.
+- [x] 3.2 Verify the success path is untouched: a test asserts a server that binds prints what it printed before, waits for nothing, and answers `/health`. Done: `startup-failure.test.mjs` asserts the address line, the absence of any prompt to dismiss, and a served `/health`. "Never consulted" is structural rather than asserted — the probe has one call site, inside the `catch` at `server/src/index.ts:742`; nothing on the success path can reach it.
+
+## 4. Proving it where it was found
+
+- [ ] 4.1 On Windows, double-click the standalone executable while another instance holds the port, and confirm the window stays open with the message in it until dismissed; record what appears verbatim.
+- [ ] 4.2 On the same machine, run the same failing start from PowerShell and confirm it exits immediately with the same line and no prompt to dismiss.
+
+## 5. Scenario coverage and validation
+
+- [x] 5.1 Enumerate every `#### Scenario:` in the delta, write the scenario-to-test matrix with assertion-level evidence, and leave none partial or uncovered; name explicitly which scenarios only tasks 4.1/4.2 can establish — `scenario-coverage.md`: 4/5 covered, `TheMessageOutlivesTheWindow` partial by construction, since only a Windows machine can prove a double-clicked process has `explorer.exe` above it.
+- [x] 5.2 Run the focused tests, then the server suite, typecheck, lint, and `openspec validate say-why-the-server-could-not-start --strict` — 18 focused tests passed; server suite 1,642 passed with nothing skipped; typecheck and lint clean; strict validation passed.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -58,6 +58,7 @@ import { readInstalledPiSdkVersion } from "./piSdkVersion.ts";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { CliError, helpText, parseCli, readSecret, runInit } from "./cli.ts";
+import { bindFailureMessage, ownsItsConsole, parentImageName, waitForAKey } from "./startupFailure.ts";
 import { BuildExeError, buildExecutable } from "./buildExe.ts";
 import { browsableUrl, openBrowser, shouldOpenBrowser } from "./openBrowser.ts";
 import { runStartupUpdateNotice, runUpdateCommand, updateCheckEnabled, whyCheckingDisabled } from "./update.ts";
@@ -730,7 +731,25 @@ if (EMBEDDED_WEB && Object.keys(EMBEDDED_WEB).length > 0) {
   console.log(`[server] serving web UI from ${WEB_DIST}`);
 }
 
-await app.listen({ port: PORT, host: HOST });
+/**
+ * The one startup step that used to fail without a sentence.
+ *
+ * Everything else in this file reports through `complain()` and an exit code; this
+ * threw into an unhandled rejection, and the operator got a stack trace. Held open
+ * afterwards where the console belongs to this process — a double-clicked executable
+ * has no terminal behind it, so exiting would close the window and take the only
+ * copy of the message with it.
+ */
+try {
+  await app.listen({ port: PORT, host: HOST });
+} catch (error) {
+  complain(bindFailureMessage(error, HOST, PORT));
+  if (ownsItsConsole({ parent: parentImageName() })) {
+    console.error("[pi] press any key to close this window");
+    await waitForAKey();
+  }
+  process.exit(1);
+}
 
 /**
  * Land the operator in the interface they just started.

--- a/server/src/startupFailure.ts
+++ b/server/src/startupFailure.ts
@@ -1,0 +1,170 @@
+/**
+ * A server that cannot begin listening, and how it says so.
+ *
+ * Every other failure this binary can have already goes through `complain()` and an
+ * exit code — a bad flag, a failed `init`, a refused `build-exe`. Binding the port
+ * was the one that did not, so it arrived as an unhandled rejection and a stack
+ * trace: where the code was, rather than what the operator must do.
+ *
+ * The second half is where the sentence lands. A process started from a file manager
+ * on Windows *owns* its console window: the window exists because the process does,
+ * and closes when it exits. There is no scrollback to return to and no terminal
+ * behind it. The same `console.error` is permanent from a shell and a flash from a
+ * double-click, and nothing in the message can tell the difference — so the process
+ * has to.
+ */
+import { spawnSync } from "node:child_process";
+
+/**
+ * The line an operator reads when the bind failed.
+ *
+ * The occupied port is the case worth naming: it is the one that happens, it is the
+ * one with an answer, and the answer is a flag. Everything else still gets a
+ * sentence rather than a trace — an unknown reason is not a reason to fall back to
+ * printing the stack.
+ */
+export function bindFailureMessage(error: unknown, host: string, port: number): string {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  const address = `${endpointHost(host)}:${port}`;
+  if (code === "EADDRINUSE") {
+    return `cannot start: ${address} is already in use — something is listening there already; "--port <n>" starts this one somewhere else`;
+  }
+  if (code === "EACCES") {
+    // Only a privileged port gets the privileged-port explanation. A high port can be
+    // refused too — a reserved range, a policy, a security product — and telling that
+    // operator to find a port above 1024 sends them to look at the one they already
+    // have.
+    const why = port < 1024 ? "a port below 1024 needs privileges" : "the system refused it";
+    return `cannot start: not allowed to bind ${address} — ${why}; "--port <n>" chooses another`;
+  }
+  if (code === "EADDRNOTAVAIL") {
+    return `cannot start: ${address} is not an address of this machine — "--host <addr>" chooses another`;
+  }
+  const detail = error instanceof Error ? error.message : String(error);
+  return `cannot start: could not listen on ${address} — ${detail}`;
+}
+
+/**
+ * The host as it appears in an endpoint.
+ *
+ * A literal IPv6 address needs its brackets, or `::1` and port 3141 read as
+ * `::1:3141` — which is a plausible IPv6 address and names no port at all. The same
+ * reasoning, and the same treatment, as `browsableUrl` in openBrowser.ts.
+ */
+function endpointHost(host: string): string {
+  return host.includes(":") ? `[${host}]` : host;
+}
+
+/** The parent's image name, or undefined where the question could not be answered. */
+export type ParentProbe = () => string | undefined;
+
+export interface ConsoleOwnership {
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  /** The parent's image name. Supplied rather than looked up, so this stays a decision. */
+  parent?: string | undefined;
+}
+
+/**
+ * Whether this console dies with this process.
+ *
+ * Not "is a terminal attached": `stdin.isTTY` is true for a double-clicked window
+ * *and* for a shell, so it separates nothing. It only says a person could type. The
+ * question is whether the window is ours, and the parent answers it — a console
+ * spawned by the file manager has `explorer.exe` above it; a shell has the shell.
+ *
+ * Only a confident yes holds anything. No parent, a probe that failed, a platform
+ * with no answer: all exit immediately, which is what happened before this existed.
+ * A signal that cannot be read degrades to today's behaviour rather than to a
+ * process that hangs.
+ */
+export function ownsItsConsole({ platform = process.platform, env = process.env, parent }: ConsoleOwnership = {}): boolean {
+  // First, and for the same reason `shouldOpenBrowser` asks it first: a runner has
+  // nobody watching, and a runner that waits for a keypress waits for its timeout.
+  if (env.CI !== undefined && env.CI !== "" && env.CI !== "false") return false;
+  // Elsewhere a terminal outlives the process that printed into it, so there is
+  // nothing to hold: the message is already where the operator can read it.
+  if (platform !== "win32") return false;
+  return parent?.trim().toLowerCase() === "explorer.exe";
+}
+
+/**
+ * Who launched us, on the platform where it decides something.
+ *
+ * `/FO CSV /NH` rather than the default layout: `tasklist` localises its headers and
+ * aligns its columns to the locale's widths, and neither survives being parsed. The
+ * image name itself is not localised. Run once, only after a bind has already
+ * failed — the successful start never pays for this.
+ */
+export const parentImageName: ParentProbe = () => {
+  if (process.platform !== "win32") return undefined;
+  const ppid = process.ppid;
+  if (!Number.isInteger(ppid) || ppid <= 0) return undefined;
+  const result = spawnSync("tasklist", ["/FI", `PID eq ${ppid}`, "/FO", "CSV", "/NH"], {
+    encoding: "utf8",
+    timeout: 5_000,
+    windowsHide: true,
+  });
+  if (result.error !== undefined || result.status !== 0) return undefined;
+  return parseTasklistImageName(result.stdout ?? "");
+};
+
+/**
+ * The image name out of one CSV row, or undefined.
+ *
+ * `tasklist` answers a filter that matched nothing with a sentence rather than an
+ * empty result — "INFO: No tasks are running which match the specified criteria" —
+ * and exits zero while doing it. A parser that trusts the exit code alone would take
+ * the first word of that sentence for a process name.
+ */
+export function parseTasklistImageName(stdout: string): string | undefined {
+  const line = stdout.split(/\r?\n/).find((candidate) => candidate.trim().length > 0);
+  if (line === undefined) return undefined;
+  const quoted = /^"([^"]*)"/.exec(line.trim());
+  if (quoted === null) return undefined;
+  const name = quoted[1].trim();
+  return name.length > 0 ? name : undefined;
+}
+
+/** The stream this waits on, narrowed to what it uses so a test can supply one. */
+export interface Holdable {
+  isTTY?: boolean;
+  setRawMode?: (mode: boolean) => unknown;
+  resume: () => unknown;
+  pause: () => unknown;
+  once: (event: "data", listener: () => void) => unknown;
+}
+
+/**
+ * Hold the window until the operator dismisses it.
+ *
+ * A key, not a timeout: the window is the only copy of the message there is, and
+ * there is no honest number of seconds after which to throw it away. Where raw mode
+ * is unavailable this returns rather than degrading into a wait nothing can end.
+ */
+export async function waitForAKey(stdin: Holdable = process.stdin): Promise<void> {
+  const setRawMode = stdin.setRawMode;
+  if (stdin.isTTY !== true || typeof setRawMode !== "function") return;
+  await new Promise<void>((resolve) => {
+    let settled = false;
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      try {
+        setRawMode.call(stdin, false);
+      } catch {
+        // Restoring the terminal is a courtesy; the process is about to exit anyway.
+      }
+      stdin.pause();
+      resolve();
+    };
+    try {
+      setRawMode.call(stdin, true);
+    } catch {
+      resolve();
+      return;
+    }
+    stdin.resume();
+    stdin.once("data", done);
+  });
+}

--- a/server/test/startup-failure.test.mjs
+++ b/server/test/startup-failure.test.mjs
@@ -1,0 +1,113 @@
+/**
+ * A port already taken, at the wire.
+ *
+ * The unit tests beside this one prove the message and the decision. This is the
+ * half that lives at the call site: that `listen` is actually guarded, that the
+ * failure goes through the file's own reporting rather than an unhandled rejection,
+ * and that what reaches the operator is one line and not a trace. A regression that
+ * removed the guard would leave every unit test green.
+ *
+ * The port is bound at 0 and read back, never a fixed number: a test that hard-codes
+ * 3141 fails on the machine of anyone who has the interface open, which is everyone
+ * working on this.
+ */
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { writeFile } from "node:fs/promises";
+import net from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "node:test";
+import { makeWorkspace, startServer } from "./harness.mjs";
+
+const SERVER_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const ENTRY = path.join(SERVER_DIR, "src", "index.ts");
+
+/** A listening socket, and the port it took. Kept open so the server cannot have it. */
+async function occupyAPort() {
+  const holder = net.createServer();
+  await new Promise((resolve, reject) => {
+    holder.once("error", reject);
+    holder.listen(0, "127.0.0.1", resolve);
+  });
+  return { port: holder.address().port, release: () => new Promise((r) => holder.close(r)) };
+}
+
+/** Start a server that is expected to fail, and collect everything it said. */
+async function startAndWaitForExit(root, port) {
+  const configPath = path.join(root, "pi-outpost.test.json");
+  await writeFile(
+    configPath,
+    JSON.stringify({
+      cwd: root,
+      agentDir: path.join(root, ".pi-agent"),
+      noSkills: true,
+      noPromptTemplates: true,
+      webContext: false,
+      openBrowser: false,
+      server: { host: "127.0.0.1", port },
+    }),
+  );
+  const env = { ...process.env, PI_OUTPOST_CONFIG: configPath, PI_OFFLINE: "1" };
+  delete env.NODE_V8_COVERAGE;
+  const child = spawn(process.execPath, ["--import=tsx/esm", ENTRY], {
+    cwd: SERVER_DIR,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (d) => (stdout += d));
+  child.stderr.on("data", (d) => (stderr += d));
+  const code = await new Promise((resolve) => child.once("exit", resolve));
+  return { code, stdout, stderr };
+}
+
+// openlore: {"domain":"cli","requirement":"AFailureToStartIsSaidOutLoud","scenario":"ThePortIsAlreadyTaken","specFile":"openspec/changes/say-why-the-server-could-not-start/specs/cli/spec.md"}
+describe("a port that is already taken", () => {
+  test("exits non-zero with one readable line and no stack trace", async () => {
+    const held = await occupyAPort();
+    const root = await makeWorkspace();
+    try {
+      const { code, stderr } = await startAndWaitForExit(root, held.port);
+
+      assert.notEqual(code, 0, "a server that never listened must not report success");
+      assert.match(stderr, new RegExp(`127\\.0\\.0\\.1:${held.port}`), "the address refused is named");
+      assert.match(stderr, /already in use/);
+      assert.match(stderr, /--port/, "the way out is named");
+
+      // The point of the change: what an operator gets is a sentence, not a trace.
+      assert.doesNotMatch(stderr, /^\s+at /m, "no stack frames");
+      assert.doesNotMatch(stderr, /EADDRINUSE\b[\s\S]*\n\s+at /, "no rethrown listen error");
+      assert.doesNotMatch(stderr, /unhandled|UnhandledPromiseRejection/i);
+      // One line about the failure, and nothing waiting to be dismissed: this is a
+      // shell, and a shell's console outlives the process that printed into it.
+      assert.doesNotMatch(stderr, /press any key/);
+      const complaints = stderr.split(/\r?\n/).filter((line) => line.includes("cannot start"));
+      assert.equal(complaints.length, 1, `expected one line, got:\n${stderr}`);
+    } finally {
+      await held.release();
+    }
+  });
+});
+
+// openlore: {"domain":"cli","requirement":"AFailureToStartIsSaidOutLoud","scenario":"AServerThatStartsIsUnchanged","specFile":"openspec/changes/say-why-the-server-could-not-start/specs/cli/spec.md"}
+describe("a server that binds", () => {
+  test("says what it always said, waits for nothing, and serves", async () => {
+    const root = await makeWorkspace();
+    const server = await startServer(root);
+    try {
+      // Serving: the harness only resolves once /health answered, so reaching here
+      // already proves the process did not stop to be dismissed.
+      const health = await fetch(`${server.base}/health`);
+      assert.equal(health.ok, true);
+
+      const log = server.log();
+      assert.match(log, new RegExp(`\\[server\\] http://127\\.0\\.0\\.1:${server.port}/`), "the address is printed as before");
+      assert.doesNotMatch(log, /press any key/, "nothing to dismiss on a successful start");
+      assert.doesNotMatch(log, /cannot start/);
+    } finally {
+      await server.stop();
+    }
+  });
+});

--- a/server/test/startupFailure.test.ts
+++ b/server/test/startupFailure.test.ts
@@ -1,0 +1,177 @@
+/**
+ * What a server says when it cannot start, and whether it waits to be read.
+ *
+ * Both halves are decisions, and a decision is cheap to test everywhere and
+ * expensive to test through its effect: the message is a function of the error and
+ * the address, and holding the console is a function of the platform, the
+ * environment and the parent. The keypress itself is the only impure part, and it is
+ * driven here through a stream the test supplies rather than a terminal it does not
+ * have.
+ */
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import {
+  bindFailureMessage,
+  ownsItsConsole,
+  parentImageName,
+  parseTasklistImageName,
+  waitForAKey,
+} from "../src/startupFailure.ts";
+
+const errno = (code: string): NodeJS.ErrnoException => Object.assign(new Error(`listen ${code} 127.0.0.1:3141`), { code });
+
+// openlore: {"domain":"cli","requirement":"AFailureToStartIsSaidOutLoud","scenario":"ThePortIsAlreadyTaken","specFile":"openspec/changes/say-why-the-server-could-not-start/specs/cli/spec.md"}
+describe("the line an operator reads", () => {
+  test("an occupied port names the address refused and the flag that moves it", () => {
+    const message = bindFailureMessage(errno("EADDRINUSE"), "127.0.0.1", 3141);
+    assert.match(message, /127\.0\.0\.1:3141/);
+    assert.match(message, /already in use/);
+    assert.match(message, /--port/);
+  });
+
+  test("the address is the one that was refused, not a remembered default", () => {
+    const message = bindFailureMessage(errno("EADDRINUSE"), "0.0.0.0", 8080);
+    assert.match(message, /0\.0\.0\.0:8080/);
+    assert.doesNotMatch(message, /3141/);
+  });
+
+  // openlore: {"domain":"cli","requirement":"AFailureToStartIsSaidOutLoud","scenario":"TheBindFailsForSomeOtherReason","specFile":"openspec/changes/say-why-the-server-could-not-start/specs/cli/spec.md"}
+  test("another reason still gets a sentence", () => {
+    const denied = bindFailureMessage(errno("EACCES"), "127.0.0.1", 80);
+    assert.match(denied, /127\.0\.0\.1:80/);
+    assert.match(denied, /--port/);
+
+    const absent = bindFailureMessage(errno("EADDRNOTAVAIL"), "10.1.2.3", 3141);
+    assert.match(absent, /10\.1\.2\.3:3141/);
+    assert.match(absent, /--host/);
+  });
+
+  test("a permission refused on a high port does not blame privilege", () => {
+    // A reserved range or a security product refuses a high port with EACCES too, and
+    // "below 1024" would send that operator to inspect a number that is already fine.
+    const high = bindFailureMessage(errno("EACCES"), "127.0.0.1", 3141);
+    assert.match(high, /127\.0\.0\.1:3141/);
+    assert.doesNotMatch(high, /1024/);
+    assert.match(bindFailureMessage(errno("EACCES"), "127.0.0.1", 80), /below 1024/);
+  });
+
+  test("a literal IPv6 host keeps its brackets, so the port is still a port", () => {
+    assert.match(bindFailureMessage(errno("EADDRINUSE"), "::1", 3141), /\[::1\]:3141/);
+    assert.match(bindFailureMessage(errno("EADDRNOTAVAIL"), "fe80::1", 8080), /\[fe80::1\]:8080/);
+    // and an IPv4 host gains nothing it did not have
+    assert.match(bindFailureMessage(errno("EADDRINUSE"), "127.0.0.1", 3141), /(?<!\[)127\.0\.0\.1:3141/);
+  });
+
+  test("an unknown reason carries the reason, and never a stack", () => {
+    const error = errno("EPERM");
+    const message = bindFailureMessage(error, "127.0.0.1", 3141);
+    assert.match(message, /127\.0\.0\.1:3141/);
+    assert.match(message, /listen EPERM/);
+    assert.doesNotMatch(message, /\n\s+at /);
+    assert.ok(!message.includes(String(error.stack)));
+  });
+
+  test("something thrown that is not an Error is still a sentence", () => {
+    assert.match(bindFailureMessage("port went missing", "127.0.0.1", 3141), /port went missing/);
+  });
+});
+
+// openlore: {"domain":"cli","requirement":"AFailureToStartIsSaidOutLoud","scenario":"TheMessageOutlivesTheWindow","specFile":"openspec/changes/say-why-the-server-could-not-start/specs/cli/spec.md"}
+describe("whether this console dies with this process", () => {
+  test("a file manager above us on Windows owns the window", () => {
+    assert.equal(ownsItsConsole({ platform: "win32", env: {}, parent: "explorer.exe" }), true);
+    // However tasklist spelled it.
+    assert.equal(ownsItsConsole({ platform: "win32", env: {}, parent: "Explorer.EXE" }), true);
+    assert.equal(ownsItsConsole({ platform: "win32", env: {}, parent: " explorer.exe " }), true);
+  });
+
+  // openlore: {"domain":"cli","requirement":"AFailureToStartIsSaidOutLoud","scenario":"NobodyElseIsMadeToWait","specFile":"openspec/changes/say-why-the-server-could-not-start/specs/cli/spec.md"}
+  test("a shell borrows a console that outlives us", () => {
+    assert.equal(ownsItsConsole({ platform: "win32", env: {}, parent: "cmd.exe" }), false);
+    assert.equal(ownsItsConsole({ platform: "win32", env: {}, parent: "powershell.exe" }), false);
+    assert.equal(ownsItsConsole({ platform: "win32", env: {}, parent: "pwsh.exe" }), false);
+    assert.equal(ownsItsConsole({ platform: "win32", env: {}, parent: "WindowsTerminal.exe" }), false);
+  });
+
+  test("no answer is not a yes", () => {
+    assert.equal(ownsItsConsole({ platform: "win32", env: {}, parent: undefined }), false);
+    assert.equal(ownsItsConsole({ platform: "win32", env: {}, parent: "" }), false);
+  });
+
+  test("elsewhere the terminal outlives the process, so nothing is held", () => {
+    assert.equal(ownsItsConsole({ platform: "darwin", env: {}, parent: "explorer.exe" }), false);
+    assert.equal(ownsItsConsole({ platform: "linux", env: {}, parent: "explorer.exe" }), false);
+  });
+
+  test("a runner is never made to wait, whatever is above it", () => {
+    assert.equal(ownsItsConsole({ platform: "win32", env: { CI: "true" }, parent: "explorer.exe" }), false);
+    assert.equal(ownsItsConsole({ platform: "win32", env: { CI: "1" }, parent: "explorer.exe" }), false);
+    // and CI=false is how some runners say "not one"
+    assert.equal(ownsItsConsole({ platform: "win32", env: { CI: "false" }, parent: "explorer.exe" }), true);
+  });
+});
+
+describe("who launched us", () => {
+  test("one CSV row yields the image name", () => {
+    assert.equal(parseTasklistImageName('"explorer.exe","4242","Console","1","54,321 K"\r\n'), "explorer.exe");
+    assert.equal(parseTasklistImageName('"pwsh.exe","17","Console","1","9 K"'), "pwsh.exe");
+  });
+
+  test("tasklist's polite refusal is not a process name", () => {
+    // It exits zero while saying this, so a parser trusting the status alone would
+    // take "INFO:" for an image name.
+    assert.equal(parseTasklistImageName("INFO: No tasks are running which match the specified criteria.\r\n"), undefined);
+    assert.equal(parseTasklistImageName(""), undefined);
+    assert.equal(parseTasklistImageName("\r\n\r\n"), undefined);
+    assert.equal(parseTasklistImageName('"","4242"'), undefined);
+  });
+
+  test("the real probe answers rather than throwing, on every platform", () => {
+    // On anything but Windows there is no question to answer; on Windows a hardened
+    // machine may refuse the call. Neither may take the failure path down with it.
+    assert.doesNotThrow(() => parentImageName());
+    if (process.platform !== "win32") assert.equal(parentImageName(), undefined);
+  });
+});
+
+describe("holding the window", () => {
+  test("a stream that is not a terminal is not waited on", async () => {
+    let resumed = false;
+    await waitForAKey({
+      isTTY: false,
+      resume: () => (resumed = true),
+      pause: () => {},
+      once: () => {},
+    });
+    assert.equal(resumed, false, "nothing to hold, so nothing was held");
+  });
+
+  test("raw mode that cannot be set is skipped, not hung", async () => {
+    await waitForAKey({
+      isTTY: true,
+      setRawMode: () => {
+        throw new Error("no raw mode here");
+      },
+      resume: () => assert.fail("should not have started waiting"),
+      pause: () => {},
+      once: () => {},
+    });
+  });
+
+  test("a key ends the wait and hands the terminal back", async () => {
+    const raw: boolean[] = [];
+    let paused = false;
+    let resumed = false;
+    await waitForAKey({
+      isTTY: true,
+      setRawMode: (mode) => raw.push(mode),
+      resume: () => (resumed = true),
+      // A key already waiting: the listener fires as soon as it is attached.
+      pause: () => (paused = true),
+      once: (_event, listener) => listener(),
+    });
+    assert.equal(resumed, true, "the stream was read before it was waited on");
+    assert.deepEqual(raw, [true, false]);
+    assert.equal(paused, true);
+  });
+});


### PR DESCRIPTION
## Why

`await app.listen(...)` was the one startup step in `server/src/index.ts` that nothing caught. A port already in use threw into an unhandled rejection and the operator got a stack trace — where every neighbouring failure in that file (a bad flag, a failed `init`, a refused `build-exe`) already gets a sentence through `complain()` and an exit code.

Opening the interface in a window of its own made this worse, and now. That change made the double-click the way in on Windows, and a double-clicked process **owns** its console: the window exists because the process does, and closes when it exits. The message flashes and is gone — and since the interface never opens either, there is no second place to look.

Observed on a real Windows machine this week: a second instance started while a first held 3141 died silently, and the browser window in front of the operator belonged to the *older* server. The new build was judged on the old one's state.

## What it does

- A failed bind goes through the file's own `complain()` and exits non-zero. One line, never a stack.
- An occupied port names the address that was refused and `--port`, which is the way out. EACCES and EADDRNOTAVAIL get their own sentences; anything else still gets a readable one.
- Where the console belongs to this process, the window is held until a key is pressed. A shell, a script and CI are never made to wait.

## The one interesting decision

Not "is a terminal attached". `stdin.isTTY` is true for a double-clicked window *and* for a shell, so it separates nothing — it only says a person could type. The question is whether this console dies with this process, and the **parent** answers it: `explorer.exe` above us means the window is ours. Probed once, on the failure path only; a successful start never pays for it.

Only a confident yes holds anything. No parent, a probe that failed, a platform with no answer, CI — all exit immediately, which is exactly today's behaviour. A signal that cannot be read degrades to what already happens rather than to a process that hangs.

The alternative (hold whenever stdin is a TTY and CI is unset, with a timeout) is written down in `design.md` and rejected there: it makes a shell user press a key on an error they can already read, and the timeout is a second guess layered on the first.

## Codex review

Two P2 findings, both on the sentence this change exists to write, both fixed with tests:

- EACCES no longer blames privilege on a high port — a reserved range or a security product refuses those too, and "below 1024" sent that operator to inspect a number that was already fine.
- A literal IPv6 host keeps its brackets, so `[::1]:3141` still names a port instead of reading as an address.

## Verification

- 20 focused tests: the message per error code, the console-ownership decision in every direction, the `tasklist` parse including its zero-exit refusal, and the keypress wait driven through a supplied stream.
- The occupied-port case at the wire: a real port held (bound at 0 and read back, never a fixed number), a real server started against it, asserting the exit code, the single line, and the absence of any stack frame.
- The success path: address printed as before, `/health` served, nothing to dismiss.
- Server suite 1,644 passed, nothing skipped. Typecheck, lint, and `openspec validate --strict` clean.

## Still open

Tasks 4.1 and 4.2 in the change, both on Windows: the double-click on an occupied port holding its window, and the same failure from PowerShell exiting immediately. `TheMessageOutlivesTheWindow` is marked partial for exactly that reason — no test on any other machine can establish that a double-clicked executable really does have the file manager above it.

## Out of scope, deliberately

Single-instance rendezvous (a second launch joining the running server), ephemeral ports, and surfacing extension-loading failures in the interface. Each is its own change; the last one is what left the interface unconnectable on that same Windows machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnLiEJCFdTuZkLEEmoextk