### PR TITLE
fix(update): respect npm registry configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,7 +475,11 @@ check, and why, and exits non-zero.
 | Key | Effect |
 |------|------|
 | `updateCheck` | `false` disables checking entirely. `true` enables it **even under `offline`**. Unset, `offline` decides |
-| `updateRegistry` | The registry to query, when npm's own configuration does not name the right one |
+| `updateRegistry` | Optional registry override, when npm's own configuration does not name the right one |
+
+Version checks normally run through `npm view`, so an existing `.npmrc` remains the source
+of truth for an internal registry, authentication, CA certificates and proxies. No duplicate
+pi-outpost setting is required for a Nexus setup that already works with npm.
 
 `offline` means "remote model catalogs are unreachable", which is not the same network as a
 package registry — a host air-gapped from the former can still reach an internal npm proxy,

--- a/openspec/specs/update/spec.md
+++ b/openspec/specs/update/spec.md
@@ -134,14 +134,14 @@ A source checkout SHALL NOT be compared against the registry at startup, because
 
 ### Requirement: UpdateChecksUseTheConfiguredRegistry
 
-The system SHALL query the package registry the host is configured to use, rather than a fixed public address. It SHALL take the registry from the package manager's own configuration when one is set, SHALL accept an explicit override in pi-outpost's configuration, and SHALL fall back to the public registry when neither names one.
+The system SHALL query the package registry the host is configured to use, rather than a fixed public address. Where the package manager is available, the check SHALL ask it for the newest version instead of merely reading its registry URL and making a separate request. This preserves the package manager's complete transport configuration, including authentication, CA certificates and proxies from `.npmrc`. It SHALL accept an explicit override in pi-outpost's configuration and pass that override to the package manager. Only when the package manager executable is absent SHALL it fall back to a direct registry request.
 
 An installation performed by the command SHALL go through the package manager. Where the registry came from the package manager's own configuration, the command SHALL NOT restate it. Where pi-outpost's configuration overrode it, the command SHALL name that registry to the installer, so that the registry an update is announced from is the one it is installed from.
 
 #### Scenario: UsesThePackageManagerRegistry
-- **GIVEN** the package manager is configured with an internal registry proxy
+- **GIVEN** the package manager is configured through `.npmrc` with an internal registry proxy and any transport settings it needs
 - **WHEN** an update check runs
-- **THEN** the request goes to that registry, not to the public one
+- **THEN** the version lookup is performed by the package manager, so the request goes to that registry with its authentication, CA and proxy configuration rather than through a separate public-registry request
 
 #### Scenario: ConfiguredOverrideWins
 - **GIVEN** pi-outpost's configuration names a registry

--- a/server/src/update.ts
+++ b/server/src/update.ts
@@ -127,42 +127,9 @@ export const PACKAGE_NAME = "pi-outpost";
  */
 export const RELEASES_URL = "https://github.com/laurentftech/pi-outpost/releases";
 
-/** Where packages come from when nothing on the host says otherwise. */
+/** Used only when npm is not installed (not when npm reports a registry error). */
 export const PUBLIC_REGISTRY = "https://registry.npmjs.org";
 
