### PR TITLE
feat(tool-progress): show a determinate bar while a tool reports its progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,22 @@ Extensions using pi's [Custom UI](https://github.com/earendil-works/pi/blob/main
 
 Custom messages (`pi.sendMessage()` with a `customType`, see [Message and Entry Rendering](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/extensions.md#message-and-entry-rendering)) show up too, but without the extension's `MessageRenderer` — that returns a terminal `Component`, which has no browser equivalent. Instead it falls back to pi's own default look (violet card, markdown-rendered content), with any `details` payload collapsed behind a toggle (never verbose JSON by default). Messages sent with `display: false` stay hidden, same as in the TUI.
 
+### Reporting progress from a tool
+
+A long-running tool can report how far along it is. From `execute`, call the `onUpdate` callback with a `progress` fraction between `0` and `1` in `details` — the same call you already make to stream partial output:
+
+```ts
+async execute(toolCallId, params, signal, onUpdate) {
+  for (let i = 1; i <= steps; i++) {
+    await doOneStep();
+    onUpdate?.({ content: [{ type: "text", text: `step ${i}/${steps}` }], isPartial: true, details: { progress: i / steps } });
+  }
+  return { content: [{ type: "text", text: "done" }] };
+}
+```
+
+The web UI shows a determinate progress bar on the tool card while the call runs. It is a hint: no label is needed (the streamed text is already shown), a value outside `0..1` is clamped, the bar only appears once the first fraction has arrived, and it disappears when the tool finishes. A tool that reports nothing looks exactly as it does today.
+
 ## Work Plans
 
 The Work Plan belongs to the agent. For non-trivial work it is the agent's explicit working-state representation: a persistent hierarchy used to decompose objectives, track execution and dependencies, record resources and blockers, and reconcile verification before declaring the work complete. It is not a second activity log or a ceremonial progress report; trivial interactions need no plan.

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -446,6 +446,23 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
     { env: { ...onlyOneFakeProvider(), FAKE_PI_RPC_CONFIG: notifyFakeConfig } },
   );
 
+  // A sixth server whose scripted RPC child, on every prompt, runs a tool that
+  // reports a rising completion fraction — the offline stand-in for an extension
+  // tool calling onUpdate(). The whole path from the runtime out is real.
+  const progressRoot = await makeWorkspace({ "readme.md": "# progress\n" });
+  const progressFakeConfig = path.join(progressRoot, "fake-rpc.json");
+  await writeFile(
+    progressFakeConfig,
+    JSON.stringify({ state: { sessionId: "progress-1" }, progressDemo: { steps: 5, intervalMs: 500, toolName: "crawl" } }),
+  );
+  const progress = await startServer(
+    progressRoot,
+    {
+      agentRuntime: { mode: "rpc", executable: process.execPath, args: [path.join(REPO, "server/test/fixtures/fake-pi-rpc.mjs")], startupTimeoutMs: 20_000 },
+      sandbox: undefined,
+    },
+    { env: { ...onlyOneFakeProvider(), FAKE_PI_RPC_CONFIG: progressFakeConfig } },
+  );
 
   process.env.PI_E2E_HOST_URL = host.url;
   process.env.PI_E2E_SERVER_URL = server.base;
@@ -460,6 +477,7 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
   process.env.PI_E2E_DIAGRAMS_URL = diagrams.base;
   process.env.PI_E2E_PLANS_URL = plans.base;
   process.env.PI_E2E_NOTIFY_URL = notifications.base;
+  process.env.PI_E2E_PROGRESS_URL = progress.base;
   process.env.PI_E2E_PLAN_SOURCE = sourceSession;
   process.env.PI_E2E_PLAN_FORK = forkSession;
   process.env.PI_E2E_EXTENSIONS_DIR = extensionsDir;
@@ -467,6 +485,7 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
   process.env.PI_E2E_TOKEN = E2E_TOKEN;
 
   return async () => {
+    await progress.stop();
     await notifications.stop();
     await plans.stop();
     await diagrams.stop();

--- a/e2e/tool-progress.spec.ts
+++ b/e2e/tool-progress.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "@playwright/test";
+
+async function prompt(page: import("@playwright/test").Page, text: string) {
+  const composer = page.getByRole("textbox", { name: /message pi/i });
+  await expect(composer).toBeEnabled();
+  await composer.fill(text);
+  await composer.press("Enter");
+}
+
+test("a running tool shows a determinate progress bar that advances and then clears", async ({ page }) => {
+  await page.goto(process.env.PI_E2E_PROGRESS_URL!);
+  await expect(page.getByTitle("connected")).toBeVisible();
+
+  // The scripted RPC child runs a tool that reports a rising 0..1 fraction —
+  // the offline stand-in for an extension tool calling onUpdate().
+  await prompt(page, "run the demo");
+
+  const bar = page.getByRole("progressbar");
+  await expect(bar).toBeVisible();
+
+  // It appears determinate and partway, not full.
+  const first = await bar.evaluate((el) => (el as HTMLProgressElement).value);
+  expect(first).toBeGreaterThan(0);
+  expect(first).toBeLessThan(1);
+
+  // It advances to completion.
+  await expect
+    .poll(async () => bar.evaluate((el) => (el as HTMLProgressElement).value), { timeout: 10_000 })
+    .toBeGreaterThanOrEqual(1);
+
+  // And the tool ends: the bar is chrome for a running call, so it goes away.
+  await expect(page.getByRole("progressbar")).toHaveCount(0);
+});

--- a/openspec/changes/show-progress-for-a-running-tool/.openspec.yaml
+++ b/openspec/changes/show-progress-for-a-running-tool/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-30

--- a/openspec/changes/show-progress-for-a-running-tool/design.md
+++ b/openspec/changes/show-progress-for-a-running-tool/design.md
@@ -1,0 +1,138 @@
+## Context
+
+See `proposal.md` — Why. Three facts about the current code shape the approach.
+
+- The pi SDK already hands every tool an update callback:
+  `execute(toolCallId, params, signal, onUpdate, ctx)`
+  (`core/extensions/types.d.ts`). `onUpdate` takes a partial `AgentToolResult<TDetails>`,
+  and the `tool_execution_update` event that results carries `partialResult` typed
+  `any`. `AgentToolResult` is generic on `TDetails` — `details` is the SDK's own slot
+  for tool-defined payload, and it already survives to the client on `tool_end`.
+- pi-outpost already turns `tool_execution_update` into a live `tool_update`
+  broadcast: `rpcRuntime.ts` / `embeddedRuntime.ts` read `partialResult.content`,
+  `server/src/index.ts` flattens it to text and `broadcast`s
+  `{ type: "tool_update", toolCallId, text }`, and `useAgent.ts` merges that onto the
+  tool chat-item as `output`. Everything that is not a text block is dropped at
+  `contentText()`.
+- `tool_update` is never written to session history. `convert.ts` rebuilds tool
+  cards from history without it, marking a trailing tool "running" only from the
+  stream state.
+
+The only gap is a typed number travelling that existing path and a bar drawn from it.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One number, `0..1`, from the tool to every client, on the stream that already
+  exists, with no change to the pi SDK.
+- The client shows it only while it is true — during the run, after it is known —
+  and never has to reason about a stale value.
+- A tool that does not report progress, and code that renders its card, are
+  untouched.
+
+**Non-Goals:**
+
+- A label, an ETA, step counts, or any second progress signal. The card already
+  streams detail.
+- Persisting progress or replaying it after a reconnect.
+- Making progress authoritative or monotonic. It is a hint the tool volunteers.
+- Rendering progress for anything other than a tool call (assistant turns,
+  compaction, uploads are their own concerns).
+
+## Decisions
+
+### Carry the fraction on `partialResult.details.progress`, not a new SDK surface
+
+`onUpdate` and `details` already exist and already flow. A tool reports progress by
+calling `onUpdate({ content, isPartial: true, details: { progress } })` — the same
+call it makes to stream text.
+
+- *Alternative: a first-class `onProgress` / `ctx.reportProgress` in the SDK.*
+  Out of this repo's control, slower to land, and unnecessary — `details` is the
+  slot the SDK provides for exactly this.
+- *Alternative: parse a `progress: NN%` token out of the streamed text.* Rejected
+  in exploration: an implicit text contract, broken by truncation, and not
+  first-class.
+
+The runtimes read it defensively — `partialResult?.details?.progress` — so a
+runtime dialect that does not carry `details` on updates simply yields no bar.
+The RPC record and the SDK event differ *around* the partial result but not in
+this extraction, so both runtimes call one shared `toolUpdateEvent(toolCallId,
+partial)` helper in `agentRuntime.ts` rather than each open-coding the reach —
+one place to read defensively, one place a test pins.
+
+### A typed `progress?: number` on `tool_update`, not a new message
+
+`tool_update` already fires on the exact SDK event, at the exact cadence, for the
+exact tool call. Adding an optional field is one edit per hop
+(`agentRuntime.ts` event type → `protocol.ts` wire type → `useAgent.ts` merge).
+
+- *Alternative: a parallel `tool_progress` message.* Doubles the plumbing and adds
+  an ordering question (progress vs. text for the same call) for no gain.
+- *Alternative: overload `text`.* That is the text-token approach under another name.
+
+### Clamp and validate once, at the server broadcast boundary
+
+`server/src/index.ts`'s `tool_update` case is the single point every client and the
+embedded widget pass through. It coerces `progress` to a finite number, clamps to
+`[0, 1]`, and omits the field entirely when the value is not a finite number. The
+runtimes pass `details?.progress` up untouched; the UI trusts what it receives.
+
+- *Alternative: validate in the UI.* Two clients, one contract — the wire should
+  never carry an out-of-range or `NaN` progress.
+- A decreasing value is *valid* and passes through unchanged; only the shape is
+  enforced here, not the trajectory.
+
+### The bar is card chrome, drawn from item state, cleared by `running`
+
+`useAgent.ts` already flips `running: false` on `tool_end`. `ToolCard` gates the
+bar on `item.running && item.progress != null`, so:
+
+- No bar before the first fraction (`progress` starts `undefined`).
+- `tool_update` merges `progress` onto the item **only when the message carries
+  one**, so a later text-only update leaves the last value in place.
+- `tool_end` needs no progress bookkeeping — `running` goes false and the gate
+  closes. The last `progress` value may stay on the item unused.
+
+The bar sits in the card container, above the presentation slot, independent of
+which presentation (built-in, extension, structured-exchange) renders the output.
+Because `ToolCard` is shared, `@pi-outpost/embed` gets the bar with no embed-side
+change.
+
+### Render with the native `<progress>` element
+
+`<progress value={f} max={1}>` — `f` is already `0..1`, so no conversion, and the
+element carries `role="progressbar"` / `aria-valuenow` semantics for free.
+
+- *Alternative: a styled `<div>` bar like `WorkPlanPanel`'s inline one.* More code,
+  manual a11y. `<progress>` can be themed later (accent colour, height) without
+  touching the contract.
+
+## Risks / Trade-offs
+
+- **The SDK's `partialResult` shape is `any` and could drift, or the OMP RPC
+  dialect may not include `details` on updates.** → Read every hop defensively
+  (`?.`); the failure mode is "no bar", which is today's behaviour. A test covers
+  an update with no `details`.
+- **A tool that calls `onUpdate` with a new fraction every few milliseconds
+  causes re-render churn.** → The payload is one number and one `<progress>`
+  attribute; React reconciliation is cheap here. If it ever matters, a minimum
+  broadcast interval can be added at the server boundary without a contract change.
+- **`text` is truncated at the server; a reader might assume `progress` is too.** →
+  It is a number, unaffected by `truncate()`. Stated here so no one adds a guard
+  that is not needed.
+- **An embed consumer that tightly styles tool cards sees a new element appear.** →
+  It appears only for tools that opt in by reporting, and only inside the existing
+  card container. Documented in the extension authoring note.
+- **A client that reconnects mid-run shows no bar for up to one update interval.**
+  → Accepted by the spec ("only while running, only after a fraction has
+  arrived"); persisting a value that is stale the moment it is written would cost
+  a history-schema field for no real gain.
+
+## Open Questions
+
+- Whether to theme `<progress>` to match the product accent now or leave it
+  browser-default. Cosmetic; no contract or task impact.
+- Whether a minimum broadcast interval for progress is worth adding pre-emptively.
+  Deferrable — it is a server-local tweak with no spec or client impact.

--- a/openspec/changes/show-progress-for-a-running-tool/proposal.md
+++ b/openspec/changes/show-progress-for-a-running-tool/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+An extension tool can take a long time — indexing, crawling, a remote job — and while it runs the tool card shows only its streamed text and a spinner. The tool often knows exactly how far along it is (the same function elsewhere drives a real progress bar), but there is no first-class way for it to say so, and no place for the UI to show it. The plumbing is already almost there: the pi SDK gives every tool an `onUpdate` callback, and pi-outpost already turns those into live `tool_update` messages — it just drops everything that is not text.
+
+## What Changes
+
+- A running tool MAY report a **completion fraction** — a number in `0..1` — as often as it likes while it executes. It rides on the partial result the tool already emits (`onUpdate({ …, details: { progress } })`); no change to the pi SDK.
+- The `tool_update` server→client message gains an optional `progress` field carrying that fraction. Both the RPC runtime and the embedded runtime forward it.
+- The tool card shows a **determinate progress bar** for a running tool once a fraction has arrived. Before the first fraction there is no bar; the last fraction stays on screen if a later update omits it; the bar disappears when the tool ends. The bar is chrome on the card, independent of whichever presentation renders the output.
+- Out-of-range values are clamped to `0..1`; a non-number, `NaN`, or infinity is ignored for that update rather than shown or thrown. A fraction that goes backwards is shown as-is — no monotonic enforcement.
+- The fraction is **ephemeral**: it is not written to session history, so a client that reconnects mid-run shows no bar until the tool sends its next update.
+- Because the tool card is shared, the bar appears in the embedded widget (`@pi-outpost/embed`) as well.
+
+## Capabilities
+
+### New Capabilities
+
+- `tool-progress`: how a running tool reports how far along it is, how that fraction travels from the tool to every connected client, and how the client shows it while the tool runs.
+
+### Modified Capabilities
+
+<!-- None. The edits to protocol.ts, the runtimes and the tool card are the implementation of the new capability's requirements, not changes to an existing capability's contract. -->
+
+## Impact
+
+- **Wire** — `shared/src/protocol.ts`: `tool_update` gains `progress?: number`. `server/src/agentRuntime.ts`: the internal `tool_update` event type gains it too.
+- **Runtimes** — `server/src/rpcRuntime.ts` and `server/src/embeddedRuntime.ts` read `partialResult.details?.progress`; `server/src/index.ts` clamps it and includes it in the broadcast.
+- **Client** — `shared` chat-item (tool kind) gains `progress?: number`; `ui/src/useAgent.ts` carries it onto the item on `tool_update` and clears it on `tool_end`; `ui/src/components/ToolCard.tsx` renders the bar while `running`.
+- **Docs** — extension authoring reference gains a short note on reporting progress from a tool.
+- No new dependency. No change to the pi SDK, to tool arguments, to session persistence, or to any tool that never reports progress — such a tool renders exactly as it does today.

--- a/openspec/changes/show-progress-for-a-running-tool/scenario-coverage.md
+++ b/openspec/changes/show-progress-for-a-running-tool/scenario-coverage.md
@@ -1,0 +1,48 @@
+# Scenario coverage
+
+Every `#### Scenario:` in `specs/tool-progress/spec.md`, enumerated with
+`rg '^#### Scenario:' openspec/changes/show-progress-for-a-running-tool/`, with the
+assertion that would fail if the contract broke. Read the assertions, not the names.
+
+Test files:
+
+- `server/test/toolProgress.test.ts` (`helper`) — the shared `toolUpdateEvent()` extraction both runtimes use
+- `server/test/pi-rpc.test.ts` (`rpc`) — the RPC runtime, over the real fake-pi-rpc child
+- `server/test/convert.test.ts` (`conv`) — `toProgressFraction()` and `historyToItems()`
+- `server/test/multiProjectWorkspaces.test.mjs` (`wire`) — real server + real WebSocket, two workspaces
+- `ui/src/useAgent.test.ts` (`reducer`) — the client reducer over `mockWs`
+- `ui/src/components/ToolCard.test.tsx` (`card`) — the tool card component
+- `e2e/tool-progress.spec.ts` (`e2e`) — Chromium against the running app, RPC child scripted with `progressDemo`
+
+| Scenario | Status | Where | What would fail |
+|---|---|---|---|
+| A tool reports its progress partway through | covered | `helper` "carries the completion fraction the tool put in details"; `rpc` "forwards a tool's completion fraction…"; `wire` "a tool's progress reaches its own project's clients…" | `helper` asserts `toolUpdateEvent("t1", {details:{progress:0.4}})` yields `progress: 0.4`. `rpc` scripts a real `tool_execution_update` with `partialResult.details.progress = 0.4` and asserts the emitted `tool_update` carries it. `wire` asserts the fraction arrives at a subscribed browser client. Remove the `details?.progress` read and all three fail. |
+| A tool emits partial output but no fraction | covered | `helper` "a partial with no details yields no progress and does not throw"; `rpc` "…and omits it when the tool sends none"; `reducer` "does not set progress from a text-only tool_update" | `helper`/`rpc` assert `progress` is `undefined` on an update whose `partialResult` has `content` but no `details`. `reducer` drives `tool_update {text}` with no `progress` and asserts `item.progress` stays `undefined`. |
+| Two clients watch the same running tool | covered | `wire` "a tool's progress reaches its own project's clients, clamped, and no others" | Two real WebSocket clients subscribe to the same workspace; the test reads the `progress` values off the client bound to that workspace as `[0.8, 0.3, 1]`. (The second client in that test is bound elsewhere — see next row — so "both receive it" is asserted for the one on-workspace client plus the isolation client; a same-workspace second subscriber follows from `broadcast()` fanning to every socket of the workspace, which the existing `MessagesReachOnlyTheirWorkspace` suite pins.) |
+| Another workspace is unaffected | covered | `wire` same test | The client bound to the *other* project asserts `tool_update` frame count is `0` — a `progress` frame for workspace A never reaches a B subscriber. Route the broadcast workspace-wide and it fails. |
+| A fraction outside the range | covered | `conv` "clamps a value outside the range rather than dropping it"; `wire` same test | `conv` asserts `toProgressFraction(1.7) === 1` and `toProgressFraction(-0.2) === 0`. `wire` scripts a real `1.7` update and asserts the delivered value is `1`. |
+| A fraction that is not a finite number | covered | `conv` "a value that is not a finite number yields undefined"; `helper` "the fraction is carried raw here…" | `conv` asserts `NaN`, `±Infinity`, `"0.5"`, `null`, `undefined`, an object all yield `undefined` (field omitted at the broadcast). `helper` shows the runtime carries `NaN` raw — so the omission is proven to happen at the single sanitising point, not before. Nothing throws. |
+| A fraction that decreases | covered | `conv` "does not police the trajectory…"; `wire` same test | `conv` asserts `toProgressFraction(0.3) === 0.3` unconditionally. `wire` scripts `0.8` then `0.3` for one `toolCallId` and asserts the delivered sequence keeps the `0.3` (no `Math.max`). |
+| The first fraction arrives | covered | `card` "shows no bar while running before a fraction has arrived" + "shows a determinate bar at the reported fraction"; `reducer` "carries a tool's completion fraction…"; `e2e` | `card` asserts `querySelector("progress")` is `null` for a running item with no `progress`, and non-null with `value ≈ 0.25` once set. `e2e` asserts the `progressbar` role becomes visible after the prompt with `0 < value < 1`. |
+| A later update omits the fraction | covered | `reducer` "carries a tool's completion fraction, and keeps the last one when an update omits it"; `card` "keeps the last fraction the item carries" | `reducer` sends `tool_update {progress:0.25}` then `tool_update {text}` and asserts `item.progress` is still `0.25`. `card` rerenders with a later text-only item and asserts the bar's `value` is still `0.25`. |
+| The tool finishes | covered | `card` "removes the bar once the tool has ended, even with a fraction left on the item"; `reducer` "…" ; `e2e` | `card` asserts no `progress` element for an item with `running:false` and `progress:0.9`, for both `isError:false` and `isError:true`. `reducer` asserts `running === false` after `tool_end`. `e2e` asserts `progressbar` `toHaveCount(0)` after the tool ends. |
+| The bar shows wherever the tool card shows | partial | `card` "shows the bar independently of a specialized presentation" | `card` renders a running `edit` tool (which selects the diff presentation) with `progress:0.6` and finds the bar at `0.6` — the bar is chrome, not part of any presentation, and the tool card is the same component the embedded widget mounts. Not driven through the embed host itself: that would need a second embed server wired to `progressDemo`. The component identity plus this assertion is the evidence. |
+| A client reconnects mid-run | covered | `conv` "a tool call rebuilt from history carries no completion fraction" | `historyToItems(..., streaming=true)` for a pending tool call yields `running:true` and `progress: undefined` — a reconnecting client's view is rebuilt this way, so it shows no bar until the next `tool_update` with a fraction. |
+| A finished tool in history | covered | `conv` same test | `historyToItems` for a completed `toolResult` yields a tool item with `progress: undefined`. Progress is never written to history, so it cannot be reconstructed. |
+
+## Result
+
+**12 of 13 scenarios covered, 1 partial** — "The bar shows wherever the tool card shows" is
+asserted at the shared component (a specialized presentation does not suppress the bar) but
+not driven through a live embedded-widget host; the tool card is literally the same
+component in both, and `ToolCard.test.tsx` is app-agnostic.
+
+## The run
+
+- `npm run typecheck` — clean across `shared`, `server`, `web`, `embed`
+- lint (`oxlint`) — clean; the warnings printed are pre-existing and in untouched files
+- focused: `toolProgress.test.ts`, `convert.test.ts`, `pi-rpc.test.ts`, `multiProjectWorkspaces.test.mjs`, `ui` `ToolCard`/`useAgent` (161 pass) — all green
+- `e2e/tool-progress.spec.ts` — passes headless (`npx playwright test tool-progress`); the `<progress>` element appears partway, advances to `1`, and is removed when the tool ends
+- full `server` suite — 1626 pass; 3 pre-existing environmental failures on this Windows box (`pptx_extract` needs tooling not installed, `listServerDirectories`/`update` need symlink privilege, `detectChannel` reads git tags), each reproduced with the branch stashed
+- full `ui` suite — the `localStorage`-dependent files (`authToken`, `useTheme`, `Sidebar`, `GitFileHistory`, parts of `App`) fail on this machine for lack of `--localstorage-file`; reproduced 23/23 on a clean `main` checkout, unrelated to this change
+- `openspec validate show-progress-for-a-running-tool --strict` — valid

--- a/openspec/changes/show-progress-for-a-running-tool/specs/tool-progress/spec.md
+++ b/openspec/changes/show-progress-for-a-running-tool/specs/tool-progress/spec.md
@@ -1,0 +1,101 @@
+## Purpose
+
+Lets a long-running tool report how far along it is, carries that completion fraction from the tool to every connected client, and shows it as a determinate progress bar on the tool card while the tool runs.
+
+## ADDED Requirements
+
+### Requirement: A running tool can report a completion fraction
+
+While a tool executes, it MAY report a completion fraction as often as it chooses. A reported fraction SHALL be a number from `0` (not started) to `1` (complete) and SHALL carry no label or unit — the tool card already shows the streamed detail. The fraction rides on the partial results the tool already emits during execution; a tool that emits no fraction is reporting no progress, which is the default.
+
+#### Scenario: A tool reports its progress partway through
+
+- **GIVEN** a tool that has begun executing
+- **WHEN** it emits a partial result carrying a completion fraction of `0.4`
+- **THEN** that fraction is delivered toward the clients as the tool's current progress
+
+#### Scenario: A tool emits partial output but no fraction
+
+- **GIVEN** a running tool that streams text updates
+- **WHEN** none of its updates carries a completion fraction
+- **THEN** the tool is treated as reporting no progress, exactly as tools do today
+
+### Requirement: The fraction reaches every client watching the workspace
+
+A reported fraction SHALL be delivered to every client subscribed to the workspace whose agent is running the tool, on the same stream of tool updates that already carries the tool's partial output. Whichever runtime is executing the agent SHALL forward it; the fraction SHALL NOT be delivered to clients of another workspace.
+
+#### Scenario: Two clients watch the same running tool
+
+- **GIVEN** two clients subscribed to the same workspace
+- **WHEN** the running tool reports a completion fraction
+- **THEN** both clients receive that fraction for that tool call
+
+#### Scenario: Another workspace is unaffected
+
+- **GIVEN** a tool reporting progress in workspace A
+- **WHEN** a client is subscribed only to workspace B
+- **THEN** that client receives no progress for A's tool call
+
+### Requirement: Invalid or out-of-range fractions never fault and never display as given
+
+A fraction below `0` or above `1` SHALL be clamped into that range before it reaches a client. A value that is not a finite number — a non-number, `NaN`, or an infinity — SHALL be ignored for that update, leaving the tool's progress unchanged rather than faulting the update or the turn. A fraction that is lower than one already reported SHALL be delivered as given; progress is not required to move only forward.
+
+#### Scenario: A fraction outside the range
+
+- **WHEN** a tool reports a completion fraction of `1.7`
+- **THEN** clients receive `1` for that tool call
+
+#### Scenario: A fraction that is not a finite number
+
+- **GIVEN** a tool that has reported a fraction of `0.5`
+- **WHEN** its next update carries `NaN` as the fraction
+- **THEN** the update is still delivered, the tool's progress stays at `0.5`, and no error is raised
+
+#### Scenario: A fraction that decreases
+
+- **GIVEN** a tool that has reported `0.8`
+- **WHEN** it reports `0.3`
+- **THEN** clients receive `0.3` for that tool call
+
+### Requirement: The client shows a determinate bar only while the tool runs and only after a fraction has arrived
+
+The tool card SHALL show a determinate progress bar for a tool call when that call is still running and at least one completion fraction has been received for it. Before the first fraction there SHALL be no bar. If a later update for a running tool carries no fraction, the most recently received fraction SHALL remain shown. When the tool call ends — whether it succeeds or fails — the bar SHALL be removed. The bar is independent of whichever presentation renders the tool's output.
+
+#### Scenario: The first fraction arrives
+
+- **GIVEN** a running tool whose card shows no progress bar
+- **WHEN** the client receives a completion fraction of `0.25` for it
+- **THEN** the card shows a determinate progress bar at one quarter
+
+#### Scenario: A later update omits the fraction
+
+- **GIVEN** a running tool whose card shows a bar at `0.25`
+- **WHEN** the client receives a further text update for it with no fraction
+- **THEN** the bar stays at `0.25`
+
+#### Scenario: The tool finishes
+
+- **GIVEN** a running tool whose card shows a progress bar
+- **WHEN** the tool call ends, with or without an error
+- **THEN** the card no longer shows a progress bar and shows the tool's result
+
+#### Scenario: The bar shows wherever the tool card shows
+
+- **GIVEN** the tool card rendered inside the embeddable widget
+- **WHEN** a running tool reports a completion fraction
+- **THEN** the widget shows the same determinate progress bar as the full interface
+
+### Requirement: The completion fraction is not persisted
+
+A completion fraction SHALL NOT be written to session history. A client that connects or reconnects while a tool is running SHALL show no progress bar for that tool until it receives a further update carrying a fraction. A tool call reconstructed from history SHALL show no progress bar.
+
+#### Scenario: A client reconnects mid-run
+
+- **GIVEN** a tool that reported progress and is still running
+- **WHEN** a client connects and its view is rebuilt from session history
+- **THEN** that tool's card shows no progress bar until the next fraction arrives
+
+#### Scenario: A finished tool in history
+
+- **WHEN** the conversation is rebuilt from history and a tool call in it has already completed
+- **THEN** its card shows no progress bar

--- a/openspec/changes/show-progress-for-a-running-tool/tasks.md
+++ b/openspec/changes/show-progress-for-a-running-tool/tasks.md
@@ -1,0 +1,46 @@
+## 1. The wire
+
+- [x] 1.1 Add `progress?: number` to the `tool_update` server→client message in `shared/src/protocol.ts`, documented as a fraction in `0..1`, absent when unknown; verify `npm run typecheck` passes and a protocol snapshot/shape test (if present) is updated. Done — field added with a doc comment; no snapshot test exists; typecheck clean.
+- [x] 1.2 Add `progress?: number` to the internal `tool_update` event in `server/src/agentRuntime.ts`; verify typecheck passes across `server`. Done — typed `progress?: unknown` (carried raw, sanitised once at the broadcast; matches the event's existing `content: unknown`).
+- [x] 1.3 Add `progress?: number` to the tool chat-item (tool `kind`) in `shared` and thread the type through `ui/src/useAgent.ts`'s tool-item shape; verify typecheck passes across `shared` and `ui`. Done — added to `ChatItem` tool kind; `ui`'s `ToolItem = Extract<ChatItem, {kind:"tool"}>` picks it up; full `npm run typecheck` clean.
+
+## 2. The runtimes read what the tool volunteered
+
+- [x] 2.1 In `server/src/rpcRuntime.ts` `tool_execution_update`, read `partialResult?.details?.progress` and include it on the emitted `tool_update` event, untouched; verify a `pi-rpc` runtime test drives an update whose `partialResult.details.progress` is `0.4` and asserts the emitted event carries `progress: 0.4`. Done — both runtimes now call a shared `toolUpdateEvent(toolCallId, partial)` helper in `agentRuntime.ts` (see design.md, decision 3). `pi-rpc.test.ts` "forwards a tool's completion fraction…" drives `0.4` through the real fake-RPC child.
+- [x] 2.2 In `server/src/embeddedRuntime.ts` `tool_execution_update`, do the same from `event.partialResult?.details?.progress`; verify an embedded-runtime test asserts the emitted event carries the fraction. Done — `embeddedRuntime.ts` calls the same `toolUpdateEvent` helper; the helper's own tests (`toolProgress.test.ts`) assert the fraction and its absence for the exact extraction both runtimes use. (No embedded-runtime harness exists; the helper is the seam, tested directly.)
+- [x] 2.3 Verify both runtimes are defensive: a test drives a `tool_execution_update` with no `details` (and one with no `partialResult`) and asserts the emitted event simply omits `progress` and does not throw. Done — `toolProgress.test.ts` covers no `details` and no `partial` at all; `pi-rpc.test.ts` drives a real update with no `details` and asserts `progress` is omitted.
+
+## 3. Clamp and validate once, at the broadcast boundary
+
+- [x] 3.1 In `server/src/index.ts` `tool_update` case, coerce `event.progress` to a finite number, clamp to `[0, 1]`, and include it on the broadcast only when it is a finite number; verify unit tests cover: `1.7 → 1`, `-0.2 → 0`, `0.3 → 0.3`, `NaN`/`Infinity`/`"x"`/`undefined → field omitted`. Done — `toProgressFraction()` in `convert.ts`, used by the `tool_update` case; a progress-only update (no text) now still broadcasts. `convert.test.ts` "toProgressFraction" covers every listed case.
+- [x] 3.2 Verify a decreasing fraction passes through unchanged: a test broadcasts `0.8` then `0.3` for one `toolCallId` and asserts the second broadcast carries `progress: 0.3` (no `Math.max`). Done — `multiProjectWorkspaces.test.mjs` "a tool's progress reaches its own project's clients, clamped, and no others" asserts the delivered sequence is `[0.8, 0.3, 1]` over the real server + WebSocket; `toProgressFraction` unit test also asserts no trajectory policing.
+- [x] 3.3 Verify workspace isolation: a test with two workspaces asserts a `tool_update` with `progress` for workspace A reaches only A's subscribers (extend/assert on the existing broadcast-scoping test). Done — same `multiProjectWorkspaces.test.mjs` test: the client bound to the other project receives zero `tool_update` frames.
+
+## 4. The client carries it while the tool runs
+
+- [x] 4.1 In `ui/src/useAgent.ts` `tool_update` handler, merge `progress` onto the tool item **only when the message carries a number**, so a text-only update leaves the previous value in place; verify a reducer test: `tool_start` → `tool_update {progress:0.25}` → `tool_update {text:"…"}` leaves `item.progress === 0.25`. Done — `useAgent.test.ts` "carries a tool's completion fraction, and keeps the last one when an update omits it".
+- [x] 4.2 Verify `tool_end` closes the bar without progress bookkeeping: a reducer test asserts that after `tool_end` the item has `running === false` (its `progress` value may remain but is no longer shown per task 5). Done — same reducer test ends the tool and asserts `running === false`.
+- [x] 4.3 Verify history reconstruction carries no progress: a `convert.ts` test asserts a tool item rebuilt from session history has `progress === undefined`, whether the tool is mid-run or already complete. Done — `convert.test.ts` "a tool call rebuilt from history carries no completion fraction".
+
+## 5. The bar
+
+- [x] 5.1 In `ui/src/components/ToolCard.tsx`, render a determinate `<progress value={item.progress} max={1}>` in the card container, above the presentation slot, gated on `item.running && item.progress != null`; verify component tests: no bar before a fraction, a bar at the right value after one, the last value retained when a later update omits it, and no bar after `tool_end` (success and error). Done — bar sits between the header button and the body; `ToolCard.test.tsx` "completion progress bar" covers all four cases.
+- [x] 5.2 Verify the bar is presentation-independent: a component test with a specialized presentation (e.g. a structured-exchange or code-search result) still shows the bar while running. Done — "shows the bar independently of a specialized presentation" uses a running `edit` tool (diff presentation) and still finds the bar at `0.6`.
+
+## 6. A tool that reports progress
+
+- [x] 6.1 Ship the progress-reporting artifacts. (a) A `progress-demo.mjs` extension tool whose `execute` calls `onUpdate({ content, isPartial: true, details: { progress } })` a few times over a short delay then returns — the documented pattern, usable under `BENCH_LIVE=1` with a real model; verify its `ToolDefinition` shape typechecks. (b) A `progressDemo` scripting path in `server/test/fixtures/fake-pi-rpc.mjs` that, on `prompt`, emits `tool_execution_start` → spaced `tool_execution_update` records with a rising `partialResult.details.progress` → `tool_execution_end`. Done — (a) `server/test/fixtures/progress-demo.ts`, typed as `ToolDefinition` from the SDK so `tsc` verifies the `execute(…, onUpdate, …)` signature; (b) `emitProgressDemo()` in `fake-pi-rpc.mjs`, `{ steps, intervalMs, toolName, error }`. `pi-rpc.test.ts` (31 tests) still green.
+
+## 7. Docs
+
+- [x] 7.1 Add a short "Reporting progress from a tool" note to the extension authoring reference. Done — new subsection under "Extension Custom UI" in `README.md`: report a `0..1` fraction via `onUpdate(…, { details: { progress } })`, with a code sample matching `ToolDefinition`; it is a hint, shown only while running, no label, clamped, appears after the first fraction, clears on finish.
+
+## 8. Scenario coverage and validation
+
+- [x] 8.1 Enumerate every `#### Scenario:` in `specs/tool-progress/spec.md` and write a scenario-to-test matrix in `scenario-coverage.md`. Done — 13 scenarios, 12 `covered`, 1 `partial` ("The bar shows wherever the tool card shows" — asserted at the shared `ToolCard` with a specialized presentation, not driven through a live embed host).
+- [x] 8.2 Run the focused tests, the relevant `server`/`ui` suites, typecheck, lint, and strict validation; record in `scenario-coverage.md`. Done — typecheck clean; lint clean; focused suites green (`toolProgress`, `convert`, `pi-rpc`, `multiProjectWorkspaces`, `ToolCard`/`useAgent` 161); `openspec validate --strict` valid. Pre-existing environmental failures noted (server: pptx tooling / symlink privilege / git-tag; ui: `--localstorage-file` — 23/23 reproduced on clean `main`).
+
+## 9. Prove it in the running app
+
+- [x] 9.1 Rebuild `web` → `@pi-outpost/embed` → `build:e2e-host`; on a server whose fake-pi-rpc child is configured with `progressDemo`, send a prompt and read the DOM back. Done — a sixth e2e server (`PI_E2E_PROGRESS_URL`, `progressDemo: { steps: 5, intervalMs: 500 }`) in `global-setup.ts`; the spec reads the `<progress>` element's `value` property (rises `0.2…→1`) and its removal after `tool_execution_end`. Screenshot captured showing the green determinate bar on the running `crawl` card between the header and the body. Embed host: not driven separately — same `ToolCard` component, covered by the `partial` row in `scenario-coverage.md`.
+- [x] 9.2 Add a Playwright spec that points at the `progressDemo`-scripted server and asserts the bar appears, advances, and disappears on completion. Done — `e2e/tool-progress.spec.ts`; passes headless (`npx playwright test --config e2e/playwright.config.ts tool-progress`).

--- a/scripts/embed-bench.mts
+++ b/scripts/embed-bench.mts
@@ -221,6 +221,30 @@ const diagrams = await startServer(
   { env: { ...onlyOneFakeProvider(), FAKE_PI_RPC_CONFIG: fakeConfig } },
 );
 
+// A server whose scripted RPC child runs a tool that reports a rising completion
+// fraction on every prompt — so the tool-card progress bar can be watched by hand.
+const progressRoot = await makeWorkspace({ "readme.md": "# progress\n" });
+const progressConfig = path.join(progressRoot, "fake-rpc.json");
+await writeFile(
+  progressConfig,
+  JSON.stringify({ state: { sessionId: "progress-1" }, progressDemo: { steps: 8, intervalMs: 600, toolName: "crawl" } }),
+);
+const progress = await startServer(
+  progressRoot,
+  {
+    server: { allowedOrigins: [host.url], port: HOST_PORT + 5 },
+    branding: { title: "bench progress" },
+    agentRuntime: {
+      mode: "rpc",
+      executable: process.execPath,
+      args: [path.join(REPO, "server/test/fixtures/fake-pi-rpc.mjs")],
+      startupTimeoutMs: 20_000,
+    },
+    sandbox: undefined,
+  },
+  { env: { ...onlyOneFakeProvider(), FAKE_PI_RPC_CONFIG: progressConfig } },
+);
+
 // The three embed workspace-control policies, each on its own server, because the
 // policy is loaded configuration rather than a mount option: the only way to see
 // what a deployment would show is to run a server configured that way.
@@ -263,6 +287,7 @@ console.log(
     : "  offline: no model (BENCH_LIVE=1 npm run bench to talk to a real one)",
 );
 console.log(`  seeded transcript           ${link(diagrams.base)}   (diagrams + table)`);
+console.log(`  tool progress bar           ${link(progress.base)}   (send any prompt, watch the tool card)`);
 console.log("\n  embed workspace controls — the same widget under each policy\n");
 console.log(`  settings (the default)      ${link(plain.base)}   no header control; the root lives in Settings`);
 console.log(`  root                        ${link(rootMode.base)}   one root, moved from the header`);
@@ -275,6 +300,7 @@ const stop = async () => {
   stopping = true;
   await projectsMode.stop();
   await rootMode.stop();
+  await progress.stop();
   await diagrams.stop();
   await plain.stop();
   await host.close();

--- a/server/src/agentRuntime.ts
+++ b/server/src/agentRuntime.ts
@@ -103,7 +103,10 @@ export type RuntimeEvent =
   | { type: "assistant_end"; message: unknown }
   | { type: "custom_message"; message: unknown }
   | { type: "tool_start"; toolCallId: string; toolName: string; args: unknown }
-  | { type: "tool_update"; toolCallId: string; content: unknown }
+  // `progress` is whatever the tool put in `partialResult.details.progress` — a
+  // completion fraction, in principle `0..1`. Carried raw and sanitised once, at
+  // the broadcast boundary in index.ts, so both runtimes stay pass-through.
+  | { type: "tool_update"; toolCallId: string; content: unknown; progress?: unknown }
   | { type: "tool_end"; toolCallId: string; toolName: string; content: unknown; details: unknown; isError: boolean }
   | { type: "queue"; steering: string[]; followUp: string[] }
   | { type: "thinking_changed"; level: ThinkingLevel }
@@ -117,6 +120,20 @@ export type RuntimeEvent =
   | { type: "error"; message: string }
   /** Fail-closed: the runtime is unusable from here on. Reported once. */
   | { type: "runtime_failed"; message: string };
+
+/**
+ * Build a `tool_update` event from a tool's partial result, the same way for
+ * both runtimes — the RPC record and the SDK event differ around it but not in
+ * this shape. Everything is read defensively: a partial with no `details`, or no
+ * partial at all, yields an event with no `progress` rather than a throw. The
+ * fraction is carried raw and sanitised once, at the broadcast boundary.
+ */
+export function toolUpdateEvent(
+  toolCallId: string,
+  partial: { content?: unknown; details?: { progress?: unknown } } | undefined,
+): Extract<RuntimeEvent, { type: "tool_update" }> {
+  return { type: "tool_update", toolCallId, content: partial?.content, progress: partial?.details?.progress };
+}
 
 export interface PromptOptions {
   images?: WireImage[];

--- a/server/src/convert.ts
+++ b/server/src/convert.ts
@@ -121,6 +121,19 @@ export function truncate(text: string, max = MAX_TOOL_OUTPUT): string {
   return `${text.slice(0, max)}\n… [truncated, ${text.length} chars total]`;
 }
 
+/**
+ * A completion fraction a running tool volunteered, sanitised for the wire.
+ *
+ * Only a finite number survives — a non-number, `NaN` or an infinity yields
+ * `undefined`, which the client reads as "no change". A value outside `0..1` is
+ * clamped rather than dropped. The trajectory is not policed: a fraction lower
+ * than one seen before is a legitimate report and passes through unchanged.
+ */
+export function toProgressFraction(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  return value < 0 ? 0 : value > 1 ? 1 : value;
+}
+
 function assistantBlocks(content: string | AnyContent[]): AssistantBlock[] {
   const blocks: AssistantBlock[] = [];
   if (!Array.isArray(content)) return blocks;

--- a/server/src/embeddedRuntime.ts
+++ b/server/src/embeddedRuntime.ts
@@ -29,6 +29,7 @@ import type {
   RuntimeTreeNode,
   TitleCapability,
 } from "./agentRuntime.ts";
+import { toolUpdateEvent } from "./agentRuntime.ts";
 import { CredentialError, providerConfig, type ProviderDeclaration, storeApiKey, storeProvider } from "./credentials.ts";
 import { ExtensionUiBridge } from "./extensionUiBridge.ts";
 import { generateSessionTitle } from "./sessions.ts";
@@ -230,7 +231,7 @@ class EmbeddedRuntime implements AgentRuntime {
         this.emit({ type: "tool_start", toolCallId: event.toolCallId, toolName: event.toolName, args: event.args });
         break;
       case "tool_execution_update":
-        this.emit({ type: "tool_update", toolCallId: event.toolCallId, content: event.partialResult?.content });
+        this.emit(toolUpdateEvent(event.toolCallId, event.partialResult));
         break;
       case "tool_execution_end":
         this.emit({

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -76,7 +76,7 @@ import {
   validBaseUrl,
   validProviderId,
 } from "./credentials.ts";
-import { assistantToItem, contentText, customMessageToItem, historyToItems, structuredExchangeField, truncate } from "./convert.ts";
+import { assistantToItem, contentText, customMessageToItem, historyToItems, structuredExchangeField, toProgressFraction, truncate } from "./convert.ts";
 
 import { isStackExhaustion, noteCompaction, noteToolOutcome, noteTurnOutcome, recordTurnFailure } from "./turnFailureLog.ts";
 import {
@@ -1500,7 +1500,16 @@ function onRuntimeEvent(workspace: Workspace, event: RuntimeEvent): void {
     }
     case "tool_update": {
       const text = contentText(event.content as never);
-      if (text) broadcast(workspace, { type: "tool_update", toolCallId: event.toolCallId, text: truncate(text) });
+      const progress = toProgressFraction(event.progress);
+      // A progress-only update carries no text; still send it so the bar can move.
+      if (text || progress !== undefined) {
+        broadcast(workspace, {
+          type: "tool_update",
+          toolCallId: event.toolCallId,
+          text: truncate(text),
+          ...(progress !== undefined ? { progress } : {}),
+        });
+      }
       break;
     }
     case "tool_end": {

--- a/server/src/rpcRuntime.ts
+++ b/server/src/rpcRuntime.ts
@@ -31,6 +31,7 @@ import type {
   RuntimeSnapshot,
   RuntimeTreeNode,
 } from "./agentRuntime.ts";
+import { toolUpdateEvent } from "./agentRuntime.ts";
 import type { AgentRuntimeConfig } from "./config.ts";
 import { PiRpcProcess, probeAgentLabel, type RpcIncoming } from "./piRpcProcess.ts";
 import { explainRejectedFlags } from "./rpcResourceArgs.ts";
@@ -361,11 +362,12 @@ class RpcRuntime implements AgentRuntime {
         });
         break;
       case "tool_execution_update":
-        this.emit({
-          type: "tool_update",
-          toolCallId: String(record.toolCallId),
-          content: (record.partialResult as { content?: unknown } | undefined)?.content,
-        });
+        this.emit(
+          toolUpdateEvent(
+            String(record.toolCallId),
+            record.partialResult as { content?: unknown; details?: { progress?: unknown } } | undefined,
+          ),
+        );
         break;
       case "tool_execution_end": {
         const result = record.result as { content?: unknown; details?: unknown } | undefined;

--- a/server/test/convert.test.ts
+++ b/server/test/convert.test.ts
@@ -3,6 +3,7 @@ import { describe, test } from "node:test";
 import {
   contentText,
   truncate,
+  toProgressFraction,
   historyToItems,
   assistantToItem,
   customMessageToItem,
@@ -81,6 +82,37 @@ describe("truncate", () => {
   test("uses the default max (20 000)", () => {
     const short = "ok";
     assert.equal(truncate(short), short);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toProgressFraction — the completion fraction, sanitised for the wire
+// ---------------------------------------------------------------------------
+
+describe("toProgressFraction", () => {
+  test("passes a fraction inside 0..1 through unchanged", () => {
+    assert.equal(toProgressFraction(0), 0);
+    assert.equal(toProgressFraction(0.3), 0.3);
+    assert.equal(toProgressFraction(1), 1);
+  });
+
+  test("clamps a value outside the range rather than dropping it", () => {
+    assert.equal(toProgressFraction(1.7), 1);
+    assert.equal(toProgressFraction(-0.2), 0);
+  });
+
+  test("does not police the trajectory — a decrease is a legitimate report", () => {
+    assert.equal(toProgressFraction(0.3), 0.3);
+  });
+
+  test("a value that is not a finite number yields undefined", () => {
+    assert.equal(toProgressFraction(Number.NaN), undefined);
+    assert.equal(toProgressFraction(Number.POSITIVE_INFINITY), undefined);
+    assert.equal(toProgressFraction(Number.NEGATIVE_INFINITY), undefined);
+    assert.equal(toProgressFraction("0.5"), undefined);
+    assert.equal(toProgressFraction(null), undefined);
+    assert.equal(toProgressFraction(undefined), undefined);
+    assert.equal(toProgressFraction({ progress: 0.5 }), undefined);
   });
 });
 
@@ -235,6 +267,25 @@ describe("historyToItems", () => {
     assert.equal(running.running, true);
     assert.equal(running.toolName, "bash");
     assert.equal(running.output, "");
+  });
+
+  test("a tool call rebuilt from history carries no completion fraction", () => {
+    // Progress is never persisted, so it cannot be reconstructed — mid-run or done.
+    const midRunItems = historyToItems(
+      [{ role: "assistant", content: [{ type: "toolCall", id: "run1", name: "crawl", arguments: {} }] }],
+      true,
+    );
+    const midRun = midRunItems.find((i) => i.kind === "tool") as Extract<(typeof midRunItems)[0], { kind: "tool" }>;
+    assert.equal(midRun.running, true);
+    assert.equal(midRun.progress, undefined);
+
+    const doneItems = historyToItems([
+      { role: "assistant", content: [{ type: "toolCall", id: "run2", name: "crawl", arguments: {} }] },
+      { role: "toolResult", toolCallId: "run2", toolName: "crawl", content: "done", isError: false },
+    ]);
+    const done = doneItems.find((i) => i.kind === "tool") as Extract<(typeof doneItems)[0], { kind: "tool" }>;
+    assert.equal(done.running ?? false, false);
+    assert.equal(done.progress, undefined);
   });
 
   test("does not add running tool cards without streaming flag", () => {

--- a/server/test/fixtures/fake-pi-rpc.mjs
+++ b/server/test/fixtures/fake-pi-rpc.mjs
@@ -181,7 +181,42 @@ function finishSuccessfulCommand(command, type, script, responseId) {
   for (const write of script?.writes ?? []) fs.writeFileSync(write.path, write.content);
   emitAll(script?.after);
   if (config.malformedAfter === type) emitRaw(`${config.malformedLine ?? "{not json"}\n`);
+  if (type === "prompt" && config.progressDemo) emitProgressDemo(config.progressDemo);
   if (config.exitAfter === type) process.exit(config.exitCode ?? 7);
+}
+
+/**
+ * A tool call that reports its completion fraction, for the running-app check.
+ *
+ * `{ steps: n, intervalMs: ms, toolName, error: bool }` — emits a start, `n`
+ * spaced `tool_execution_update` records whose `partialResult.details.progress`
+ * climbs from `1/n` to `1`, then an end. The real thing an extension tool does
+ * through `onUpdate`, without a model in the loop.
+ */
+function emitProgressDemo({ steps = 4, intervalMs = 400, toolName = "crawl", error = false } = {}) {
+  const toolCallId = `progress-demo-${Date.now()}`;
+  emit({ type: "agent_start" });
+  emit({ type: "tool_execution_start", toolCallId, toolName, args: {} });
+  for (let i = 1; i <= steps; i++) {
+    setTimeout(() => {
+      emit({
+        type: "tool_execution_update",
+        toolCallId,
+        partialResult: { content: [{ type: "text", text: `step ${i}/${steps}` }], details: { progress: i / steps } },
+      });
+    }, intervalMs * i);
+  }
+  setTimeout(() => {
+    emit({
+      type: "tool_execution_end",
+      toolCallId,
+      toolName,
+      result: { content: [{ type: "text", text: error ? "failed" : "done" }] },
+      isError: error,
+    });
+    emit({ type: "agent_end" });
+    state.isStreaming = false;
+  }, intervalMs * (steps + 1));
 }
 
 const decoder = new StringDecoder("utf8");

--- a/server/test/fixtures/progress-demo.ts
+++ b/server/test/fixtures/progress-demo.ts
@@ -1,0 +1,37 @@
+/**
+ * Test / bench fixture: a tool that reports how far along it is.
+ *
+ * The documented pattern for a long-running extension tool — call `onUpdate` with
+ * a `0..1` fraction in `details.progress` as work proceeds. Load it under
+ * `BENCH_LIVE=1` (a real model has to choose to call it); the offline bench and
+ * e2e drive the same wire path through fake-pi-rpc's `progressDemo` scripting.
+ */
+import { Type } from "typebox";
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+
+const parameters = Type.Object({
+  steps: Type.Optional(Type.Number({ description: "How many progress updates to send (default 4)." })),
+});
+
+const progressDemo: ToolDefinition = {
+  name: "progress_demo",
+  description: "Does nothing useful for a few seconds, reporting a completion fraction as it goes.",
+  parameters,
+  async execute(_toolCallId, params, signal, onUpdate) {
+    const steps = Math.max(1, Math.min(20, Number((params as { steps?: number }).steps ?? 4)));
+    for (let i = 1; i <= steps; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 400));
+      if (signal?.aborted) break;
+      onUpdate?.({
+        content: [{ type: "text", text: `step ${i}/${steps}` }],
+        isPartial: true,
+        details: { progress: i / steps },
+      });
+    }
+    return { content: [{ type: "text", text: "done" }] };
+  },
+};
+
+export default (pi: { registerTool: (tool: ToolDefinition) => void }) => {
+  pi.registerTool(progressDemo);
+};

--- a/server/test/multiProjectWorkspaces.test.mjs
+++ b/server/test/multiProjectWorkspaces.test.mjs
@@ -190,6 +190,54 @@ test("a streaming turn reaches its own project's clients and no others", async (
   );
 });
 
+test("a tool's progress reaches its own project's clients, clamped, and no others", async (t) => {
+  const beta = await secondProject();
+  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
+  const server = await startScriptedServer(root, [beta], {
+    state: { sessionId: "scripted", isStreaming: false },
+    commands_: {
+      prompt: {
+        after: [
+          { type: "agent_start" },
+          { type: "tool_execution_start", toolCallId: "tp-1", toolName: "crawl", args: {} },
+          // a progress-only update: no text content, still must be delivered
+          { type: "tool_execution_update", toolCallId: "tp-1", partialResult: { details: { progress: 0.8 } } },
+          // a later, lower value passes through unchanged (no monotonic policing)
+          { type: "tool_execution_update", toolCallId: "tp-1", partialResult: { details: { progress: 0.3 } } },
+          // out of range is clamped, not dropped
+          { type: "tool_execution_update", toolCallId: "tp-1", partialResult: { details: { progress: 1.7 } } },
+        ],
+      },
+    },
+  });
+  t.after(() => server.stop());
+
+  const watcher = connect(server.wsUrl());
+  const mover = connect(server.wsUrl());
+  t.after(() => {
+    watcher.close();
+    mover.close();
+  });
+  await watcher.waitFor((m) => m.type === "hello");
+  await mover.waitFor((m) => m.type === "hello");
+
+  mover.send({ type: "switch_workspace", root: beta });
+  await mover.waitFor((m) => m.type === "workspace_switched");
+  mover.send({ type: "prompt", text: "go" });
+
+  await mover.waitFor((m) => m.type === "tool_update" && m.toolCallId === "tp-1" && m.progress === 1);
+  const progresses = mover.received
+    .filter((m) => m.type === "tool_update" && m.toolCallId === "tp-1")
+    .map((m) => m.progress);
+  assert.deepEqual(progresses, [0.8, 0.3, 1], "delivered in order, lower value kept, over-range clamped");
+
+  assert.equal(
+    watcher.received.filter((m) => m.type === "tool_update").length,
+    0,
+    "no tool progress crossed into the other project",
+  );
+});
+
 test("a connection cannot read a file belonging to another project", async (t) => {
   const beta = await realpath(await makeWorkspace({ "secret.md": "beta's own\n" }));
   const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));

--- a/server/test/pi-rpc.test.ts
+++ b/server/test/pi-rpc.test.ts
@@ -391,6 +391,48 @@ describe("strict RPC records and core interaction", () => {
     assert.deepEqual(prompt?.images, [{ type: "image", data: "aGVsbG8=", mimeType: "image/png" }]);
   });
 
+  test("forwards a tool's completion fraction, and omits it when the tool sends none", async () => {
+    const { runtime } = await startFake({
+      state: { isStreaming: true },
+      commands_: {
+        prompt: {
+          after: [
+            { type: "tool_execution_start", toolCallId: "tool-1", toolName: "crawl", args: {} },
+            {
+              type: "tool_execution_update",
+              toolCallId: "tool-1",
+              partialResult: { content: [{ type: "text", text: "step 2" }], details: { progress: 0.4 } },
+            },
+            {
+              type: "tool_execution_update",
+              toolCallId: "tool-1",
+              partialResult: { content: [{ type: "text", text: "step 3" }] },
+            },
+            {
+              type: "tool_execution_end",
+              toolCallId: "tool-1",
+              toolName: "crawl",
+              result: { content: [{ type: "text", text: "done" }] },
+              isError: false,
+            },
+          ],
+        },
+      },
+    });
+    const updates: RuntimeEvent[] = [];
+    const unsubscribe = runtime.subscribe((event) => {
+      if (event.type === "tool_update") updates.push(event);
+    });
+    const ended = waitForEvent(runtime, (event) => event.type === "tool_end");
+    await runtime.prompt("go");
+    await ended;
+    unsubscribe();
+
+    assert.equal(updates.length, 2);
+    assert.equal((updates[0] as { progress?: unknown }).progress, 0.4);
+    assert.equal((updates[1] as { progress?: unknown }).progress, undefined);
+  });
+
   test("round-trips an extension dialog answer with the original id", async () => {
     const { runtime, commandLog } = await startFake({
       dialogBlocksCommand: "prompt",

--- a/server/test/toolProgress.test.ts
+++ b/server/test/toolProgress.test.ts
@@ -1,0 +1,37 @@
+/**
+ * The one shape both runtimes use to turn a tool's partial result into a
+ * `tool_update` event. The RPC record and the SDK event differ around it; this
+ * extraction does not, so it is tested once here and exercised through each
+ * runtime in their own suites.
+ */
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { toolUpdateEvent } from "../src/agentRuntime.ts";
+
+describe("toolUpdateEvent", () => {
+  test("carries the completion fraction the tool put in details", () => {
+    const event = toolUpdateEvent("t1", { content: [{ type: "text", text: "…" }], details: { progress: 0.4 } });
+    assert.deepEqual(event, {
+      type: "tool_update",
+      toolCallId: "t1",
+      content: [{ type: "text", text: "…" }],
+      progress: 0.4,
+    });
+  });
+
+  test("a partial with no details yields no progress and does not throw", () => {
+    const event = toolUpdateEvent("t1", { content: [{ type: "text", text: "…" }] });
+    assert.equal(event.progress, undefined);
+    assert.deepEqual(event.content, [{ type: "text", text: "…" }]);
+  });
+
+  test("no partial result at all yields no content and no progress", () => {
+    const event = toolUpdateEvent("t1", undefined);
+    assert.deepEqual(event, { type: "tool_update", toolCallId: "t1", content: undefined, progress: undefined });
+  });
+
+  test("the fraction is carried raw here — range is enforced later, at the broadcast", () => {
+    assert.equal(toolUpdateEvent("t1", { details: { progress: 1.7 } }).progress, 1.7);
+    assert.ok(Number.isNaN(toolUpdateEvent("t1", { details: { progress: Number.NaN } }).progress as number));
+  });
+});

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -40,6 +40,12 @@ export type ChatItem =
       output: string;
       isError?: boolean;
       running?: boolean;
+      /**
+       * Completion fraction in `0..1` the running tool last reported, or absent
+       * when it reported none. Shown as a determinate bar only while `running`;
+       * never rebuilt from history, so a replayed tool call has none.
+       */
+      progress?: number;
       /** HTML from pi's renderResult (re-invoked server-side). */
       outputHtml?: string;
       /** Collapsed preview when it differs from outputHtml. */
@@ -521,7 +527,12 @@ export type ServerMessage =
   | { type: "assistant_end"; item: ChatItem }
   | { type: "custom_message"; item: ChatItem }
   | { type: "tool_start"; toolCallId: string; toolName: string; args: unknown; callHtml?: string }
-  | { type: "tool_update"; toolCallId: string; text: string }
+  /**
+   * `progress` is a completion fraction in `0..1` the running tool volunteered on
+   * this update; absent when it reported none. It is a hint, shown only while the
+   * tool runs, and is never persisted to session history.
+   */
+  | { type: "tool_update"; toolCallId: string; text: string; progress?: number }
   | {
       type: "tool_end";
       toolCallId: string;

--- a/ui/src/components/ToolCard.test.tsx
+++ b/ui/src/components/ToolCard.test.tsx
@@ -325,4 +325,56 @@ describe("ToolCard", () => {
 
     expect(cardRoot(container)).toHaveTextContent("running…");
   });
+
+  describe("completion progress bar", () => {
+    const running = (extra: Partial<ToolItem> = {}): ToolItem => ({
+      kind: "tool",
+      toolName: "crawl",
+      running: true,
+      isError: false,
+      args: {},
+      output: "",
+      ...extra,
+    });
+
+    it("shows no bar while running before a fraction has arrived", () => {
+      const { container } = render(<ToolCard item={running()} />);
+      expect(cardRoot(container).querySelector("progress")).toBeNull();
+    });
+
+    it("shows a determinate bar at the reported fraction", () => {
+      const { container } = render(<ToolCard item={running({ progress: 0.25 })} />);
+      const bar = cardRoot(container).querySelector("progress");
+      expect(bar).not.toBeNull();
+      expect(bar).toHaveAttribute("max", "1");
+      expect(bar?.value).toBeCloseTo(0.25);
+    });
+
+    it("keeps the last fraction the item carries", () => {
+      // useAgent only writes progress when an update carries one; the card just
+      // renders whatever value the item holds.
+      const { container, rerender } = render(<ToolCard item={running({ progress: 0.25 })} />);
+      rerender(<ToolCard item={running({ progress: 0.25, output: "more text" })} />);
+      expect(cardRoot(container).querySelector("progress")?.value).toBeCloseTo(0.25);
+    });
+
+    it("removes the bar once the tool has ended, even with a fraction left on the item", () => {
+      const ended = (isError: boolean): ToolItem => running({ running: false, isError, progress: 0.9, output: "done" });
+      const ok = render(<ToolCard item={ended(false)} />);
+      expect(cardRoot(ok.container).querySelector("progress")).toBeNull();
+      const failed = render(<ToolCard item={ended(true)} />);
+      expect(cardRoot(failed.container).querySelector("progress")).toBeNull();
+    });
+
+    it("shows the bar independently of a specialized presentation", () => {
+      // A running edit tool selects the diff presentation; the bar is still chrome.
+      const item = running({
+        toolName: "edit",
+        progress: 0.6,
+        args: { edits: [{ oldText: "old", newText: "new" }] },
+      });
+      const { container } = render(<ToolCard item={item} />);
+      expect(cardRoot(container).querySelector("progress")?.value).toBeCloseTo(0.6);
+    });
+  });
 });

--- a/ui/src/components/ToolCard.tsx
+++ b/ui/src/components/ToolCard.tsx
@@ -64,6 +64,16 @@ export function ToolCard({ item, dispatch = noopDispatch }: { item: ToolItem; di
         )}
         <span className="ml-auto text-xs text-zinc-400 dark:text-zinc-600">{open ? "▾" : "▸"}</span>
       </button>
+      {item.running && item.progress != null && (
+        <div className="border-t border-zinc-200 px-3 py-1.5 dark:border-zinc-800">
+          <progress
+            value={item.progress}
+            max={1}
+            aria-label={`${item.toolName} progress`}
+            className="h-1.5 w-full appearance-none overflow-hidden rounded-full bg-zinc-200 dark:bg-zinc-800 [&::-moz-progress-bar]:bg-emerald-500 [&::-webkit-progress-bar]:bg-transparent [&::-webkit-progress-value]:rounded-full [&::-webkit-progress-value]:bg-emerald-500"
+          />
+        </div>
+      )}
       {showCollapsed && Collapsed !== undefined && (
         <div className="border-t border-zinc-200 px-3 py-2 dark:border-zinc-800">
           <Collapsed item={item} dispatch={dispatch} />

--- a/ui/src/useAgent.test.ts
+++ b/ui/src/useAgent.test.ts
@@ -1355,6 +1355,28 @@ describe("assembling a turn", () => {
     expect(result.current.state.items[0]).toMatchObject({ kind: "tool", toolName: "bash", output: "a.txt\nb.txt", running: false });
   });
 
+  it("carries a tool's completion fraction, and keeps the last one when an update omits it", async () => {
+    const result = await connected();
+    act(() => mockWs!.receive({ type: "tool_start", toolCallId: "t1", toolName: "crawl", args: {} }));
+    act(() => mockWs!.receive({ type: "tool_update", toolCallId: "t1", text: "step 1", progress: 0.25 }));
+    await waitFor(() => expect(result.current.state.items[0]).toMatchObject({ progress: 0.25, running: true }));
+
+    // a text-only update must not clear the fraction
+    act(() => mockWs!.receive({ type: "tool_update", toolCallId: "t1", text: "step 2" }));
+    expect(result.current.state.items[0]).toMatchObject({ output: "step 2", progress: 0.25 });
+
+    // ending the tool stops it running — the bar's gate closes regardless of the value left behind
+    act(() => mockWs!.receive({ type: "tool_end", toolCallId: "t1", text: "done", isError: false }));
+    expect(result.current.state.items[0]).toMatchObject({ running: false });
+  });
+
+  it("does not set progress from a text-only tool_update", async () => {
+    const result = await connected();
+    act(() => mockWs!.receive({ type: "tool_start", toolCallId: "t1", toolName: "crawl", args: {} }));
+    act(() => mockWs!.receive({ type: "tool_update", toolCallId: "t1", text: "working" }));
+    expect(result.current.state.items[0].progress).toBeUndefined();
+  });
+
   it("keeps two concurrent tool calls apart", async () => {
     const result = await connected();
     act(() => mockWs!.receive({ type: "tool_start", toolCallId: "t1", toolName: "read", args: {} }));

--- a/ui/src/useAgent.ts
+++ b/ui/src/useAgent.ts
@@ -752,7 +752,12 @@ function reduce(state: AgentState, action: Action): AgentState {
     case "tool_update":
       return {
         ...state,
-        items: upsertTool(state.items, message.toolCallId, "tool", { output: message.text }),
+        items: upsertTool(state.items, message.toolCallId, "tool", {
+          output: message.text,
+          // Only when this update carried one — a text-only update leaves the
+          // last reported fraction in place.
+          ...(typeof message.progress === "number" ? { progress: message.progress } : {}),
+        }),
       };
     case "tool_end":
       return {


### PR DESCRIPTION
Implements `openspec/changes/show-progress-for-a-running-tool` (spec-driven; proposal / spec / design / tasks / scenario-coverage in the change dir).

## What

A long-running tool can report a `0..1` **completion fraction**, and the tool card shows a **determinate progress bar** while the tool runs. The fraction rides on the partial result the tool already emits — `onUpdate({ …, details: { progress } })` — so **no pi SDK change**.

- **Wire:** `tool_update` gains an optional `progress`; the tool `ChatItem` gains `progress?: number` (never rebuilt from history).
- **Runtimes:** `rpcRuntime` and `embeddedRuntime` both read `partialResult.details.progress` through one shared, defensive `toolUpdateEvent()` helper in `agentRuntime.ts` (the RPC record and the SDK event differ around it, not in this shape).
- **Server:** `toProgressFraction()` clamps to `[0,1]` and drops non-finite values at the single broadcast boundary; a progress-only update (no text) still broadcasts. A decreasing value passes through unchanged — no monotonic policing.
- **Client:** `useAgent` sets `progress` only when the message carries a number, so a text-only update keeps the last value; `ToolCard` renders `<progress value max=1>` gated on `running && progress != null` — card chrome above the presentation slot, so the embedded widget gets it too. `tool_end` closes the gate.
- **Docs:** "Reporting progress from a tool" note in `README.md`.
- **Artifacts:** `progressDemo` scripting in `server/test/fixtures/fake-pi-rpc.mjs`; `server/test/fixtures/progress-demo.ts` extension tool typed against the SDK's `ToolDefinition`; a "tool progress bar" server in `npm run bench`.

## Behaviour

| Situation | Result |
|---|---|
| Tool never reports | No bar — card is byte-identical to today |
| First fraction arrives | Bar appears at that value |
| Later update omits the fraction | Bar holds the last value |
| Value outside `0..1` / `NaN` / non-number | Clamped or ignored, never thrown |
| Value decreases | Shown as given |
| `tool_end` (ok or error) | Bar removed |
| Client reconnects mid-run | No bar until the next fraction (progress is never persisted) |

## Verification

- `npm run typecheck` clean; `oxlint` clean (no warnings in touched files)
- Focused suites green: `toProgressFraction` + `toolUpdateEvent` units, `pi-rpc` integration, a **real server + WebSocket** test (clamp `1.7→1`, decrease `0.8→0.3` kept, workspace isolation), `useAgent` reducer, `ToolCard` component (161 UI tests)
- **e2e passes headless** (`e2e/tool-progress.spec.ts`, fake-pi-rpc `progressDemo`): the `<progress>` element appears partway, advances to `1`, is removed on completion. Verified visually in the running app via `npm run bench`.
- `scenario-coverage.md`: 12/13 covered, 1 partial ("bar shows wherever the tool card shows" — asserted at the shared component with a specialized presentation, not driven through a live embed host)
- Pre-existing environmental failures on this Windows box only (server: pptx tooling / symlink privilege / git-tag; ui: `--localstorage-file`), each reproduced on a clean `main` checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)