### PR TITLE
fix(cli): hold the console for any pre-listen startup failure

### DIFF
--- a/openspec/changes/say-why-the-server-could-not-start/proposal.md
+++ b/openspec/changes/say-why-the-server-could-not-start/proposal.md
@@ -23,6 +23,10 @@ build was judged on the old one's state.
 - Hold the console open when the process owns it, so the line can be read. A shell, a
   script and CI SHALL NOT be made to wait — only the launch that has nowhere else to
   print.
+- Hold it for the failures that come *before* the bind, too. A missing configuration file
+  and an unparseable flag both `process.exit` on a console that a double-click owns, and
+  the Windows check found the no-config window vanishing the same way the bind one did.
+  One shared hold now wraps every pre-listen exit.
 - No change to a server that starts: this is entirely on the path where it does not.
 
 ## Capabilities

--- a/openspec/changes/say-why-the-server-could-not-start/scenario-coverage.md
+++ b/openspec/changes/say-why-the-server-could-not-start/scenario-coverage.md
@@ -7,18 +7,27 @@ contract broke. Enumerated with `rg '^#### Scenario:' openspec/changes/say-why-t
 |---|---|---|---|
 | ThePortIsAlreadyTaken | covered | `server/test/startup-failure.test.mjs` — "exits non-zero with one readable line and no stack trace"; `server/test/startupFailure.test.ts` — "an occupied port names the address refused and the flag that moves it" | The integration test holds a real port (bound at 0, read back), starts a real server against it, and asserts the exit code is non-zero, that stderr names `127.0.0.1:<that port>`, says "already in use", names `--port`, carries no `at ` stack frame, no `unhandled`, and exactly one `cannot start` line. Remove the `try`/`catch` at `server/src/index.ts:742` and every one of those fails. |
 | TheBindFailsForSomeOtherReason | covered | `server/test/startupFailure.test.ts` — "another reason still gets a sentence", "an unknown reason carries the reason, and never a stack" | Asserts EACCES and EADDRNOTAVAIL each name the address and the flag that applies (`--port`, `--host`); that EACCES on a high port does not blame privilege, which a reserved range or a security product can cause; that a literal IPv6 host keeps its brackets so `[::1]:3141` still names a port; and that an unrecognised code still yields a sentence carrying the underlying message and never the stack. Reached at the wire only through a port the machine refuses, which is not portable to assert; the message is the whole of what changes between codes, and it is asserted directly. |
-| TheMessageOutlivesTheWindow | partial | `server/test/startupFailure.test.ts` — "a file manager above us on Windows owns the window", "a key ends the wait and hands the terminal back"; task 4.1 | The decision is asserted in full: `explorer.exe` above us on Windows is the only yes, in three spellings. The wait is driven through a supplied stream and asserts raw mode goes on and back off and the stream is paused. What no test here can establish is that a double-clicked executable on Windows really does have `explorer.exe` as its parent and really does own its window — that is task 4.1, on the requester's machine. |
-| NobodyElseIsMadeToWait | covered | `server/test/startupFailure.test.ts` — "a shell borrows a console that outlives us", "no answer is not a yes", "elsewhere the terminal outlives the process", "a runner is never made to wait"; `server/test/startup-failure.test.mjs` — the same test as row 1 | Four shells answer no, an absent or empty parent answers no, macOS and Linux answer no whatever the parent, and `CI` answers no even with `explorer.exe` above. At the wire, the integration test asserts stderr never says "press any key" — it runs from a test runner, which is exactly this case, and it would hang rather than fail if the decision went the other way. |
+| TheMessageOutlivesTheWindow | covered | `server/test/startupFailure.test.ts` — "a file manager above us on Windows owns the window", "a key ends the wait and hands the terminal back"; **task 4.1 on real Windows** | The decision is asserted in full: `explorer.exe` above us on Windows is the only yes, in three spellings. The wait is driven through a supplied stream and asserts raw mode goes on and back off and the stream is paused. Task 4.1 established the rest on a real machine: a shortcut-launched (double-click) SEA with the port taken has `explorer.exe` as `ParentProcessId`, holds the window (process alive 20+ s, no timeout) showing the `cannot start` line and `press any key to close this window`, and exits on a keypress. |
+| AFailureBeforeListeningIsHeldToo | covered | `server/test/startupFailure.test.ts` — "a file-manager launch that fails before listening still holds the window", "a shell launch is not held…"; `server/test/startup-failure.test.mjs` — "no configuration file: one readable line, no stack, and nothing to dismiss from a shell"; **task 5.3 on real Windows** | `holdConsoleIfOwned` is now the single hold, called before the `NoConfigError`, `complain()` and `parseCli` exits as well as the bind catch. The unit test drives the file-manager branch (prompt printed, `waitForAKey` sequenced raw:true→wait→raw:false→pause) and the shell/CI/non-Windows branches (nothing touched). The integration test starts a real `index.ts` with no discoverable config and asserts exit≠0, the "no configuration file found" line, no stack, and — from a test runner — no "press any key" and no hang. Task 5.3: the same no-config double-click on Windows 11 now holds until a keypress. |
+| NobodyElseIsMadeToWait | covered | `server/test/startupFailure.test.ts` — "a shell borrows a console that outlives us", "no answer is not a yes", "elsewhere the terminal outlives the process", "a runner is never made to wait", "a shell launch is not held…", "a runner is never held…"; `server/test/startup-failure.test.mjs` — rows 1 and the no-config row; **task 4.2 on real Windows** | Four shells answer no, an absent or empty parent answers no, macOS and Linux answer no whatever the parent, and `CI` answers no even with `explorer.exe` above. Both integration tests assert stderr never says "press any key" — they run from a test runner and would hang rather than fail if the decision flipped. Task 4.2: from PowerShell (`pwsh.exe` parent) the occupied-port start exits code 1 at once with the one line and no prompt. |
 | AServerThatStartsIsUnchanged | covered | `server/test/startup-failure.test.mjs` — "says what it always said, waits for nothing, and serves" | Starts a real server through the harness, which only resolves once `/health` answers — so a process that stopped to be dismissed fails by timing out. Then asserts the `[server] http://127.0.0.1:<port>/` line is printed as before and that the log contains neither "press any key" nor "cannot start". |
 
 ## What no test here establishes
 
