### PR TITLE
docs: correct user and developer guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,25 @@ and report the fallback.
 - ALWAYS use `rg` (ripgrep) instead of `grep` for code search and file inspection.
 - NEVER run recursive `grep -r` commands. `rg` is faster and respects `.gitignore`.
 
+## Documentation impact before every PR
+
+Before opening or updating any pull request:
+
+1. Inspect the diff for changes that affect documented behaviour: user flows, CLI
+   commands and flags, configuration keys/defaults, environment variables, APIs,
+   UI behaviour, deployment, compatibility, prerequisites, or developer workflows.
+2. Search every relevant user and developer document (`README.md`, `docs/`, package
+   READMEs, examples, and operational guides) for the affected concepts.
+3. Compare affected claims, examples, and commands against the implementation,
+   schemas, CLI help, package scripts, and tests. Update stale documentation in the
+   same PR.
+4. Validate changed documentation proportionately: local links and anchors, fenced
+   JSON, documented commands, and externally referenced facts where applicable.
+5. Add a `Documentation impact` note to the PR description. List the files updated,
+   or state `None` with a brief reason when the diff has no documentation impact.
+
+This is an impact review, not a mandatory full reread of unrelated documentation.
+
 ## Spec scenario coverage
 
 Before calling a feature complete, prove that every applicable OpenSpec scenario

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,25 @@ and report the fallback.
 - ALWAYS use `rg` (ripgrep) instead of `grep` for code search and file inspection.
 - NEVER run recursive `grep -r` commands. `rg` is faster and respects `.gitignore`.
 
+## Documentation impact before every PR
+
+Before opening or updating any pull request:
+
+1. Inspect the diff for changes that affect documented behaviour: user flows, CLI
+   commands and flags, configuration keys/defaults, environment variables, APIs,
+   UI behaviour, deployment, compatibility, prerequisites, or developer workflows.
+2. Search every relevant user and developer document (`README.md`, `docs/`, package
+   READMEs, examples, and operational guides) for the affected concepts.
+3. Compare affected claims, examples, and commands against the implementation,
+   schemas, CLI help, package scripts, and tests. Update stale documentation in the
+   same PR.
+4. Validate changed documentation proportionately: local links and anchors, fenced
+   JSON, documented commands, and externally referenced facts where applicable.
+5. Add a `Documentation impact` note to the PR description. List the files updated,
+   or state `None` with a brief reason when the diff has no documentation impact.
+
+This is an impact review, not a mandatory full reread of unrelated documentation.
+
 ## Spec scenario coverage
 
 Before calling a feature complete, prove that every applicable OpenSpec scenario

--- a/README.md
+++ b/README.md
@@ -205,13 +205,15 @@ one needs, the command that proves it works, and the caution that goes with it.
 
 ## Model credentials
 
-Credentials come from either **provider environment variables** (`ANTHROPIC_API_KEY`, …) or
-an **`auth.json` in the agent directory** — `<agentDir>/auth.json`, which is
-`~/.pi/agent/auth.json` unless your configuration names its own `agentDir`.
+For built-in providers, credentials come from either **provider environment variables**
+(`ANTHROPIC_API_KEY`, …) or an **`auth.json` in the agent directory** —
+`<agentDir>/auth.json`, which is `~/.pi/agent/auth.json` unless your configuration names its
+own `agentDir`. A custom OpenAI-compatible provider, including its key, is stored separately
+in `<agentDir>/models.json`.
 
 | | |
 |---|---|
-| **The interface** | With no usable model, pi-outpost shows a setup screen instead of a chat that could only fail. Paste a key, or declare your own endpoint. It writes `<agentDir>/auth.json` and starts working immediately — no restart |
+| **The interface** | With no usable model, pi-outpost shows a setup screen instead of a chat that could only fail. Pasting a key for a built-in provider writes `<agentDir>/auth.json`; declaring your own endpoint writes the provider and its key to `<agentDir>/models.json`. Either takes effect immediately — no restart |
 | **`pi-outpost login`** | For headless servers, where no browser will ever open the interface:<br>`pi-outpost login --provider anthropic` (prompts, not echoed)<br>`echo "$KEY" \| pi-outpost login --provider anthropic` (scripted)<br>The key has no flag on purpose — argv is readable by anyone who can list processes |
 | **Environment** | `export ANTHROPIC_API_KEY=…` before starting. Nothing is written to disk |
 
