### PR TITLE
chore(release): v0.17.1

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-outpost",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "type": "module",
   "description": "A web interface for the pi coding agent: a browser chat UI you run with npx — no clone, no build.",
   "license": "MIT",

--- a/embed/package.json
+++ b/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-outpost/embed",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "type": "module",
   "description": "Mount pi-outpost as a Shadow-DOM-isolated widget inside another web app.",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "cli": {
       "name": "pi-outpost",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "^0.84.4",
@@ -42,7 +42,7 @@
     },
     "embed": {
       "name": "@pi-outpost/embed",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT",
       "devDependencies": {
         "@microsoft/api-extractor": "^7.58.9",


### PR DESCRIPTION
## Summary

Prepare the `0.17.1` patch release after #137:

- bump `pi-outpost` from 0.17.0 to 0.17.1
- bump `@pi-outpost/embed` to the same release version, as required by the tag-driven release workflow
- update the workspace lockfile

## Draft release notes

### Improvements

- **Model-aware thinking levels.** The thinking control now offers only the levels accepted by the selected model, including models whose supported levels contain gaps. The available choices refresh after a model change. (#133)

### Fixes

- **File browser recovery after reconnect.** The Files panel now reloads its root after a WebSocket reconnect, and Refresh can recover an empty tree without requiring a page reload. (#136)
- **Update checks behind npm proxies and Nexus.** `pi-outpost update` now resolves the latest version through npm itself, so existing `.npmrc` authentication, CA certificates, proxy settings, and internal registries are respected. Explicit `updateRegistry` overrides remain supported. Lookup and installation are also safe on Windows. (#137)

### Documentation

- Reworked the README around operating pi-outpost, covering projects, persisted settings, sandboxing, skills, extensions, interface options, and previously undocumented configuration keys. (#134)
- Added a five-minute getting-started path and task-oriented recipes for local models, remote access, profiles, shared deployments, systemd, standalone executables, embedding, and troubleshooting. (#135)

### Upgrade

```bash
npm install -g pi-outpost@0.17.1
```

Existing Nexus or private-registry users do not need a separate pi-outpost registry setting when npm is already configured through `.npmrc`.

**Full changelog:** https://github.com/laurentftech/pi-outpost/compare/v0.17.0...v0.17.1

## Validation

- release workflow/channel tests: 10/10 passed
- `node scripts/release-channel.mjs 0.17.1` resolves to `latest`
- CLI, embed, and lockfile versions all resolve to 0.17.1
- `git diff --check` passed

Merging this PR does not publish the release. Publication remains triggered separately by pushing tag `v0.17.1`.