-The parent-process probe answers a real question only on Windows. `parentImageName()` is
-asserted not to throw on every platform and to answer `undefined` off Windows, and
-`parseTasklistImageName` is asserted against real `tasklist` CSV output and against its
-polite refusal ("INFO: No tasks are running..."), which exits zero. That the string
-`tasklist` actually prints for an Explorer-launched process is `explorer.exe` is what task
-4.1 checks, on a machine that has one.
+Every scenario is now backed by a test *and*, for the Windows-only behaviour, by a real
+run on Windows 11 (tasks 4.1, 4.2, 5.3). The one thing still outside a test's reach is a
+genuinely browser/`tasklist`-less hardened Windows box: `parentImageName()` is asserted
+not to throw and to answer `undefined` off Windows, and `parseTasklistImageName` is
+asserted against real `tasklist` CSV and its polite refusal — but a machine where
+`tasklist` is absent or blocked can only be reasoned about (the probe returns `undefined`,
+`ownsItsConsole` says no, the process exits as it does today).
 
-Task 4.2 is the other direction on the same machine: the same failing start from
-PowerShell, exiting immediately with the same line and no prompt.
+## The run
+
+- typecheck clean; lint clean (warnings pre-existing, none in touched files)
+- focused: `startupFailure.test.ts` + `startup-failure.test.mjs` — all pass, including the
+  five new `holdConsoleIfOwned` unit tests and the no-config integration test
+- `openspec validate say-why-the-server-could-not-start --strict` — valid
+- full server suite: pre-existing environmental failures on this Windows box only (pptx
+  tooling absent, symlink privilege, release-channel tag detection), each reproduced with
+  the branch stashed

--- a/openspec/changes/say-why-the-server-could-not-start/specs/cli/spec.md
+++ b/openspec/changes/say-why-the-server-could-not-start/specs/cli/spec.md
@@ -2,23 +2,24 @@
 
 ### Requirement: AFailureToStartIsSaidOutLoud
 