@@ -327,7 +329,7 @@ One exception, and it is deliberate: **a sandbox that grants write or bash but n
 turn "write inside my project" into "write inside `/`" without touching the file that
 granted it. Name the root, and the grant says what it covers.
 
-Relative paths are resolved against the configuration file's directory. A full example lives
+Relative paths are resolved against the configuration file's directory. A larger example lives
 in [`pi-outpost.config.example.json`](pi-outpost.config.example.json).
 
 ### Workspace and sandbox
@@ -351,6 +353,7 @@ in [`pi-outpost.config.example.json`](pi-outpost.config.example.json).
 | Key | Effect |
 |-----|--------|
 | `agentRuntime` | `{ "mode": "embedded" }` (default) keeps the pi SDK session in this process; `{ "mode": "rpc", "executable": "pi", "args": [] }` supervises a `pi --mode rpc` child. See [Agent runtimes](#agent-runtimes) |
+| `agentRuntime.startupTimeoutMs` / `commandTimeoutMs` / `shutdownGraceMs` | RPC child startup, per-command and graceful-shutdown ceilings. Defaults: `60000`, `300000` and `5000` ms |
 | `tools` | Tool allowlist when no sandbox is configured, e.g. `["read","grep","find","ls"]` |
 | `noExtensions` / `extensionPaths` / `extensionScripts` | Disable extension discovery, or name extension files and directories the deployment loads |
 | `userExtensionPaths` | Extension directories added from Settings. Written by the server; `extensionPaths` stays yours |
@@ -379,7 +382,7 @@ in [`pi-outpost.config.example.json`](pi-outpost.config.example.json).
 | `server.port` | Port to listen on (default `3141`). `--port` and `PI_OUTPOST_PORT`/`PORT` override it |
 | `server.host` | Address to bind (default `127.0.0.1` — only change this if you have read the security note above) |
 | `server.allowedOrigins` | Extra exact Origins accepted on the WebSocket, and given CORS headers on the HTTP endpoints |
-| `server.token` | Shared secret required on the WebSocket and `/branding` (`PI_OUTPOST_TOKEN` overrides). Mandatory in practice off loopback |
+| `server.token` | Shared secret required on the WebSocket, `/branding` and `/files/raw` (`PI_OUTPOST_TOKEN` overrides). Mandatory in practice off loopback |
 | `openBrowser` | Whether starting the server opens the interface (default: wherever a desktop session exists) |
 | `openIn` | `"window"` (its own window, the default) or `"browser"` (a tab). `openBrowser` still decides *whether* |
 | `branding` | `title` (default `"π"`), `welcome` message, `accentColor` |

--- a/cli/README.md
+++ b/cli/README.md
@@ -7,7 +7,10 @@ npx pi-outpost init   # writes a starter pi-outpost.config.json here
 npx pi-outpost        # http://127.0.0.1:3141/
 ```
 
-Requires Node ≥ 22.19 and [pi](https://github.com/earendil-works/pi) configured (`~/.pi/agent/auth.json`, or a provider variable like `ANTHROPIC_API_KEY`).
+Requires Node ≥ 24 and a model credential (`~/.pi/agent/auth.json`, a provider variable
+like `ANTHROPIC_API_KEY`, or the setup screen). The default embedded runtime already carries
+the [pi coding agent](https://github.com/earendil-works/pi); a separate `pi` executable is
+needed only when `agentRuntime.mode` is `"rpc"`.
 
 ## It will not start without a configuration file
 
@@ -37,8 +40,12 @@ The **first** of these that exists is read, and only that one — configurations
 | `--cwd <dir>` | Directory the agent works in |
 | `--agent-dir <dir>` | pi config/session store (default `~/.pi/agent`) |
 | `--port <n>` / `--host <addr>` | Where to listen (default `127.0.0.1:3141`) |
+| `--offline` | Never fetch remote model catalogs |
+| `--open` / `--no-open` | Whether to open the interface once listening |
+| `--open-in window\|browser` | Open in a standalone window (default) or a browser tab |
 
-Environment: `PI_OUTPOST_PORT` (falls back to `PORT`), `PI_OUTPOST_HOST`, `PI_OUTPOST_CWD`, `PI_OUTPOST_AGENT_DIR`, `PI_OUTPOST_TOKEN`.
+Environment: `PI_OUTPOST_PORT` (falls back to `PORT`), `PI_OUTPOST_HOST`,
+`PI_OUTPOST_CWD`, `PI_OUTPOST_AGENT_DIR`, `PI_OUTPOST_TOKEN`, `PI_OFFLINE`.
 
 ## Security
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -58,7 +58,8 @@ write never returns, the runner then reports every test as passing and prints no
 because a test file that never exits never reports. Run it before pushing anything that
 touches paths, permissions, signals, or file watching.
 
-It runs both server steps of the ubuntu leg — `npm test` and then `npm run test:coverage` —
+It runs both server steps of the ubuntu leg — `npm test --workspace server` and then
+`npm run test:coverage --workspace server` —
 because each has gone red on its own while the other was green, and coverage runs on no
 other platform. That step once failed on `main` with 1250 tests passing and none failing:
 npm children spawned by the code under test inherited `NODE_V8_COVERAGE`, were killed at

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -88,8 +88,9 @@ Two knobs, if the defaults do not suit:
 
 `workspaceIdleTimeoutMs` is how long an unused project stays alive before it is
 retired and rebuilt on next use (`0` never retires; a project running a turn is never
-retired). `workspaceLock: true` pins the server to one project and removes the
-controls entirely — that is what an embedding host uses.
+retired). `workspaceLock: true` pins the server to one project and removes the controls
+entirely. Use it for a deployment, embedded or standalone, whose project root must not
+change.
 
 ## Use a local or self-hosted model
 
@@ -137,19 +138,23 @@ Locally declared models are unaffected.
 
 ## Reach it from your phone or another machine
 
-Three things, and all three are needed:
+Three security decisions, and all three are needed. The example also spells out the default
+port because the same value appears in the allowed origin and browser URL:
 
 ```json
 {
   "server": {
     "host": "0.0.0.0",
+    "port": 3141,
     "token": "…",
     "allowedOrigins": ["http://192.168.1.10:3141"]
   }
 }
 ```
 
-1. **`host`** off `127.0.0.1`. The server refuses to bind off loopback without a
+1. **`host`** off `127.0.0.1`, and **`port`** names the port used below. `3141` is the
+   default, but spelling it out keeps the listen address and browser origin visibly aligned.
+   The server refuses to bind off loopback without a
    token, so this alone will not start.
 2. **`token`** — a long random secret, `openssl rand -hex 32`. Prefer the
    `PI_OUTPOST_TOKEN` environment variable, which overrides the file and keeps the
@@ -169,13 +174,63 @@ granted it that.
 
 ## Run it permanently on a Linux server
 
+Install the package, locate the installed binary, and create a dedicated identity and
+directories. The paths below are examples; use the home and binary paths chosen by your
+distribution and npm installation.
+
 ```bash
 npm install -g pi-outpost
-pi-outpost init --global          # writes ~/.config/pi-outpost/config.json
-pi-outpost login --provider anthropic   # prompts; no browser needed
+command -v pi-outpost             # use this exact path in ExecStart below
+sudo useradd --system --create-home --shell /usr/sbin/nologin pi-outpost
+sudo install -d -o pi-outpost -g pi-outpost /etc/pi-outpost
+sudo install -d -o pi-outpost -g pi-outpost /var/lib/pi-outpost/agent
+sudo install -d -o pi-outpost -g pi-outpost /srv/pi-outpost/workspace
 ```
 
-Then a unit file:
+Create `/etc/pi-outpost/config.json`, owned by `pi-outpost`, so the setup commands and the
+service deliberately use the same configuration and agent directory:
+
+```json
+{
+  "cwd": "/srv/pi-outpost/workspace",
+  "agentDir": "/var/lib/pi-outpost/agent",
+  "sandbox": {
+    "root": "/srv/pi-outpost/workspace",
+    "allowWrite": false,
+    "allowBash": false
+  },
+  "server": { "host": "127.0.0.1", "port": 3141 }
+}
+```
+
+Then apply the promised ownership and permissions:
+
+```bash
+sudo chown pi-outpost:pi-outpost /etc/pi-outpost/config.json
+sudo chmod 600 /etc/pi-outpost/config.json
+```
+
+Store the model credential as the service identity. Replace `/usr/local/bin/pi-outpost` with
+the path printed by `command -v`:
+
+```bash
+sudo -u pi-outpost env PI_OUTPOST_CONFIG=/etc/pi-outpost/config.json \
+  /usr/local/bin/pi-outpost login --provider anthropic
+```
+
+Generate a token with `openssl rand -hex 32`. Create `/etc/pi-outpost/environment`, put a
+single `PI_OUTPOST_TOKEN=<paste the generated hex value>` line in it, and make it readable
+only by root:
+
+```bash
+openssl rand -hex 32
+sudo touch /etc/pi-outpost/environment
+sudo chown root:root /etc/pi-outpost/environment
+sudo chmod 600 /etc/pi-outpost/environment
+sudoedit /etc/pi-outpost/environment
+```
+
+Then create `/etc/systemd/system/pi-outpost.service`:
 
 ```ini
 [Unit]
@@ -185,19 +240,24 @@ After=network-online.target
 [Service]
 User=pi-outpost
 Environment=PI_OUTPOST_CONFIG=/etc/pi-outpost/config.json
-Environment=PI_OUTPOST_TOKEN=replace-me
-ExecStart=/usr/bin/pi-outpost --no-open
+EnvironmentFile=/etc/pi-outpost/environment
+ExecStart=/usr/local/bin/pi-outpost --no-open
 Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target
 ```
 
-`ExecStart` needs the real path — `which pi-outpost` after the global install, or the
-executable's own path if you deployed one of those. A headless host opens no browser
-anyway — pi-outpost only opens one where a desktop
-session exists — but `--no-open` says so explicitly. Give the service its own user,
-and point `cwd`, `sandbox.root` and `agentDir` at directories that user owns.
+The system manager reads the environment file, so it can remain owned by root with mode
+`0600`; do not put the token directly in the world-readable unit. A headless host opens no
+browser anyway — pi-outpost only opens one where a desktop session exists — but `--no-open`
+says so explicitly.
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now pi-outpost
+sudo systemctl status pi-outpost
+```
 
 From a checkout rather than a package, `npm run start` is the equivalent single
 command: it builds the interface once and serves everything from one process.
@@ -371,7 +431,7 @@ past message, and automatic session titles.
 |---|---|
 | `no configuration file found` | pi-outpost never starts without one. `pi-outpost init`, or `init --global` |
 | `cannot start: … is already in use` | Something else holds the port. `--port <n>` |
-| The setup screen keeps coming back | No provider can answer. `pi-outpost config` shows which `agentDir` it reads, and credentials live in `<agentDir>/auth.json` |
+| The setup screen keeps coming back | No provider can answer. `pi-outpost config` shows which `agentDir` it reads. Built-in provider credentials live in `<agentDir>/auth.json`; custom provider declarations and keys live in `<agentDir>/models.json` |
 | A bare `fetch failed` | A TLS-inspecting proxy. `export NODE_EXTRA_CA_CERTS=/path/to/corp-ca.pem` |
 | Every turn fails on your own endpoint | The compatibility flags. Untick both, or set `compat` in `models.json` |
 | Each credential change hangs ~20 s | Remote model catalogs are unreachable. `"offline": true` |

--- a/docs/sea-packaging.md
+++ b/docs/sea-packaging.md
@@ -1,7 +1,7 @@
-# Packaging pi-outpost as a Windows executable (Node SEA)
+# Packaging pi-outpost as a standalone executable (Node SEA)
 
 Node's [Single Executable Applications](https://nodejs.org/api/single-executable-applications.html)
-(SEA) feature bundles the server **and the built web UI** into one `.exe` with
+(SEA) feature bundles the server **and the built web UI** into one executable with
 the Node runtime baked in — end users need nothing installed, no `npm install`,
 no terminal, and **no separate web/ folder** next to the executable. The UI is
 inlined at build time into the bundle.
@@ -10,14 +10,13 @@ inlined at build time into the bundle.
 
 ## The two ways to get one
 
-**Download it.** Every release carries an executable per platform, under
+**Download it.** Current releases carry these platform executables under
 [Releases](https://github.com/laurentftech/pi-outpost/releases): `pi-outpost-<version>-macos-arm64`,
 `-linux-x64`, `-windows-x64.exe`. Nothing installed, nothing built.
 
-No Intel macOS build: GitHub retired the `macos-13` runner, and a job asking for it
-queues until it times out rather than failing. On an Intel Mac, build your own with
-`npx pi-outpost build-exe` — it works, and it is what produced the executables this
-feature was tested with.
+No Intel macOS artifact is currently published. On an Intel Mac, build your own with
+`npx pi-outpost build-exe` — the fallback path used for the macOS x64 runtime is covered by
+the build command's launch smoke test.
 
 They are **not signed for distribution**. macOS Gatekeeper and Windows SmartScreen
 both warn on a downloaded unsigned binary; on macOS you clear it with
@@ -41,10 +40,11 @@ requires it, and prints the path.
 --force        replace an existing file at that path
 ```
 
-On **Node ≥ 26** it uses `node --build-sea`. On anything older it falls back to
-injecting the shipped `sea-prep.blob` into a copy of your `node` binary with
-`postject`, and says so — the two artifacts are not identical, and when one of them
-misbehaves the first question is which one you have.
+On **Node ≥ 26** it first uses `node --build-sea`. If that executable fails its launch
+smoke test on a platform where direct SEA building is unreliable, the command may fall back
+to injecting the shipped `sea-prep.blob` into a copy of the same Node runtime with
+`postject`, and says so. Node versions older than 26 are refused: they cannot load the
+ES-module SEA blob used by pi-outpost.
 
 On macOS the result is signed ad-hoc (`codesign --sign -`). That is what makes a
 modified binary *launch* at all: without it the kernel kills it, naming neither the
@@ -52,11 +52,12 @@ signature nor the remedy. It is not a distribution signature.
 
 ## Starting it
 
-Running the executable starts the server and opens the interface in your default
-browser, at the address it actually bound — including when the configuration asked
-for port `0` and the operating system chose. Launching it from a file manager works
-the same way, which is the point: there is no terminal there for an address to be
-printed to.
+Running the executable starts the server and, by default, opens the interface in a window of
+its own at the address it actually bound — including when the configuration asked for port
+`0` and the operating system chose. It falls back to a browser tab if a standalone window
+cannot be launched; `--open-in browser` requests the tab explicitly. Launching it from a file
+manager works the same way, which is the point: there is no terminal there for an address to
+be printed to.
 
 No browser is opened where none can be shown — no desktop session, a container, a
 remote shell, a CI runner. `--open` and `--no-open` decide it explicitly, and
@@ -87,7 +88,9 @@ The `build:sea` step in `server/scripts/build-sea.mjs`:
    `server/src/embedded-web.ts` so the bundle is self-contained.
 2. **Bundles** `server/src/index.ts` via esbuild into one ESM file (`bundle.mjs`).
 3. **Generates a cross-platform blob** (`sea-prep.blob`) via `--experimental-sea-config`.
-4. **On Windows only** (skipped in CI), builds a native `.exe` via `--build-sea`.
+4. **Outside CI**, builds a host-specific executable named `server/dist/pi-outpost.exe`
+   via `--build-sea`. Release jobs use `pi-outpost build-exe --out …` instead, so each
+   published artifact gets its platform-specific name and launch smoke test.
 
 ## Server-only / embed mode (no inlined UI)
 
@@ -115,10 +118,11 @@ With `BUILD_EMBED_WEB=0`:
 This is the recommended setup when the executable is a **backend for an embedded
 widget** rather than a standalone desktop app.
 
-## Using the cross-platform blob (any platform)
+## Using the cross-platform blob (supported Node runtimes)
 
 The `sea-prep.blob` is included in the npm package and can be injected into
-any Node.js binary of the same major version using postject:
+a Node.js 26 binary of the same major version using postject. Older runtimes cannot load its
+ES-module entry point:
 
 ```powershell
 copy "C:\path\to\node.exe" pi-outpost.exe
@@ -146,11 +150,20 @@ extensions from inside the executable:
 ```ts
 // ext.ts, sitting next to pi-outpost, with no node_modules anywhere
 import { Type } from "typebox";
-import * as agent from "@earendil-works/pi-coding-agent";
+import { defineTool, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
-export default function extension() {
-  const schema = Type.Object({ ok: Type.Boolean() });
-  return { name: "my-extension", tools: [] };
+const healthTool = defineTool({
+  name: "health_check",
+  label: "Health check",
+  description: "Return a typed health result.",
+  parameters: Type.Object({ verbose: Type.Optional(Type.Boolean()) }),
+  async execute() {
+    return { content: [{ type: "text", text: "ok" }] };
+  },
+});
+
+export default function extension(pi: ExtensionAPI) {
+  pi.registerTool(healthTool);
 }
 ```
 

--- a/docs/structured-exchange.md
+++ b/docs/structured-exchange.md
@@ -118,6 +118,28 @@ Diagnostics name the rule and point at the value:
 
 Every broken rule is reported, not just the first.
 
+## Grouping graph and sequence elements
+
+Graphs and sequences may declare `data.containers`, then assign a node or participant with
+its `container` field:
+
+```json
+{
+  "schema": "urn:structured-exchange:1",
+  "kind": "graph",
+  "data": {
+    "containers": [{ "id": "backend", "label": "Backend", "kind": "service-group" }],
+    "nodes": [{ "id": "billing", "label": "Billing", "container": "backend" }],
+    "edges": []
+  }
+}
+```
+
+A container groups elements visually; it is not itself an element or relationship endpoint.
+Container identifiers must be unique, and every `container` reference must resolve to one
+declared in the same document. Moving an existing element between containers is a change, so
+put the new container id under `set.container` beside that element's `ref`.
+
 ## Getting a diagram into a document
 
 Use **download SVG**, then insert the file as a picture. Word does not accept an SVG
@@ -136,12 +158,14 @@ and an envelope declaring a table with a `target` or a `removal` is refused. It 
 still report on a change it projects. Any row may declare what it plays:
 
 ```json
-"rows": [
-  { "role": "added",   "cells": ["REQ-5", "Log every actuation.", "draft"] },
-  { "role": "changed", "cells": ["REQ-2", "Signal a fault within 200 ms.", "in review"] },
-  { "role": "removed", "cells": ["REQ-3", "Read battery voltage at 10 Hz.", "withdrawn"] },
-  { "cells": ["REQ-1", "Stop within 40 m.", "approved"] }
-]
+{
+  "rows": [
+    { "role": "added",   "cells": ["REQ-5", "Log every actuation.", "draft"] },
+    { "role": "changed", "cells": ["REQ-2", "Signal a fault within 200 ms.", "in review"] },
+    { "role": "removed", "cells": ["REQ-3", "Read battery voltage at 10 Hz.", "withdrawn"] },
+    { "cells": ["REQ-1", "Stop within 40 m.", "approved"] }
+  ]
+}
 ```
 
 `role` is `added`, `changed`, `context` or `removed`, and it is rendered with the

--- a/embed/README.md
+++ b/embed/README.md
@@ -30,6 +30,7 @@ const widget = mount(document.getElementById("assistant"), {
   serverUrl: "https://your-pi-outpost-server", // omit for same-origin
   theme: "dark", // optional; falls back to the server's branding.defaultTheme, then "system"
   token: "…", // only for servers with `server.token` set
+  workspace: "/srv/projects/example", // optional resolved root of an already-open project
 });
 
 widget.setTheme("light"); // change the theme at runtime
@@ -37,6 +38,10 @@ widget.unmount(); // tear down the React tree
 ```
 
 `mount(container, options?)` returns `{ unmount(), setTheme(theme) }`. The container itself stays in the DOM after `unmount()`, with an empty shadow root.
+
+When `workspace` is set, the host binds that widget to the named open project and the widget
+offers no project switcher. If the root is not open, the server falls back to its default
+project rather than leaving the widget disconnected.
 
 ### Which theme wins
 
@@ -67,6 +72,10 @@ In Next.js, the component doing this must be a client component (`"use client"`)
 Configure this on the pi-outpost server, whatever the deployment topology:
 
 - **`server.allowedOrigins`** — the widget carries the *host page's* origin (e.g. `https://your-app.example.com`), not pi-outpost's own. Add it explicitly; even same-domain deployments need this (only `localhost`/`127.0.0.1` are trusted automatically). Listing it is all a cross-origin mount needs: the server answers those origins with the CORS headers the browser requires on every HTTP route, and applies the same allowlist to the WebSocket handshake. It grants no authority of its own — a token-protected route still wants its token.
+- **`embed.workspaceControls`** — when the host does not pass `workspace`, choose what the
+  widget exposes: `"settings"` (the one-project default), `"root"` (a compact root chooser)
+  or `"projects"` (open/switch/close controls). `workspaceLock` still overrides this and
+  pins the deployment to one project.
 
 ## License
 

--- a/server/test/README.md
+++ b/server/test/README.md
@@ -1,9 +1,11 @@
 # Server tests
 
-Integration tests: each one boots a real server (`npx tsx src/index.ts`) against a throwaway
-workspace in `$TMPDIR` and talks to it over HTTP/WebSocket, the way a browser does. Nothing is
-mocked — what these guard is the wiring (path confinement, auth, session bookkeeping) that unit
-tests of the pure functions cannot see.
+Integration tests boot a real server (`node --import=tsx/esm src/index.ts`) against a
+throwaway workspace in `$TMPDIR` and talk to it over HTTP/WebSocket, the way a browser does.
+The server and its wiring are not mocked; suites that need a deterministic external boundary
+may use a controlled provider, npm executable or RPC child. What these guard is the wiring
+(path confinement, auth, process supervision, session bookkeeping) that unit tests of pure
+functions cannot see.
 
 The harness pins `agentDir` inside the temp workspace, so runs never touch your real
 `~/.pi/agent` (no reading your extensions, no writing your sessions).

--- a/shared/conformance/README.md
+++ b/shared/conformance/README.md
@@ -23,11 +23,16 @@ JSON Schema decides shape. These are the relational rules that follow it, and th
 | Rule | What it refuses |
 |---|---|
 | `duplicate-identifier` | two elements sharing an envelope-scoped `id` |
+| `duplicate-container-identifier` | two containers sharing an `id` |
 | `unresolved-endpoint` | a relationship endpoint that no declared element carries |
+| `unresolved-container` | an element assigned to a container the document never declares |
 | `kind-data-mismatch` | a declared `kind` that disagrees with the data variant present |
 | `kind-not-proposable` | a `table` carrying a `target` or a `removal` |
 | `removal-without-target` | a removal in a document that targets nothing |
 | `duplicate-reference` | the same reference addressed twice — changed twice, or changed and removed |
+| `change-without-reference` | a `set` with no `ref` naming what should change |
+| `change-without-target` | a `set` in an envelope that names no target authority |
+| `too-many-kinds` | more distinct element or relationship kinds than the rendering can distinguish |
 | `row-column-mismatch` | a row whose length differs from the declared columns |
 
 Rules prefixed `schema/` come from the JSON Schema itself; the suffix is the keyword

--- a/web/README.md
+++ b/web/README.md
@@ -1,32 +1,40 @@
-# React + TypeScript + Vite
+# pi-outpost standalone web app
 
-This template provides a minimal setup to get React working in Vite with HMR and some Oxlint rules.
+This private workspace is the Vite shell for the standalone pi-outpost interface. The
+shared React application lives in `@pi-outpost/ui`; this package supplies the page entry
+point, global stylesheet, web manifest and icons used by the server-hosted app. It has no
+service worker and does not cache the interface for offline use.
 
-Currently, two official plugins are available:
+## Development
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
+From the repository root:
 
-## React Compiler
-
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
-
-## Expanding the Oxlint configuration
-
-If you are developing a production application, we recommend enabling type-aware lint rules by installing `oxlint-tsgolint` and editing `.oxlintrc.json`:
-
-```json
-{
-  "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["react", "typescript", "oxc"],
-  "options": {
-    "typeAware": true
-  },
-  "rules": {
-    "react/rules-of-hooks": "error",
-    "react/only-export-components": ["warn", { "allowConstantExport": true }]
-  }
-}
+```bash
+npm install
+npm run dev
 ```
 
-See the [Oxlint rules documentation](https://oxc.rs/docs/guide/usage/linter/rules) for the full list of rules and categories.
+That starts Vite on `http://localhost:5173` and the agent server on
+`http://127.0.0.1:3141`. Vite proxies `/ws`, `/branding`, `/health` and `/files` to the
+server. Set `PI_OUTPOST_PORT` when the development server listens on another port.
+
+The root command deliberately supplies
+[`pi-outpost.config.dev.json`](../pi-outpost.config.dev.json) to the agent server. Running
+the web workspace alone starts only Vite; it does not start or configure pi-outpost:
+
+```bash
+npm run dev --workspace web
+```
+
+## Checks and production build
+
+```bash
+npm run typecheck --workspace web
+npm run lint --workspace web
+npm run build --workspace web
+```
+
+The build writes `web/dist/`. `npm run start` from the repository root builds that output
+and starts the server that serves it. Packaging builds may instead inline the same assets
+into the CLI bundle or standalone executable; see
+[`docs/sea-packaging.md`](../docs/sea-packaging.md).


### PR DESCRIPTION
## Summary

- make the remote-server and systemd recipes explicit and runnable, including the documented port, service identity, shared configuration, credentials, token file, and activation steps
- correct SEA guidance for Node 26, fallback behavior, launch shape, release artifacts, and the current extension API
- align credential storage, RPC timeouts, CLI Node requirements, embed workspace options, test harness wording, and npm commands with the implementation
- replace the leftover Vite template README with project-specific web development guidance
- document structured-exchange containers and every non-schema conformance rule
- require a documentation-impact review before every pull request in AGENTS.md and CLAUDE.md

## Documentation impact

Updated AGENTS.md and CLAUDE.md to require each PR to identify affected user/developer documentation, verify claims and examples against implementation evidence, validate changed documentation, and list the documentation impact in the PR description. The rule explicitly does not require rereading unrelated documentation.

## Documentation reviewed

The audit covered the main README; docs/how-to.md, docs/development.md, docs/sea-packaging.md, and docs/structured-exchange.md; the CLI, embed, web, server-test, skills, conformance, and design READMEs; and the example configuration.

## Validation

- git diff --check
- all local Markdown links and anchors across 12 user/developer documents
- all 23 fenced JSON examples parse
- all 37 documented npm run invocations resolve to real package scripts
- source CLI help compared with the documented flags
- conformance README covers all 12 non-schema rules
- v0.17.1 release assets verified for Linux x64, macOS arm64, and Windows x64

Documentation-only change; no runtime code changed.