### PR TITLE
feat(model-bar): offer only the thinking levels the current model accepts

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -464,6 +464,26 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
     { env: { ...onlyOneFakeProvider(), FAKE_PI_RPC_CONFIG: progressFakeConfig } },
   );
 
+  // A seventh server whose model accepts a proper subset of the thinking levels —
+  // no `high` — so the model-aware slider can be read back.
+  const thinkingRoot = await makeWorkspace({ "readme.md": "# thinking\n" });
+  const thinkingFakeConfig = path.join(thinkingRoot, "fake-rpc.json");
+  await writeFile(
+    thinkingFakeConfig,
+    JSON.stringify({
+      state: { sessionId: "thinking-1", model: { provider: "local", id: "qwen3.8", name: "Qwen3.8", reasoning: true } },
+      commands_: { get_available_thinking_levels: { data: { levels: ["low", "medium", "xhigh"] } } },
+    }),
+  );
+  const thinking = await startServer(
+    thinkingRoot,
+    {
+      agentRuntime: { mode: "rpc", executable: process.execPath, args: [path.join(REPO, "server/test/fixtures/fake-pi-rpc.mjs")], startupTimeoutMs: 20_000 },
+      sandbox: undefined,
+    },
+    { env: { ...onlyOneFakeProvider(), FAKE_PI_RPC_CONFIG: thinkingFakeConfig } },
+  );
+
   process.env.PI_E2E_HOST_URL = host.url;
   process.env.PI_E2E_SERVER_URL = server.base;
   process.env.PI_E2E_PRIMARY_PROJECT = await realpath(root);
@@ -478,6 +498,7 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
   process.env.PI_E2E_PLANS_URL = plans.base;
   process.env.PI_E2E_NOTIFY_URL = notifications.base;
   process.env.PI_E2E_PROGRESS_URL = progress.base;
+  process.env.PI_E2E_THINKING_URL = thinking.base;
   process.env.PI_E2E_PLAN_SOURCE = sourceSession;
   process.env.PI_E2E_PLAN_FORK = forkSession;
   process.env.PI_E2E_EXTENSIONS_DIR = extensionsDir;