-A server that cannot begin listening SHALL report why in the same voice as every other
-failure this binary can have: one line naming what went wrong, and a non-zero exit. It
-SHALL NOT exit on an unhandled error, and it SHALL NOT print a stack trace as its
-explanation — a stack is where the code was, not what the operator must do.
+A server that cannot start SHALL report why in the same voice as every other failure this
+binary can have: one line naming what went wrong, and a non-zero exit. This holds wherever
+the start fails — no configuration file to be found, a flag that will not parse, or a port
+that will not bind. It SHALL NOT exit on an unhandled error, and it SHALL NOT print a stack
+trace as its explanation — a stack is where the code was, not what the operator must do.
 
 An address already in use SHALL be named for what it is. The message SHALL carry the host
 and port that were refused, and SHALL name the way to move it, so that reading the line is
 enough to act on it. Any other reason a bind fails SHALL still produce a readable line
 rather than a trace.
 
-The message SHALL survive the console it was printed on. Where the process owns that
-console — a standalone executable started from a file manager, which is how the interface
-is meant to be opened and which has no terminal behind it — the process SHALL hold it open
-until the operator dismisses it, because exiting would close the window and take the only
-copy of the message with it. Where the console belongs to something else — a shell, a
-script, a continuous integration runner — the process SHALL exit immediately and wait for
-no one.
+The message SHALL survive the console it was printed on, for every one of those failures.
+Where the process owns that console — a standalone executable started from a file manager,
+which is how the interface is meant to be opened and which has no terminal behind it — the
+process SHALL hold it open until the operator dismisses it, because exiting would close the
+window and take the only copy of the message with it. Where the console belongs to
+something else — a shell, a script, a continuous integration runner — the process SHALL
+exit immediately and wait for no one.
 
 A server that starts SHALL be unaffected: nothing added to its output, and nothing to
 dismiss.
@@ -38,6 +39,12 @@ dismiss.
 - **GIVEN** a launch that owns its console, with no terminal behind it
 - **WHEN** the server fails to start
 - **THEN** the process holds the console open until the operator dismisses it, so the message can be read
+
+#### Scenario: AFailureBeforeListeningIsHeldToo
+- **GIVEN** a launch that owns its console
+- **WHEN** the start fails before it reaches the port — no configuration file, or a flag that will not parse
+- **THEN** the console is held open until the operator dismisses it, exactly as a bind failure is
+- **AND** the same launch from a shell exits at once, with the message and no prompt
 
 #### Scenario: NobodyElseIsMadeToWait
 - **GIVEN** a launch from a shell, a script, or a continuous integration runner

--- a/openspec/changes/say-why-the-server-could-not-start/tasks.md
+++ b/openspec/changes/say-why-the-server-could-not-start/tasks.md
@@ -14,10 +14,32 @@
 
 ## 4. Proving it where it was found
 
-- [ ] 4.1 On Windows, double-click the standalone executable while another instance holds the port, and confirm the window stays open with the message in it until dismissed; record what appears verbatim.
-- [ ] 4.2 On the same machine, run the same failing start from PowerShell and confirm it exits immediately with the same line and no prompt to dismiss.
+- [x] 4.1 On Windows, double-click the standalone executable while another instance holds the port, and confirm the window stays open with the message in it until dismissed; record what appears verbatim. Done on Windows 11 against a fresh SEA. Launched through a shortcut (a double-click, parent `explorer.exe` confirmed via `ParentProcessId`) with port 3141 already bound. The window stayed open — process alive 9–20+ s, no timeout — showing verbatim:
+  ```
+  [config] loaded C:\Users\lfran\pi-outpost\server\dist\pi-outpost.config.json
+  [config] agent runtime embedded
+  [config] no sandbox: full toolset in C:\Users\lfran\pi-outpost\server\dist
+  [server] serving web UI from embedded bundle (190 assets)
+  [pi] cannot start: 127.0.0.1:3141 is already in use — something is listening there already; "--port <n>" starts this one somewhere else
+  [pi] press any key to close this window
+  ```
+  A space keypress ended it and the process exited. One `[pi] cannot start:` line, no stack trace.
+- [x] 4.2 On the same machine, run the same failing start from PowerShell and confirm it exits immediately with the same line and no prompt to dismiss. Done. Parent = `pwsh.exe`; exit code 1; stderr was exactly `[pi] cannot start: 127.0.0.1:3141 is already in use — something is listening there already; "--port <n>" starts this one somewhere else` — no "press any key", no stack, no `unhandled`. It returned as soon as the bind failed (the ~2.6 s was startup work, not a wait).
 
