### PR TITLE
fix(file-tree): recover the browser root after a reconnect

### DIFF
--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -60,6 +60,10 @@ export function Sidebar({
 }: SidebarProps) {
   const resize = useResizablePanelWidth(FILES_SIDEBAR_WIDTH);
 
+  // First open arms the browser root. Keeping it listed afterwards — across
+  // reconnects and session snapshots, which clear the tree — is useAgent's job
+  // (see its "keep the file-browser root listed" effect); this only has to fire
+  // the initial request.
   useEffect(() => {
     if (tree[""] === undefined) onExpand("");
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/ui/src/useAgent.test.ts
+++ b/ui/src/useAgent.test.ts
@@ -1963,13 +1963,128 @@ describe("directory_changed", () => {
     }
   });
 
-  it("asks for nothing on refresh when the tree holds nothing", async () => {
+  it("still asks for the root on refresh when the tree came up empty", async () => {
+    // The reconnect bug: a fresh `hello` clears `fileTree` while the sidebar is
+    // open, so the old refresh — which only re-listed directories the tree was
+    // already holding — had nothing to iterate and did nothing at all. A browser
+    // reload was the only way back. The root is now always re-requested.
     const result = await connected();
     const before = mockWs!.sent.length;
 
     act(() => result.current.refreshFileTree());
 
+    expect(sentSince(before)).toContainEqual(expect.objectContaining({ type: "list_directory", path: "" }));
+    // ...and nothing else: there are no held directories to re-list.
+    expect(sentSince(before).filter((frame) => frame.type === "list_directory")).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Keeping the file-browser root alive across reconnects and session snapshots.
+//
+// The rare-but-painful bug: the sidebar requested the root once, from its mount
+// effect. Every WebSocket (re)connect answers with a `hello`, and applySnapshot
+// clears `fileTree` — so a drop while the sidebar was open left the tree empty,
+// the refresh button (held-directories only) unable to recover it, and a browser
+// page reload the only way back.
+// ---------------------------------------------------------------------------
+describe("file-browser root across snapshots", () => {
+  const helloFrame = (overrides: Record<string, unknown> = {}) => ({
+    type: "hello",
+    sessionId: "sess_2",
+    branding: {},
+    model: "",
+    thinkingLevel: "off",
+    models: [],
+    commands: [],
+    isStreaming: false,
+    items: [],
+    contextUsage: null,
+    gitAvailable: false,
+    ...overrides,
+  });
+  const sentSince = (from: number) => mockWs!.sent.slice(from).map((raw) => JSON.parse(raw) as Record<string, unknown>);
+  const answerRootListing = () =>
+    act(() =>
+      mockWs!.receive({
+        type: "directory_listing",
+        requestId: lastRequestId(),
+        path: "",
+        entries: [{ name: "readme.md", type: "file" }],
+      }),
+    );
+
+  it("re-requests the root on its own when a reconnect snapshot clears the tree", async () => {
+    const result = await connected();
+
+    // The sidebar's first open asks for the root; the server answers it.
+    act(() => result.current.listDirectory(""));
+    answerRootListing();
+    await waitFor(() => expect(result.current.state.fileTree[""]).toHaveLength(1));
+
+    // A reconnect delivers a fresh hello and applySnapshot wipes the tree — but
+    // the hook re-asks for the root on its own, so it lands straight on "loading"
+    // rather than staying blank until someone touches the refresh button.
+    const before = mockWs!.sent.length;
+    act(() => mockWs!.receive(helloFrame()));
+    expect(result.current.state.fileTree[""]).toBe("loading");
+    expect(sentSince(before)).toContainEqual(expect.objectContaining({ type: "list_directory", path: "" }));
+
+    // ...and the tree fills back in once the answer lands.
+    answerRootListing();
+    await waitFor(() => expect(result.current.state.fileTree[""]).toHaveLength(1));
+  });
+
+  it("recovers the root after a workspace switch clears the tree with the sidebar open", async () => {
+    const result = await connected();
+    act(() => result.current.listDirectory(""));
+    answerRootListing();
+    await waitFor(() => expect(result.current.state.fileTree[""]).toHaveLength(1));
+
+    const before = mockWs!.sent.length;
+    act(() =>
+      mockWs!.receive(
+        helloFrame({
+          type: "workspace_switched",
+          sessionId: "session-beta",
+          workspace: { root: "/srv/beta", name: "beta", activity: "idle", needsAttention: false },
+        }),
+      ),
+    );
+
+    // The switched-to project's root is requested on its own — only session_replaced
+    // used to do this, so an open sidebar went blank until a manual refresh.
+    expect(result.current.state.fileTree[""]).toBe("loading");
+    expect(sentSince(before)).toContainEqual(expect.objectContaining({ type: "list_directory", path: "" }));
+  });
+
+  it("stays lazy: never asks for the root when the sidebar was never opened", async () => {
+    const result = await connected();
+    const before = mockWs!.sent.length;
+
+    // Two more snapshots, as reconnects and a config reload would deliver them.
+    act(() => mockWs!.receive(helloFrame()));
+    act(() => mockWs!.receive(helloFrame({ sessionId: "sess_3" })));
+    await waitFor(() => expect(result.current.state.sessionId).toBe("sess_3"));
+
     expect(sentSince(before)).not.toContainEqual(expect.objectContaining({ type: "list_directory" }));
+  });
+
+  it("fires once per gap, not in a loop", async () => {
+    const result = await connected();
+    act(() => result.current.listDirectory(""));
+    answerRootListing();
+    await waitFor(() => expect(result.current.state.fileTree[""]).toHaveLength(1));
+
+    const before = mockWs!.sent.length;
+    act(() => mockWs!.receive(helloFrame()));
+    await waitFor(() =>
+      expect(sentSince(before).filter((frame) => frame.type === "list_directory")).toHaveLength(1),
+    );
+    // `dir_list_started` marks the entry "loading"; the effect must not re-fire
+    // on that state change.
+    await waitFor(() => expect(result.current.state.fileTree[""]).toBe("loading"));
+    expect(sentSince(before).filter((frame) => frame.type === "list_directory")).toHaveLength(1);
   });
 });
 

--- a/ui/src/useAgent.ts
+++ b/ui/src/useAgent.ts
@@ -1117,6 +1117,10 @@ export function useAgent(serverUrl = "", explicitToken?: string, embedded = fals
   useEffect(() => {
     writableRootRef.current = state.writableRoot;
   }, [state.writableRoot]);
+  // Set once the browser root has been asked for at all (the sidebar's first
+  // open, or a manual refresh). From then on the connection-driven effect below
+  // keeps the root listed across reconnects and snapshots — see its comment.
+  const rootListingRequestedRef = useRef(false);
 
   const sendMessage = useCallback((message: ClientMessage) => {
     const socket = socketRef.current;
@@ -1127,6 +1131,7 @@ export function useAgent(serverUrl = "", explicitToken?: string, embedded = fals
 
   const requestDirectory = useCallback(
     (path: string, preserveEntries = false) => {
+      if (path === "") rootListingRequestedRef.current = true;
       const requestId = `dir:${crypto.randomUUID()}`;
       dispatch({ type: "dir_list_started", path, requestId, preserveEntries });
       sendMessage({ type: "list_directory", path, requestId });
@@ -1185,10 +1190,43 @@ export function useAgent(serverUrl = "", explicitToken?: string, embedded = fals
    * conditional on it: `fs.watch` is best-effort by contract, and a filesystem
    * that emits no events — a network mount, a spent inotify budget, watching
    * turned off — is indistinguishable from a workspace that did not change.
+   *
+   * The browser root is re-listed unconditionally, not through `relistDirectory`:
+   * a tree that came up empty — a reconnect delivered a fresh `hello`, which
+   * clears `fileTree`, before the sidebar could re-request the root — holds no
+   * keys to iterate, and this button is exactly where someone reaches for a way
+   * out of an empty tree. Everything else still goes through `relistDirectory`,
+   * which skips directories nothing is showing.
    */
   const refreshFileTree = useCallback(() => {
-    for (const path of Object.keys(fileTreeRef.current)) relistDirectory(path);
-  }, [relistDirectory]);
+    requestDirectory("", true);
+    for (const path of Object.keys(fileTreeRef.current)) {
+      if (path !== "") relistDirectory(path);
+    }
+  }, [relistDirectory, requestDirectory]);
+
+  /**
+   * Keep the file-browser root listed for as long as a connection needs it.
+   *
+   * The root used to be requested once, from the sidebar's mount effect. But
+   * every WebSocket (re)connect answers with a `hello`, and `applySnapshot`
+   * clears `fileTree` — so a drop while the sidebar was open left the tree
+   * permanently empty, and the refresh button (which only re-lists what the tree
+   * already holds) could not bring it back. A browser reload was the only way
+   * out.
+   *
+   * Once the root has been asked for even once (`rootListingRequestedRef`), this
+   * re-requests it on every (re)connect that comes back without it — first
+   * connect, reconnect, `hello`, `workspace_switched`, `update_config_ack`, all
+   * in one place. Kept lazy: a session whose Files panel is never opened still
+   * lists nothing. `dir_list_started` then sets the entry to `"loading"`, so this
+   * fires at most once per gap.
+   */
+  useEffect(() => {
+    if (!state.connected || !rootListingRequestedRef.current) return;
+    if (fileTreeRef.current[""] !== undefined) return;
+    requestDirectory("");
+  }, [state.connected, state.fileTree, requestDirectory]);
 
   // Branding is pure config (no session dependency) and served as soon as the process
   // starts — fetch it directly instead of waiting on the WS "hello", which only arrives


### PR DESCRIPTION
The file-browser root was requested once, from the sidebar's mount effect.
Every WebSocket (re)connect answers with a fresh `hello`, and applySnapshot
clears `fileTree` — so a drop while the sidebar was open left the tree
permanently empty. The refresh button only re-lists directories the tree is
already holding, so with no root key it did nothing, and a browser page
reload was the only way back.

- useAgent: a connection-driven effect re-requests the root on every
  (re)connect that comes back without it (first connect, reconnect, hello,
  workspace_switched, update_config_ack). Stays lazy via a ref armed only
  once the root has been asked for — a session whose Files panel is never
  opened still lists nothing. Only session_replaced re-requested before.
- refreshFileTree: always re-list the root, not just held directories, so
  the button can recover a tree that came up empty.

Verified in the running app: server restart + reconnect with the sidebar
open now shows "loading" then the full tree, with no page reload; before,
the tree stayed empty and the refresh button was inert.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013Khcs828FGZSQux6qdFjeh
