### PR TITLE
docs: add a five-minute start and task-by-task how-tos

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ once — each with its own sandbox, history and agent — and a sandbox you deci
 
 ## Contents
 
+- [Start in 5 minutes](#start-in-5-minutes)
+- [How do I…](#how-do-i)
 - [What you get](#what-you-get)
-- [Quick start](#quick-start)
 - [Model credentials](#model-credentials)
 - [Projects](#projects)
 - [Settings from the browser](#settings-from-the-browser)
@@ -33,6 +34,109 @@ once — each with its own sandbox, history and agent — and a sandbox you deci
 - [Embedding](#embedding)
 - [Work Plans](#work-plans)
 - [Development](#development)
+
+## Start in 5 minutes
+
+You need Node ≥ 24 (what the pi SDK itself requires) and an API key for one model
+provider. You do *not* need [pi](https://github.com/earendil-works/pi) installed — its SDK
+is bundled here.
+
+**1. Go to the project you want to work on.** The configuration is written here, and the
+agent starts out confined to this directory.
+
+```bash
+cd ~/projects/my-app
+```
+
+**2. Write a starter configuration.**
+
+```bash
+npx pi-outpost init
+```
+
+That gives you a read-only agent — it can read this directory, and nothing else: no
+writing, no shell.
+
+**3. Start it.**
+
+```bash
+npx pi-outpost
+```
+
+It serves on `http://127.0.0.1:3141/` and opens the interface in a window of its own — no
+tabs, no address bar. `--open-in browser` puts it in a normal browser tab, `--no-open`
+leaves it closed.
+
+**4. Give it a model.** With no credentials, the interface asks for them instead of showing
+a chat that could only fail: pick a provider and paste an API key, or declare an
+OpenAI-compatible endpoint of your own — a corporate gateway, vLLM, Ollama, LM Studio.
+Nothing to restart; the chat works as soon as you save.
+
+**5. Ask it something.** "What does this project do?" is a good first turn — it can read
+everything under this directory, and you will see it search and open files as it goes.
+
+Then, when you want it to actually change things, open `pi-outpost.config.json` and widen
+the sandbox — or do it from the gear menu, which applies immediately and writes the same
+file:
+
+```json
+{
+  "cwd": ".",
+  "sandbox": { "root": ".", "allowWrite": true, "writableRoot": "./src", "allowBash": false }
+}
+```
+
+**No Node, no npm?** Each release carries a single executable per platform under
+[Releases](https://github.com/laurentftech/pi-outpost/releases), server and interface
+inside. They are unsigned, so macOS and Windows warn on first launch; see
+[docs/sea-packaging.md](docs/sea-packaging.md), which also covers building one yourself with
+`npx pi-outpost build-exe`.
+
+### Why it insists on a configuration file
+
+pi-outpost never starts without one: the agent's working directory, its tools and its
+sandbox are decided there, and guessing them from whatever directory you happen to be
+standing in is not a decision anyone wants made for them. `init` writes the safe version of
+that file — read-only, no bash — for you to open up as needed:
+
+```json
+{
+  "cwd": ".",
+  "agentRuntime": { "mode": "embedded" },
+  "sandbox": { "root": ".", "allowWrite": false, "allowBash": false },
+  "server": { "port": 3141, "host": "127.0.0.1" },
+  "branding": { "title": "π" }
+}
+```
+
+Not sure which file is in force, or why a setting has the value it has? **`pi-outpost
+config`** prints the resolved configuration and the file it came from, without starting
+anything.
+
+> **Security note.** The server binds to `127.0.0.1` and validates the WebSocket `Origin`
+> header. The agent can be given bash, edit and write tools — never expose this server on a
+> network without a sandbox **and** an auth token: set `server.token` (or the
+> `PI_OUTPOST_TOKEN` environment variable, which wins) to a long random secret, e.g.
+> `openssl rand -hex 32`. Binding off loopback without one is **refused**, not merely
+> discouraged. Clients authenticate by opening `http://host:3141/?token=<secret>` once
+> (stored locally, stripped from the URL) or via the embed widget's `token` option. Use a
+> reverse proxy or Tailscale for transport encryption.
+
+## How do I…
+
+Task-by-task recipes live in [`docs/how-to.md`](docs/how-to.md) — the configuration each
+one needs, the command that proves it works, and the caution that goes with it.
+
+| | |
+|---|---|
+| [Let the agent write in one folder only](docs/how-to.md#let-the-agent-write-in-one-folder-only) | [Give the agent a shell](docs/how-to.md#give-the-agent-a-shell) |
+| [Work on several projects at once](docs/how-to.md#work-on-several-projects-at-once) | [Use a local or self-hosted model](docs/how-to.md#use-a-local-or-self-hosted-model) |
+| [Reach it from your phone](docs/how-to.md#reach-it-from-your-phone-or-another-machine) | [Run it on a Linux server](docs/how-to.md#run-it-permanently-on-a-linux-server) |
+| [Keep several setups side by side](docs/how-to.md#keep-several-setups-side-by-side) | [Hand it to someone who has no Node](docs/how-to.md#hand-it-to-someone-who-has-no-node) |
+| [Teach the agent something](docs/how-to.md#teach-the-agent-something) | [Restrict which models can be picked](docs/how-to.md#restrict-which-models-can-be-picked) |
+| [Read a big PDF, Word or Excel file](docs/how-to.md#let-the-agent-read-a-big-pdf-word-or-excel-file) | [Lock down a shared deployment](docs/how-to.md#lock-down-a-shared-deployment) |
+| [Put it inside your own web app](docs/how-to.md#put-it-inside-your-own-web-app) | [Use an existing pi installation](docs/how-to.md#use-an-existing-pi-installation) |
+| [When something does not work](docs/how-to.md#when-something-does-not-work) | |
 
 ## What you get
 
@@ -98,60 +202,6 @@ once — each with its own sandbox, history and agent — and a sandbox you deci
   prefill
 - Two agent runtimes behind the same interface: the bundled pi SDK, or a supervised
   `pi --mode rpc` child process
-
-## Quick start
-
-Requirements: Node ≥ 24 (what the pi SDK itself requires), and **model credentials**. You do
-*not* need [pi](https://github.com/earendil-works/pi) installed — its SDK is bundled here.
-
-```bash
-npx pi-outpost init   # writes a starter pi-outpost.config.json here
-npx pi-outpost        # serves the interface on http://127.0.0.1:3141/
-```
-
-Once it is listening, the interface opens in a window of its own — no tabs, no address bar.
-`--open-in browser` puts it in a normal browser tab instead, and `--no-open` (or
-`"openBrowser": false`) leaves it closed.
-
-Open it with no credentials and it asks for them: pick a provider and paste an API key, or
-declare an OpenAI-compatible endpoint of your own (see [Model
-credentials](#model-credentials)). Nothing to restart — the chat works as soon as you save.
-
-**No Node, no npm?** Each release carries a single executable per platform under
-[Releases](https://github.com/laurentftech/pi-outpost/releases), server and interface
-inside. They are unsigned, so macOS and Windows warn on first launch; see
-[docs/sea-packaging.md](docs/sea-packaging.md), which also covers building one yourself with
-`npx pi-outpost build-exe`.
-
-### Why it insists on a configuration file
-
-pi-outpost never starts without one: the agent's working directory, its tools and its
-sandbox are decided there, and guessing them from whatever directory you happen to be
-standing in is not a decision anyone wants made for them. `init` writes the safe version of
-that file — read-only, no bash — for you to open up as needed:
-
-```json
-{
-  "cwd": ".",
-  "agentRuntime": { "mode": "embedded" },
-  "sandbox": { "root": ".", "allowWrite": false, "allowBash": false },
-  "server": { "port": 3141, "host": "127.0.0.1" },
-  "branding": { "title": "π" }
-}
-```
-
-Not sure which file is in force, or why a setting has the value it has? **`pi-outpost
-config`** prints the resolved configuration and the file it came from, without starting
-anything.
-
-> **Security note.** The server binds to `127.0.0.1` and validates the WebSocket `Origin`
-> header. The agent can be given bash, edit and write tools — never expose this server on a
-> network without a sandbox **and** an auth token: set `server.token` (or the
-> `PI_OUTPOST_TOKEN` environment variable, which wins) to a long random secret, e.g.
-> `openssl rand -hex 32`. Binding off loopback without one is **refused**, not merely
-> discouraged. Clients authenticate by opening `http://host:3141/?token=<secret>` once
-> (stored locally, stripped from the URL) or via the embed widget's `token` option. Use a
-> reverse proxy or Tailscale for transport encryption.
 
 ## Model credentials
 

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -1,0 +1,381 @@
+# How-to
+
+Short recipes for the things people actually set out to do. Each one is
+self-contained: the configuration it needs, the command that proves it works, and the
+caution that goes with it. The [README](../README.md) has the reference — every key,
+every flag.
+
+- [Let the agent write in one folder only](#let-the-agent-write-in-one-folder-only)
+- [Give the agent a shell](#give-the-agent-a-shell)
+- [Work on several projects at once](#work-on-several-projects-at-once)
+- [Use a local or self-hosted model](#use-a-local-or-self-hosted-model)
+- [Reach it from your phone or another machine](#reach-it-from-your-phone-or-another-machine)
+- [Run it permanently on a Linux server](#run-it-permanently-on-a-linux-server)
+- [Keep several setups side by side](#keep-several-setups-side-by-side)
+- [Hand it to someone who has no Node](#hand-it-to-someone-who-has-no-node)
+- [Teach the agent something](#teach-the-agent-something)
+- [Restrict which models can be picked](#restrict-which-models-can-be-picked)
+- [Let the agent read a big PDF, Word or Excel file](#let-the-agent-read-a-big-pdf-word-or-excel-file)
+- [Lock down a shared deployment](#lock-down-a-shared-deployment)
+- [Put it inside your own web app](#put-it-inside-your-own-web-app)
+- [Use an existing pi installation](#use-an-existing-pi-installation)
+- [When something does not work](#when-something-does-not-work)
+
+## Let the agent write in one folder only
+
+The most common shape: it reads your whole project, and may only change one part of
+it.
+
+```json
+{
+  "cwd": "/home/me/projects/site",
+  "sandbox": {
+    "root": "/home/me/projects/site",
+    "allowWrite": true,
+    "writableRoot": "/home/me/projects/site/src",
+    "allowBash": false
+  }
+}
+```
+
+`root` is what it can read (symlinks resolved, nothing above it reachable);
+`writableRoot` is the only place `edit` and `write` may touch. In the file browser,
+everything outside the writable zone is dimmed, so you can see the boundary rather
+than discover it.
+
+Check it took effect: `pi-outpost config` prints the sandbox it resolved, and every
+start logs it too.
+
+## Give the agent a shell
+
+```json
+{ "sandbox": { "root": "/home/me/projects/site", "allowWrite": true, "allowBash": true } }
+```
+
+Be deliberate about this one. **Bash cannot be path-confined**: `allowBash` gives the
+agent everything the account running the server can do, inside the sandbox or not.
+Where that matters, run pi-outpost as a dedicated user, or in a container, and treat
+the sandbox as being that boundary rather than the `sandbox` key.
+
+To grant it for yourself while preventing anyone from turning it on from the browser:
+
+```json
+{ "sandboxLocks": { "allowBash": true } }
+```
+
+A lock is refused by the server, not merely hidden by the interface.
+
+## Work on several projects at once
+
+Nothing to configure. The project control in the header opens one: browse the
+server's directories, pick it, and it is usable immediately — the set survives
+restarts.
+
+Each project gets its own agent, sandbox, file tree and session history. Switching
+never disturbs the others: a turn you leave running finishes, and its result is
+waiting when you come back. The selector says what each one is doing (idle, working,
+waiting for you), and a project that needs an answer while you are elsewhere raises a
+browser notification naming it.
+
+Two knobs, if the defaults do not suit:
+
+```json
+{
+  "workspaceIdleTimeoutMs": 1800000,
+  "workspaceLock": false
+}
+```
+
+`workspaceIdleTimeoutMs` is how long an unused project stays alive before it is
+retired and rebuilt on next use (`0` never retires; a project running a turn is never
+retired). `workspaceLock: true` pins the server to one project and removes the
+controls entirely — that is what an embedding host uses.
+
+## Use a local or self-hosted model
+
+Ollama, LM Studio, vLLM, SGLang, a corporate gateway — anything speaking the OpenAI
+API.
+
+**If pi-outpost has no usable model yet** (a fresh `agentDir`, no provider environment
+variable), it shows the setup screen: pick the *OpenAI-compatible endpoint* tab and
+fill in a name, the base URL, a key and one model id.
+
+| Server | Base URL | Key |
+|---|---|---|
+| Ollama | `http://127.0.0.1:11434/v1` | anything non-empty |
+| LM Studio | `http://127.0.0.1:1234/v1` | anything non-empty |
+| vLLM / SGLang | `http://host:8000/v1` | whatever it was started with |
+
+If every turn then fails with an error that names nothing useful, untick the two
+**compatibility** boxes: many such servers reject the `developer` role and the
+`reasoning_effort` field pi sends to reasoning-capable models.
+
+**If you already have a working provider**, the setup screen does not come back — it
+only appears when no model can answer. Write the endpoint into
+`<agentDir>/models.json` yourself, which is the same file the screen writes:
+
+```json
+{
+  "providers": {
+    "ollama": {
+      "baseUrl": "http://127.0.0.1:11434/v1",
+      "api": "openai-completions",
+      "apiKey": "ollama",
+      "compat": { "supportsDeveloperRole": false, "supportsReasoningEffort": false },
+      "models": [{ "id": "qwen3:14b" }]
+    }
+  }
+}
+```
+
+That file holds a key: keep it readable by you alone (`chmod 600`). Restart, and the
+model appears in the switcher.
+
+On a machine that cannot reach the public model catalogs, add `"offline": true` —
+otherwise every credential change waits 20 s for a fetch that will never arrive.
+Locally declared models are unaffected.
+
+## Reach it from your phone or another machine
+
+Three things, and all three are needed:
+
+```json
+{
+  "server": {
+    "host": "0.0.0.0",
+    "token": "…",
+    "allowedOrigins": ["http://192.168.1.10:3141"]
+  }
+}
+```
+
+1. **`host`** off `127.0.0.1`. The server refuses to bind off loopback without a
+   token, so this alone will not start.
+2. **`token`** — a long random secret, `openssl rand -hex 32`. Prefer the
+   `PI_OUTPOST_TOKEN` environment variable, which overrides the file and keeps the
+   secret out of it. There is no `--token` flag on purpose: argv is readable by anyone
+   who can list processes.
+3. **`allowedOrigins`** with the exact origin *you will type in the browser*. Only
+   `localhost` and `127.0.0.1` are trusted automatically, so a connection from
+   `http://192.168.1.10:3141` is rejected as a forbidden origin until you list it.
+
+Then open `http://192.168.1.10:3141/?token=<secret>` once. The token is stored locally
+and stripped from the URL.
+
+There is no transport encryption here: put it behind a reverse proxy with TLS, or on a
+Tailscale network, before it crosses anything you do not control. And remember what
+you are exposing — an agent that can read your files, and write or run commands if you
+granted it that.
+
+## Run it permanently on a Linux server
+
+```bash
+npm install -g pi-outpost
+pi-outpost init --global          # writes ~/.config/pi-outpost/config.json
+pi-outpost login --provider anthropic   # prompts; no browser needed
+```
+
+Then a unit file:
+
+```ini
+[Unit]
+Description=pi-outpost
+After=network-online.target
+
+[Service]
+User=pi-outpost
+Environment=PI_OUTPOST_CONFIG=/etc/pi-outpost/config.json
+Environment=PI_OUTPOST_TOKEN=replace-me
+ExecStart=/usr/bin/pi-outpost --no-open
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+`ExecStart` needs the real path — `which pi-outpost` after the global install, or the
+executable's own path if you deployed one of those. A headless host opens no browser
+anyway — pi-outpost only opens one where a desktop
+session exists — but `--no-open` says so explicitly. Give the service its own user,
+and point `cwd`, `sandbox.root` and `agentDir` at directories that user owns.
+
+From a checkout rather than a package, `npm run start` is the equivalent single
+command: it builds the interface once and serves everything from one process.
+
+## Keep several setups side by side
+
+A profile is an ordinary configuration file living in
+`~/.config/pi-outpost/profiles/`:
+
+```bash
+mkdir -p ~/.config/pi-outpost/profiles
+cp pi-outpost.config.json ~/.config/pi-outpost/profiles/work.json
+pi-outpost --profile work     # from anywhere
+```
+
+`$PI_OUTPOST_PROFILE` does the same without the flag. Give each profile its own
+`server.port` if you want two running at once, and its own `agentDir` if their
+sessions and credentials should not mix.
+
+## Hand it to someone who has no Node
+
+Download the executable for their platform from
+[Releases](https://github.com/laurentftech/pi-outpost/releases) — server and interface
+are inside it, nothing to install. It is unsigned, so macOS and Windows warn on first
+launch; [`sea-packaging.md`](sea-packaging.md) covers that, and building one yourself
+with `pi-outpost build-exe`.
+
+Ship a configuration file beside it (`pi-outpost.config.json` in the directory they
+launch from) so they never see a start that refuses. Double-clicked, it opens the
+interface in a window of its own; if it fails before listening, the window waits for a
+keypress instead of vanishing with the message.
+
+Tell them to install it from the browser too: the interface declares itself as an app,
+so it lands in the dock or taskbar with its own icon and opens without an address bar.
+
+## Teach the agent something
+
+| What | Where | Loaded from |
+|---|---|---|
+| Skills | `skillPaths`, or the Settings menu | Files or directories; `skillPaths` loads even under `noSkills` |
+| Prompt templates | `promptPaths`, plus what is auto-discovered from `agentDir` and the project's `cwd/.pi/prompts` | Available as `/` commands in the composer |
+| Extensions | `extensionPaths`, `extensionScripts`, or the Settings menu | A directory is enough — its extensions are discovered |
+
+```json
+{
+  "skillPaths": ["/srv/shared/skills/house-style"],
+  "promptPaths": ["./my-prompts"]
+}
+```
+
+Paths are resolved against the configuration file's directory, and are automatically
+made readable to the agent even when they sit outside the sandbox root.
+
+Adding a directory from the Settings menu instead writes it under `userSkillPaths` or
+`userExtensionPaths` and rebuilds the session at once — no restart, and what the
+configuration file declares is never touched.
+
+For real isolation, remember that skills also load from `~/.agents/skills` and from
+`.agents/skills` walked up from `cwd`, neither of which `agentDir` scopes: that is
+what `noSkills` is for.
+
+## Restrict which models can be picked
+
+```json
+{
+  "allowedModels": [
+    { "provider": "anthropic", "id": "claude-sonnet-5" },
+    { "provider": "ollama", "id": "qwen3:14b" }
+  ]
+}
+```
+
+Without it the switcher lists every built-in model whose provider has credentials —
+usually far more variants than a given deployment actually serves.
+
+## Let the agent read a big PDF, Word or Excel file
+
+Nothing to enable: `pdf_extract`, `docx_extract`, `xlsx_extract` and `pptx_extract`
+are available wherever `read` is, need no shell and no external binary, and are
+confined to the sandbox root like every other file tool. Drop the document into the
+composer and it is uploaded into the workspace and attached as a path, which is what
+those tools take.
+
+The ceiling is 25 MB per format, raise it if your documents are bigger:
+
+```json
+{ "pdf": { "maxBytes": 52428800 }, "xlsx": { "maxBytes": 52428800 } }
+```
+
+For a long document, ask for `output_path`: the extractor writes the whole thing to a
+workspace file and returns a summary, instead of spending the context on it twice.
+
+## Lock down a shared deployment
+
+For a server other people connect to, decide what the browser may change:
+
+```json
+{
+  "sandboxLocks": { "root": true, "writableRoot": true, "allowWrite": true, "allowBash": true },
+  "extensionLock": true,
+  "workspaceLock": true,
+  "noSkills": false
+}
+```
+
+- `sandboxLocks` freezes the sandbox fields, individually
+- `extensionLock` forbids adding extension directories — that is loading *code*, which
+  is why it is separate from skill paths, and why skill paths stay editable under it
+- `workspaceLock` pins the server to one project
+
+All of it is enforced by the server: a client that sends the request anyway is
+refused, nothing is persisted and no session is rebuilt. Add `server.token`, and read
+the security note in the README before binding off loopback.
+
+## Put it inside your own web app
+
+```bash
+npm install @pi-outpost/embed
+```
+
+```js
+import { mount } from "@pi-outpost/embed";
+
+const widget = mount(document.getElementById("assistant"), {
+  serverUrl: "https://outpost.internal",
+  token: currentUser.outpostToken,   // no token screen for your users
+  workspace: "/srv/projects/acme",   // which project this widget shows
+  theme: "dark",
+});
+```
+
+Server side, two settings decide what the widget is:
+
+```json
+{
+  "server": { "allowedOrigins": ["https://your-app.example.com"] },
+  "embed": { "workspaceControls": "settings" },
+  "workspaceLock": true
+}
+```
+
+`allowedOrigins` must list your host page's origin — the widget's WebSocket carries
+*that* origin, not pi-outpost's, and the same list now grants CORS on the HTTP routes,
+so a cross-origin widget works without a proxy in front.
+`embed.workspaceControls` chooses what it offers around the project: `settings` (one
+project, root editable through Settings only), `root` (a compact root chooser) or
+`projects` (the full open/switch/close controls).
+
+## Use an existing pi installation
+
+```json
+{ "agentRuntime": { "mode": "rpc", "executable": "pi", "args": [] } }
+```
+
+pi-outpost then supervises a `pi --mode rpc` child instead of running the SDK
+in-process — to match an installation you already maintain, or to isolate a crash. It
+appends `--mode rpc` and derives `--session-dir` itself, and passes the rest of the
+configuration (skills, extensions, prompt templates, tools, system prompt) to the
+child, so the same file describes the same agent either way.
+
+Two things to know first: **`sandbox` cannot be combined with `rpc`** — the pair is
+refused at load, because the sandbox is a toolset this server builds and a child builds
+its own; isolate it with a container or a dedicated user instead. And a few features
+have no RPC equivalent and say so rather than failing quietly: storing credentials,
+declaring a provider, changing the sandbox from Settings, tree navigation, editing a
+past message, and automatic session titles.
+
+## When something does not work
+
+| What you see | What it is |
+|---|---|
+| `no configuration file found` | pi-outpost never starts without one. `pi-outpost init`, or `init --global` |
+| `cannot start: … is already in use` | Something else holds the port. `--port <n>` |
+| The setup screen keeps coming back | No provider can answer. `pi-outpost config` shows which `agentDir` it reads, and credentials live in `<agentDir>/auth.json` |
+| A bare `fetch failed` | A TLS-inspecting proxy. `export NODE_EXTRA_CA_CERTS=/path/to/corp-ca.pem` |
+| Every turn fails on your own endpoint | The compatibility flags. Untick both, or set `compat` in `models.json` |
+| Each credential change hangs ~20 s | Remote model catalogs are unreachable. `"offline": true` |
+| A remote browser cannot connect | The origin is not allowed. Add the exact origin you type to `server.allowedOrigins`; the log line names it |
+| The file tree does not follow changes | Watching may be off (`files.watch`) or the filesystem emits no events. The tree's ↻ control re-lists by hand |
+| Settings will not change the sandbox | Either a `sandboxLocks` entry, or the RPC runtime, which has no sandbox to change |
+| Not sure which file is in force | `pi-outpost config` prints the resolved configuration and where it came from |


### PR DESCRIPTION
Follow-up to #134, which brought the README up to date on *what* everything does. This one is about getting someone from nothing to a working agent.

## Start in 5 minutes

Replaces "Quick start" and becomes the first section after the contents: five numbered steps from `cd` into a project to a first question answered, then the one-line change that widens the sandbox once you want the agent to write. The feature list moves below it — someone arriving wants to run the thing, not read an inventory.

## `docs/how-to.md`

Fifteen recipes for what people actually set out to do, each with the configuration it needs, the command that proves it works, and the caution that goes with it:

| | |
|---|---|
| Write in one folder only | Give the agent a shell (and what that costs) |
| Several projects at once | A local or self-hosted model (Ollama, LM Studio, vLLM) |
| Reach it from your phone | A systemd unit on a Linux server |
| Profiles side by side | An executable for someone with no Node |
| Skills, prompts, extensions | Restrict which models can be picked |
| Big PDF / Word / Excel files | Lock down a shared deployment |
| Embed it in your own app | Use an existing pi installation |
| Symptom-to-cause table | |

The README links them in a grid under **How do I…**.

## Three details that are not guessable

Checked against the code rather than written from memory, because each one costs an hour otherwise:

- **Reaching the server from another machine** needs the browser's own origin in `server.allowedOrigins` — `ORIGIN_ALLOWLIST` in `server/src/index.ts` trusts only `localhost`/`127.0.0.1`, so `http://192.168.1.10:3141` is rejected as a forbidden origin while everything else looks correctly configured.
- **Declaring an OpenAI-compatible endpoint once you already have a working provider**: the setup screen never comes back — `ui/src/App.tsx` shows it only when no model can answer — so the recipe gives the `<agentDir>/models.json` to write by hand, in the exact shape `storeProvider()` writes, `compat` flags included.
- That file holds an API key, so the recipe says to keep it at `chmod 600`.

## Notes

- Documentation only: no source, test or configuration-schema change.
- All internal and cross-file anchors validated; no dead links.
- Rebased onto `main` after #134 merged, so the diff is only this commit.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X7bocd8kqhYsTMePHB7Lqb)_