-## 5. Scenario coverage and validation
+## 5. The rest of the pre-listen failures
 
-- [x] 5.1 Enumerate every `#### Scenario:` in the delta, write the scenario-to-test matrix with assertion-level evidence, and leave none partial or uncovered; name explicitly which scenarios only tasks 4.1/4.2 can establish — `scenario-coverage.md`: 4/5 covered, `TheMessageOutlivesTheWindow` partial by construction, since only a Windows machine can prove a double-clicked process has `explorer.exe` above it.
-- [x] 5.2 Run the focused tests, then the server suite, typecheck, lint, and `openspec validate say-why-the-server-could-not-start --strict` — 18 focused tests passed; server suite 1,642 passed with nothing skipped; typecheck and lint clean; strict validation passed.
+The Windows check turned up the gap this section closes. The hold wrapped only the
+`await app.listen()` rejection. Every earlier exit — no configuration file, a flag that
+will not parse, an unreadable setting — went straight to `process.exit(1)`, so a
+double-clicked launch that failed for the commonest first-run reason (no config yet)
+still flashed its message and vanished. Verified on Windows before the fix: the no-config
+window closed on its own in ~2 s.
+
+- [x] 5.1 Factor the hold into `holdConsoleIfOwned()` in `startupFailure.ts` and call it before the `NoConfigError`, the `complain()`-then-exit, and the `parseCli` failure exits, as well as the existing bind catch; the decision stays injectable so a test can drive both directions off Windows. `server/src/startupFailure.ts`, `server/src/index.ts` (the config and `parseCli` IIFEs become `await`ed).
+- [x] 5.2 Unit tests for `holdConsoleIfOwned`: a file-manager parent on Windows prints the prompt and drives `waitForAKey` (raw on, wait, raw off, pause, in order); a shell parent, a CI runner, a non-Windows platform, and a probe that could not answer each touch nothing. Integration test in `startup-failure.test.mjs`: a real `index.ts` started with a launch dir that has no config and an empty `XDG_CONFIG_HOME` exits non-zero with the "no configuration file found" line, no stack, and — run from a test runner, not a file manager — no "press any key" and no hang.
+- [x] 5.3 On Windows 11, a fresh SEA double-clicked (shortcut, parent `explorer.exe`) with no discoverable config now holds the window until a keypress, showing the "no configuration file found" block followed by `[pi] press any key to close this window`. The same start from PowerShell still exits at once with no prompt.
+
+## 6. Scenario coverage and validation
+
+- [x] 6.1 Enumerate every `#### Scenario:` in the delta, write the scenario-to-test matrix with assertion-level evidence, and leave none partial or uncovered — `scenario-coverage.md`. `TheMessageOutlivesTheWindow` and the new `AFailureBeforeListeningIsHeldToo` are now established on a real Windows machine (task 4.1 / 5.3), not left partial.
+- [x] 6.2 Run the focused tests, then the server suite, typecheck, lint, and `openspec validate say-why-the-server-could-not-start --strict` — see `scenario-coverage.md` for the run.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -58,7 +58,7 @@ import { readInstalledPiSdkVersion } from "./piSdkVersion.ts";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { CliError, helpText, parseCli, readSecret, runInit } from "./cli.ts";
-import { bindFailureMessage, ownsItsConsole, parentImageName, waitForAKey } from "./startupFailure.ts";
+import { bindFailureMessage, holdConsoleIfOwned } from "./startupFailure.ts";
 import { BuildExeError, buildExecutable } from "./buildExe.ts";
 import { browsableUrl, openBrowser, shouldOpenBrowser } from "./openBrowser.ts";
 import { runStartupUpdateNotice, runUpdateCommand, updateCheckEnabled, whyCheckingDisabled } from "./update.ts";
@@ -151,11 +151,13 @@ function complain(error: unknown): void {
   console.error(message.startsWith("[") ? message : `[pi] ${message}`);
 }
 