@@ -485,6 +506,7 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
   process.env.PI_E2E_TOKEN = E2E_TOKEN;
 
   return async () => {
+    await thinking.stop();
     await progress.stop();
     await notifications.stop();
     await plans.stop();

--- a/e2e/thinking-levels.spec.ts
+++ b/e2e/thinking-levels.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/test";
+
+test("the thinking slider offers only the levels the model accepts, in order, with no gap stop", async ({ page }) => {
+  await page.goto(process.env.PI_E2E_THINKING_URL!);
+  await expect(page.getByTitle("connected")).toBeVisible();
+
+  // The scripted model accepts low, medium and xhigh — no `high`.
+  const button = page.getByTitle("thinking level");
+  await button.click();
+
+  const slider = page.getByLabel("Thinking level");
+  await expect(slider).toBeVisible();
+
+  // Four stops: off, low, medium, xhigh — not the global six, and no `high`.
+  await expect(slider).toHaveAttribute("max", "3");
+
+  // Each stop maps to the level it should, and the last one — xhigh — is reached
+  // without ever landing on `high`, and it sticks (no snap-back).
+  for (const [pos, level] of [["0", "off"], ["1", "low"], ["2", "medium"], ["3", "xhigh"]] as const) {
+    await slider.fill(pos);
+    await expect(button).toHaveText(new RegExp(`\\b${level}\\b`));
+  }
+});
+
+test("a model that accepts every level still shows all six stops", async ({ page }) => {
+  await page.goto(process.env.PI_E2E_SERVER_URL!);
+  await expect(page.getByTitle("connected")).toBeVisible();
+  const button = page.getByTitle("thinking level");
+  if ((await button.count()) === 0) {
+    test.skip(true, "the primary e2e model does not reason");
+    return;
+  }
+  await button.click();
+  await expect(page.getByLabel("Thinking level")).toHaveAttribute("max", "5");
+});

--- a/openspec/changes/offer-only-the-thinking-levels-a-model-accepts/.openspec.yaml
+++ b/openspec/changes/offer-only-the-thinking-levels-a-model-accepts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-30

--- a/openspec/changes/offer-only-the-thinking-levels-a-model-accepts/design.md
+++ b/openspec/changes/offer-only-the-thinking-levels-a-model-accepts/design.md
@@ -1,0 +1,95 @@
+## Context
+
+See `proposal.md` — Why. Three facts shape the approach.
+
+- The SDK already answers the question. `AgentSession.getAvailableThinkingLevels(): ThinkingLevel[]`
+  in the embedded runtime; the `get_available_thinking_levels` RPC command
+  (`{ levels: ThinkingLevel[] }`) in the RPC runtime. `AgentSession` also clamps on
+  `setThinkingLevel` (`_clampThinkingLevel`), which is why a rejected level echoes
+  back a different one today.
+- pi-outpost passes the client one boolean about the model's reasoning —
+  `modelSupportsReasoning` (`ModelChoice.reasoning`). Nothing about *which* levels.
+- `ThinkingControl` in `ModelBar.tsx` builds its `<input type="range">` from the
+  module constant `THINKING_LEVELS` (`shared/src/protocol.ts`), `min=0`,
+  `max=length-1`, `value = THINKING_LEVELS.indexOf(current)`. It is a single
+  hardcoded scale for every model.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Every stop the slider offers is a level the current model accepts, so a
+  selection never snaps back.
+- A model whose accepted set has a gap (`low, medium, xhigh`, no `high`) is
+  presented as ordered stops, not a range with a dead position in the middle.
+- Nothing regresses where the list is unavailable — an OMP RPC child, an older
+  one — or where the model accepts everything.
+
+**Non-Goals:**
+
+- Changing `set_thinking` validation or the SDK's clamping. This makes the
+  control honest; enforcement stays where it is.
+- A per-level explanation or cost hint. Out of scope.
+- Persisting the accepted set. It is derived from the model, re-fetched on
+  connect and on model change.
+
+## Decisions
+
+### The runtime reports the set; the wire carries it optional
+
+`RuntimeSnapshot` gains `thinkingLevels?: ThinkingLevel[]`. Embedded fills it from
+`session.getAvailableThinkingLevels()`. RPC issues `get_available_thinking_levels`
+and caches the answer, **probed like `get_commands`**: a dialect that does not
+implement it (OMP) leaves the field undefined, and `rpcRuntime` already has this
+"try once, fall back" shape for optional commands.
+
+- The `hello` snapshot and the `model_changed` message both gain
+  `thinkingLevels?: ThinkingLevel[]`. The set only changes on connect and on a
+  model switch, and each already has a message — a dedicated message would be a
+  third thing to keep in sync.
+- *Alternative: derive the set on the client from `model.reasoning` plus a
+  table.* That is the guessing this change removes.
+
+### Optional, and absence means "fall back"
+
+`thinkingLevels` undefined → the client uses the full `THINKING_LEVELS` constant,
+exactly today's behaviour. This is the OMP path and the older-child path, and it
+is also the safe default if a future runtime forgets to fill it.
+
+### The list is normalised before it reaches the control
+
+The server intersects whatever the runtime returned with `THINKING_LEVELS`
+(a bundled model map can name a level this build does not know, e.g. `max`), keeps
+the canonical order, and ensures `off` is the first entry — thinking can always be
+turned off, whatever the model's effort tiers are. The client trusts what it
+receives and does not re-filter.
+
+### `ThinkingControl` ranges over the supplied list, not the constant
+
+`levels = props.thinkingLevels ?? THINKING_LEVELS`. The slider is then
+`min=0`, `max=levels.length-1`, `value = Math.max(0, levels.indexOf(current))`,
+`onChange → levels[i]`, end labels `levels[0]` / `levels.at(-1)`. A gap collapses
+to adjacent stops for free — the control never knew about global indices, only
+about positions in a list. `indexOf` of a level not in the list (a stale value
+mid-switch) yields `-1`, clamped to `0`, and the next `thinking_changed` corrects
+it.
+
+## Risks / Trade-offs
+
+- **The SDK returns a level name this build's `THINKING_LEVELS` does not have.** →
+  The server drops it in the intersection step; the control only ever sees known
+  levels. A test feeds an unknown name and asserts it is not offered.
+- **`model_changed` must carry the new set, which means fetching it after the
+  switch resolves.** → Read it in the same `.then()` that already reads
+  `reasoning` after `setModel`. One extra call on a path that is already async and
+  user-initiated.
+- **OMP has no `get_available_thinking_levels`.** → Probed, not assumed; the field
+  is omitted and the control falls back. An OMP integration test asserts the
+  snapshot omits it and the control still offers the full set.
+- **A model that accepts only `off`** (reasoning declared but no tiers) → the
+  slider has one stop past `off` at most, or just `off`; it stays usable because
+  `max` can equal `min`. The control already renders at `index 0`.
+
+## Open Questions
+
+None.

--- a/openspec/changes/offer-only-the-thinking-levels-a-model-accepts/proposal.md
+++ b/openspec/changes/offer-only-the-thinking-levels-a-model-accepts/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+The thinking-level slider in `ModelBar` is built from one hardcoded list —
+`THINKING_LEVELS = ["off","minimal","low","medium","high","xhigh"]` — and never
+asks the model which of those it accepts. So a model that stops at `high`, or one
+whose accepted set has a gap, gets a slider that offers levels the runtime then
+silently clamps. Dragging to `xhigh` sends `set_thinking: xhigh`, the SDK clamps
+it, `thinking_changed` echoes back the clamped level, and the thumb snaps
+backward. The operator sees a control that "won't go past `high`" with no reason
+given.
+
+The SDK already knows the answer: `AgentSession.getAvailableThinkingLevels()`
+embedded, and the `get_available_thinking_levels` RPC command. Nothing carries it
+to the client.
+
+## What Changes
+
+- The runtime exposes the current model's **accepted thinking levels** — the
+  ordered subset of `THINKING_LEVELS` the model will actually honour.
+- The state snapshot carries that list, and `model_changed` carries the new list
+  when the model changes (a different model accepts a different set).
+- `ModelBar`'s thinking control builds its scale from that list instead of the
+  global constant. Every stop on the slider is a level the model accepts; there
+  is no position that snaps back. A set with a gap (accepts `low, medium, xhigh`
+  but not `high`) is presented as three ordered stops, not a range with a hole.
+- Where the list is unavailable — an older or OMP RPC child that does not answer
+  `get_available_thinking_levels` — the control falls back to today's full list,
+  so nothing regresses.
+- No change to `set_thinking` validation or to the SDK's own clamping: this makes
+  the control honest, it does not move the enforcement.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- None. -->
+
+### Modified Capabilities
+
+- `api`: `GETWebSocket` — the state snapshot gains the current model's accepted
+  thinking levels, alongside the model and thinking-level state it already
+  carries.
+- `components`: `RuntimeControls` — `ModelBar`'s thinking control SHALL offer only
+  the levels supplied for the current model, falling back to the full set when
+  none are supplied.
+
+## Impact
+
+- **Runtime** — `server/src/agentRuntime.ts` (`RuntimeSnapshot` gains the list),
+  `server/src/embeddedRuntime.ts` (`session.getAvailableThinkingLevels()`),
+  `server/src/rpcRuntime.ts` (the `get_available_thinking_levels` command, probed
+  and cached like `get_commands`).
+- **Wire** — `shared/src/protocol.ts`: the `hello` snapshot and the
+  `model_changed` message gain `thinkingLevels?: ThinkingLevel[]`.
+- **Client** — `ui/src/useAgent.ts` carries the list into state on `hello` and
+  `model_changed`; `ui/src/components/ModelBar.tsx` `ThinkingControl` builds its
+  slider from it.
+- No new dependency. No change to `set_thinking`, to persistence, or to any model
+  that already accepts the full set.

--- a/openspec/changes/offer-only-the-thinking-levels-a-model-accepts/scenario-coverage.md
+++ b/openspec/changes/offer-only-the-thinking-levels-a-model-accepts/scenario-coverage.md
@@ -1,0 +1,64 @@
+# Scenario coverage
+
+Every `#### Scenario:` in the two delta files, enumerated with
+`rg '^#### Scenario:' openspec/changes/offer-only-the-thinking-levels-a-model-accepts/`.
+Both requirements are MODIFIED, so the deltas reproduce scenarios this change does not
+touch; those are marked **retained** and point at the suite that already proves them.
+
+Test files:
+
+- `server/test/thinkingLevels.test.ts` (`norm`) — the shared `normalizeThinkingLevels` sanitiser
+- `server/test/pi-rpc.test.ts` (`rpc`) — the RPC runtime over the real fake-pi-rpc child
+- `server/test/pi-rpc-server.test.mjs` (`wire`) — a real server + real WebSocket
+- `ui/src/useAgent.test.ts` (`reducer`) — the client reducer over `mockWs`
+- `ui/src/components/ModelBar.test.tsx` (`bar`) — the `ThinkingControl` component
+- `e2e/thinking-levels.spec.ts` (`e2e`) — Chromium against the running app, RPC child scripted
+
+## api — GETWebSocket
+
+| Scenario | Status | Where | What would fail |
+|---|---|---|---|
+| EstablishWebSocketConnection | retained | existing `server/test/*` websocket suites | unchanged by this change |
+| DisallowedOrigin | retained | `server/test/cors.test.mjs` | unchanged |
+| SnapshotCarriesCredentialStatus | retained | `server/test/credentials.test.mjs` | unchanged |
+| ConnectionWithoutAWorkspaceNamed | retained | `server/test/multiProjectWorkspaces.test.mjs` | unchanged |
+| ASingleProjectIsStillDescribed | retained | `server/test/multiProjectWorkspaces.test.mjs` | unchanged |
+| MessagesReachOnlyTheirWorkspace | retained | `server/test/multiProjectWorkspaces.test.mjs` | unchanged |
+| SnapshotCarriesTheModelsAcceptedThinkingLevels | covered | `wire` "the snapshot carries the model's accepted thinking levels, and they follow a model change"; `rpc` "carries the model's accepted thinking levels when the child reports them" | `wire` connects a real client to a server whose RPC child returns `["low","medium","xhigh"]` and asserts `hello.thinkingLevels === ["off","low","medium","xhigh"]` (sanitised). `rpc` asserts the runtime snapshot carries it, unknown names dropped. Remove the `get_available_thinking_levels` call and both fail. |
+| TheAcceptedLevelsFollowAModelChange | covered | `wire` same test; `reducer` "replaces the list on model_changed…" | `wire` sends `set_model` to a second model whose scripted answer is `["off","high"]` and asserts the `model_changed` frame carries exactly that. `reducer` asserts the client state replaces the stored list on `model_changed`. |
+| AnUnreportableSetIsOmitted | covered | `rpc` "omits the accepted levels when the child has no command for them"; `norm` "an empty list, a non-array, or all-unknown names yield undefined" | `rpc` scripts the child to reject `get_available_thinking_levels` as an unknown command and asserts `snapshot().thinkingLevels === undefined` and `runtime.ok`. `norm` asserts the sanitiser yields `undefined` for empty / non-array / all-unknown input, so the field is genuinely omitted rather than an empty array. |
+
+## components — RuntimeControls
+
+| Scenario | Status | Where | What would fail |
+|---|---|---|---|
+| ChangeModelOrThinkingLevel | covered | `bar` "sets the thinking level from the slider" (retained assertion) | selecting a level still invokes `onSetThinking` with the chosen value |
+| TheThinkingControlOffersOnlyTheModelsLevels | covered | `bar` "offers only the levels the model accepts, gap and all"; `e2e` "the thinking slider offers only the levels the model accepts, in order, with no gap stop" | `bar` supplies `["off","low","medium","xhigh"]`, asserts the slider `max` is `3` (four stops, no `high`), that `medium` sits at index 2, and that the last stop reports `xhigh`. `e2e` drives the same over the real app: `max="3"`, and stepping `0..3` shows `off, low, medium, xhigh` on the button — `xhigh` reached without ever landing on `high`. |
+| TheThinkingControlFallsBackWithoutAList | covered | `bar` "falls back to the full set when no accepted-levels list is supplied", "renders at the first stop when the current level is not one the model accepts"; `reducer` "…clears it when the message omits one"; `e2e` "a model that accepts every level still shows all six stops" | `bar` with no `thinkingLevels` prop asserts the slider `max` equals `THINKING_LEVELS.length - 1`. `reducer` asserts `model_changed` / `credentials_changed` without a list clear the state field. `e2e` asserts the full-set model's slider `max` is `5`. |
+| PresentSandboxSettings | retained | `ui/src/components/SettingsMenu.test.tsx` | unchanged |
+| Select a server skill directory | retained | `SettingsMenu.test.tsx` | unchanged |
+| Remove a user skill path | retained | `SettingsMenu.test.tsx` | unchanged |
+| Select a server extension directory | retained | `SettingsMenu.test.tsx` | unchanged |
+| Remove a user extension path | retained | `SettingsMenu.test.tsx` | unchanged |
+| Adding an extension path says what it means | retained | `SettingsMenu.test.tsx` | unchanged |
+| A locked deployment offers no extension control | retained | `SettingsMenu.test.tsx` | unchanged |
+| Every inventory opens from a counted summary | retained | `SettingsMenu.test.tsx` | unchanged |
+| Inventories read in a stable order | retained | `SettingsMenu.test.tsx` | unchanged |
+| SubmitAuthenticationToken | retained | `ui/src/components/TokenGate.test.tsx` | unchanged |
+| NavigateConversationTree | retained | `ui/src/components/TreeMenu.test.tsx` | unchanged |
+
+## Result
+
+All three new `api` scenarios and both new `components` scenarios are **covered**. The
+retained scenarios are unchanged by this change and remain proven by their existing
+suites.
+
+## The run
+
+- `npm run typecheck` — clean across `shared`, `server`, `web`, `embed`
+- lint (`oxlint`) — clean; the warnings printed are pre-existing and in untouched files
+- focused: `thinkingLevels.test.ts`, `pi-rpc.test.ts` (31), `pi-rpc-server.test.mjs`, `ui` `ModelBar`/`useAgent` (156 pass) — all green
+- `e2e/thinking-levels.spec.ts` — passes headless (`npx playwright test thinking-levels`): a `["low","medium","xhigh"]` model shows a 4-stop slider ending at `xhigh` with no `high`; a full-set model shows six
+- full `server` suite — 1633 pass; pre-existing environmental failures on this Windows box (`pptx_extract` tooling absent, `listServerDirectories`/`update` symlink privilege, `detectChannel` git tags) plus two load-only flakes (`serializedBytes`, the RPC command-timeout timing test) that pass in isolation
+- full `ui` suite — the `localStorage`-dependent files fail on this machine for lack of `--localstorage-file`, and one pre-existing `ModelBar` context-ring test fails on clean `main`; unrelated to this change
+- `openspec validate offer-only-the-thinking-levels-a-model-accepts --strict` — valid

--- a/openspec/changes/offer-only-the-thinking-levels-a-model-accepts/specs/api/spec.md
+++ b/openspec/changes/offer-only-the-thinking-levels-a-model-accepts/specs/api/spec.md
@@ -1,0 +1,56 @@
+## MODIFIED Requirements
+
+### Requirement: GETWebSocket
+
+The API SHALL support `GET /ws` to establish a websocket connection for real-time communication. The connection SHALL be bound to exactly one workspace: the one named in the upgrade request, or the server's default workspace when none is named. The state snapshot it sends SHALL describe that workspace, and SHALL carry the server's credential status: which providers are configured and whether a usable model exists — never a stored key. The snapshot SHALL additionally list every open project with its activity state, so a client can show background work without subscribing to it.
+
+The snapshot SHALL also carry the current model's **accepted thinking levels** — the ordered subset of the known levels the model will actually honour — so a client can present a control that offers only those. Where the runtime cannot report them, the snapshot SHALL omit the list rather than guess, and a client SHALL then fall back to offering the full set.
+
+Both SHALL be present whatever the number of projects open, one included: a client that is told nothing about the project it is bound to cannot name it, and naming it is what the interface owes its user before anything else.
+
+Server messages carrying workspace content SHALL reach only the connections bound to the workspace that produced them. Workspace activity and attention changes SHALL reach every connection regardless of what it is bound to.
+
+#### Scenario: EstablishWebSocketConnection
+- **GIVEN** The application is running and the request Origin is allowed
+- **WHEN** GET /ws is called with a WebSocket upgrade
+- **THEN** WebSocket connection is established and a state snapshot is sent
+
+#### Scenario: DisallowedOrigin
+- **GIVEN** The application is running
+- **WHEN** GET /ws is called with an Origin that is neither localhost nor listed in `server.allowedOrigins`
+- **THEN** The upgrade is rejected
+
+#### Scenario: SnapshotCarriesCredentialStatus
+- **GIVEN** a server whose agent directory holds no credentials
+- **WHEN** a client connects
+- **THEN** the snapshot reports that no provider is configured and no model is usable
+
+#### Scenario: ConnectionWithoutAWorkspaceNamed
+- **GIVEN** a client that connects without naming a workspace
+- **WHEN** the snapshot is sent
+- **THEN** it describes the server's default workspace
+
+#### Scenario: ASingleProjectIsStillDescribed
+- **GIVEN** a server with exactly one open project
+- **WHEN** a client connects
+- **THEN** the snapshot describes that project and lists it among the open ones
+
+#### Scenario: MessagesReachOnlyTheirWorkspace
+- **GIVEN** one connection bound to workspace A and another bound to workspace B
+- **WHEN** the agent in A emits a streaming event
+- **THEN** only the connection bound to A receives it
+
+#### Scenario: SnapshotCarriesTheModelsAcceptedThinkingLevels
+- **GIVEN** a server whose current model accepts a proper subset of the known thinking levels
+- **WHEN** a client connects
+- **THEN** the snapshot carries that ordered subset
+
+#### Scenario: TheAcceptedLevelsFollowAModelChange
+- **GIVEN** a connected client
+- **WHEN** the model is changed to one that accepts a different subset of thinking levels
+- **THEN** the client is told the new subset for the new model
+
+#### Scenario: AnUnreportableSetIsOmitted
+- **GIVEN** a runtime that cannot report which thinking levels the model accepts
+- **WHEN** a client connects
+- **THEN** the snapshot omits the list rather than inventing one

--- a/openspec/changes/offer-only-the-thinking-levels-a-model-accepts/specs/components/spec.md
+++ b/openspec/changes/offer-only-the-thinking-levels-a-model-accepts/specs/components/spec.md
@@ -1,0 +1,103 @@
+## MODIFIED Requirements
+
+### Requirement: RuntimeControls
+
+The component layer SHALL expose runtime controls through `Header`, `ModelBar`, `SettingsMenu`,
+`Onboarding`, `TokenGate`, and `TreeMenu`. These components SHALL render only the runtime,
+configuration, credential, authentication, session-tree, and version state supplied to them and
+SHALL report requested changes through callbacks. `SettingsMenu` SHALL show the user's own
+skill paths separately from built-in skills, SHALL NOT present the configuration file's skill paths
+as editable, and SHALL offer server-directory exploration controls for every path-valued setting it
+edits.
+
+`ModelBar`'s thinking-level control SHALL offer only the levels supplied for the current model, in
+the order supplied, and SHALL present a set with gaps as that many ordered stops rather than a
+continuous range — every stop it shows SHALL be a level the model accepts, so a selection never
+snaps back. Where no such list is supplied it SHALL fall back to the full set of known levels, which
+is the behaviour before this control was made model-aware.
+
+`SettingsMenu` SHALL offer the same controls for the user's own extension paths that it offers for
+skill paths — server-directory exploration, per-entry removal, and reporting the result through its
+update callback — and SHALL NOT present the configuration file's extension paths as editable.
+
+Because an extension is code that runs with the agent's privileges, and a directory loads every
+extension found inside it, `SettingsMenu` SHALL state that before an extension path is added,
+in the flow that adds one rather than only in a caption. Where extension paths are locked it SHALL
+offer no control that would change them.
+
+Every inventory `SettingsMenu` presents SHALL be reachable from a single collapsed summary line
+stating how many it holds — "3 extensions loaded" — rather than drawn open. A menu whose sections
+are all expanded is one an installation with many resources cannot read; the count is what the
+summary is for. Each list SHALL be presented in a stable order that does not depend on the order
+the server happened to report.
+
+#### Scenario: ChangeModelOrThinkingLevel
+- **GIVEN** model choices and thinking state supplied to `ModelBar`
+- **WHEN** the user selects a model or thinking level
+- **THEN** the corresponding callback is invoked with the requested value
+
+#### Scenario: TheThinkingControlOffersOnlyTheModelsLevels
+- **GIVEN** `ModelBar` is supplied with a current model that accepts `low`, `medium` and `xhigh` but not `high`
+- **WHEN** the thinking control is opened
+- **THEN** it presents `off`, `low`, `medium` and `xhigh` as ordered stops and no `high`
+- **AND** selecting the last stop reports `xhigh` through the callback
+
+#### Scenario: TheThinkingControlFallsBackWithoutAList
+- **GIVEN** `ModelBar` is supplied with no accepted-levels list for the current model
+- **WHEN** the thinking control is opened
+- **THEN** it offers the full set of known levels, as it did before
+
+#### Scenario: PresentSandboxSettings
+- **GIVEN** sandbox, extension-path, and version state supplied to `SettingsMenu`
+- **WHEN** the settings menu is opened
+- **THEN** the supplied settings and version information are presented
+
+#### Scenario: Select a server skill directory
+- **GIVEN** SettingsMenu is supplied with the user's skill paths and a server-directory explorer callback
+- **WHEN** the user chooses a mounted directory for additional skills
+- **THEN** SettingsMenu reports the selected server path in its requested settings update
+
+#### Scenario: Remove a user skill path
+- **GIVEN** SettingsMenu is supplied with a skill path the user added
+- **WHEN** the user removes it and requests an apply
+- **THEN** the requested update carries the remaining user skill paths and nothing from the configuration file
+
+#### Scenario: Select a server extension directory
+- **GIVEN** SettingsMenu is supplied with the user's extension paths and a server-directory explorer callback
+- **WHEN** the user chooses a mounted directory for additional extensions
+- **THEN** SettingsMenu reports the selected server path in its requested settings update
+
+#### Scenario: Remove a user extension path
+- **GIVEN** SettingsMenu is supplied with an extension path the user added
+- **WHEN** the user removes it and requests an apply
+- **THEN** the requested update carries the remaining user extension paths and nothing from the configuration file
+
+#### Scenario: Adding an extension path says what it means
+- **GIVEN** SettingsMenu is supplied with the user's extension paths
+- **WHEN** the user starts adding an extension directory
+- **THEN** the menu states that extensions are code run with the agent's privileges and that every extension in the directory is loaded, before the path is added
+
+#### Scenario: A locked deployment offers no extension control
+- **GIVEN** SettingsMenu is supplied with state reporting extension paths as locked
+- **WHEN** the settings menu is opened
+- **THEN** it presents the loaded extensions without any control that would add or remove one
+
+#### Scenario: Every inventory opens from a counted summary
+- **GIVEN** SettingsMenu is supplied with loaded extensions and skills
+- **WHEN** the settings menu is opened
+- **THEN** each inventory shows a summary line stating how many it holds, none of them expanded, and opening one reveals its entries
+
+#### Scenario: Inventories read in a stable order
+- **GIVEN** SettingsMenu is supplied with entries in an order the server chose
+- **WHEN** the settings menu is opened
+- **THEN** each list is presented in a stable order rather than the order supplied
+
+#### Scenario: SubmitAuthenticationToken
+- **GIVEN** `TokenGate` is displayed after authentication is required
+- **WHEN** the user submits a token
+- **THEN** the token is reported through the component's submit callback
+
+#### Scenario: NavigateConversationTree
+- **GIVEN** conversation-tree state supplied to `TreeMenu`
+- **WHEN** the user selects a navigation or fork action
+- **THEN** the requested action is reported through the corresponding callback

--- a/openspec/changes/offer-only-the-thinking-levels-a-model-accepts/tasks.md
+++ b/openspec/changes/offer-only-the-thinking-levels-a-model-accepts/tasks.md
@@ -1,0 +1,29 @@
+## 1. The runtime reports the accepted set
+
+- [x] 1.1 Add `thinkingLevels?: ThinkingLevel[]` to `RuntimeSnapshot` in `server/src/agentRuntime.ts`; verify `npm run typecheck` passes across `server`. Done — typecheck clean.
+- [x] 1.2 In `server/src/embeddedRuntime.ts`, fill it from `session.getAvailableThinkingLevels()` in `snapshot()`. Done — read defensively (optional method, try/catch → "cannot say"), through the shared `normalizeThinkingLevels`. No embedded-runtime harness exists in this repo, so the shape is verified by `thinkingLevels.test.ts` (the normalisation both runtimes share) and the whole path is integration-tested on the RPC side; the embedded read is a three-line defensive call structurally identical to it.
+- [x] 1.3 In `server/src/rpcRuntime.ts`, add a `get_available_thinking_levels` call, probed like `get_commands` (rejection → undefined), refreshed on catalog refresh and after `set_model`. Done — `refreshThinkingLevels()`; `pi-rpc.test.ts` "carries the model's accepted thinking levels when the child reports them" and "omits the accepted levels when the child has no command for them" (startup stays `ok`). The bootstrap command-order assertion was updated to include the new call.
+- [x] 1.4 Normalise centrally. Done — `normalizeThinkingLevels()` beside `THINKING_LEVELS` in `shared/src/protocol.ts` (shared, so both runtimes and the tests use one implementation). `server/test/thinkingLevels.test.ts` covers: unknown name dropped, canonical order, `off` ensured, off-only kept, gap kept, and empty/non-array/all-unknown → `undefined`.
+
+## 2. The wire carries it
+
+- [x] 2.1 Done — both message shapes gain `thinkingLevels?: ThinkingLevel[]` with a doc comment; typecheck clean across all workspaces.
+- [x] 2.2 Done — `snapshot()` puts `state.thinkingLevels` on `hello`; the `set_model` `.then()` reads `workspace.agent.snapshot().thinkingLevels` and includes it on `model_changed`. `pi-rpc-server.test.mjs` "the snapshot carries the model's accepted thinking levels, and they follow a model change" drives both over a real client + WebSocket.
+
+## 3. The client carries it into state
+
+- [x] 3.1 Done — `thinkingLevels?` on `AgentState`; `hello` reducer stores `message.thinkingLevels`, `model_changed` replaces it outright (a message with no list clears it), and `credentials_changed` clears it since the model may have changed and it carries no new list. `useAgent.test.ts` "stores the accepted-levels list from the snapshot", "replaces the list on model_changed, and clears it when the message omits one", and "drops a stale accepted-levels list when credentials change the model".
+- [x] 3.2 Done — `App.tsx` passes `thinkingLevels={state.thinkingLevels}` to `ModelBar`; `npm run typecheck` clean.
+
+## 4. The control offers only those levels
+
+- [x] 4.1 Done — `ThinkingControl` takes `thinkingLevels`, computes `levels = thinkingLevels?.length ? thinkingLevels : THINKING_LEVELS`, and the slider + end labels range over `levels`. `ModelBar.test.tsx`: "offers only the levels the model accepts, gap and all" (`max` = 3, `medium` at index 2, last stop → `xhigh`), "renders at the first stop when the current level is not one the model accepts" (stale `high` → index 0, no crash), "falls back to the full set when no accepted-levels list is supplied" (`max` = `THINKING_LEVELS.length - 1`).
+
+## 5. Scenario coverage and validation
+
+- [x] 5.1 Done — `scenario-coverage.md`: 5 new scenarios covered, 17 retained scenarios pointed at their existing suites, none partial.
+- [x] 5.2 Done — typecheck clean; lint clean (warnings pre-existing, none in touched files); focused suites green; `openspec validate --strict` valid. Full-suite pre-existing/environmental failures recorded in `scenario-coverage.md`.
+
+## 6. Prove it in the running app
+
+- [x] 6.1 Done — a seventh e2e server (`PI_E2E_THINKING_URL`) whose fake-pi-rpc child answers `get_available_thinking_levels` with `["low","medium","xhigh"]`. `e2e/thinking-levels.spec.ts` (passes headless): the slider `max` is `3`, stepping `0..3` shows `off, low, medium, xhigh` on the button — `xhigh` reached without landing on `high` — and a full-set model's slider `max` is `5`. Verified visually: the popover's end labels read `off` … `xhigh`.

--- a/scripts/embed-bench.mts
+++ b/scripts/embed-bench.mts
@@ -245,6 +245,33 @@ const progress = await startServer(
   { env: { ...onlyOneFakeProvider(), FAKE_PI_RPC_CONFIG: progressConfig } },
 );
 
+// A server whose model accepts only a subset of the thinking levels — no `high` —
+// so the model-aware thinking slider can be watched by hand.
+const thinkingRoot = await makeWorkspace({ "readme.md": "# thinking\n" });
+const thinkingConfig = path.join(thinkingRoot, "fake-rpc.json");
+await writeFile(
+  thinkingConfig,
+  JSON.stringify({
+    state: { sessionId: "thinking-1", model: { provider: "local", id: "qwen3.8-27b", name: "Qwen3.8 27B", reasoning: true } },
+    commands_: { get_available_thinking_levels: { data: { levels: ["low", "medium", "xhigh"] } } },
+  }),
+);
+const thinking = await startServer(
+  thinkingRoot,
+  {
+    server: { allowedOrigins: [host.url], port: HOST_PORT + 6 },
+    branding: { title: "bench thinking" },
+    agentRuntime: {
+      mode: "rpc",
+      executable: process.execPath,
+      args: [path.join(REPO, "server/test/fixtures/fake-pi-rpc.mjs")],
+      startupTimeoutMs: 20_000,
+    },
+    sandbox: undefined,
+  },
+  { env: { ...onlyOneFakeProvider(), FAKE_PI_RPC_CONFIG: thinkingConfig } },
+);
+
 // The three embed workspace-control policies, each on its own server, because the
 // policy is loaded configuration rather than a mount option: the only way to see
 // what a deployment would show is to run a server configured that way.
@@ -288,6 +315,7 @@ console.log(
 );
 console.log(`  seeded transcript           ${link(diagrams.base)}   (diagrams + table)`);
 console.log(`  tool progress bar           ${link(progress.base)}   (send any prompt, watch the tool card)`);
+console.log(`  model-aware thinking slider ${link(thinking.base)}   (open the 🧠 control: off..xhigh, no high)`);
 console.log("\n  embed workspace controls — the same widget under each policy\n");
 console.log(`  settings (the default)      ${link(plain.base)}   no header control; the root lives in Settings`);
 console.log(`  root                        ${link(rootMode.base)}   one root, moved from the header`);
@@ -300,6 +328,7 @@ const stop = async () => {
   stopping = true;
   await projectsMode.stop();
   await rootMode.stop();
+  await thinking.stop();
   await progress.stop();
   await diagrams.stop();
   await plain.stop();

--- a/server/src/agentRuntime.ts
+++ b/server/src/agentRuntime.ts
@@ -72,6 +72,12 @@ export interface RuntimeSnapshot {
   sessionFile?: string;
   model?: RuntimeModel;
   thinkingLevel: ThinkingLevel;
+  /**
+   * The ordered levels the current model actually accepts — a subset of
+   * `THINKING_LEVELS`. Absent when the runtime cannot say (an RPC dialect with no
+   * command for it), and a client then offers the full set.
+   */
+  thinkingLevels?: ThinkingLevel[];
   isStreaming: boolean;
   /** Conversation history on the active branch, oldest first. */
   messages: unknown[];

--- a/server/src/embeddedRuntime.ts
+++ b/server/src/embeddedRuntime.ts
@@ -16,6 +16,7 @@ import type {
   ModelChoice,
   ThinkingLevel,
 } from "@pi-outpost/shared";
+import { normalizeThinkingLevels } from "@pi-outpost/shared";
 import type {
   AgentRuntime,
   CredentialCapability,
@@ -91,6 +92,15 @@ class EmbeddedRuntime implements AgentRuntime {
   snapshot(): RuntimeSnapshot {
     const session = this.session;
     const model = session.model as { provider?: string; id?: string; name?: string; reasoning?: boolean } | undefined;
+    // The SDK knows which levels this model honours; a missing method (older SDK)
+    // or a throw degrades to "cannot say", and the client offers the full set.
+    let acceptedLevels: unknown;
+    try {
+      acceptedLevels = (session as { getAvailableThinkingLevels?: () => unknown }).getAvailableThinkingLevels?.();
+    } catch {
+      acceptedLevels = undefined;
+    }
+    const thinkingLevels = normalizeThinkingLevels(acceptedLevels);
     return {
       sessionId: session.sessionId,
       sessionFile: session.sessionManager.getSessionFile(),
@@ -98,6 +108,7 @@ class EmbeddedRuntime implements AgentRuntime {
         ? { model: { provider: model.provider, id: model.id, name: model.name, reasoning: model.reasoning } }
         : {}),
       thinkingLevel: session.thinkingLevel as ThinkingLevel,
+      ...(thinkingLevels ? { thinkingLevels } : {}),
       isStreaming: session.isStreaming,
       messages: session.messages as unknown[],
       models: this.models(),

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1244,6 +1244,7 @@ function snapshot(workspace: Workspace): SessionSnapshot {
     sessionId: state.sessionId,
     model: modelName(workspace),
     thinkingLevel: state.thinkingLevel,
+    ...(state.thinkingLevels ? { thinkingLevels: state.thinkingLevels } : {}),
     isStreaming: state.isStreaming,
     items: historyToItems(
       state.messages as never,
@@ -3040,7 +3041,15 @@ function handleClientMessage(socket: WebSocket, raw: string): void {
       const { provider, id } = message;
       workspace.agent
         .setModel(provider, id)
-        .then((model) => broadcast(workspace, { type: "model_changed", model: modelName(workspace), reasoning: model.reasoning ?? false }))
+        .then((model) => {
+          const levels = workspace.agent.snapshot().thinkingLevels;
+          broadcast(workspace, {
+            type: "model_changed",
+            model: modelName(workspace),
+            reasoning: model.reasoning ?? false,
+            ...(levels ? { thinkingLevels: levels } : {}),
+          });
+        })
         .catch((error) => {
           if (!refuseUnsupported(socket, error)) {
             send(socket, { type: "error", message: error instanceof Error ? error.message : String(error) });

--- a/server/src/rpcRuntime.ts
+++ b/server/src/rpcRuntime.ts
@@ -22,6 +22,7 @@ import type {
   ModelChoice,
   ThinkingLevel,
 } from "@pi-outpost/shared";
+import { normalizeThinkingLevels } from "@pi-outpost/shared";
 import type {
   AgentRuntime,
   PromptOptions,
@@ -82,6 +83,8 @@ class RpcRuntime implements AgentRuntime {
   private sessionFile: string | undefined;
   private model: RpcModel | undefined;
   private thinkingLevel: ThinkingLevel = "off";
+  /** The levels the current model accepts; undefined when the child has no command for it. */
+  private acceptedThinkingLevels: ThinkingLevel[] | undefined;
   private streaming = false;
   private messages: unknown[] = [];
   private sessionEntries: RuntimeEntry[] = [];
@@ -201,6 +204,23 @@ class RpcRuntime implements AgentRuntime {
         } satisfies CommandInfo,
       ];
     });
+    await this.refreshThinkingLevels();
+  }
+
+  /**
+   * Which thinking levels the current model accepts. Optional: a dialect without
+   * `get_available_thinking_levels` (OMP) leaves it undefined, and the client
+   * offers the full set. Depends on the model, so it is refreshed on every
+   * catalog refresh and after a `set_model`.
+   */
+  private async refreshThinkingLevels(): Promise<void> {
+    try {
+      const answer = (await this.process.command("get_available_thinking_levels")) as { levels?: unknown } | undefined;
+      this.acceptedThinkingLevels = normalizeThinkingLevels(answer?.levels);
+    } catch (error) {
+      if (!isUnknownCommand(error, "get_available_thinking_levels")) throw error;
+      this.acceptedThinkingLevels = undefined;
+    }
   }
 
   /** History, entries, tree and context usage — everything a finished turn can change. */
@@ -526,6 +546,7 @@ class RpcRuntime implements AgentRuntime {
       ...(this.sessionFile ? { sessionFile: this.sessionFile } : {}),
       ...(this.model ? { model: this.model } : {}),
       thinkingLevel: this.thinkingLevel,
+      ...(this.acceptedThinkingLevels ? { thinkingLevels: this.acceptedThinkingLevels } : {}),
       isStreaming: this.streaming,
       messages: this.messages,
       models: this.availableModels,
@@ -618,6 +639,8 @@ class RpcRuntime implements AgentRuntime {
     const data = await this.command("set_model", { provider, modelId: id });
     const model = toModel(data) ?? { provider, id };
     this.model = model;
+    // A different model accepts a different set of thinking levels.
+    await this.refreshThinkingLevels();
     return model;
   }
 

--- a/server/test/pi-rpc-server.test.mjs
+++ b/server/test/pi-rpc-server.test.mjs
@@ -153,3 +153,51 @@ test("RPC server fails readiness closed and refuses a later prompt after child e
     await server.stop();
   }
 });
+
+test("the snapshot carries the model's accepted thinking levels, and they follow a model change", async () => {
+  const root = await makeWorkspace();
+  const fakeConfig = path.join(root, "fake-rpc.json");
+  await writeFile(
+    fakeConfig,
+    JSON.stringify({
+      state: { sessionId: "levels-1", model: { provider: "local", id: "qwen3.8", name: "Qwen3.8", reasoning: true } },
+      commands_: {
+        // first answer at bootstrap, second after set_model
+        get_available_thinking_levels: [
+          { data: { levels: ["low", "medium", "xhigh"] } },
+          { data: { levels: ["off", "high"] } },
+        ],
+        get_available_models: {
+          data: {
+            models: [
+              { provider: "local", id: "qwen3.8", name: "Qwen3.8", reasoning: true },
+              { provider: "local", id: "other", name: "Other", reasoning: true },
+            ],
+          },
+        },
+      },
+    }),
+  );
+
+  const server = await startServer(
+    root,
+    {
+      sandbox: undefined,
+      agentRuntime: { mode: "rpc", executable: process.execPath, args: [FAKE], startupTimeoutMs: 5_000 },
+    },
+    { env: { FAKE_PI_RPC_CONFIG: fakeConfig } },
+  );
+  const client = connect(server.wsUrl());
+  try {
+    const hello = await client.waitFor("hello");
+    assert.deepEqual(hello.thinkingLevels, ["off", "low", "medium", "xhigh"], "sanitised: off ensured, canonical order");
+
+    client.send({ type: "set_model", provider: "local", id: "other" });
+    const changed = await client.waitFor("model_changed");
+    assert.equal(changed.model, "local/other");
+    assert.deepEqual(changed.thinkingLevels, ["off", "high"], "the new model's set, not the old one");
+  } finally {
+    client.close();
+    await server.stop();
+  }
+});

--- a/server/test/pi-rpc.test.ts
+++ b/server/test/pi-rpc.test.ts
@@ -205,7 +205,16 @@ describe("RpcRuntimeStarts", () => {
     assert.deepEqual(launch.argv, ["--session-dir", path.join(root, "sessions"), "--mode", "rpc"]);
     assert.deepEqual(
       (await commands(commandLog)).map((command) => command.type),
-      ["get_state", "get_available_models", "get_commands", "get_messages", "get_tree", "get_entries", "get_session_stats"],
+      [
+        "get_state",
+        "get_available_models",
+        "get_commands",
+        "get_available_thinking_levels",
+        "get_messages",
+        "get_tree",
+        "get_entries",
+        "get_session_stats",
+      ],
     );
   });
 
@@ -259,6 +268,23 @@ describe("RpcRuntimeStarts", () => {
       omitResponseIdsFor: ["get_commands", "get_available_commands"],
     });
     assert.deepEqual(runtime.snapshot().commands, []);
+    assert.equal(runtime.ok, true);
+  });
+
+  test("carries the model's accepted thinking levels when the child reports them", async () => {
+    const { runtime } = await startFake({
+      commands_: { get_available_thinking_levels: { data: { levels: ["low", "medium", "xhigh", "bogus"] } } },
+    });
+    // sanitised: unknown name dropped, canonical order, `off` ensured
+    assert.deepEqual(runtime.snapshot().thinkingLevels, ["off", "low", "medium", "xhigh"]);
+  });
+
+  test("omits the accepted levels when the child has no command for them", async () => {
+    const { runtime } = await startFake({
+      failures: { get_available_thinking_levels: "Unknown command: get_available_thinking_levels" },
+      omitResponseIdsFor: ["get_available_thinking_levels"],
+    });
+    assert.equal(runtime.snapshot().thinkingLevels, undefined);
     assert.equal(runtime.ok, true);
   });
 

--- a/server/test/thinkingLevels.test.ts
+++ b/server/test/thinkingLevels.test.ts
@@ -1,0 +1,41 @@
+/**
+ * The wire-side sanitiser for a model's accepted thinking levels. Both runtimes
+ * feed whatever the SDK / RPC child returned through this before it reaches a
+ * client, so the client can trust the shape.
+ */
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { normalizeThinkingLevels } from "@pi-outpost/shared";
+
+describe("normalizeThinkingLevels", () => {
+  test("drops names this build does not know and keeps canonical order", () => {
+    assert.deepEqual(normalizeThinkingLevels(["xhigh", "low", "medium", "bogus", "max"]), [
+      "off",
+      "low",
+      "medium",
+      "xhigh",
+    ]);
+  });
+
+  test("ensures off is always a stop, even when the runtime omits it", () => {
+    assert.deepEqual(normalizeThinkingLevels(["low", "medium", "xhigh"]), ["off", "low", "medium", "xhigh"]);
+  });
+
+  test("keeps a genuine off-only set as off-only", () => {
+    assert.deepEqual(normalizeThinkingLevels(["off"]), ["off"]);
+  });
+
+  test("a set with a gap stays a set with a gap", () => {
+    // the qwen3.8-max case: low, medium, xhigh — no high
+    assert.deepEqual(normalizeThinkingLevels(["low", "medium", "xhigh"]).includes("high" as never), false);
+  });
+
+  test("an empty list, a non-array, or all-unknown names yield undefined", () => {
+    assert.equal(normalizeThinkingLevels([]), undefined);
+    assert.equal(normalizeThinkingLevels(["bogus", "nope"]), undefined);
+    assert.equal(normalizeThinkingLevels(undefined), undefined);
+    assert.equal(normalizeThinkingLevels(null), undefined);
+    assert.equal(normalizeThinkingLevels("high"), undefined);
+    assert.equal(normalizeThinkingLevels(42), undefined);
+  });
+});

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -113,6 +113,23 @@ export const MIN_SESSION_QUERY_LENGTH = 2;
 export const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
 export type ThinkingLevel = (typeof THINKING_LEVELS)[number];
 
+/**
+ * The thinking levels a model accepts, as a runtime reports them, sanitised for
+ * the wire: only names this build knows, in the canonical `THINKING_LEVELS`
+ * order, with `off` always a stop — thinking can be turned off whatever the
+ * model's effort tiers are. An input that names nothing recognisable (an empty
+ * list, or a runtime that could not answer) yields `undefined`, which a client
+ * reads as "offer the full set".
+ */
+export function normalizeThinkingLevels(levels: unknown): ThinkingLevel[] | undefined {
+  if (!Array.isArray(levels)) return undefined;
+  const known = new Set(
+    levels.filter((l): l is ThinkingLevel => typeof l === "string" && (THINKING_LEVELS as readonly string[]).includes(l)),
+  );
+  if (known.size === 0) return undefined;
+  return THINKING_LEVELS.filter((l) => l === "off" || known.has(l));
+}
+
 /** Slash command available in the composer (extension command, prompt template or skill). */
 export interface CommandInfo {
   /** Invocation name without the leading slash (e.g. "commit", "skill:review"). */
@@ -388,6 +405,12 @@ export interface SessionSnapshot {
   sessionId: string;
   model: string;
   thinkingLevel: string;
+  /**
+   * The ordered thinking levels the current model accepts. Absent when the
+   * runtime cannot report them (an RPC dialect with no command for it); a client
+   * then offers the full `THINKING_LEVELS` set.
+   */
+  thinkingLevels?: ThinkingLevel[];
   isStreaming: boolean;
   items: ChatItem[];
   models: ModelChoice[];
@@ -495,7 +518,8 @@ export type ServerMessage =
   | { type: "sessions"; sessions: SessionSummary[] }
   /** Answer to search_sessions — sent only to the client that asked. */
   | { type: "session_search_results"; requestId: string; query: string; sessions: SessionSummary[] }
-  | { type: "model_changed"; model: string; reasoning: boolean }
+  /** `thinkingLevels` is the new model's accepted set; absent means "offer the full set". */
+  | { type: "model_changed"; model: string; reasoning: boolean; thinkingLevels?: ThinkingLevel[] }
   /**
    * A credential was stored or a provider declared: the model list and the credential
    * status changed, nothing else did. Deliberately *not* a session snapshot — the

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1099,6 +1099,7 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
                 model={state.model}
                 models={state.models}
                 thinkingLevel={state.thinkingLevel}
+                thinkingLevels={state.thinkingLevels}
                 modelSupportsReasoning={state.modelSupportsReasoning}
                 isStreaming={state.isStreaming}
                 contextUsage={state.contextUsage}

--- a/ui/src/components/ModelBar.test.tsx
+++ b/ui/src/components/ModelBar.test.tsx
@@ -148,6 +148,29 @@ describe("ModelBar controls", () => {
     expect(props.onSetThinking).toHaveBeenCalledWith(THINKING_LEVELS[2]);
   });
 
+  it("offers only the levels the model accepts, gap and all", () => {
+    const props = renderFull({ thinkingLevel: "medium", thinkingLevels: ["off", "low", "medium", "xhigh"] });
+    fireEvent.click(screen.getByTitle("thinking level"));
+    const slider = screen.getByLabelText("Thinking level") as HTMLInputElement;
+    expect(slider.max).toBe("3"); // four stops: off, low, medium, xhigh — no high
+    expect(slider.value).toBe("2"); // current "medium" sits at index 2 of the supplied list
+    fireEvent.change(slider, { target: { value: "3" } });
+    expect(props.onSetThinking).toHaveBeenCalledWith("xhigh"); // the last stop, reached without passing "high"
+  });
+
+  it("renders at the first stop when the current level is not one the model accepts", () => {
+    renderFull({ thinkingLevel: "high", thinkingLevels: ["off", "low", "medium", "xhigh"] });
+    fireEvent.click(screen.getByTitle("thinking level"));
+    expect((screen.getByLabelText("Thinking level") as HTMLInputElement).value).toBe("0");
+  });
+
+  it("falls back to the full set when no accepted-levels list is supplied", () => {
+    renderFull({ thinkingLevel: "off" });
+    fireEvent.click(screen.getByTitle("thinking level"));
+    const slider = screen.getByLabelText("Thinking level") as HTMLInputElement;
+    expect(slider.max).toBe(String(THINKING_LEVELS.length - 1));
+  });
+
   it("closes the thinking popover on Escape", () => {
     renderFull();
     fireEvent.click(screen.getByTitle("thinking level"));

--- a/ui/src/components/ModelBar.tsx
+++ b/ui/src/components/ModelBar.tsx
@@ -8,6 +8,8 @@ interface ModelBarProps {
   model: string;
   models: ModelChoice[];
   thinkingLevel: string;
+  /** The levels the current model accepts, in order; absent means offer the full set. */
+  thinkingLevels?: ThinkingLevel[];
   modelSupportsReasoning: boolean;
   isStreaming: boolean;
   contextUsage: ContextUsage | null;
@@ -139,18 +141,24 @@ function ContextRing({ usage }: { usage: ContextUsage | null }) {
 }
 
 /**
- * 🧠 button showing the current level; clicking opens a popover with a slider
- * scale (off → xhigh). Replaces the old "think: level" dropdown.
+ * 🧠 button showing the current level; clicking opens a popover with a slider.
+ * The slider's stops are the levels the current model accepts — every stop is a
+ * level `onSetThinking` will keep, so a selection never snaps back. A model whose
+ * accepted set has a gap (`low, medium, xhigh`, no `high`) is presented as three
+ * ordered stops, not a range with a dead position. Absent a list, it offers the
+ * full set, which is what it did before it was model-aware.
  */
 function ThinkingControl({
   thinkingLevel,
+  thinkingLevels,
   isStreaming,
   onSetThinking,
-}: Pick<ModelBarProps, "thinkingLevel" | "isStreaming" | "onSetThinking">) {
+}: Pick<ModelBarProps, "thinkingLevel" | "thinkingLevels" | "isStreaming" | "onSetThinking">) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const active = thinkingLevel !== "off";
-  const index = Math.max(0, THINKING_LEVELS.indexOf(thinkingLevel as ThinkingLevel));
+  const levels = thinkingLevels && thinkingLevels.length > 0 ? thinkingLevels : THINKING_LEVELS;
+  const index = Math.max(0, levels.indexOf(thinkingLevel as ThinkingLevel));
 
   useEffect(() => {
     if (!open) return;
@@ -195,17 +203,17 @@ function ThinkingControl({
           <input
             type="range"
             min={0}
-            max={THINKING_LEVELS.length - 1}
+            max={levels.length - 1}
             step={1}
             value={index}
-            onChange={(e) => onSetThinking(THINKING_LEVELS[Number(e.target.value)])}
+            onChange={(e) => onSetThinking(levels[Number(e.target.value)])}
             aria-label="Thinking level"
             aria-valuetext={thinkingLevel}
             className="w-full accent-amber-500"
           />
           <div className="mt-0.5 flex justify-between font-mono text-[9px] text-zinc-400 dark:text-zinc-600">
-            <span>{THINKING_LEVELS[0]}</span>
-            <span>{THINKING_LEVELS[THINKING_LEVELS.length - 1]}</span>
+            <span>{levels[0]}</span>
+            <span>{levels[levels.length - 1]}</span>
           </div>
         </div>
       )}
@@ -239,6 +247,7 @@ export function ModelBar(props: ModelBarProps) {
       {modelSupportsReasoning && (
         <ThinkingControl
           thinkingLevel={thinkingLevel}
+          thinkingLevels={props.thinkingLevels}
           isStreaming={isStreaming}
           onSetThinking={props.onSetThinking}
         />

--- a/ui/src/useAgent.test.ts
+++ b/ui/src/useAgent.test.ts
@@ -1282,6 +1282,72 @@ describe("credentials_changed", () => {
     expect(result.current.state.modelSupportsReasoning).toBe(true);
     expect(result.current.state.errors).toHaveLength(1);
   });
+
+  it("drops a stale accepted-levels list when credentials change the model", async () => {
+    const { result } = renderHook(() => useAgent());
+    act(() => mockWs!.open());
+    await waitFor(() => expect(result.current.state.connected).toBe(true));
+    act(() =>
+      mockWs!.receive({
+        type: "hello",
+        sessionId: "s",
+        branding: {},
+        model: "local/a",
+        thinkingLevel: "off",
+        thinkingLevels: ["off", "low", "medium"],
+        models: [],
+        commands: [],
+        isStreaming: false,
+        items: [],
+        contextUsage: null,
+        gitAvailable: false,
+      }),
+    );
+    await waitFor(() => expect(result.current.state.thinkingLevels).toEqual(["off", "low", "medium"]));
+    act(() =>
+      mockWs!.receive({
+        type: "credentials_changed",
+        model: "local/b",
+        models: [{ provider: "local", id: "b", reasoning: true }],
+        credentials: { usableModel: true, hasProvider: true, hasKey: true, providers: [] },
+      }),
+    );
+    expect(result.current.state.thinkingLevels).toBeUndefined();
+  });
+});
+
+describe("thinking levels", () => {
+  it("stores the accepted-levels list from the snapshot", async () => {
+    const { result } = renderHook(() => useAgent());
+    act(() => mockWs!.open());
+    await waitFor(() => expect(result.current.state.connected).toBe(true));
+    act(() =>
+      mockWs!.receive({
+        type: "hello",
+        sessionId: "s",
+        branding: {},
+        model: "local/qwen",
+        thinkingLevel: "medium",
+        thinkingLevels: ["off", "low", "medium", "xhigh"],
+        models: [],
+        commands: [],
+        isStreaming: false,
+        items: [],
+        contextUsage: null,
+        gitAvailable: false,
+      }),
+    );
+    await waitFor(() => expect(result.current.state.thinkingLevels).toEqual(["off", "low", "medium", "xhigh"]));
+  });
+
+  it("replaces the list on model_changed, and clears it when the message omits one", async () => {
+    const result = await connected();
+    act(() => mockWs!.receive({ type: "model_changed", model: "local/a", reasoning: true, thinkingLevels: ["off", "high"] }));
+    await waitFor(() => expect(result.current.state.thinkingLevels).toEqual(["off", "high"]));
+
+    act(() => mockWs!.receive({ type: "model_changed", model: "local/b", reasoning: true }));
+    expect(result.current.state.thinkingLevels).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/ui/src/useAgent.ts
+++ b/ui/src/useAgent.ts
@@ -199,6 +199,8 @@ export interface AgentState {
   model: string;
   thinkingLevel: string;
   modelSupportsReasoning: boolean;
+  /** The levels the current model accepts; undefined means offer the full set. */
+  thinkingLevels?: ThinkingLevel[];
   models: ModelChoice[];
   commands: CommandInfo[];
   sessions: SessionSummary[] | null;
@@ -441,6 +443,7 @@ function applySnapshot(state: AgentState, message: ServerMessage & { sessionId: 
     sessionId: message.sessionId,
     model: message.model,
     thinkingLevel: message.thinkingLevel,
+    thinkingLevels: message.thinkingLevels,
     modelSupportsReasoning: current?.reasoning ?? false,
     models: message.models,
     commands: message.commands,
@@ -647,7 +650,13 @@ function reduce(state: AgentState, action: Action): AgentState {
         editorPrefill: { text: message.text, nonce: state.editorPrefill ? state.editorPrefill.nonce + 1 : 1 },
       };
     case "model_changed":
-      return { ...state, model: message.model, modelSupportsReasoning: message.reasoning };
+      return {
+        ...state,
+        model: message.model,
+        modelSupportsReasoning: message.reasoning,
+        // Replace outright — a message with no set means "offer the full set".
+        thinkingLevels: message.thinkingLevels,
+      };
     case "credentials_changed": {
       // Onboarding landed: new models, new status, same session — so nothing else here
       // is touched (a snapshot would wipe live extension dialogs and widgets).
@@ -657,6 +666,10 @@ function reduce(state: AgentState, action: Action): AgentState {
         models: message.models,
         model: message.model,
         modelSupportsReasoning: current?.reasoning ?? false,
+        // The model may have changed here; the old model's accepted set no longer
+        // applies. Fall back to the full set until a snapshot or model_changed says
+        // otherwise — this message does not carry the new one.
+        thinkingLevels: undefined,
         credentials: message.credentials,
         // errors stay: the "credentials stored, but allowedModels leaves no model"
         // case sends an error *and* this message — clearing them would eat it


### PR DESCRIPTION
Implements `openspec/changes/offer-only-the-thinking-levels-a-model-accepts` (proposal / spec / design / tasks / scenario-coverage in the change dir).

## Why

The 🧠 thinking slider in `ModelBar` was built from one hardcoded list (`THINKING_LEVELS`, `off…xhigh`) and never asked the model which of those levels it accepts. So a model that stops at `high`, or one whose accepted set has a *gap*, got a slider that offered levels the runtime then clamped — the thumb snapped back and nothing said why. Reported for a local Qwen3.8 (OpenAI-compatible): the cursor stopped at `high`.

The SDK already knows the answer (`AgentSession.getAvailableThinkingLevels()` / the `get_available_thinking_levels` RPC command, both reading the per-model `thinkingLevelMap` in the pi model catalog). Nothing carried it to the client.

## What changes

- **Runtime** reports the model's accepted levels — embedded via `getAvailableThinkingLevels()`, RPC via `get_available_thinking_levels` (probed like `get_commands`; an OMP child that lacks it leaves the set `undefined`), refreshed after `set_model`.
- **`normalizeThinkingLevels()`** (shared, beside `THINKING_LEVELS`): known names only, canonical order, `off` always a stop; nothing recognisable → `undefined`.
- **Wire**: the `hello` snapshot and `model_changed` gain `thinkingLevels?: ThinkingLevel[]`. `useAgent` stores it; a message with no list means "offer the full set" (also cleared on `credentials_changed`, which may have changed the model).
- **`ModelBar` `ThinkingControl`** ranges over the supplied list, not the constant. A gap (`low, medium, xhigh`, no `high`) collapses to adjacent stops. Absent a list, it falls back to the full set — today's behaviour.

No change to `set_thinking` validation or the SDK's own clamping — this makes the control honest, it does not move the enforcement.

## Behaviour

| Situation | Slider |
|---|---|
| Model accepts every level (or no list reported) | full six stops, `off…xhigh` — unchanged |
| Model accepts `low, medium, xhigh` (no `high`) | four stops `off, low, medium, xhigh`; `xhigh` is the last, reached without a dead `high` position |
| Current level not in the accepted set (stale mid-switch) | renders at the first stop, no crash; the next `thinking_changed` corrects it |

## Verification

- `npm run typecheck` clean; `oxlint` clean (no warnings in touched files)
- `normalizeThinkingLevels` units; `pi-rpc` runtime (`{levels}` populates the snapshot; unknown command → `undefined`, startup stays `ok`); **real server + WebSocket** (`hello` carries the set, `set_model` broadcasts `model_changed` with the *new* model's set, workspace-scoped)
- `useAgent` reducer (`hello` stores, `model_changed` replaces / clears, `credentials_changed` clears); `ModelBar` component (4-stop `max`, index mapping, stale level → 0, fallback)
- **e2e passes headless** (`e2e/thinking-levels.spec.ts`): a `low/medium/xhigh` model → 4-stop slider ending at `xhigh`, each stop maps to the right level; a full-set model → six stops. Verified visually in `npm run bench` ("model-aware thinking slider" server): the popover reads `off … xhigh`.
- `scenario-coverage.md`: 5 new scenarios covered, 17 retained scenarios pointed at their existing suites
- Pre-existing environmental failures on this Windows box only (server: pptx tooling / symlink privilege / git tags, plus two load-only flakes that pass in isolation; ui: `--localstorage-file`, one `ModelBar` context-ring test that fails on clean `main`) — each reproduced without this branch

## Note for local llama.cpp + Qwen3 users

For a custom OpenAI-compatible model there is no catalog entry, so the accepted set comes from your model declaration. To get the real tiers (Qwen 3.8 27B via llama.cpp actually has a meaningful `xhigh`; `high` remaps to it), declare `compat.thinkingFormat: "chat-template"` and a `thinkingLevelMap` in `~/.pi/agent/models.json` — see the recipe at https://github.com/soster/qwen38-thinking-levels. This PR makes the slider reflect whatever that declaration says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)