-/**
- * Which registry to ask.
- *
- * Hardcoding the public one breaks the deployment that needs update checking
- * most: air-gapped from the wider internet, reaching npm through an internal
- * proxy. npm already knows that address, so it is asked before anything is
- * assumed. Order: pi-outpost's own setting, the variable npm exports to scripts
- * it runs, npm's stored configuration, then the public default.
- *
- * `npm config get registry` is last because it costs a child process, and this
- * runs on a path that must not delay startup — it is consulted only when the
- * environment did not already answer.
- *
- * The install path needs none of this: `npm install` reads the same
- * configuration itself, and telling it a registry we resolved would be one more
- * way to disagree with npm.
- */
-export function resolveRegistry(configured?: string): string {
-  const fromConfig = configured?.trim();
-  if (fromConfig) return trimSlash(fromConfig);
-
-  const fromEnv = process.env.npm_config_registry?.trim();
-  if (fromEnv) return trimSlash(fromEnv);
-
-  const fromNpm = npmConfiguredRegistry();
-  if (fromNpm) return trimSlash(fromNpm);
-
-  return PUBLIC_REGISTRY;
-}
-
-const trimSlash = (url: string): string => url.replace(/\/+$/, "");
-
-/** npm's stored registry, or nothing if npm is absent or slow to answer. */
 /**
  * The environment for a short-lived npm child, without the parent's coverage sink.
  *
@@ -191,9 +158,8 @@ function envForNpm(): NodeJS.ProcessEnv {
  * proxy whose address lives only in the operator's `.npmrc`, which npm alone can
  * read. Reported from such a site, on Windows, where this had never worked.
  *
- * `shell: true` would also run the batch file, by handing a command *string* to
- * `cmd.exe` to parse. Naming the file is enough, and keeps every argument a
- * vector element that nothing re-splits.
+ * The Windows lookup and installer builders below therefore invoke `cmd.exe`
+ * with fixed command text and keep configuration values in npm's environment.
  *
  * `npm_execpath` still wins where npm exported it: that is npm telling us which
  * npm is running, and it is a `.js` file run by this node, on every platform.
@@ -203,7 +169,7 @@ export function npmExecutable(platform: NodeJS.Platform = process.platform): str
 }
 
 /**
- * The probes additionally prefer the npm that started this process, when there
+ * Registry lookups additionally prefer the npm that started this process, when there
  * is one. The installer deliberately does not: it must run the npm the operator
  * would run by hand, reading their own configuration, rather than whichever npm
  * happened to launch the server.
@@ -216,48 +182,87 @@ export function npmCommand(
   return [npmExecutable(platform), []];
 }
 
-let npmRegistryMemo: { value: string | undefined; failure?: string } | undefined;
-
-/**
- * Why asking npm for the registry did not work, when it did not.
- *
- * The probe cannot print anything itself — it runs on the startup path, before
- * anyone has decided whether this is a background check or a command. But
- * swallowing the reason turns "npm could not be asked" into "npm said nothing",
- * which is indistinguishable from "npm says the public registry" at the point
- * where it matters: an operator behind an internal proxy, being told about a
- * version that came from the wrong place. The caller prints this when it falls
- * back to the public default.
- */
-export function npmRegistryProbeFailure(): string | undefined {
-  return npmRegistryMemo?.failure;
+export interface NpmViewInvocation {
+  command: string;
+  args: string[];
+  env: NodeJS.ProcessEnv;
 }
 
-function npmConfiguredRegistry(): string | undefined {
-  // At most once per process. Each call is a child process with a five-second
-  // ceiling, and nothing about npm's configuration changes while this runs.
-  if (npmRegistryMemo !== undefined) return npmRegistryMemo.value;
-  npmRegistryMemo = { value: undefined };
-  try {
-    // `getBuiltinModule` rather than `require`, which does not exist in an ES
-    // module, and rather than a dynamic import, which cannot be awaited here.
-    const { execFileSync } = process.getBuiltinModule("node:child_process");
-    const [command, argv] = npmCommand();
-    const out = execFileSync(command, [...argv, "config", "get", "registry"], {
-      encoding: "utf8",
-      timeout: 5_000,
-      stdio: ["ignore", "pipe", "ignore"],
-      shell: false,
-      env: envForNpm(),
-    }).trim();
-    // npm prints "undefined" rather than nothing when a key is unset.
-    npmRegistryMemo.value = out && out !== "undefined" && out !== "null" ? out : undefined;
-    if (npmRegistryMemo.value === undefined) npmRegistryMemo.failure = "npm has no registry configured";
-    return npmRegistryMemo.value;
-  } catch (error) {
-    npmRegistryMemo.failure = error instanceof Error ? error.message : String(error);
-    return undefined;
+function npmEnvironmentWithOverride(
+  registry: string | undefined,
+  base: NodeJS.ProcessEnv = envForNpm(),
+): NodeJS.ProcessEnv {
+  if (!registry) return { ...base };
+  const env = Object.fromEntries(
+    Object.entries(base).filter(([key]) => key.toLowerCase() !== "npm_config_registry"),
+  );
+  env.npm_config_registry = registry;
+  return env;
+}
+
+/**
+ * Build the npm-view process without asking a shell to parse configuration data.
+ *
+ * Windows cannot execute npm.cmd directly through execFile. When there is no
+ * npm_execpath to run with Node, cmd.exe receives a completely fixed command
+ * string; the optional registry travels through npm's environment instead. That
+ * keeps registry URLs (and their shell metacharacters) out of cmd.exe's input.
+ */
+export function npmViewInvocation(
+  registry?: string,
+  platform: NodeJS.Platform = process.platform,
+  npmExecPath = process.env.npm_execpath,
+): NpmViewInvocation {
+  const viewArgs = ["view", `${PACKAGE_NAME}@latest`, "version", "--json"];
+  if (platform === "win32" && !npmExecPath?.trim()) {
+    return {
+      command: process.env.ComSpec?.trim() || "cmd.exe",
+      args: ["/d", "/s", "/c", `npm.cmd ${viewArgs.join(" ")}`],
+      env: npmEnvironmentWithOverride(registry),
+    };
   }
+
+  const [command, prefix] = npmCommand(platform, npmExecPath);
+  return {
+    command,
+    args: [...prefix, ...viewArgs, ...(registry ? ["--registry", registry] : [])],
+    env: envForNpm(),
+  };
+}
+
+export interface NpmInstallInvocation extends NpmViewInvocation {
+  displayCommand: string;
+  displayArgs: string[];
+}
+
+/** Build a Windows-safe global install while keeping registry data out of cmd.exe. */
+export function npmInstallInvocation(
+  registry?: string,
+  platform: NodeJS.Platform = process.platform,
+): NpmInstallInvocation {
+  const displayCommand = npmExecutable(platform);
+  const displayArgs = [
+    "install",
+    "-g",
+    ...(registry ? ["--registry", registry] : []),
+    `${PACKAGE_NAME}@latest`,
+  ];
+  if (platform === "win32") {
+    return {
+      command: process.env.ComSpec?.trim() || "cmd.exe",
+      args: ["/d", "/s", "/c", `npm.cmd install -g ${PACKAGE_NAME}@latest`],
+      env: npmEnvironmentWithOverride(registry, process.env),
+      displayCommand,
+      displayArgs,
+    };
+  }
+  return {
+    command: displayCommand,
+    args: displayArgs,
+    env: { ...process.env },
+    displayCommand,
+    displayArgs,
+  };
 }
 
 /** Long enough for a slow link, short enough that `update --check` stays a command. */
@@ -282,99 +287,125 @@ export type VersionCheck =
   | { status: "incomparable"; running: string; latest: string }
   | { status: "failed"; running: string; reason: string };
 
-/**
- * What a registry answer has to look like, and the whole of what is asked of it.
- *
- * Narrower than `fetch` on purpose: this is the seam tests replace, and a seam the
- * shape of the standard API would invite the rest of that API to be relied on. It is
- * also what lets the real request be an `https.request` rather than a `fetch` — see
- * `registryRequest` for why it has to be.
- */
-export interface RegistryResponse {
-  ok: boolean;
-  status: number;
-  json: () => Promise<unknown>;
-}
-
-export type RegistryFetch = (
-  url: string,
+/** The narrow seam tests replace: ask the package manager for one dist-tag. */
+export type VersionLookup = (
   options: {
     signal: AbortSignal;
-    /**
-     * Whether the request may be the reason this process stays alive.
-     *
-     * False for a check somebody asked for — `update --check` has nothing else
-     * pending, so a request that cannot hold the loop open lets the process drain
-     * before the answer arrives: no output, and node exits 13 complaining about an
-     * unsettled top-level await. True only for the background notice, which nobody
-     * asked for and which must never delay a shutdown.
-     */
-    unref: boolean;
+    registry?: string;
+    /** True only when the lookup must not keep the process alive. */
+    background: boolean;
   },
-) => Promise<RegistryResponse>;
+) => Promise<unknown>;
 
 /**
- * One GET, with a socket that cannot hold the process open.
+ * Ask npm itself for the latest dist-tag.
  *
- * `fetch` would be the obvious way to write this and it cannot satisfy the contract:
- * it exposes no handle to `unref`, so a request still in flight keeps the event loop
- * alive until it settles. For a check nobody asked for, running in the background,
- * that turns "stop the server" into "wait out the registry timeout" — and it is
- * invisible against a registry that refuses fast, which is every registry until the
- * one that hangs.
- *
- * So the request is made through `node:https` and its socket can be unref'd. No new
- * dependency either way; what changes is that there is something to unref.
- *
- * Whether it *is* unref'd is the caller's to say. Unconditionally unref'ing was a bug
- * with no failing test: `update --check` awaits this at top level with nothing else
- * pending, so the loop emptied and the process exited 13 without printing a verdict.
- * Every test injected a fake, so the real request was never on the path being asserted.
+ * Resolving npm's registry URL and then issuing our own HTTP request was only a
+ * partial delegation: it bypassed the authentication, CA bundle, proxy and other
+ * transport settings in `.npmrc`. That made `npm view` work behind a corporate
+ * Nexus while `pi-outpost update` still tried (or failed) on a different path.
+ * Keeping the whole exchange inside npm makes its configuration the single source
+ * of truth. An explicit pi-outpost override is still passed as `--registry`.
  */
-const registryRequest: RegistryFetch = async (url, options) => {
-  const target = new URL(url);
+const npmViewLatestVersion: VersionLookup = async (options) => {
+  const { execFile } = process.getBuiltinModule("node:child_process");
+  const { command, args, env } = npmViewInvocation(options.registry);
+
+  return await new Promise<unknown>((resolve, reject) => {
+    const child = execFile(
+      command,
+      args,
+      {
+        encoding: "utf8",
+        env,
+        maxBuffer: 256 * 1024,
+        shell: false,
+        signal: options.signal,
+        windowsHide: true,
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+            reject(error);
+            return;
+          }
+          const detail = stderr.trim();
+          reject(new Error(detail || error.message));
+          return;
+        }
+        try {
+          resolve(JSON.parse(stdout.trim()) as unknown);
+        } catch {
+          reject(new Error("npm answered without a JSON version"));
+        }
+      },
+    );
+
+    // A startup check is a courtesy, never a reason the process must stay alive.
+    // The child and both pipe handles are ref'd independently by Node.
+    if (options.background) {
+      child.unref();
+      (child.stdout as { unref?: () => void } | null)?.unref?.();
+      (child.stderr as { unref?: () => void } | null)?.unref?.();
+    }
+  });
+};
+
+/**
+ * Preserve update checks for a self-contained executable on a host without npm.
+ * This is a fallback for an absent executable only: an npm registry/auth/CA error
+ * must be reported as-is, never retried through a request that bypasses `.npmrc`.
+ */
+const directRegistryLatestVersion: VersionLookup = async (options) => {
+  const configured = options.registry ?? process.env.npm_config_registry;
+  const base = configured?.trim() || PUBLIC_REGISTRY;
+  const target = new URL(`${base.replace(/\/+$/, "")}/${PACKAGE_NAME}/latest`);
   const transport = target.protocol === "http:"
     ? await import("node:http")
     : await import("node:https");
 
-  return await new Promise<RegistryResponse>((resolve, reject) => {
+  return await new Promise<unknown>((resolve, reject) => {
     const request = transport.request(
-      {
-        protocol: target.protocol,
-        hostname: target.hostname,
-        port: target.port,
-        path: `${target.pathname}${target.search}`,
-        method: "GET",
-        headers: { accept: "application/json" },
-      },
+      target,
+      { headers: { accept: "application/json" }, signal: options.signal },
       (response) => {
         const chunks: Buffer[] = [];
         response.on("data", (chunk: Buffer) => chunks.push(chunk));
         response.on("end", () => {
           const status = response.statusCode ?? 0;
-          resolve({
-            ok: status >= 200 && status < 300,
-            status,
-            json: async () => JSON.parse(Buffer.concat(chunks).toString("utf8")) as unknown,
-          });
+          if (status < 200 || status >= 300) {
+            reject(new Error(`the registry answered ${status}`));
+            return;
+          }
+          try {
+            const body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as { version?: unknown };
+            resolve(body.version);
+          } catch {
+            reject(new Error("the registry answered without JSON"));
+          }
         });
-        // The response body is a handle too, and it arrives after the socket one.
-        if (options.unref) response.socket?.unref();
+        if (options.background) response.socket?.unref();
       },
     );
-    // The reason this function exists. `socket` fires once the connection is assigned,
-    // which is the earliest point there is anything to unref.
-    if (options.unref) request.on("socket", (socket) => socket.unref());
+    if (options.background) request.on("socket", (socket) => socket.unref());
     request.on("error", reject);
-    options.signal.addEventListener("abort", () => request.destroy(new Error("aborted")), { once: true });
     request.end();
   });
+};
+
+const defaultLatestVersionLookup: VersionLookup = async (options) => {
+  try {
+    return await npmViewLatestVersion(options);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    return await directRegistryLatestVersion(options);
+  }
 };
 
 /**
  * Ask the registry for the newest published version.
  *
- * Exactly one field is taken from the answer. Nothing from the response is
+ * Exactly one version string is taken from npm's answer. Nothing from it is
  * executed, interpolated into a command, or trusted beyond a string comparison —
  * the install path names `@latest` rather than anything fetched, so a hostile
  * answer cannot choose what gets installed.
@@ -382,41 +413,35 @@ const registryRequest: RegistryFetch = async (url, options) => {
 export async function fetchLatestVersion(
   running: string,
   options: {
-    fetchImpl?: RegistryFetch;
+    lookupImpl?: VersionLookup;
     timeoutMs?: number;
     registry?: string;
     /**
-     * Nobody asked for this check, so it may not hold the process open — the socket
-     * and the timeout are both unref'd. Defaults to false, which is the safe way
+     * Nobody asked for this check, so it may not hold the process open — the child,
+     * its pipes and the timeout are unref'd. Defaults to false, which is the safe way
      * round: an answer that arrives late costs a caller some seconds, where an
      * answer that never arrives costs it the answer.
      */
     background?: boolean;
   } = {},
 ): Promise<VersionCheck> {
-  const doFetch = options.fetchImpl ?? registryRequest;
-  const registry = resolveRegistry(options.registry);
-  // A public-registry check on a host that configured another one is a check of
-  // the wrong shelf; say so rather than reporting its answer as the truth.
-  const probeFailure = registry === PUBLIC_REGISTRY ? npmRegistryProbeFailure() : undefined;
+  const lookup = options.lookupImpl ?? defaultLatestVersionLookup;
   const background = options.background ?? false;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), options.timeoutMs ?? REGISTRY_TIMEOUT_MS);
-  // Unref'd for the same reason the socket is, and under the same condition: for a
+  // Unref'd for the same reason the npm child is, and under the same condition: for a
   // background check neither may be why a process that wants to exit does not. For a
   // command, this timer is what turns a registry that hangs into a reported failure
   // rather than a silent exit.
   if (background) timer.unref?.();
   try {
-    const response = await doFetch(`${registry}/${PACKAGE_NAME}/latest`, {
+    const latest: unknown = await lookup({
       signal: controller.signal,
-      unref: background,
+      background,
+      ...(options.registry ? { registry: options.registry } : {}),
     });
-    if (!response.ok) return { status: "failed", running, reason: `the registry answered ${response.status}` };
-    const body: unknown = await response.json();
-    const latest = (body as { version?: unknown } | null)?.version;
     if (typeof latest !== "string" || latest === "") {
-      return { status: "failed", running, reason: "the registry answered without a version" };
+      return { status: "failed", running, reason: "npm answered without a version" };
     }
     if (isNewer(latest, running)) return { status: "newer", running, latest };
     // "not newer" is three different facts, and only one of them is "up to date".
@@ -429,15 +454,7 @@ export async function fetchLatestVersion(
       : error instanceof Error
         ? error.message
         : String(error);
-    // On a host that configured its own registry, a failure against the public
-    // one is a failure to *find* the configured address, not a failure of the
-    // network. Without this the operator reads "ENOTFOUND registry.npmjs.org"
-    // and has no way to know their own proxy was never consulted.
-    return {
-      status: "failed",
-      running,
-      reason: probeFailure === undefined ? reason : `${reason} (asked the public registry: ${probeFailure})`,
-    };
+    return { status: "failed", running, reason };
   } finally {
     clearTimeout(timer);
   }
@@ -484,10 +501,10 @@ export interface UpdateCommandOptions {
   /** Which setting did that, so the refusal can be acted on. */
   disabledReason?: string;
   channel?: InstallChannel;
-  fetchImpl?: RegistryFetch;
+  lookupImpl?: VersionLookup;
   registry?: string;
   /** Runs the installer. Injected so a test never installs anything. */
-  install?: (command: string, args: string[]) => Promise<number>;
+  install?: (command: string, args: string[], env?: NodeJS.ProcessEnv) => Promise<number>;
   log?: (line: string) => void;
 }
 
@@ -506,7 +523,7 @@ export async function runUpdateCommand(options: UpdateCommandOptions): Promise<n
   // process has left to do. Nothing here may be unref'd, or the loop empties before
   // the registry answers and the command prints nothing at all.
   const check = await fetchLatestVersion(options.version, {
-    ...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+    ...(options.lookupImpl ? { lookupImpl: options.lookupImpl } : {}),
     ...(options.registry ? { registry: options.registry } : {}),
   });
 
@@ -577,20 +594,10 @@ export async function runUpdateCommand(options: UpdateCommandOptions): Promise<n
       // the check would query the internal proxy and the install would then fetch
       // from the public one, announcing a private update and performing a different
       // one. Exactly the deployment the setting exists for.
-      const args = [
-        "install",
-        "-g",
-        ...(options.registry !== undefined ? ["--registry", options.registry] : []),
-        `${PACKAGE_NAME}@latest`,
-      ];
-      // The same argv vector the probes use, for the same Windows reason: a bare
-      // "npm" here reached `child.on("error")` and was reported as "the installer
-      // exited with 1", which reads as npm refusing the install rather than npm
-      // never having been started.
-      const npm = npmExecutable();
-      say(`[pi] running: ${npm} ${args.join(" ")}`);
+      const invocation = npmInstallInvocation(options.registry);
+      say(`[pi] running: ${invocation.displayCommand} ${invocation.displayArgs.join(" ")}`);
       const run = options.install ?? runInstaller;
-      const code = await run(npm, args);
+      const code = await run(invocation.command, invocation.args, invocation.env);
       if (code !== 0) {
         say(`[pi] the installer exited with ${code}; nothing was changed by pi-outpost itself`);
         return code;
@@ -602,10 +609,10 @@ export async function runUpdateCommand(options: UpdateCommandOptions): Promise<n
 }
 
 /** The installer as a child process: argv vector, no shell, output passed through. */
-async function runInstaller(command: string, args: string[]): Promise<number> {
+async function runInstaller(command: string, args: string[], env?: NodeJS.ProcessEnv): Promise<number> {
   const { spawn } = await import("node:child_process");
   return await new Promise<number>((resolve) => {
-    const child = spawn(command, args, { stdio: "inherit", shell: false });
+    const child = spawn(command, args, { stdio: "inherit", shell: false, env });
     child.on("error", () => resolve(1));
     child.on("exit", (code) => resolve(code ?? 1));
   });
@@ -840,7 +847,7 @@ export interface StartupNoticeOptions {
   settings: { updateCheck?: boolean; offline?: boolean };
   registry?: string;
   channel?: InstallChannel;
-  fetchImpl?: RegistryFetch;
+  lookupImpl?: VersionLookup;
   now?: number;
   log?: (line: string) => void;
 }
@@ -900,7 +907,7 @@ export async function runStartupUpdateNotice(options: StartupNoticeOptions): Pro
 
   const check = await fetchLatestVersion(options.version, {
     background: true,
-    ...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+    ...(options.lookupImpl ? { lookupImpl: options.lookupImpl } : {}),
     ...(options.registry ? { registry: options.registry } : {}),
   });
   // Silent on failure, and nothing cached: a failed check must not become a

--- a/server/test/update-command-process.test.mjs
+++ b/server/test/update-command-process.test.mjs
@@ -1,21 +1,22 @@
 /**
  * What `pi-outpost update` does at process level, which is where it was broken.
  *
- * Every other test of this command injects a `fetchImpl`, so the real request was
- * never on the path being asserted — and the real request unref'd its socket
+ * Every other test of this command injects a `lookupImpl`, so the real npm child was
+ * never on the path being asserted — and the old request unref'd its socket
  * unconditionally. `runUpdateCommand` is awaited at top level in index.ts with nothing
  * else pending, so the loop emptied before the registry answered: the command printed
  * no verdict at all and node exited 13 complaining about an unsettled top-level await.
  * Thirty-five scenarios passed over it.
  *
- * So these drive the real `registryRequest` against a real socket, in a child process
- * that awaits the command the way the binary does. The assertion that matters is not
+ * So these drive the real `npm view` path through a controlled fake npm, in a child
+ * process that awaits the command the way the binary does. The assertion that matters is not
  * the text — it is that there *is* output, and that the exit code is the command's own.
  */
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import http from "node:http";
-import net from "node:net";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { describe, test } from "node:test";
@@ -29,100 +30,176 @@ function envWithoutCoverageSink() {
   return rest;
 }
 
-/** A registry that answers, for the duration of one test. */
-async function withRegistry(version, body) {
-  const server = http.createServer((request, response) => {
-    response.writeHead(200, { "content-type": "application/json" });
-    response.end(JSON.stringify({ version }));
-  });
-  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
-  server.unref();
-  try {
-    return await body(`http://127.0.0.1:${server.address().port}`);
-  } finally {
-    server.close();
-  }
-}
-
-/**
- * A registry that accepts and never answers. An unroutable address will not do: it is
- * refused in milliseconds, so nothing is ever pending and the test passes whatever the
- * code does.
- */
-async function withBlackHole(body) {
-  const sockets = new Set();
-  const server = net.createServer((socket) => {
-    socket.unref();
-    sockets.add(socket);
-    socket.on("close", () => sockets.delete(socket));
-  });
-  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
-  server.unref();
-  try {
-    return await body(`http://127.0.0.1:${server.address().port}`);
-  } finally {
-    for (const socket of sockets) socket.destroy();
-    sockets.clear();
-    server.close();
-  }
-}
-
 /** Awaits the command at top level, as index.ts does, and exits with what it returned. */
-async function runCommandInChild(registry, { timeout }) {
+async function runCommandInChild(mode, { timeout, registry } = {}) {
+  const root = await mkdtemp(path.join(os.tmpdir(), "pi-outpost-fake-npm-"));
+  const fakeNpm = path.join(root, "npm-cli.mjs");
+  const expectedRegistry = registry ?? null;
+  await writeFile(fakeNpm, `
+    const args = process.argv.slice(2);
+    const expected = ["view", "pi-outpost@latest", "version", "--json"];
+    if (JSON.stringify(args.slice(0, 4)) !== JSON.stringify(expected)) {
+      console.error("unexpected npm argv: " + JSON.stringify(args));
+      process.exit(2);
+    }
+    const registryIndex = args.indexOf("--registry");
+    const expectedRegistry = ${JSON.stringify(expectedRegistry)};
+    if (expectedRegistry === null ? registryIndex !== -1 : args[registryIndex + 1] !== expectedRegistry) {
+      console.error("unexpected registry override: " + JSON.stringify(args));
+      process.exit(2);
+    }
+    if (${JSON.stringify(mode)} === "hang") setInterval(() => {}, 1_000);
+    else setTimeout(() => console.log(JSON.stringify("9.9.9")), 50);
+  `);
   const script = `
     import { runUpdateCommand } from ${JSON.stringify(UPDATE_MODULE)};
     const code = await runUpdateCommand({
       version: "0.1.0",
       checkOnly: true,
       channel: "global",
-      registry: ${JSON.stringify(registry)},
+      ${registry === undefined ? "" : `registry: ${JSON.stringify(registry)},`}
     });
     process.exit(code);
   `;
-  return await new Promise((resolve, reject) => {
-    const child = execFile(
-      process.execPath,
-      ["--import", "tsx/esm", "--input-type=module", "--eval", script],
-      { cwd: SERVER_DIR, timeout, env: envWithoutCoverageSink() },
-      (error, stdout, stderr) => {
-        if (error && error.killed) reject(new Error(`the command never finished:\n${stdout}${stderr}`));
-        else resolve({ code: error?.code ?? 0, stdout, stderr });
-      },
-    );
-    child.on("error", reject);
-  });
+  try {
+    return await new Promise((resolve, reject) => {
+      const child = execFile(
+        process.execPath,
+        ["--import", "tsx/esm", "--input-type=module", "--eval", script],
+        { cwd: SERVER_DIR, timeout, env: { ...envWithoutCoverageSink(), npm_execpath: fakeNpm } },
+        (error, stdout, stderr) => {
+          if (error && error.killed) reject(new Error(`the command never finished:\n${stdout}${stderr}`));
+          else resolve({ code: error?.code ?? 0, stdout, stderr });
+        },
+      );
+      child.on("error", reject);
+    });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 }
 
-// openlore: {"domain":"update","requirement":"UpdateReportsWhatIsAvailable","scenario":"TheCheckOutlivesNothingButItselfIsNotCutShort","specFile":"openspec/changes/add-cli-update-command/specs/update/spec.md"}
+/** Run through the host's real npm with its registry supplied only by `.npmrc`. */
+async function runThroughNpmrc(registry, { timeout }) {
+  const root = await mkdtemp(path.join(os.tmpdir(), "pi-outpost-npmrc-"));
+  const userconfig = path.join(root, ".npmrc");
+  await writeFile(userconfig, `registry=${registry}\n`);
+  const script = `
+    import { runUpdateCommand } from ${JSON.stringify(UPDATE_MODULE)};
+    const code = await runUpdateCommand({
+      version: "0.1.0",
+      checkOnly: true,
+      channel: "global",
+    });
+    process.exit(code);
+  `;
+  const {
+    npm_execpath: _npmExecPath,
+    npm_config_registry: _npmRegistry,
+    NPM_CONFIG_REGISTRY: _npmRegistryUpper,
+    ...baseEnv
+  } = envWithoutCoverageSink();
+  try {
+    return await new Promise((resolve, reject) => {
+      const child = execFile(
+        process.execPath,
+        ["--import", "tsx/esm", "--input-type=module", "--eval", script],
+        {
+          cwd: SERVER_DIR,
+          timeout,
+          env: {
+            ...baseEnv,
+            NPM_CONFIG_USERCONFIG: userconfig,
+            npm_config_cache: path.join(root, "cache"),
+            npm_config_update_notifier: "false",
+            NO_PROXY: "127.0.0.1",
+          },
+        },
+        (error, stdout, stderr) => {
+          if (error && error.killed) reject(new Error(`the command never finished:\n${stdout}${stderr}`));
+          else resolve({ code: error?.code ?? 0, stdout, stderr });
+        },
+      );
+      child.on("error", reject);
+    });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+async function withNexus(body) {
+  let requests = 0;
+  const server = http.createServer((request, response) => {
+    requests += 1;
+    response.writeHead(200, { "content-type": "application/json" });
+    if (request.url?.includes("/-/package/pi-outpost/dist-tags")) {
+      response.end(JSON.stringify({ latest: "9.9.9" }));
+    } else if (request.url?.endsWith("/latest")) {
+      response.end(JSON.stringify({ name: "pi-outpost", version: "9.9.9" }));
+    } else {
+      response.end(JSON.stringify({
+        name: "pi-outpost",
+        "dist-tags": { latest: "9.9.9" },
+        versions: { "9.9.9": { name: "pi-outpost", version: "9.9.9" } },
+      }));
+    }
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    return await body(`http://127.0.0.1:${server.address().port}`, () => requests);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+// openlore: {"domain":"update","requirement":"UpdateReportsWhatIsAvailable","scenario":"TheCheckOutlivesNothingButItselfIsNotCutShort","specFile":"openspec/specs/update/spec.md"}
+// openlore: {"domain":"update","requirement":"UpdateChecksUseTheConfiguredRegistry","scenario":"FallsBackToThePublicRegistry","specFile":"openspec/specs/update/spec.md"}
 describe("a check somebody asked for", () => {
   test("prints its verdict rather than draining the process first", async () => {
-    await withRegistry("9.9.9", async (registry) => {
-      const { code, stdout, stderr } = await runCommandInChild(registry, { timeout: 30_000 });
+    const { code, stdout, stderr } = await runCommandInChild("answer", { timeout: 30_000 });
 
-      // The exit code first: 13 is node's for an unsettled top-level await, and it is
-      // what this produced before the request could be ref'd. Naming it separates the
-      // regression from any other non-zero exit.
-      assert.notEqual(code, 13, `the process drained with the check still in flight:\n${stdout}${stderr}`);
+    // The exit code first: 13 is node's for an unsettled top-level await, and it is
+    // what this produced before the request could be ref'd. Naming it separates the
+    // regression from any other non-zero exit.
+    assert.notEqual(code, 13, `the process drained with the check still in flight:\n${stdout}${stderr}`);
+    assert.equal(code, 0, `update --check exited ${code}:\n${stdout}${stderr}`);
+    assert.match(stdout, /0\.1\.0 is installed; 9\.9\.9 is available/);
+    // And nothing about an await that never settled.
+    assert.doesNotMatch(stderr, /unsettled top-level await/);
+  });
+});
+
+// openlore: {"domain":"update","requirement":"UpdateChecksUseTheConfiguredRegistry","scenario":"UsesThePackageManagerRegistry","specFile":"openspec/specs/update/spec.md"}
+describe("a Nexus registry configured only in .npmrc", () => {
+  test("is reached through npm with no duplicate pi-outpost setting", async () => {
+    await withNexus(async (registry, requests) => {
+      const { code, stdout, stderr } = await runThroughNpmrc(registry, { timeout: 30_000 });
       assert.equal(code, 0, `update --check exited ${code}:\n${stdout}${stderr}`);
       assert.match(stdout, /0\.1\.0 is installed; 9\.9\.9 is available/);
-      // And nothing about an await that never settled.
-      assert.doesNotMatch(stderr, /unsettled top-level await/);
+      assert.ok(requests() > 0, "npm never queried the Nexus registry from .npmrc");
     });
   });
 });
 
-// openlore: {"domain":"update","requirement":"UpdateReportsWhatIsAvailable","scenario":"TheCheckOutlivesNothingButItselfIsNotCutShort","specFile":"openspec/changes/add-cli-update-command/specs/update/spec.md"}
+// openlore: {"domain":"update","requirement":"UpdateChecksUseTheConfiguredRegistry","scenario":"ConfiguredOverrideWins","specFile":"openspec/specs/update/spec.md"}
+describe("an explicit registry override", () => {
+  test("is passed to npm while the default leaves npm's own configuration alone", async () => {
+    const registry = "https://nexus.internal/repository/npm-group";
+    const { code, stdout, stderr } = await runCommandInChild("answer", { timeout: 30_000, registry });
+    assert.equal(code, 0, `update --check exited ${code}:\n${stdout}${stderr}`);
+  });
+});
+
+// openlore: {"domain":"update","requirement":"UpdateReportsWhatIsAvailable","scenario":"TheCheckOutlivesNothingButItselfIsNotCutShort","specFile":"openspec/specs/update/spec.md"}
 describe("a registry that never answers", () => {
   test("is reported as a failed check, not as silence", async () => {
     // The other half of the same property. The timeout is what turns a hang into a
     // verdict, and an unref'd timer cannot fire in a process with nothing else to do —
     // it would exit silently instead, which is the answer that stops someone looking.
-    await withBlackHole(async (registry) => {
-      const { code, stdout, stderr } = await runCommandInChild(registry, { timeout: 30_000 });
+    const { code, stdout, stderr } = await runCommandInChild("hang", { timeout: 30_000 });
 
-      assert.equal(code, 1, `expected a reported failure, got ${code}:\n${stdout}${stderr}`);
-      assert.match(stdout, /could not check for updates/);
-      assert.doesNotMatch(stdout, /newest published version/);
-    });
+    assert.equal(code, 1, `expected a reported failure, got ${code}:\n${stdout}${stderr}`);
+    assert.match(stdout, /could not check for updates/);
+    assert.doesNotMatch(stdout, /newest published version/);
   });
 });

--- a/server/test/update.test.ts
+++ b/server/test/update.test.ts
@@ -21,15 +21,16 @@ import {
   isNewer,
   npmCommand,
   npmExecutable,
+  npmInstallInvocation,
+  npmViewInvocation,
   readCache,
-  resolveRegistry,
   runStartupUpdateNotice,
   runUpdateCommand,
   shouldCheckAtStartup,
   writeCache,
   type ChannelEvidence,
   type InstallChannel,
-  type RegistryFetch,
+  type VersionLookup,
 } from "../src/update.ts";
 
 const roots: string[] = [];
@@ -195,115 +196,53 @@ describe("isNewer", () => {
 });
 
 describe("fetchLatestVersion", () => {
-  const respond = (body: unknown, ok = true, status = 200): RegistryFetch =>
-    async () => ({ ok, status, json: async () => body });
+  const respond = (version: unknown): VersionLookup => async () => version;
 
   test("reports a newer version with both numbers", async () => {
-    const result = await fetchLatestVersion("0.8.0", { fetchImpl: respond({ version: "0.9.0" }) });
+    const result = await fetchLatestVersion("0.8.0", { lookupImpl: respond("0.9.0") });
     assert.deepEqual(result, { status: "newer", running: "0.8.0", latest: "0.9.0" });
   });
 
   test("reports current when the registry has nothing later", async () => {
-    const result = await fetchLatestVersion("0.9.0", { fetchImpl: respond({ version: "0.9.0" }) });
+    const result = await fetchLatestVersion("0.9.0", { lookupImpl: respond("0.9.0") });
     assert.equal(result.status, "current");
   });
 
-  test("asks for exactly one package's latest, and reads only its version", async () => {
-    let asked = "";
-    const spy: RegistryFetch = async (url) => {
-      asked = String(url);
-      // Everything else in a registry document is ignored on purpose.
-      return { ok: true, status: 200, json: async () => ({ version: "0.9.0", scripts: { postinstall: "rm -rf /" } }) };
+  test("passes an explicit registry override to npm's lookup", async () => {
+    let asked: string | undefined;
+    const spy: VersionLookup = async (options) => {
+      asked = options.registry;
+      return "0.9.0";
     };
-    const result = await fetchLatestVersion("0.8.0", { fetchImpl: spy, registry: "https://registry.example" });
-    assert.equal(asked, "https://registry.example/pi-outpost/latest");
+    const result = await fetchLatestVersion("0.8.0", { lookupImpl: spy, registry: "https://registry.example" });
+    assert.equal(asked, "https://registry.example");
     assert.equal(result.status, "newer");
   });
 
   /** The whole point of the third state: a failed check is not "you are current". */
   test("a transport error is a failure, not a verdict", async () => {
-    const boom: RegistryFetch = async () => {
+    const boom: VersionLookup = async () => {
       throw new Error("getaddrinfo ENOTFOUND registry.npmjs.org");
     };
-    const result = await fetchLatestVersion("0.8.0", { fetchImpl: boom });
+    const result = await fetchLatestVersion("0.8.0", { lookupImpl: boom });
     assert.equal(result.status, "failed");
     assert.match(result.status === "failed" ? result.reason : "", /ENOTFOUND/);
   });
 
-  test("a non-OK response is a failure naming the status", async () => {
-    const result = await fetchLatestVersion("0.8.0", { fetchImpl: respond({}, false, 503) });
-    assert.equal(result.status, "failed");
-    assert.match(result.status === "failed" ? result.reason : "", /503/);
-  });
-
   test("an answer without a version is a failure, not a comparison against undefined", async () => {
-    const result = await fetchLatestVersion("0.8.0", { fetchImpl: respond({ name: "pi-outpost" }) });
+    const result = await fetchLatestVersion("0.8.0", { lookupImpl: respond({ name: "pi-outpost" }) });
     assert.equal(result.status, "failed");
   });
 
   test("a registry that never answers is bounded", async () => {
-    const never = ((_url: string, init?: { signal?: AbortSignal }) =>
+    const never: VersionLookup = (options) =>
       new Promise((_resolve, reject) => {
-        init?.signal?.addEventListener("abort", () => reject(new Error("aborted")));
-      })) as unknown as typeof fetch;
+        options.signal.addEventListener("abort", () => reject(new Error("aborted")));
+      });
     const started = Date.now();
-    const result = await fetchLatestVersion("0.8.0", { fetchImpl: never, timeoutMs: 50 });
+    const result = await fetchLatestVersion("0.8.0", { lookupImpl: never, timeoutMs: 50 });
     assert.equal(result.status, "failed");
     assert.ok(Date.now() - started < 2_000, "the request must not outlive its timeout");
-  });
-});
-
-/**
- * The deployment that needs update checking most is air-gapped from the public
- * internet and reaches npm through an internal proxy. Hardcoding
- * registry.npmjs.org would make the feature useless exactly there.
- */
-describe("resolveRegistry", () => {
-  const withEnv = async (value: string | undefined, body: () => void | Promise<void>) => {
-    const had = Object.hasOwn(process.env, "npm_config_registry");
-    const previous = process.env.npm_config_registry;
-    if (value === undefined) delete process.env.npm_config_registry;
-    else process.env.npm_config_registry = value;
-    try {
-      await body();
-    } finally {
-      if (had) process.env.npm_config_registry = previous;
-      else delete process.env.npm_config_registry;
-    }
-  };
-
-  test("pi-outpost's own setting wins over everything", async () => {
-    await withEnv("https://from-env.example", () => {
-      assert.equal(resolveRegistry("https://nexus.internal/repository/npm"), "https://nexus.internal/repository/npm");
-    });
-  });
-
-  test("npm's exported variable is used when nothing is configured", async () => {
-    await withEnv("https://nexus.internal/repository/npm/", () => {
-      assert.equal(resolveRegistry(), "https://nexus.internal/repository/npm");
-    });
-  });
-
-  test("a trailing slash is trimmed, so the path join cannot double it", async () => {
-    await withEnv(undefined, () => {
-      assert.equal(resolveRegistry("https://nexus.internal/npm///"), "https://nexus.internal/npm");
-    });
-  });
-
-  test("blank settings do not count as an answer", async () => {
-    await withEnv("   ", () => {
-      // Falls through to npm's stored config or the public default — either is a
-      // real registry, which "" is not.
-      assert.notEqual(resolveRegistry("  "), "");
-      assert.match(resolveRegistry("  "), /^https?:\/\//);
-    });
-  });
-
-  test("the public registry is the last resort, not the first choice", async () => {
-    // Whatever this host's npm says, the answer is a usable absolute URL.
-    await withEnv(undefined, () => {
-      assert.match(resolveRegistry(), /^https?:\/\//);
-    });
   });
 });
 
@@ -376,11 +315,11 @@ describe("the remembered answer", () => {
  * are injected, and the install spy is what proves "--check installs nothing" rather
  * than a comment claiming it.
  */
-function stubRegistry(latest: string): RegistryFetch {
-  return async () => ({ ok: true, status: 200, json: async () => ({ version: latest }) });
+function stubLookup(latest: string): VersionLookup {
+  return async () => latest;
 }
 
-const unreachable: RegistryFetch = async () => {
+const unreachable: VersionLookup = async () => {
   throw new Error("getaddrinfo ENOTFOUND registry.example");
 };
 
@@ -397,7 +336,7 @@ async function runUpdate(
     checkOnly?: boolean;
     channel?: InstallChannel;
     latest?: string;
-    fetchImpl?: RegistryFetch;
+    lookupImpl?: VersionLookup;
     installExit?: number;
     checkingDisabled?: boolean;
     disabledReason?: string;
@@ -415,10 +354,7 @@ async function runUpdate(
     // is tested directly, next door.
     channel: over.channel ?? "global",
     ...(over.checkingDisabled ? { checkingDisabled: true, disabledReason: over.disabledReason } : {}),
-    fetchImpl: over.fetchImpl ?? stubRegistry(over.latest ?? "0.9.0"),
-    // Named explicitly so resolveRegistry never shells out to `npm config get
-    // registry`: that costs a child process per run, and makes the result depend on
-    // whatever registry the developer's npm happens to point at.
+    lookupImpl: over.lookupImpl ?? stubLookup(over.latest ?? "0.9.0"),
     ...(over.registry === null ? {} : { registry: over.registry ?? "https://registry.example" }),
     install: async (command, args) => {
       installs.push({ command, args });
@@ -448,6 +384,48 @@ describe("npmCommand", () => {
       assert.deepEqual(npmCommand(platform, "/npm/bin/npm-cli.js"), [process.execPath, ["/npm/bin/npm-cli.js"]]);
     }
   });
+
+  test("runs npm.cmd through cmd.exe on Windows without putting the registry in shell input", () => {
+    const registry = "https://nexus.internal/npm?one=1&two=2";
+    const invocation = npmViewInvocation(registry, "win32", "");
+    assert.match(invocation.command.toLowerCase(), /cmd(?:\.exe)?$/);
+    assert.deepEqual(invocation.args, [
+      "/d",
+      "/s",
+      "/c",
+      "npm.cmd view pi-outpost@latest version --json",
+    ]);
+    assert.equal(invocation.env.npm_config_registry, registry);
+    assert.ok(!invocation.args.some((arg) => arg.includes(registry)));
+  });
+
+  test("removes case-insensitive registry collisions before applying a Windows override", () => {
+    const previousUpper = process.env.NPM_CONFIG_REGISTRY;
+    const previousLower = process.env.npm_config_registry;
+    process.env.NPM_CONFIG_REGISTRY = "https://wrong.example";
+    process.env.npm_config_registry = "https://also-wrong.example";
+    try {
+      const invocation = npmViewInvocation("https://nexus.internal/npm", "win32", "");
+      const registryKeys = Object.keys(invocation.env)
+        .filter((key) => key.toLowerCase() === "npm_config_registry");
+      assert.deepEqual(registryKeys, ["npm_config_registry"]);
+      assert.equal(invocation.env.npm_config_registry, "https://nexus.internal/npm");
+    } finally {
+      if (previousUpper === undefined) delete process.env.NPM_CONFIG_REGISTRY;
+      else process.env.NPM_CONFIG_REGISTRY = previousUpper;
+      if (previousLower === undefined) delete process.env.npm_config_registry;
+      else process.env.npm_config_registry = previousLower;
+    }
+  });
+
+  test("runs a Windows install through cmd.exe with a fixed shell command", () => {
+    const registry = "https://nexus.internal/npm?one=1&two=2";
+    const invocation = npmInstallInvocation(registry, "win32");
+    assert.match(invocation.command.toLowerCase(), /cmd(?:\.exe)?$/);
+    assert.deepEqual(invocation.args, ["/d", "/s", "/c", "npm.cmd install -g pi-outpost@latest"]);
+    assert.equal(invocation.env.npm_config_registry, registry);
+    assert.ok(!invocation.args.some((arg) => arg.includes(registry)));
+  });
 });
 
 describe("update --check", () => {
@@ -466,7 +444,7 @@ describe("update --check", () => {
   });
 
   test("a registry it cannot reach is a failure, never a claim of currency", async () => {
-    const run = await runUpdate({ checkOnly: true, channel: "global", fetchImpl: unreachable });
+    const run = await runUpdate({ checkOnly: true, channel: "global", lookupImpl: unreachable });
     assert.equal(run.code, 1, "a failed check must not exit zero");
     assert.ok(run.said(/could not check for updates/));
     assert.ok(!run.said(/newest published version/), "a failed check must not read as up to date");
@@ -491,15 +469,15 @@ describe("update --check", () => {
 
   test("configuration that disabled checking is named, and no request is made", async () => {
     let asked = false;
-    const spy: RegistryFetch = async () => {
+    const spy: VersionLookup = async () => {
       asked = true;
-      return { ok: true, status: 200, json: async () => ({}) };
+      return "9.9.9";
     };
     const run = await runUpdate({
       checkOnly: true,
       checkingDisabled: true,
       disabledReason: '"updateCheck" is false',
-      fetchImpl: spy,
+      lookupImpl: spy,
     });
     assert.equal(run.code, 1);
     assert.ok(run.said(/update checking is disabled: "updateCheck" is false/));
@@ -513,12 +491,12 @@ describe("update, by channel", () => {
     assert.equal(run.code, 0);
     // `npmExecutable()` rather than the literal "npm": on Windows it is npm.cmd,
     // and pinning the name here would assert the very bug this file now guards.
-    const npm = npmExecutable();
-    assert.deepEqual(run.installs, [{ command: npm, args: ["install", "-g", "pi-outpost@latest"] }]);
+    const invocation = npmInstallInvocation();
+    assert.deepEqual(run.installs, [{ command: invocation.command, args: invocation.args }]);
     // The printed command and the executed one must be the same thing: printing it
     // is what makes the action auditable, and a mismatch makes that worse than useless.
     const printed = run.lines.find((line) => line.startsWith("[pi] running:"));
-    assert.equal(printed, `[pi] running: ${npm} install -g pi-outpost@latest`);
+    assert.equal(printed, `[pi] running: ${invocation.displayCommand} ${invocation.displayArgs.join(" ")}`);
   });
 
   test("the installer runs the npm this platform can actually execute", async () => {
@@ -530,8 +508,9 @@ describe("update, by channel", () => {
     // `registry: null` for the bare form: an override would add --registry and
     // say nothing about the command, which is what this test is about.
     const run = await runUpdate({ channel: "global", latest: "0.9.0", registry: null });
-    assert.equal(run.installs[0]?.command, process.platform === "win32" ? "npm.cmd" : "npm");
-    assert.deepEqual(run.installs[0]?.args, ["install", "-g", "pi-outpost@latest"], "the argv vector is untouched");
+    const invocation = npmInstallInvocation();
+    assert.equal(run.installs[0]?.command, invocation.command);
+    assert.deepEqual(run.installs[0]?.args, invocation.args);
     assert.ok(run.said(/running: npm(\.cmd)? install -g/), `announced: ${run.lines.join(" | ")}`);
   });
 
@@ -539,7 +518,7 @@ describe("update, by channel", () => {
     // @latest, not the fetched string: the registry says what is newest, and does
     // not get to say what gets installed.
     const run = await runUpdate({ channel: "global", latest: "9.9.9", registry: null });
-    assert.deepEqual(run.installs[0]?.args, ["install", "-g", "pi-outpost@latest"]);
+    assert.deepEqual(run.installs[0]?.args, npmInstallInvocation().args);
     assert.ok(!JSON.stringify(run.installs).includes("9.9.9"));
   });
 
@@ -550,18 +529,13 @@ describe("update, by channel", () => {
     assert.deepEqual(run.installs, []);
   });
 
+  // openlore: {"domain":"update","requirement":"UpdateChecksUseTheConfiguredRegistry","scenario":"TheInstallUsesTheRegistryTheCheckUsed","specFile":"openspec/specs/update/spec.md"}
   test("a configured registry is passed to the installer, so check and install agree", async () => {
     // Without this the check queries the internal proxy and the install fetches from
     // the public one: an update announced from one registry and performed from
     // another, in exactly the deployment the setting exists for.
     const run = await runUpdate({ channel: "global", latest: "0.9.0", registry: "https://nexus.internal/npm" });
-    assert.deepEqual(run.installs[0]?.args, [
-      "install",
-      "-g",
-      "--registry",
-      "https://nexus.internal/npm",
-      "pi-outpost@latest",
-    ]);
+    assert.deepEqual(run.installs[0]?.args, npmInstallInvocation("https://nexus.internal/npm").args);
     // And what was printed is still what was run.
     assert.equal(
       run.lines.find((line) => line.startsWith("[pi] running:")),
@@ -571,7 +545,7 @@ describe("update, by channel", () => {
 
   test("no override leaves the command bare, so npm reads its own configuration", async () => {
     const run = await runUpdate({ channel: "global", latest: "0.9.0", registry: null });
-    assert.deepEqual(run.installs[0]?.args, ["install", "-g", "pi-outpost@latest"]);
+    assert.deepEqual(run.installs[0]?.args, npmInstallInvocation().args);
   });
 
   test("an installer that fails surfaces its code and claims nothing", async () => {
@@ -671,13 +645,13 @@ describe("whether to check at startup", () => {
 
 describe("the startup notice", () => {
   /** Counts requests, so "made no request" is asserted rather than assumed. */
-  function countingRegistry(latest: string): { fetchImpl: RegistryFetch; calls: () => number } {
+  function countingLookup(latest: string): { lookupImpl: VersionLookup; calls: () => number } {
     let calls = 0;
-    const fetchImpl: RegistryFetch = async () => {
+    const lookupImpl: VersionLookup = async () => {
       calls += 1;
-      return { ok: true, status: 200, json: async () => ({ version: latest }) };
+      return latest;
     };
-    return { fetchImpl, calls: () => calls };
+    return { lookupImpl, calls: () => calls };
   }
 
   async function notice(over: {
@@ -685,7 +659,7 @@ describe("the startup notice", () => {
     settings?: { updateCheck?: boolean; offline?: boolean };
     channel?: InstallChannel;
     latest?: string;
-    fetchImpl?: RegistryFetch;
+    lookupImpl?: VersionLookup;
     now?: number;
     agentDir?: string;
   }): Promise<{ lines: string[]; agentDir: string }> {
@@ -697,7 +671,7 @@ describe("the startup notice", () => {
       settings: over.settings ?? {},
       channel: over.channel ?? "global",
       registry: "https://registry.example",
-      ...(over.fetchImpl ? { fetchImpl: over.fetchImpl } : {}),
+      ...(over.lookupImpl ? { lookupImpl: over.lookupImpl } : {}),
       ...(over.now !== undefined ? { now: over.now } : {}),
       log: (line) => lines.push(line),
     });
@@ -705,24 +679,24 @@ describe("the startup notice", () => {
   }
 
   test("says a newer version exists, and names the command that acts on it", async () => {
-    const { fetchImpl } = countingRegistry("0.9.0");
-    const { lines } = await notice({ fetchImpl });
+    const { lookupImpl } = countingLookup("0.9.0");
+    const { lines } = await notice({ lookupImpl });
     assert.equal(lines.length, 1);
     assert.match(lines[0]!, /0\.9\.0 is available \(running 0\.8\.0\)/);
     assert.match(lines[0]!, /pi-outpost update/);
   });
 
   test("is silent when the running version is current", async () => {
-    const { fetchImpl } = countingRegistry("0.8.0");
-    const { lines } = await notice({ fetchImpl });
+    const { lookupImpl } = countingLookup("0.8.0");
+    const { lines } = await notice({ lookupImpl });
     assert.deepEqual(lines, []);
   });
 
   test("is silent when the check fails, and remembers nothing", async () => {
-    const boom: RegistryFetch = async () => {
+    const boom: VersionLookup = async () => {
       throw new Error("ENOTFOUND");
     };
-    const { lines, agentDir } = await notice({ fetchImpl: boom });
+    const { lines, agentDir } = await notice({ lookupImpl: boom });
     assert.deepEqual(lines, []);
     // A failure must not become a remembered answer that suppresses the next real one.
     assert.equal(await readCache(agentDir), undefined);
@@ -732,8 +706,8 @@ describe("the startup notice", () => {
     const agentDir = await workspace();
     const now = Date.now();
     await writeCache(agentDir, { latest: "0.9.0", checkedAt: now });
-    const { fetchImpl, calls } = countingRegistry("0.9.0");
-    const { lines } = await notice({ agentDir, fetchImpl, now: now + 1000 });
+    const { lookupImpl, calls } = countingLookup("0.9.0");
+    const { lines } = await notice({ agentDir, lookupImpl, now: now + 1000 });
     assert.equal(calls(), 0, "a fresh cache must not be re-queried");
     assert.match(lines[0] ?? "", /0\.9\.0 is available/);
   });
@@ -742,8 +716,8 @@ describe("the startup notice", () => {
     const agentDir = await workspace();
     const now = Date.now();
     await writeCache(agentDir, { latest: "0.8.5", checkedAt: now - CHECK_INTERVAL_MS - 1 });
-    const { fetchImpl, calls } = countingRegistry("0.9.0");
-    await notice({ agentDir, fetchImpl, now });
+    const { lookupImpl, calls } = countingLookup("0.9.0");
+    await notice({ agentDir, lookupImpl, now });
     assert.equal(calls(), 1);
     assert.deepEqual(await readCache(agentDir), { latest: "0.9.0", checkedAt: now });
   });
@@ -755,8 +729,8 @@ describe("the startup notice", () => {
       ["the key off under offline", { settings: { updateCheck: false, offline: true } }],
       ["a source checkout", { settings: {}, channel: "checkout" as InstallChannel, version: "dev" }],
     ] as const) {
-      const { fetchImpl, calls } = countingRegistry("9.9.9");
-      const { lines } = await notice({ ...over, fetchImpl });
+      const { lookupImpl, calls } = countingLookup("9.9.9");
+      const { lines } = await notice({ ...over, lookupImpl });
       assert.equal(calls(), 0, `${label} still queried the registry`);
       assert.deepEqual(lines, [], `${label} still printed something`);
     }
@@ -767,10 +741,10 @@ describe("the startup notice", () => {
     // for a version to be installed is the update command run without --check. This
     // pins the full set of effects, so an installer appearing here would show up as
     // an effect this test does not allow.
-    const { fetchImpl } = countingRegistry("0.9.0");
+    const { lookupImpl } = countingLookup("0.9.0");
     const agentDir = await workspace();
     const before = await readdir(agentDir);
-    const { lines } = await notice({ agentDir, fetchImpl });
+    const { lines } = await notice({ agentDir, lookupImpl });
 
     assert.equal(lines.length, 1, "the notice is one line, not a transcript of an install");
     assert.match(lines[0]!, /is available/);
@@ -785,8 +759,8 @@ describe("the startup notice", () => {
   });
 
   test("explicitly enabled still checks under offline", async () => {
-    const { fetchImpl, calls } = countingRegistry("0.9.0");
-    const { lines } = await notice({ settings: { offline: true, updateCheck: true }, fetchImpl });
+    const { lookupImpl, calls } = countingLookup("0.9.0");
+    const { lines } = await notice({ settings: { offline: true, updateCheck: true }, lookupImpl });
     assert.equal(calls(), 1, "an explicit yes must survive offline");
     assert.match(lines[0] ?? "", /0\.9\.0 is available/);
   });


### PR DESCRIPTION
## Summary

- resolve the latest pi-outpost version through `npm view` so npm applies the complete `.npmrc` configuration (Nexus registry, authentication, CA certificates, and proxies)
- preserve `updateRegistry` as an explicit override and keep check/install registry selection aligned
- make both lookup and installation Windows-safe without putting registry values into shell command text
- document the behavior and cover the applicable OpenSpec registry scenarios

## Validation

- focused update tests: 75/75 passed
- real npm + temporary `.npmrc` + local Nexus fixture: passed
- server TypeScript typecheck: passed
- `openspec validate --all --strict`: 45/45 passed
- final code review: approved, no findings

The full server run reached 1668/1669 before exposing an incomplete fake-Nexus response shape. The fixture was updated to serve npm metadata and dist-tag endpoints correctly, and its integration suite then passed 4/4.