-const cli = (() => {
+const cli = await (async () => {
   try {
     return parseCli(process.argv.slice(2));
   } catch (error) {
     complain(error);
+    // A shortcut with a mistyped flag is still a double-click: hold the window.
+    await holdConsoleIfOwned();
     process.exit(2);
   }
 })();
@@ -238,7 +240,7 @@ if (cli.command === "update") {
   );
 }
 
-const config = (() => {
+const config = await (async () => {
   try {
     return loadConfig(LAUNCH_DIR, cli.flags);
   } catch (error) {
@@ -253,9 +255,13 @@ const config = (() => {
           "      Or point at one:  pi-outpost --config <path>",
         ].join("\n"),
       );
+      // The likeliest failure of a first double-click, and the one whose window
+      // vanished before this: hold it so the instructions above can be read.
+      await holdConsoleIfOwned();
       process.exit(1);
     }
     complain(error);
+    await holdConsoleIfOwned();
     process.exit(1);
   }
 })();
@@ -738,16 +744,14 @@ if (EMBEDDED_WEB && Object.keys(EMBEDDED_WEB).length > 0) {
  * threw into an unhandled rejection, and the operator got a stack trace. Held open
  * afterwards where the console belongs to this process — a double-clicked executable
  * has no terminal behind it, so exiting would close the window and take the only
- * copy of the message with it.
+ * copy of the message with it. `holdConsoleIfOwned()` is the same hold the config
+ * and flag failures above now do, for the same reason.
  */
 try {
   await app.listen({ port: PORT, host: HOST });
 } catch (error) {
   complain(bindFailureMessage(error, HOST, PORT));
-  if (ownsItsConsole({ parent: parentImageName() })) {
-    console.error("[pi] press any key to close this window");
-    await waitForAKey();
-  }
+  await holdConsoleIfOwned();
   process.exit(1);
 }
 

--- a/server/src/startupFailure.ts
+++ b/server/src/startupFailure.ts
@@ -136,6 +136,27 @@ export interface Holdable {
 }
 
 /**
+ * Hold the console open if this process owns it, then return so the caller can exit.
+ *
+ * The bind failure was not the only way a launch with no terminal behind it can
+ * die before the server is listening: a missing configuration file, a mistyped
+ * flag, an unreadable setting. Each one is a `process.exit` on a console that
+ * closes with the process, and the sentence goes with it. This is the same hold
+ * the bind path already does, factored out so every pre-listen exit can share it.
+ *
+ * Where the console belongs to a shell, a script or a CI runner, `ownsItsConsole`
+ * says no and this returns at once — nothing waits that should not.
+ */
+export async function holdConsoleIfOwned(
+  opts: { probe?: ParentProbe; stdin?: Holdable } & Omit<ConsoleOwnership, "parent"> = {},
+): Promise<void> {
+  const { probe = parentImageName, stdin = process.stdin, ...ownership } = opts;
+  if (!ownsItsConsole({ ...ownership, parent: probe() })) return;
+  console.error("[pi] press any key to close this window");
+  await waitForAKey(stdin);
+}
+
+/**
  * Hold the window until the operator dismisses it.
  *
  * A key, not a timeout: the window is the only copy of the message there is, and

--- a/server/test/startup-failure.test.mjs
+++ b/server/test/startup-failure.test.mjs
@@ -13,8 +13,9 @@
  */
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { writeFile } from "node:fs/promises";
+import { mkdtemp, writeFile } from "node:fs/promises";
 import net from "node:net";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, test } from "node:test";
@@ -88,6 +89,50 @@ describe("a port that is already taken", () => {
     } finally {
       await held.release();
     }
+  });
+});
+
+// openlore: {"domain":"cli","requirement":"AFailureToStartIsSaidOutLoud","scenario":"NobodyElseIsMadeToWait","specFile":"openspec/changes/say-why-the-server-could-not-start/specs/cli/spec.md"}
+describe("a start that fails before it ever reaches listen", () => {
+  test("no configuration file: one readable line, no stack, and nothing to dismiss from a shell", async () => {
+    // A launch directory with no pi-outpost.config.json, and an XDG dir with no
+    // fallback config either — so the only outcome is NoConfigError, which used to
+    // exit straight away and, on a double-click, take its window with it.
+    const emptyLaunchDir = await mkdtemp(path.join(tmpdir(), "pi-outpost-noconfig-"));
+    const emptyXdg = await mkdtemp(path.join(tmpdir(), "pi-outpost-xdg-"));
+    // cwd stays SERVER_DIR so `tsx` resolves; LAUNCH_DIR is INIT_CWD, and that is
+    // the directory findConfigFile() actually searches.
+    const env = { ...process.env, INIT_CWD: emptyLaunchDir, XDG_CONFIG_HOME: emptyXdg, PI_OFFLINE: "1" };
+    delete env.PI_OUTPOST_CONFIG;
+    delete env.PI_OUTPOST_PROFILE;
+    delete env.NODE_V8_COVERAGE;
+
+    const child = spawn(process.execPath, ["--import=tsx/esm", ENTRY], {
+      cwd: SERVER_DIR,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => (stdout += d));
+    child.stderr.on("data", (d) => (stderr += d));
+    // A hang here is the failure: run from a test runner, the parent is not a file
+    // manager, so holdConsoleIfOwned() must fall straight through and let it exit.
+    const code = await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error(`did not exit; stderr so far:\n${stderr}`)), 20_000);
+      child.once("exit", (c) => {
+        clearTimeout(timer);
+        resolve(c);
+      });
+    });
+
+    assert.notEqual(code, 0, "a server with no configuration must not report success");
+    assert.match(stderr, /no configuration file found/, "the reason is named");
+    assert.match(stderr, /pi-outpost init|--config/, "the way forward is named");
+    assert.doesNotMatch(stderr, /^\s+at /m, "no stack frames");
+    assert.doesNotMatch(stderr, /unhandled|UnhandledPromiseRejection/i);
+    assert.doesNotMatch(stderr, /press any key/, "a shell is not made to wait");
+    assert.equal(stdout.includes("[server]"), false, "it never got as far as serving");
   });
 });
 

--- a/server/test/startupFailure.test.ts
+++ b/server/test/startupFailure.test.ts
@@ -12,6 +12,7 @@ import assert from "node:assert/strict";
 import { describe, test } from "node:test";
 import {
   bindFailureMessage,
+  holdConsoleIfOwned,
   ownsItsConsole,
   parentImageName,
   parseTasklistImageName,
@@ -173,5 +174,95 @@ describe("holding the window", () => {
     assert.equal(resumed, true, "the stream was read before it was waited on");
     assert.deepEqual(raw, [true, false]);
     assert.equal(paused, true);
+  });
+});
+
+// openlore: {"domain":"cli","requirement":"AFailureToStartIsSaidOutLoud","scenario":"TheMessageOutlivesTheWindow","specFile":"openspec/changes/say-why-the-server-could-not-start/specs/cli/spec.md"}
+describe("holding the console for any pre-listen failure", () => {
+  const heldStream = (calls: string[]): Parameters<typeof holdConsoleIfOwned>[0]["stdin"] => ({
+    isTTY: true,
+    setRawMode: (mode) => calls.push(`raw:${mode}`),
+    resume: () => calls.push("resume"),
+    pause: () => calls.push("pause"),
+    once: (_event, listener) => {
+      calls.push("wait");
+      listener();
+    },
+  });
+
+  test("a file-manager launch that fails before listening still holds the window", async () => {
+    const calls: string[] = [];
+    const errs: string[] = [];
+    const realErr = console.error;
+    console.error = (line: string) => void errs.push(line);
+    try {
+      await holdConsoleIfOwned({
+        platform: "win32",
+        env: {},
+        probe: () => "explorer.exe",
+        stdin: heldStream(calls),
+      });
+    } finally {
+      console.error = realErr;
+    }
+    assert.deepEqual(errs, ["[pi] press any key to close this window"]);
+    assert.deepEqual(calls, ["raw:true", "resume", "wait", "raw:false", "pause"]);
+  });
+
+  test("a shell launch is not held and is not told to press a key", async () => {
+    const calls: string[] = [];
+    const errs: string[] = [];
+    const realErr = console.error;
+    console.error = (line: string) => void errs.push(line);
+    try {
+      await holdConsoleIfOwned({
+        platform: "win32",
+        env: {},
+        probe: () => "pwsh.exe",
+        stdin: heldStream(calls),
+      });
+    } finally {
+      console.error = realErr;
+    }
+    assert.deepEqual(errs, [], "nothing printed");
+    assert.deepEqual(calls, [], "the stream was never touched");
+  });
+
+  test("a runner is never held, whatever launched it", async () => {
+    const calls: string[] = [];
+    await holdConsoleIfOwned({
+      platform: "win32",
+      env: { CI: "true" },
+      probe: () => "explorer.exe",
+      stdin: heldStream(calls),
+    });
+    assert.deepEqual(calls, []);
+  });
+
+  test("off Windows there is nothing to hold", async () => {
+    const calls: string[] = [];
+    await holdConsoleIfOwned({
+      platform: "linux",
+      env: {},
+      probe: () => "explorer.exe",
+      stdin: heldStream(calls),
+    });
+    assert.deepEqual(calls, []);
+  });
+
+  test("the probe is only consulted through this call, and its failure is not a yes", async () => {
+    const calls: string[] = [];
+    let probed = 0;
+    await holdConsoleIfOwned({
+      platform: "win32",
+      env: {},
+      probe: () => {
+        probed += 1;
+        return undefined; // a probe that could not answer
+      },
+      stdin: heldStream(calls),
+    });
+    assert.equal(probed, 1);
+    assert.deepEqual(calls, []);
   });
 });


### PR DESCRIPTION
## What

`say-why-the-server-could-not-start` made a failed `await app.listen()` hold the console open when a double-clicked (terminal-less) process owns it. But **every earlier exit** — no configuration file, an unparseable flag, an unreadable setting — still went straight to `process.exit(1)`. A double-clicked executable owns its console, so on the *commonest* first-run failure (no config yet) the message flashed and the window vanished — the exact problem the change exists to fix, one step earlier in startup.

Found while completing the Windows verification (tasks 4.1 / 4.2). Confirmed on Windows 11 before the fix: a no-config double-click closed its own window in ~2 s.

## Change

- Factor the hold into `holdConsoleIfOwned()` in `startupFailure.ts`; call it before the `NoConfigError`, the `complain()`-then-exit, and the `parseCli` failure exits, as well as the existing `listen` catch. The ownership decision stays injectable so a test drives both directions off Windows.
- The config and `parseCli` IIFEs in `index.ts` become `await`ed.
- Spec delta broadened from "cannot begin listening" → "cannot start", with a new `AFailureBeforeListeningIsHeldToo` scenario.

## Tests

- **Unit** (`startupFailure.test.ts`): a file-manager parent on Windows prints the prompt and sequences `waitForAKey` (`raw:true → wait → raw:false → pause`); a shell parent, a CI runner, a non-Windows platform, and an unanswered probe each touch nothing.
- **Integration** (`startup-failure.test.mjs`): a real `index.ts` started with a launch dir that has no config and an empty `XDG_CONFIG_HOME` exits non-zero with the "no configuration file found" line, no stack, and — from a test runner — no "press any key" and no hang.

## Windows verification (tasks 4.1 / 4.2 + 5.3), on Windows 11 against a fresh SEA

| Case | Result |
|---|---|
| 4.1 — double-click, port taken | Shortcut launch, parent = `explorer.exe`. Window held (alive 20+ s, no timeout) showing the `[pi] cannot start: 127.0.0.1:3141 is already in use … "--port <n>" …` line + `[pi] press any key to close this window`. A space keypress → process exits. One line, no stack. |
| 4.2 — same start from PowerShell | Parent = `pwsh.exe`; exit code 1; stderr is exactly the one `cannot start` line; no "press any key", no stack, no `unhandled`; returns as soon as the bind fails. |
| 5.3 — no-config double-click (after this fix) | Parent = `explorer.exe`; window now **held** until a keypress, showing the "no configuration file found" block + `[pi] press any key to close this window`. Same start from PowerShell still exits at once with no prompt. |

## Checks

- typecheck clean; lint clean (warnings pre-existing in `index.ts`, none in touched code)
- focused `startupFailure.test.ts` + `startup-failure.test.mjs`: 26/26
- `openspec validate say-why-the-server-could-not-start --strict`: valid
- full server suite: 1614 pass; 3 pre-existing environmental failures on this Windows box (pptx tooling absent, symlink privilege, release-channel tag detection), each reproduced with the branch stashed

## Note on the "inert web page"

On the bind-failure path the process exits **before** the browser-open code, so pi-outpost opens no tab. A stale page pointed at `:3141` is a leftover browser window from an earlier run (the proposal's own bug report) — the "single-instance rendezvous" it lists as out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)