### PR TITLE
feat(git): resolve a repository per path under a workspace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,3 +113,27 @@ shows those.
 What "exercised" means: drive the actual feature — create the file, open the
 document, ask the agent for the thing — then read back the DOM, the filesystem, or
 the session transcript to check what really happened. A screenshot is not a check.
+
+### Do not stop at the happy path
+
+Once the intended walkthrough passes, make a second pass whose only goal is to
+break it. The happy path is the sequence the code was written against, so it is
+the one least likely to be broken; the defects live in the transitions.
+
+Hammer it like a monkey tester: rapid and double clicks, a menu left open while
+the context under it changes, switching projects or sessions mid-request,
+clicking a file that was just deleted on disk, spamming expand/collapse, acting
+before the first data has arrived, and clicking in an order nobody would design
+for. Remove things underneath the running app — delete the directory, revoke the
+permission, kill the repository — and watch what it claims afterwards.
+
+Read back the DOM after each burst, and watch for the shapes that only show up
+here: stale state rendered under a new context, a reply answering a question that
+has since changed, a handler assuming an object it no longer holds, a panel stuck
+loading a request nobody made. Report what broke, not merely that the feature
+works.
+
+Two defects in the per-repository git work were exactly of this shape, and both
+had green suites over them: a commit log rendered under another project's name,
+and — once that was correlated — a menu that sat on "loading…" forever because
+the fetch only happened on the toggle.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,30 @@ What "exercised" means: drive the actual feature — create the file, open the
 document, ask the agent for the thing — then read back the DOM, the filesystem, or
 the session transcript to check what really happened. A screenshot is not a check.
 
+### Do not stop at the happy path
+
+Once the intended walkthrough passes, make a second pass whose only goal is to
+break it. The happy path is the sequence the code was written against, so it is
+the one least likely to be broken; the defects live in the transitions.
+
+Hammer it like a monkey tester: rapid and double clicks, a menu left open while
+the context under it changes, switching projects or sessions mid-request,
+clicking a file that was just deleted on disk, spamming expand/collapse, acting
+before the first data has arrived, and clicking in an order nobody would design
+for. Remove things underneath the running app — delete the directory, revoke the
+permission, kill the repository — and watch what it claims afterwards.
+
+Read back the DOM after each burst, and watch for the shapes that only show up
+here: stale state rendered under a new context, a reply answering a question that
+has since changed, a handler assuming an object it no longer holds, a panel stuck
+loading a request nobody made. Report what broke, not merely that the feature
+works.
+
+Two defects in the per-repository git work were exactly of this shape, and both
+had green suites over them: a commit log rendered under another project's name,
+and — once that was correlated — a menu that sat on "loading…" forever because
+the fetch only happened on the toggle.
+
 How: `npm run bench` (`scripts/embed-bench.mts`) leaves a real widget running —
 host page on its own origin with hostile CSS, two servers behind it, a seeded
 transcript with diagrams and tables. Fixed ports: host **4321**, plain server

--- a/openspec/changes/resolve-git-per-repo-under-workspace/.openspec.yaml
+++ b/openspec/changes/resolve-git-per-repo-under-workspace/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-01

--- a/openspec/changes/resolve-git-per-repo-under-workspace/design.md
+++ b/openspec/changes/resolve-git-per-repo-under-workspace/design.md
@@ -1,0 +1,100 @@
+## Context
+
+See proposal.md — Why.
+
+The shape of the constraint, in code as it stands:
+
+- `server/src/workspace.ts:333` builds `git: { toplevel: string } | null` from one `probeGit(browserRoot)` call. It is a constant for the life of the workspace resources, not a lookup.
+- Every git RPC in `server/src/index.ts:2818-2914` spawns with `cwd = workspace.browserRoot` and passes `workspace.git.toplevel` for path translation.
+- `server/src/git.ts` rests its security argument on one invariant, stated in its header: a fixed `cwd` at the browser root plus a trailing pathspec (`-- .` or the single confined file), so git cannot report content outside the root.
+- On the wire (`shared/src/protocol.ts:639`), `git_status` answers `{ branch, ahead, behind, files }` — one branch for the workspace. `git_log` (`:766`) and `git_show` (`:768`) carry no path or repository at all; they are implicitly "the workspace's repository".
+- In the UI, `GitMenu.tsx:41` renders that single branch, and `Header.test.tsx:122` asserts the chip appears only when `gitAvailable`.
+
+Two consumer classes matter, and they need different things. File-scoped features (tree badges, worktree diff, file history, revision-pair diff) already take a toplevel as an argument — they need only a resolver. Repository-scoped features (branch chip, commit log, commit patch) need a repository chosen, and that is where the design work is.
+
+Ambient constraint: `add-workspace-ready-for-review` is being implemented concurrently and also touches `server/src/index.ts`, `shared/src/protocol.ts` and `multi-project-workspaces`. Its spec delta covers workspace *activity*; this one covers `IsolateWorkspacesFromEachOther` only. No requirement overlaps, but the same files will be edited.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One resolution rule — longest matching repository toplevel — serving every git request that names a path.
+- Badges present before the user clicks, so a tracked leaf is identifiable as tracked.
+- Repository-scoped features bound to the current selection, with no new control on screen.
+- The confinement invariant of `git.ts` preserved when `cwd` is no longer a single fixed directory.
+- Status cost that scales with what is being looked at, not with the number of repositories on disk.
+
+**Non-Goals:**
+
+- Any aggregate across repositories: no merged commit log, no combined branch display, no "3 repos, 5 changes" summary.
+- A repository picker control.
+- Write-capable git, submodule-aware traversal, or anything that mutates a repository.
+- Changing how projects are opened, closed or switched, or how the agent's sandbox is bounded.
+- Reworking `openProjects` so a directory of repositories opens as many workspaces — that is a different change.
+
+## Decisions
+
+### Discovered repository set, not per-path `rev-parse`
+
+The workspace holds `repos: RepoSet` — an ordered list of toplevels under (or containing) the browser root. Resolution is a longest-prefix match over that list: pure, synchronous, no process spawned.
+
+*Alternative — `rev-parse --show-toplevel` with `cwd = dirname(path)` per request.* Correct and trivially small, and it is what one reaches for first. It costs one process per resolution. Tree badges resolve every visible file on every refresh, and refresh fires on `file_changed` and `agent_end`; a workspace of a few hundred files would spawn a few hundred `git` processes per keystroke-driven save. Rejected on cost, not correctness.
+
+*Alternative — leave one repository and pick it from the open file.* Solves the chip, leaves badges dark until a file is opened, which is precisely the ordering the user asked to invert ("dès que je clique sur une feuille **suivie par git**" — the leaf must already look tracked). Rejected.
+
+### Discovery scans for markers, bounded, and does not descend into a work tree
+
+Walk from the browser root looking for a `.git` marker, reusing the file browser's existing exclusions (`node_modules` and friends) and a depth bound. On finding a marker, record the toplevel and stop descending that branch: repositories inside a repository's work tree are the submodule case, and the containing repository already accounts for them as gitlinks. A marker that is a *file* (linked work tree, submodule) counts as a repository.
+
+*Alternative — ask git.* `git submodule status` or `--recurse-submodules` only answers when the parent is itself a repository. His parent is not. Rejected as inapplicable to the motivating case.
+
+The ancestor case survives unchanged: if `probeGit(browserRoot)` returns a toplevel, it joins the set, and files under no nested repository resolve to it. `RepoLargerThanRoot` keeps holding.
+
+### Status is one invocation per repository, merged, paths relative to the browser root
+
+`gitStatus` becomes a fan-out: one `git status --porcelain=v2 --branch --untracked-files=all -- .` per repository, `cwd` at that repository's toplevel, run with bounded concurrency; each entry's path is rebased from repository-relative to browser-root-relative before merging. A single-repository workspace issues exactly one invocation, as today.
+
+Cost control is by *scope*, not by caching: a `file_changed` event names a path, so only the repository owning it needs re-running. The full sweep happens on connect and on `agent_end`. Client-side coalescing already exists (`StatusRefresh`).
+
+*Alternative — one `git status` from the browser root.* Does not see into nested repositories at all; the parent is not a repository in the motivating case, so there is nothing to run. Rejected.
+
+### Repository identity on the wire is its path relative to the browser root
+
+A repository is named by its browser-root-relative posix path (`""` when it is the root or an ancestor). The client needs a prefix to attribute files to repositories anyway, so an opaque id would buy nothing and cost a lookup table.
+
+`git_status` gains `repos: { root, branch, ahead, behind }[]`; the flat `branch`/`ahead`/`behind` fields are removed rather than kept alongside, so there is one source of truth for a branch. `git_log` and `git_show` gain a `repo` field naming which repository to answer from. The client and the served UI ship in the same build, so this is a breaking protocol edit without a compatibility window; `@pi-outpost/embed` loads the UI from the server it talks to, so it moves with it.
+
+### The chip follows the selection
+
+No picker. The branch chip reads the repository owning the selected file. With no selection and exactly one repository, it names that one — the current behavior, unchanged for single-repository workspaces. With no selection and several, it stays visible and names no branch, rather than guessing or vanishing: `AlwaysNameTheProjectOnScreen` establishes that a control's first job is to say where the user is, and a chip that disappears says nothing. A selection owned by no repository leaves the chip where it was, since blanking it on every click into an unversioned file would make it flicker.
+
+*Alternative — an explicit repository picker.* Adds a control for a choice the user already expressed by clicking a file. Kept in reserve if a use case appears for reading a repository's log without opening one of its files.
+
+### Confinement extends per repository root
+
+Every discovered toplevel is `realpath`-resolved and checked with the file browser's `isWithin`/`resolveConfined` before it may become a `cwd`. A symlinked directory whose real repository lies outside the browser root is excluded from the set. The header comment in `git.ts` is rewritten to state the invariant in its new form: `cwd` is the browser root or a *confined* repository toplevel, and the pathspec still bounds what git may report.
+
+### Freshness is watcher-driven
+
+The file watcher already runs per workspace. A change touching a `.git` marker debounces a re-scan of the affected subtree. Without this, a repository cloned during a session stays invisible until restart, which for a workspace whose whole purpose is holding many projects is a daily occurrence rather than an edge case.
+
+*Alternative — TTL re-scan, or never.* A TTL spends work when nothing happened and still lags; never is the current behavior and is what makes this a bug report.
+
+## Risks / Trade-offs
+
+- **N `git status` processes per full refresh.** A directory of thirty repositories costs thirty spawns on connect and after each turn. → Bounded concurrency, and per-path scoping so ordinary edits re-run one repository. If it still bites, the fallback is to run only repositories that have a directory expanded in the tree; the spec is written in terms of what is visible, so that optimisation stays legal.
+- **Deep or hostile trees make discovery slow.** → Depth bound, the file browser's existing exclusions, and no descent past a found repository. Discovery is async and the workspace serves non-git features while it runs.
+- **Symlink escape via a repository root outside the root.** → `realpath` plus `isWithin` before any spawn; excluded repositories are never a `cwd`.
+- **Submodules could be reported twice** — once as a repository of their own, once as a gitlink in the parent. → The parent reports a submodule as a single directory entry, not per-file, so no file path appears twice; the parent's gitlink entry is dropped when its path is a repository in the set.
+- **Breaking protocol edit while another change is in flight.** `add-workspace-ready-for-review` edits `shared/src/protocol.ts` and `server/src/index.ts` concurrently. → Keep git changes to their own regions of those files, land whichever is ready first, rebase the other.
+- **The chip changes as the user navigates.** Someone used to a fixed branch chip may read the change as the branch having changed. → The chip names the repository alongside the branch when the workspace holds more than one, so the movement is legible.
+- **Ancestor plus nested repositories is genuinely ambiguous to a user.** A file inside a nested repository is invisible to the ancestor's status. → The longest-prefix rule is stated in the spec and matches what git itself does on the command line; no attempt is made to reconcile the two views.
+
+## Migration Plan
+
+No data migration, no persisted format change. A workspace whose root is a repository and which holds no nested repositories produces a one-element set and behaves exactly as before — that equivalence is the regression bar for the existing git tests. Rollback is a revert; nothing on disk is written by this change.
+
+## Open Questions
+
+- The depth bound for discovery, and whether the file browser's exclusion list is the right one to reuse verbatim. Both are tunable constants that do not change the specs or the task breakdown.
+- Whether the chip should name the repository always, or only when the workspace holds more than one. A presentation detail, settled once it is seen running.

--- a/openspec/changes/resolve-git-per-repo-under-workspace/proposal.md
+++ b/openspec/changes/resolve-git-per-repo-under-workspace/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+A workspace is assumed to be one git repository. `probeGit` runs once when the workspace is built and stores a single toplevel; when the workspace root is not itself inside a repository, that probe returns nothing and the entire git surface goes dark — no branch chip, no tree badges, no worktree diff, no file history.
+
+Developers who organise their work as a parent directory of independently versioned project folders hit exactly this. Every child is a repository, the parent is not, and pi-outpost shows them nothing. The repositories are there, under the browser root, fully readable; only the one-repository-per-workspace assumption stands between the user and the features that already exist.
+
+## What Changes
+
+- A workspace SHALL resolve git per path rather than holding one repository: it discovers the repositories under its browser root (plus the ancestor repository, when the root is inside one) and maps any path to the repository that owns it.
+- Git availability stops being one boolean over the workspace. A workspace containing at least one repository offers git features; a file outside every repository offers none.
+- File-scoped operations — tree badges, worktree diff, file commit history, revision-pair diff, file history graph — work for any tracked file under the browser root, whichever repository it belongs to.
+- Repository-scoped operations — branch with ahead/behind, commit log, commit patch — follow the file the user has selected: opening a file in one project shows that project's branch and history, without a repository picker.
+- Working-tree status covers every repository under the browser root, so a leaf is marked as tracked and changed before it is clicked.
+- Confinement is preserved per repository: a discovered repository root becomes a git `cwd` only after passing the same confinement check the file browser uses, keeping the guarantee that git never reports content outside the browser root.
+- No write operations, no repository picker control, no cross-repository aggregate view (no merged log, no combined branch display), and no change to how projects are opened or closed.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `git`: Replace single-repository detection with per-path repository resolution over a discovered repository set; extend confinement to multiple repository roots; scope working-tree status to all repositories under the browser root; bind branch, commit log and commit patch to the repository owning the current selection; state what the UI surface shows when a workspace holds several repositories or none.
+- `multi-project-workspaces`: A workspace owns a set of repositories rather than one git state.
+
+## Impact
+
+- `server/src/workspace.ts`: the `git: { toplevel } | null` resource becomes a repository set with a resolver, discovered at workspace build and refreshed when repositories appear or disappear.
+- `server/src/git.ts`: `probeGit` gains repository discovery; repository-scoped commands take the resolved repository root as their `cwd`; `gitStatus` reports across repositories.
+- `server/src/index.ts`: the git RPC handlers stop reading `workspace.git.toplevel` and resolve the repository from the requested path.
+- Shared protocol: git status entries and the session snapshot carry enough repository identity for the client to attribute a file and name a branch.
+- `ui/src/components/GitMenu.tsx`, `Header.tsx`, `FileTree.tsx`, `FileViewer.tsx`: the branch chip reflects the selection's repository; badges span repositories.
+- Server, protocol and UI tests, including a fixture workspace whose root is not a repository and whose children are.
+- No new dependency, no write-capable git command, no change to sandbox boundaries or workspace lifecycle.

--- a/openspec/changes/resolve-git-per-repo-under-workspace/specs/git/spec.md
+++ b/openspec/changes/resolve-git-per-repo-under-workspace/specs/git/spec.md
@@ -1,0 +1,247 @@
+## ADDED Requirements
+
+### Requirement: ResolveTheRepositoryOwningAPath
+
+The system SHALL own, per workspace, a set of git repositories: the repositories whose
+work tree lies under the browser root, together with the repository containing the browser
+root when the root is itself inside one. Every git request naming a path SHALL be served by
+the repository in that set whose toplevel is the longest prefix of the path; a path owned by
+no repository in the set SHALL be treated as untracked — no badge, no diff, no history — and
+SHALL NOT fail the request that carried it alongside tracked paths.
+
+Discovery SHALL be bounded so that a large workspace does not stall the server: it SHALL NOT
+descend into a repository's work tree looking for further repositories, and SHALL NOT
+descend into directories the file browser already excludes. A repository marker that is a
+file rather than a directory — as a linked work tree and a submodule both have — SHALL be
+recognised as a repository wherever discovery reaches it.
+
+These two rules settle the submodule between them: a submodule of a repository the workspace
+already holds is inside that repository's work tree, so discovery stops before it and its
+parent answers for its files. A repository nested under the browser root but outside every
+repository in the set — an embedded clone, or a submodule of a repository whose toplevel is
+an ancestor of the root — is found and answers for itself; the containing repository reports
+it as a single entry, and the set SHALL NOT report that entry as a file of its own.
+
+#### Scenario: NestedRepositoriesUnderANonRepositoryRoot
+- **GIVEN** a browser root that is not inside a git work tree, holding three child directories that are each a repository
+- **WHEN** a client requests the working-tree status
+- **THEN** files from all three repositories are reported
+
+#### Scenario: TheLongestPrefixWins
+- **GIVEN** a browser root inside a repository, holding a child directory that is its own repository
+- **WHEN** a file inside that child directory is asked about
+- **THEN** the child repository answers, not the ancestor one
+
+#### Scenario: AFileOwnedByNoRepository
+- **GIVEN** a workspace holding one repository and a loose file outside it
+- **WHEN** that loose file is opened
+- **THEN** no diff toggle and no history affordance are offered for it
+- **AND** the status request that listed its siblings still succeeds
+
+#### Scenario: ARepositoryMarkerThatIsAFile
+- **GIVEN** a child directory whose repository marker is a file, as a linked work tree and a submodule both have
+- **WHEN** the workspace discovers its repositories
+- **THEN** that directory is one of them
+
+#### Scenario: ARepositoryInsideAWorkTreeIsLeftToItsParent
+- **GIVEN** a browser root that is itself a repository, holding a submodule
+- **WHEN** the workspace discovers its repositories
+- **THEN** it holds one repository, and the submodule's files are answered by it
+
+#### Scenario: AnEmbeddedRepositoryIsNotAlsoAFile
+- **GIVEN** a browser root inside a repository, holding a child directory that is its own repository
+- **WHEN** the working-tree status is reported
+- **THEN** the child's own files carry their status
+- **AND** the containing repository's single entry for that child is not reported as a file
+
+### Requirement: RepositorySetFreshness
+
+The repository set SHALL be re-established when a repository appears under the browser root
+or stops being one during the life of the workspace, so that a repository cloned or
+initialised while the server runs becomes usable without restarting it, and a removed one
+stops being consulted.
+
+#### Scenario: ARepositoryClonedWhileRunning
+- **GIVEN** a running workspace whose repositories have already been discovered
+- **WHEN** a new repository appears under the browser root
+- **THEN** its files carry status badges and its history is available, without a restart
+
+#### Scenario: ARepositoryThatStopsBeingOne
+- **GIVEN** a workspace holding two repositories
+- **WHEN** one of them ceases to be a repository
+- **THEN** its files are reported as owned by no repository
+- **AND** no git command is spawned against its former toplevel
+
+## MODIFIED Requirements
+
+### Requirement: DetectRepository
+
+The system SHALL determine, when the workspace is built, which git repositories it holds
+(system `git` binary present and `rev-parse` succeeding): the repository containing the
+file-browser root when there is one, and the repositories whose work tree lies under that
+root. It SHALL advertise in the session snapshot (`gitAvailable`) whether the workspace
+holds at least one repository, and hide all git features in the UI when it holds none.
+
+`gitAvailable` describes the workspace, not any single file: a workspace whose root is not
+itself in a repository but which holds repositories underneath SHALL advertise git as
+available.
+
+#### Scenario: InsideRepository
+- **WHEN** the server starts with a browser root inside a git work tree
+- **THEN** the snapshot carries gitAvailable: true and git requests are served
+
+#### Scenario: NoRepository
+- **WHEN** the browser root is not inside a git work tree, holds no repository underneath, or git is not installed
+- **THEN** the snapshot carries gitAvailable: false
+- **AND** the UI renders no git affordances
+
+#### Scenario: RepositoriesOnlyUnderneath
+- **WHEN** the server starts with a browser root that is not inside a git work tree but holds repositories in its child directories
+- **THEN** the snapshot carries gitAvailable: true and git requests are served
+
+### Requirement: ConfinedGitCommands
+
+The system SHALL run only read-only git commands (`rev-parse`, `status`, `log`, `show`),
+spawned without a shell with fixed argument lists, `cwd` at the browser root or at the
+toplevel of a repository in the workspace's repository set, and a pathspec that is either
+`-- .` (repo-scoped requests) or the single confined file being asked about (file-scoped
+requests), so git itself reports nothing outside the browser root, with a timeout and output
+cap. A repository toplevel SHALL become a `cwd` only after passing the same confinement
+check the file browser uses, so a repository discovered outside the browser root is never
+consulted. Single-file operations MUST validate the path with the same confinement used by
+the file browser; commit ids MUST match `/^[0-9a-f]{7,40}$/i`, and a revision naming the
+working tree MUST be an exact literal marker, never passed to git as a revision. A path MUST
+NOT be interpretable as an option or a revision by git: file-scoped commands MUST separate
+paths from revisions with `--`.
+
+#### Scenario: RepoLargerThanRoot
+- **WHEN** the repository toplevel is an ancestor of the browser root and git_status is requested
+- **THEN** Only entries under the browser root are reported
+
+#### Scenario: PathEscapeRefused
+- **WHEN** git_diff is requested for a path resolving outside the browser root
+- **THEN** The request fails with a git_error and no git command runs on that path
+
+#### Scenario: MalformedSha
+- **WHEN** git_show is requested with a sha not matching the commit-id pattern
+- **THEN** The request fails with a git_error and no git command is spawned
+
+#### Scenario: PathLookingLikeOption
+- **WHEN** a file-scoped git request is made for a confined path beginning with a dash
+- **THEN** git treats it as a path, not as an option, and the request either succeeds or fails as a path
+
+#### Scenario: RepositoryRootOutsideTheBrowserRootIsNeverACwd
+- **WHEN** a candidate repository toplevel resolves outside the browser root
+- **THEN** it is excluded from the repository set and no git command is spawned with it as cwd
+
+### Requirement: WorkingTreeStatus
+
+The system SHALL report per-file status (modified, added, deleted, untracked, conflicted)
+for files under the browser root across every repository in the workspace's repository set,
+each file identified by its path relative to the browser root. Alongside the files, the
+system SHALL report, for each repository in the set, its current branch and its ahead/behind
+counts when a remote is tracked, so that a client can name the branch of any file it has
+without a further request.
+
+File status SHALL be gathered from one `git status --porcelain=v2 --branch` invocation per
+repository. A workspace holding one repository SHALL therefore behave exactly as before.
+
+#### Scenario: StatusReported
+- **WHEN** git_status is requested in a repo with a modified and an untracked file
+- **THEN** The response lists both files with their status and the current branch
+
+#### Scenario: StatusSpansRepositories
+- **GIVEN** a workspace holding two repositories, each with a modified file
+- **WHEN** git_status is requested
+- **THEN** both files are listed, each with a path relative to the browser root
+- **AND** both repositories are reported with their own branch and ahead/behind counts
+
+#### Scenario: StatusRefresh
+- **WHEN** a file_changed broadcast or agent_end event occurs
+- **THEN** The client refetches git_status (coalescing concurrent refetches)
+- **AND** tree badges and the header branch reflect the new state
+
+### Requirement: CommitHistory
+
+The system SHALL list recent commits (id, author, ISO date, subject; limit clamped to
+[1, 100]) and return a given commit's unified patch, capped in size with an explicit
+truncation flag. Both SHALL be scoped to one repository of the workspace's repository set —
+the repository owning the path the request names — and, within it, to the browser root.
+
+A commit id SHALL be interpreted only against the repository the request names a path for;
+a request naming a path owned by no repository SHALL fail with a git error rather than
+falling back to another repository.
+
+#### Scenario: LogListed
+- **WHEN** git_log is requested with limit 20
+- **THEN** Up to 20 commits touching the browser root are returned, newest first
+
+#### Scenario: LogIsScopedToTheNamedRepository
+- **GIVEN** a workspace holding two repositories with unrelated histories
+- **WHEN** the log is requested for a path inside the first
+- **THEN** only the first repository's commits are returned
+
+#### Scenario: CommitDiffShown
+- **WHEN** git_show is requested for a listed commit
+- **THEN** Its patch (scoped to the browser root) is returned and rendered as a diff
+
+#### Scenario: OversizedPatchTruncated
+- **WHEN** a commit's patch exceeds the size cap
+- **THEN** The patch is truncated and flagged truncated: true instead of failing
+
+#### Scenario: CommitIdFromAnotherRepository
+- **GIVEN** a commit id that exists only in the second repository
+- **WHEN** its patch is requested against the first
+- **THEN** the request fails with a git_error and no patch from either repository is returned
+
+### Requirement: GitUISurface
+
+The frontend SHALL show a branch chip in the header when git is available, mark files
+carrying a status with a colored badge in the file tree (and a dot on collapsed ancestor
+directories) whichever repository they belong to, offer a worktree diff toggle in the viewer
+for files with changes, offer a history affordance in the viewer for any tracked file — not
+only changed ones — that opens the file-history graph, and open commit history from the
+branch chip (click a commit → its patch full-pane).
+
+The branch chip SHALL name the repository owning the file the user has selected, with that
+repository's branch and ahead/behind counts, and the commit history opened from it SHALL be
+that repository's. Selecting a file in another repository SHALL move the chip to that
+repository without any picker control. When no file is selected, the chip SHALL name the
+workspace's only repository if it has exactly one, and SHALL otherwise name no branch while
+remaining visible. A selected file owned by no repository SHALL leave the chip on the last
+repository it named, and SHALL offer neither diff toggle nor history affordance.
+
+#### Scenario: BranchChipVisible
+- **WHEN** the app connects to a server with gitAvailable: true
+- **THEN** The header shows the current branch chip
+
+#### Scenario: TreeBadges
+- **WHEN** the status lists a modified file inside an expanded directory
+- **THEN** The file row shows an "M" badge and collapsed ancestors show a change dot
+
+#### Scenario: BadgesSpanRepositories
+- **GIVEN** a workspace whose root is not a repository and whose two child directories are
+- **WHEN** each holds a modified file and the tree is expanded to show them
+- **THEN** both rows carry their badge, and each child directory shows a change dot when collapsed
+
+#### Scenario: TheChipFollowsTheSelection
+- **GIVEN** a workspace holding two repositories on different branches
+- **WHEN** the user selects a file in the first and then a file in the second
+- **THEN** the chip names the first repository's branch, then the second's
+
+#### Scenario: FullGitSurfaceOnClickingATrackedLeaf
+- **GIVEN** a workspace whose root is not a repository, holding a repository with a modified tracked file
+- **WHEN** the user clicks that file in the tree
+- **THEN** the chip names its repository's branch, the viewer offers its worktree diff and its history affordance, and the chip's commit history lists that repository's commits
+
+#### Scenario: NoSelectionInAMultiRepositoryWorkspace
+- **GIVEN** a workspace holding two repositories and no file selected
+- **THEN** the chip is shown and names no branch
+
+#### Scenario: ViewerDiffToggle
+- **WHEN** a file present in the git status is open in the viewer
+- **THEN** A "diff" toggle shows its before/after against HEAD
+
+#### Scenario: ViewerHistoryAffordance
+- **WHEN** an unmodified tracked file is open in the viewer
+- **THEN** no diff toggle is offered but the history affordance is

--- a/openspec/changes/resolve-git-per-repo-under-workspace/specs/git/spec.md
+++ b/openspec/changes/resolve-git-per-repo-under-workspace/specs/git/spec.md
@@ -203,13 +203,20 @@ for files with changes, offer a history affordance in the viewer for any tracked
 only changed ones — that opens the file-history graph, and open commit history from the
 branch chip (click a commit → its patch full-pane).
 
-The branch chip SHALL name the repository owning the file the user has selected, with that
-repository's branch and ahead/behind counts, and the commit history opened from it SHALL be
-that repository's. Selecting a file in another repository SHALL move the chip to that
-repository without any picker control. When no file is selected, the chip SHALL name the
-workspace's only repository if it has exactly one, and SHALL otherwise name no branch while
-remaining visible. A selected file owned by no repository SHALL leave the chip on the last
-repository it named, and SHALL offer neither diff toggle nor history affordance.
+The branch chip SHALL name the repository owning what the user last touched in the file
+tree — a file or a directory — with that repository's branch and ahead/behind counts, and
+the commit history opened from it SHALL be that repository's. Touching anything in another
+repository SHALL move the chip to that repository without any picker control: walking into a
+project's directory says which project the user is in as surely as opening one of its files,
+and SHALL move the chip as surely.
+
+When nothing has been touched, the chip SHALL name the workspace's only repository if it has
+exactly one, and SHALL otherwise name no branch while remaining visible. A selection owned by
+no repository SHALL likewise name no branch, rather than continuing to name the last
+repository it knew — in a directory of projects the loose files at the root are exactly where
+a README lives, and a chip naming a project the user has left is worse than one admitting it
+has none. A file owned by no repository SHALL additionally offer neither diff toggle nor
+history affordance.
 
 #### Scenario: BranchChipVisible
 - **WHEN** the app connects to a server with gitAvailable: true
@@ -228,6 +235,16 @@ repository it named, and SHALL offer neither diff toggle nor history affordance.
 - **GIVEN** a workspace holding two repositories on different branches
 - **WHEN** the user selects a file in the first and then a file in the second
 - **THEN** the chip names the first repository's branch, then the second's
+
+#### Scenario: TheChipFollowsADirectoryToo
+- **GIVEN** a workspace holding two repositories, with the chip naming the first
+- **WHEN** the user clicks the second repository's directory in the tree, opening no file
+- **THEN** the chip names the second repository's branch
+
+#### Scenario: ASelectionUnderNoRepositoryNamesNothing
+- **GIVEN** a workspace holding two repositories, with the chip naming one of them
+- **WHEN** the user selects a file that lies under no repository
+- **THEN** the chip remains on screen and names no branch
 
 #### Scenario: FullGitSurfaceOnClickingATrackedLeaf
 - **GIVEN** a workspace whose root is not a repository, holding a repository with a modified tracked file

--- a/openspec/changes/resolve-git-per-repo-under-workspace/specs/multi-project-workspaces/spec.md
+++ b/openspec/changes/resolve-git-per-repo-under-workspace/specs/multi-project-workspaces/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: IsolateWorkspacesFromEachOther
+
+Each workspace SHALL own its agent session, sandbox, browser and writable roots, its set of
+git repositories, file watcher, toolset, session manager and work plan. A server message
+produced by one workspace SHALL reach only the clients subscribed to that workspace. A tool
+call in one workspace SHALL be confined to that workspace's sandbox. A git command served
+for one workspace SHALL run only against a repository in that workspace's own set, whichever
+repositories another open workspace holds.
+
+#### Scenario: EventsDoNotCrossWorkspaces
+- **GIVEN** turns running concurrently in workspace A and workspace B
+- **WHEN** each emits streaming events
+- **THEN** a client subscribed to A receives only A's events
+
+#### Scenario: SandboxIsPerWorkspace
+- **GIVEN** workspace A rooted at one directory and workspace B at another
+- **WHEN** an agent tool in A tries to read a file under B's root
+- **THEN** the tool call fails, unless that path is within A's own sandbox
+
+#### Scenario: RepositoriesArePerWorkspace
+- **GIVEN** workspace A and workspace B, each holding repositories under its own root
+- **WHEN** a git request is served for a client subscribed to A
+- **THEN** it is answered from A's repository set only, and none of B's repositories is consulted

--- a/openspec/changes/resolve-git-per-repo-under-workspace/tasks.md
+++ b/openspec/changes/resolve-git-per-repo-under-workspace/tasks.md
@@ -1,0 +1,45 @@
+## 1. Repository discovery and resolution
+
+- [x] 1.1 Add a repository-set module in `server/src/git.ts`: discover `.git` markers under a root (directory *or* file markers), reusing the file browser's exclusion list, bounded in depth, not descending past a found repository; verify with unit tests over a temp fixture holding a nested repo, a marker-file repo, an excluded `node_modules` repo, and a repo below the depth bound
+- [x] 1.2 Include the ancestor repository from `probeGit(browserRoot)` in the set when the root is inside a work tree; verify a fixture whose root is inside a repo and holds one nested repo yields both toplevels
+- [x] 1.3 Implement longest-prefix resolution from a browser-root-relative path to a repository, returning "owned by none" rather than throwing; verify unit tests cover the nested-wins case, the ancestor-fallback case, and the unowned case
+- [x] 1.4 `realpath`-resolve each candidate toplevel and reject any failing the file browser's `isWithin`/`resolveConfined` before it can enter the set; verify a fixture with a symlinked directory whose real repository lies outside the browser root leaves the set empty and spawns no git command
+- [x] 1.5 Rewrite the `git.ts` header comment to state the confinement invariant in its new form (cwd = browser root or a confined repository toplevel, pathspec still bounding output); verify by reading it against the commands actually spawned
+
+## 2. Workspace ownership
+
+- [x] 2.1 Replace `WorkspaceResources.git: { toplevel } | null` with the repository set in `server/src/workspace.ts`, discovered when resources are built; verify existing workspace tests still pass and a new test asserts a non-repository root holding two repos produces a two-element set
+- [x] 2.2 Derive `gitAvailable` from "the set is non-empty" rather than from a single probe; verify the snapshot carries `gitAvailable: true` for a non-repository root holding repositories, and `false` for a root holding none
+
+## 3. Working-tree status across repositories
+
+- [x] 3.1 Turn `gitStatus` into a per-repository fan-out with bounded concurrency, rebasing each entry's path from repository-relative to browser-root-relative; verify a two-repo fixture reports both modified files with browser-root-relative paths
+- [x] 3.2 Report each repository's branch and ahead/behind counts alongside the files; verify the two-repo fixture reports two branches, and a single-repo fixture reports exactly one and issues exactly one git invocation
+- [x] 3.3 Drop a parent's gitlink entry when its path is itself a repository in the set; verify a submodule fixture lists no duplicate path
+- [x] 3.4 Scope the refresh triggered by a `file_changed` event to the repository owning the changed path; verify a two-repo fixture spawns one `git status`, not two, when one file changes
+
+## 4. Protocol and repository-scoped requests
+
+- [x] 4.1 Replace `git_status`'s flat `branch`/`ahead`/`behind` with a `repos: { root, branch, ahead, behind }[]` array in `shared/src/protocol.ts`; verify the package typechecks and no consumer still reads the removed fields
+- [x] 4.2 Add a `repo` field to the `git_log` and `git_show` requests and resolve it against the workspace's set in `server/src/index.ts`; verify a log request naming the first repository returns none of the second's commits
+- [x] 4.3 Fail `git_show` with a git error when the sha does not exist in the named repository, with no fallback to another; verify a test asserts the error and that no patch from either repository is returned
+- [x] 4.4 Resolve the repository per path in the file-scoped handlers (`git_diff`, `git_file_log`, revision-pair diff) instead of reading a workspace-wide toplevel; verify diff and file history work for a file in a nested repository under a non-repository root
+
+## 5. Freshness
+
+- [x] 5.1 Re-scan the affected subtree, debounced, when a watcher event touches a `.git` marker; verify a test clones/inits a repository into a running workspace and observes its files gaining status without a restart
+- [x] 5.2 Drop a toplevel from the set when it stops being a repository; verify no git command is spawned against the former toplevel afterwards
+
+## 6. Interface
+
+- [x] 6.1 Render tree badges from the merged multi-repository status, including change dots on collapsed ancestors across repositories; verify a component test over a two-repo status shows both badges and both directory dots
+- [x] 6.2 Bind the branch chip to the repository owning the current selection, naming the repository alongside the branch when the set holds more than one; verify a component test selecting a file in each repository moves the chip to each branch in turn
+- [x] 6.3 Implement the no-selection and unowned-selection rules — one repository names itself, several name no branch, an unowned selection leaves the chip where it was; verify component tests for the three cases
+- [x] 6.4 Send the current selection's repository with the log and commit-patch requests opened from the chip; verify the chip's history lists only that repository's commits
+
+## 7. Verification
+
+- [x] 7.1 Build a server test fixture whose root is not a repository and whose children are, and assert the single-repository workspace behaves exactly as before it (the regression bar from design.md — Migration Plan); verify the pre-existing git test suite passes unchanged against the one-repository fixture
+- [x] 7.2 Produce the scenario-to-test matrix over every `#### Scenario:` in the `git` and `multi-project-workspaces` deltas, listing test file and test name for each and classifying it covered/partial/uncovered; verify the list against `rg '^#### Scenario:' openspec/changes/resolve-git-per-repo-under-workspace/specs/`
+- [x] 7.3 Drive the feature in the running widget per the bench workflow — rebuild `web`, then `@pi-outpost/embed`, then `build:e2e-host`, open a workspace whose root is not a repository, click a tracked leaf, and read back the DOM for badge, chip, diff toggle and history affordance; verify the observed DOM, not a screenshot
+- [x] 7.4 Run `openspec validate resolve-git-per-repo-under-workspace --strict` and the server, shared and UI suites; verify all pass

--- a/server/src/git.ts
+++ b/server/src/git.ts
@@ -1,18 +1,35 @@
 /**
  * Read-only git backend for the UI: status, worktree file diff, history.
  *
- * SECURITY: every command is spawned without a shell, with a fixed argument
- * list, `cwd` at the browser root and a trailing pathspec — `-- .` for repo-scoped
- * reads, `-- <file>` for file-scoped ones — so git only ever reports content under
- * the browser root even when the repository's toplevel is an ancestor of it. The
- * `--` also stops git reading a path starting with a dash as an option or a
- * revision. Only rev-parse/status/log/show are used — nothing here can mutate the
- * repository.
+ * A workspace holds a SET of repositories, not one: the directory it is rooted at
+ * may be inside a repository, may hold several underneath it, or both. Every
+ * request naming a path is served by the repository owning that path (`repoFor`),
+ * and paths cross this module's boundary browser-root-relative in both directions.
+ *
+ * SECURITY: every command is spawned without a shell, with a fixed argument list,
+ * a trailing pathspec — `-- .` for repo-scoped reads, `-- <file>` for file-scoped
+ * ones — and `cwd` at either the browser root or a repository toplevel that has
+ * been realpath-resolved and checked to lie under that root. Both cases keep git
+ * reporting only content under the browser root: the second because the cwd is
+ * itself under it, the first because the pathspec bounds a repository whose
+ * toplevel is an ancestor. The `--` also stops git reading a path starting with a
+ * dash as an option or a revision. Only rev-parse/status/log/show are used —
+ * nothing here can mutate the repository.
  */
 import { execFile } from "node:child_process";
+import type { Dirent } from "node:fs";
+import fs from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
-import { WORKTREE_REVISION, type GitFileLogEntry, type GitFileState, type GitFileStatus, type GitLogEntry } from "@pi-outpost/shared";
+import { isWithin, realResolve } from "./sandbox.ts";
+import {
+  WORKTREE_REVISION,
+  type GitFileLogEntry,
+  type GitFileState,
+  type GitFileStatus,
+  type GitLogEntry,
+  type GitRepoStatus,
+} from "@pi-outpost/shared";
 
 const execFileAsync = promisify(execFile);
 
@@ -50,6 +67,111 @@ export async function probeGit(root: string): Promise<{ toplevel: string } | nul
 }
 
 /**
+ * One repository serving a workspace.
+ *
+ * `cwd` and `toplevel` part company only in the ancestor case: a repository whose
+ * toplevel lies ABOVE the browser root is still usable, but git must run from the
+ * browser root so the `-- .` pathspec keeps its output inside it. For a repository
+ * at or under the root the two are the same directory.
+ */
+export interface GitRepo {
+  /** Absolute toplevel of the work tree, as git reports it. */
+  toplevel: string;
+  /** Directory git commands run in - always the browser root, or a directory under it. */
+  cwd: string;
+  /** Identity on the wire: browser-root-relative posix path; "" for the root itself or an ancestor. */
+  id: string;
+}
+
+/**
+ * Directories discovery never enters. `.git` is absent on purpose: it is what
+ * discovery looks FOR, recognised by name rather than by descending into it.
+ */
+const DISCOVERY_IGNORED_NAMES = new Set(["node_modules", "dist", "build", ".next", ".turbo", "__pycache__"]);
+
+/**
+ * How far below the browser root a repository is still found. A directory of
+ * projects is depth 1, a directory of clients each holding projects is 2; four
+ * leaves room without turning discovery into a full tree walk.
+ */
+const MAX_DISCOVERY_DEPTH = 4;
+
+function repoAt(browserRoot: string, toplevel: string): GitRepo {
+  const id = isWithin(browserRoot, toplevel) ? path.relative(browserRoot, toplevel).split(path.sep).join("/") : "";
+  return { toplevel, cwd: id === "" ? browserRoot : toplevel, id };
+}
+
+/**
+ * Every repository serving a workspace: the one containing the browser root, when
+ * there is one, plus every repository whose work tree lies under it. Ordered
+ * deepest-first, which is what `repoFor` reads as "longest match".
+ *
+ * SECURITY: a discovered toplevel becomes a git `cwd`, so it is realpath-resolved
+ * and checked against the browser root before it may enter the set - a symlinked
+ * directory whose real repository lives outside the root is dropped, and no command
+ * is ever spawned in it. Symlinked directories are not descended into at all, as the
+ * file browser's own search already declines to.
+ */
+export async function discoverRepos(browserRoot: string): Promise<GitRepo[]> {
+  const repos: GitRepo[] = [];
+  const containing = await probeGit(browserRoot);
+  if (containing) repos.push(repoAt(browserRoot, containing.toplevel));
+
+  const walk = async (dir: string, depth: number): Promise<void> => {
+    let entries: Dirent[];
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return; // an unreadable directory is not a reason to fail the whole scan
+    }
+    // The marker can be a file rather than a directory - a linked work tree or a submodule
+    if (entries.some((entry) => entry.name === ".git")) {
+      const real = await realResolve(dir);
+      if (isWithin(browserRoot, real) && !repos.some((repo) => repo.toplevel === real)) {
+        repos.push(repoAt(browserRoot, real));
+      }
+      // Repositories inside a work tree are its submodules; it already accounts for them
+      return;
+    }
+    if (depth >= MAX_DISCOVERY_DEPTH) return;
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.isSymbolicLink()) continue;
+      if (entry.name.startsWith(".") || DISCOVERY_IGNORED_NAMES.has(entry.name)) continue;
+      await walk(path.join(dir, entry.name), depth + 1);
+    }
+  };
+  await walk(browserRoot, 0);
+
+  repos.sort((a, b) => b.id.length - a.id.length);
+  return repos;
+}
+
+/**
+ * The repository owning a browser-root-relative path, or null when none does.
+ *
+ * Longest match wins, so a repository nested inside another answers for its own
+ * files. `repos` must be ordered deepest-first, as `discoverRepos` returns it: the
+ * root-or-ancestor repository has the empty id and therefore sorts last, where it
+ * acts as the fallback for everything no nested repository claims.
+ */
+export function repoFor(repos: readonly GitRepo[], relPath: string): GitRepo | null {
+  for (const repo of repos) {
+    if (repo.id === "" || relPath === repo.id || relPath.startsWith(`${repo.id}/`)) return repo;
+  }
+  return null;
+}
+
+/** Browser-root-relative path -> relative to the directory git runs in. */
+export function toRepoRelative(repo: GitRepo, relPath: string): string {
+  return repo.id === "" ? relPath : relPath.slice(repo.id.length + 1);
+}
+
+/** The inverse: what git reported, back in the browser-root terms the UI speaks. */
+export function toBrowserRelative(repo: GitRepo, repoRel: string): string {
+  return repo.id === "" ? repoRel : `${repo.id}/${repoRel}`;
+}
+
+/**
  * Undo git's C-style path quoting (core.quotePath quotes any non-ASCII byte as
  * \NNN octal — accented filenames are the everyday case, not the exception).
  */
@@ -81,33 +203,39 @@ function stateFromXY(xy: string): GitFileState {
 }
 
 export interface GitStatusResult {
-  branch: string;
-  ahead: number;
-  behind: number;
+  repos: GitRepoStatus[];
   files: GitFileStatus[];
 }
 
-export async function gitStatus(root: string): Promise<GitStatusResult> {
+/**
+ * One repository's working-tree state, with paths already expressed from the
+ * browser root so several repositories' answers merge without further translation.
+ *
+ * Also the unit of a scoped refresh: a file change names a path, and only the
+ * repository owning it has anything new to say.
+ */
+export async function gitStatusFor(repo: GitRepo): Promise<GitStatusResult> {
   // -uall lists untracked files individually (default -unormal collapses a brand-new
   // directory to one "dir/" entry, leaving the files inside without badges)
-  const out = await runGit(root, ["status", "--porcelain=v2", "--branch", "--untracked-files=all", "--", "."]);
-  const result: GitStatusResult = { branch: "", ahead: 0, behind: 0, files: [] };
+  const out = await runGit(repo.cwd, ["status", "--porcelain=v2", "--branch", "--untracked-files=all", "--", "."]);
+  const repoStatus: GitRepoStatus = { repo: repo.id, branch: "", ahead: 0, behind: 0 };
+  const result: GitStatusResult = { repos: [repoStatus], files: [] };
 
-  // status paths are cwd-relative (cwd = browser root); the `-- .` pathspec already
+  // status paths are relative to the directory git ran in; the `-- .` pathspec already
   // confines entries, the "../" guard is defense in depth
   const push = (gitPath: string, status: GitFileState) => {
     const rel = unquote(gitPath);
-    if (rel !== "" && !rel.startsWith("../")) result.files.push({ path: rel, status });
+    if (rel !== "" && !rel.startsWith("../")) result.files.push({ path: toBrowserRelative(repo, rel), status });
   };
 
   for (const line of out.split("\n")) {
     if (line.startsWith("# branch.head ")) {
-      result.branch = line.slice("# branch.head ".length);
+      repoStatus.branch = line.slice("# branch.head ".length);
     } else if (line.startsWith("# branch.ab ")) {
       const match = /\+(\d+) -(\d+)/.exec(line);
       if (match) {
-        result.ahead = Number(match[1]);
-        result.behind = Number(match[2]);
+        repoStatus.ahead = Number(match[1]);
+        repoStatus.behind = Number(match[2]);
       }
     } else if (line.startsWith("1 ")) {
       // 1 XY sub mH mI mW hH hI <path>
@@ -131,6 +259,53 @@ export async function gitStatus(root: string): Promise<GitStatusResult> {
   return result;
 }
 
+/** How many repositories are read at once. A directory of projects can hold dozens. */
+const STATUS_CONCURRENCY = 4;
+
+/**
+ * Working-tree state across every repository serving the workspace.
+ *
+ * A repository that fails to answer is dropped rather than failing the sweep: one
+ * project being mid-rebase, or having just stopped being a repository, is no reason
+ * to blank the badges of every other. If they ALL fail the first error surfaces, so
+ * a one-repository workspace still reports its errors exactly as it used to.
+ */
+export async function gitStatus(repos: readonly GitRepo[], scope?: GitRepo): Promise<GitStatusResult> {
+  // A scoped read answers "one file moved, whose repository is it in?" without
+  // asking the other twenty-nine repositories of a project directory the same thing
+  const read = scope === undefined ? repos : [scope];
+  const answers: (GitStatusResult | Error)[] = new Array(read.length);
+  let next = 0;
+  const worker = async (): Promise<void> => {
+    for (;;) {
+      const index = next++;
+      const repo = read[index];
+      if (repo === undefined) return;
+      try {
+        answers[index] = await gitStatusFor(repo);
+      } catch (error) {
+        answers[index] = error as Error;
+      }
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(STATUS_CONCURRENCY, read.length) }, worker));
+
+  const ok = answers.filter((answer): answer is GitStatusResult => !(answer instanceof Error));
+  if (ok.length === 0) {
+    const failure = answers.find((answer): answer is Error => answer instanceof Error);
+    if (failure) throw failure;
+  }
+
+  // A repository nested inside another appears twice: as itself, and as the single
+  // entry its container reports for it - a gitlink, or an untracked directory named
+  // with a trailing slash. The nested repository is the one with something to say.
+  const nested = new Set(repos.map((repo) => repo.id).filter((id) => id !== ""));
+  return {
+    repos: ok.flatMap((answer) => answer.repos),
+    files: ok.flatMap((answer) => answer.files).filter((file) => !nested.has(file.path.replace(/\/$/, ""))),
+  };
+}
+
 /** `<rev>:<path>` reads paths from the repository toplevel, not from cwd. */
 function toToplevelRelative(root: string, toplevel: string, relPath: string): string {
   const prefix = path.relative(toplevel, root).split(path.sep).join("/");
@@ -152,10 +327,10 @@ function toRootRelative(root: string, toplevel: string, toplevelRel: string): st
  * already confined `relPath`; size/binary limits are the caller's too — this
  * only refuses grossly oversized blobs via the exec buffer cap.
  */
-export async function gitHeadContent(root: string, toplevel: string, relPath: string): Promise<string> {
-  const toplevelRel = toToplevelRelative(root, toplevel, relPath);
+export async function gitHeadContent(repo: GitRepo, relPath: string): Promise<string> {
+  const toplevelRel = toToplevelRelative(repo.cwd, repo.toplevel, toRepoRelative(repo, relPath));
   try {
-    return await runGit(root, ["show", `HEAD:${toplevelRel}`]);
+    return await runGit(repo.cwd, ["show", `HEAD:${toplevelRel}`]);
   } catch (error) {
     // Only "not in HEAD" means an empty before-side (untracked/added, or an unborn
     // branch); anything else (timeout, output cap) must surface, not fake a full add
@@ -167,9 +342,9 @@ export async function gitHeadContent(root: string, toplevel: string, relPath: st
 
 const SHA_PATTERN = /^[0-9a-f]{7,40}$/i;
 
-export async function gitLog(root: string, limit: number): Promise<GitLogEntry[]> {
+export async function gitLog(repo: GitRepo, limit: number): Promise<GitLogEntry[]> {
   const n = Math.max(1, Math.min(100, Math.floor(limit)));
-  const out = await runGit(root, ["log", "--format=%H%x1f%an%x1f%aI%x1f%s", "-n", String(n), "--", "."]);
+  const out = await runGit(repo.cwd, ["log", "--format=%H%x1f%an%x1f%aI%x1f%s", "-n", String(n), "--", "."]);
   return out
     .split("\n")
     .filter((line) => line.includes("\x1f"))
@@ -312,27 +487,29 @@ async function renameSourceAt(root: string, toplevel: string, sha: string, relPa
  * one in log order — that is what joins the two sides of a seam, and what keeps a
  * limit-truncated tail connected.
  */
-export async function gitFileLog(root: string, toplevel: string, relPath: string, limit: number): Promise<GitFileLogEntry[]> {
+export async function gitFileLog(repo: GitRepo, relPath: string, limit: number): Promise<GitFileLogEntry[]> {
   const n = Math.max(1, Math.min(200, Math.floor(limit)));
   const raw: RawFileLogEntry[] = [];
   const seen = new Set<string>();
   let rev: string | null = null;
-  let currentPath = relPath;
+  // Paths stay relative to the directory git runs in for the whole walk - a pathspec
+  // is read from there - and return to browser-root terms only in the result below
+  let currentPath = toRepoRelative(repo, relPath);
 
   for (let stitch = 0; stitch <= MAX_STITCHES && raw.length < n; stitch++) {
-    const batch = await fullHistoryPass(root, rev, currentPath, n - raw.length);
+    const batch = await fullHistoryPass(repo.cwd, rev, currentPath, n - raw.length);
     for (const entry of batch) {
       if (seen.has(entry.sha)) continue;
       seen.add(entry.sha);
       // Normalise here, not at the end: git reports log paths from the repository
       // toplevel, while a pathspec — including the one the next stitch passes — is
       // read from cwd, i.e. the browser root
-      raw.push({ ...entry, path: entry.path === "" ? currentPath : toRootRelative(root, toplevel, entry.path) });
+      raw.push({ ...entry, path: entry.path === "" ? currentPath : toRootRelative(repo.cwd, repo.toplevel, entry.path) });
     }
     const tail = batch[batch.length - 1];
     // Nothing left, no parent to resume from, or the budget is spent
     if (tail === undefined || tail.parents.length === 0 || raw.length >= n) break;
-    const source = await renameSourceAt(root, toplevel, tail.sha, currentPath);
+    const source = await renameSourceAt(repo.cwd, repo.toplevel, tail.sha, currentPath);
     if (source === null) break;
     currentPath = source;
     rev = tail.parents[0];
@@ -348,7 +525,7 @@ export async function gitFileLog(root: string, toplevel: string, relPath: string
       date: entry.date,
       subject: entry.subject,
       parents: kept.length > 0 ? kept : next ? [next.sha] : [],
-      path: entry.path,
+      path: toBrowserRelative(repo, entry.path),
       added: entry.added,
       deleted: entry.deleted,
     };
@@ -363,13 +540,13 @@ export async function gitFileLog(root: string, toplevel: string, relPath: string
  * is refused before a process is spawned, so no revision expression (`HEAD@{…}`,
  * a branch name, an option-looking string) can be smuggled in.
  */
-export async function gitRevisionContent(root: string, toplevel: string, rev: string, relPath: string): Promise<string> {
+export async function gitRevisionContent(repo: GitRepo, rev: string, relPath: string): Promise<string> {
   if (rev === WORKTREE_REVISION) throw new GitError("The working tree is read from disk, not from git");
   if (!SHA_PATTERN.test(rev)) throw new GitError("Invalid commit id");
-  const toplevelRel = toToplevelRelative(root, toplevel, relPath);
+  const toplevelRel = toToplevelRelative(repo.cwd, repo.toplevel, toRepoRelative(repo, relPath));
   try {
     // ^{commit} peels annotated tags and makes git refuse blob/tree ids
-    return await runGit(root, ["show", `${rev}^{commit}:${toplevelRel}`]);
+    return await runGit(repo.cwd, ["show", `${rev}^{commit}:${toplevelRel}`]);
   } catch (error) {
     // The file simply not existing at that revision is an empty side, not a failure.
     // Everything else surfaces — notably "dereferences to blob type", which is
@@ -380,11 +557,11 @@ export async function gitRevisionContent(root: string, toplevel: string, rev: st
   }
 }
 
-export async function gitShow(root: string, sha: string): Promise<{ patch: string; truncated: boolean }> {
+export async function gitShow(repo: GitRepo, sha: string): Promise<{ patch: string; truncated: boolean }> {
   if (!SHA_PATTERN.test(sha)) throw new GitError("Invalid commit id");
   // SECURITY: ^{commit} peels annotated tags but makes git refuse blob/tree ids —
   // `show <blob> -- .` would ignore the pathspec and print content outside the root
-  const out = await runGit(root, ["show", "--format=%h %an %aI%n%s%n", "--patch", `${sha}^{commit}`, "--", "."]);
+  const out = await runGit(repo.cwd, ["show", "--format=%h %an %aI%n%s%n", "--patch", `${sha}^{commit}`, "--", "."]);
   const bytes = Buffer.from(out, "utf8");
   if (bytes.byteLength > MAX_PATCH_BYTES) {
     // Byte-accurate cap; strip the replacement char a split code point leaves behind

--- a/server/src/git.ts
+++ b/server/src/git.ts
@@ -97,8 +97,11 @@ const DISCOVERY_IGNORED_NAMES = new Set(["node_modules", "dist", "build", ".next
 const MAX_DISCOVERY_DEPTH = 4;
 
 function repoAt(browserRoot: string, toplevel: string): GitRepo {
-  const id = isWithin(browserRoot, toplevel) ? path.relative(browserRoot, toplevel).split(path.sep).join("/") : "";
-  return { toplevel, cwd: id === "" ? browserRoot : toplevel, id };
+  // git reports a toplevel with forward slashes on Windows; `resolve` puts it back in
+  // the platform's own terms so it can be compared with a path the filesystem gave us
+  const native = path.resolve(toplevel);
+  const id = isWithin(browserRoot, native) ? path.relative(browserRoot, native).split(path.sep).join("/") : "";
+  return { toplevel: native, cwd: id === "" ? browserRoot : native, id };
 }
 
 /**
@@ -112,7 +115,13 @@ function repoAt(browserRoot: string, toplevel: string): GitRepo {
  * is ever spawned in it. Symlinked directories are not descended into at all, as the
  * file browser's own search already declines to.
  */
-export async function discoverRepos(browserRoot: string): Promise<GitRepo[]> {
+export async function discoverRepos(root: string): Promise<GitRepo[]> {
+  // Canonicalise the root ONCE, and compare everything against that. A caller may
+  // hand over a path the filesystem knows by another name - on Windows `%TEMP%` is a
+  // short name, `RUNNER~1` for `runneradmin` - and every candidate below is
+  // realpath-resolved before the confinement check. Comparing a short root with an
+  // expanded child rejects the whole tree and quietly discovers nothing.
+  const browserRoot = await realResolve(root);
   const repos: GitRepo[] = [];
   const containing = await probeGit(browserRoot);
   if (containing) repos.push(repoAt(browserRoot, containing.toplevel));
@@ -205,6 +214,15 @@ function stateFromXY(xy: string): GitFileState {
 export interface GitStatusResult {
   repos: GitRepoStatus[];
   files: GitFileStatus[];
+  /**
+   * Repositories in the set that could not answer, by id.
+   *
+   * A repository stops being one without touching any directory a client has
+   * listed - `rm -rf proj/.git` changes `proj`, which nobody expanded - so the
+   * watcher never hears of it. The failure is the more reliable signal: a caller
+   * seeing this non-empty knows the set is stale and can go and look again.
+   */
+  missing: string[];
 }
 
 /**
@@ -219,7 +237,7 @@ export async function gitStatusFor(repo: GitRepo): Promise<GitStatusResult> {
   // directory to one "dir/" entry, leaving the files inside without badges)
   const out = await runGit(repo.cwd, ["status", "--porcelain=v2", "--branch", "--untracked-files=all", "--", "."]);
   const repoStatus: GitRepoStatus = { repo: repo.id, branch: "", ahead: 0, behind: 0 };
-  const result: GitStatusResult = { repos: [repoStatus], files: [] };
+  const result: GitStatusResult = { repos: [repoStatus], files: [], missing: [] };
 
   // status paths are relative to the directory git ran in; the `-- .` pathspec already
   // confines entries, the "../" guard is defense in depth
@@ -295,6 +313,7 @@ export async function gitStatus(repos: readonly GitRepo[], scope?: GitRepo): Pro
     const failure = answers.find((answer): answer is Error => answer instanceof Error);
     if (failure) throw failure;
   }
+  const missing = read.filter((_, index) => answers[index] instanceof Error).map((repo) => repo.id);
 
   // A repository nested inside another appears twice: as itself, and as the single
   // entry its container reports for it - a gitlink, or an untracked directory named
@@ -303,6 +322,7 @@ export async function gitStatus(repos: readonly GitRepo[], scope?: GitRepo): Pro
   return {
     repos: ok.flatMap((answer) => answer.repos),
     files: ok.flatMap((answer) => answer.files).filter((file) => !nested.has(file.path.replace(/\/$/, ""))),
+    missing,
   };
 }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -354,6 +354,7 @@ const workspace = await Workspace.create({
     workspace.noteDirectoryChange();
     broadcast(workspace, { type: "directory_changed", path: relPath });
   },
+  onRepositoriesChanged: () => broadcast(workspace, { type: "git_repositories_changed", available: workspace.repos.length > 0 }),
   createRuntime: () => {
     throw new Error("the boot workspace's runtime is built in index.ts and attached");
   },
@@ -1043,6 +1044,7 @@ for (const root of config.openProjects) {
         restored.noteDirectoryChange();
         broadcast(restored, { type: "directory_changed", path: relPath });
       },
+      onRepositoriesChanged: () => broadcast(restored, { type: "git_repositories_changed", available: restored.repos.length > 0 }),
       createRuntime: () => { throw new Error("unused: runtimes are built through ensureStarted"); },
     });
     workspaces.add(restored);
@@ -1956,6 +1958,7 @@ async function handleOpenProject(socket: WebSocket, rawRoot: string): Promise<vo
         opened.noteDirectoryChange();
         broadcast(opened, { type: "directory_changed", path: relPath });
       },
+      onRepositoriesChanged: () => broadcast(opened, { type: "git_repositories_changed", available: opened.repos.length > 0 }),
       createRuntime: () => { throw new Error("unused: runtimes are built through ensureStarted"); },
     });
   } catch (error) {
@@ -2849,10 +2852,19 @@ function repoById(workspace: Workspace, id: string): GitRepo {
 async function handleGitStatus(workspace: Workspace, socket: WebSocket, scope: string | undefined, requestId: string): Promise<void> {
   if (workspace.repos.length === 0) return send(socket, { type: "git_error", requestId, message: "git is not available" });
   try {
-    const { repos, files } = await gitStatus(workspace.repos, scope === undefined ? undefined : repoById(workspace, scope));
+    const { repos, files, missing } = await gitStatus(workspace.repos, scope === undefined ? undefined : repoById(workspace, scope));
     send(socket, { type: "git_status", requestId, ...(scope === undefined ? {} : { repo: scope }), repos, files });
+    // A repository that cannot answer has usually stopped being one, and did so
+    // without touching a directory any client had listed - `rm -rf proj/.git` changes
+    // `proj`, which nobody expanded, so the watcher heard nothing at all. Look again,
+    // and announce it if the set really did change.
+    if (missing.length > 0) void workspace.rediscoverRepos();
   } catch (error) {
     send(socket, { type: "git_error", requestId, message: gitErrorMessage(error) });
+    // The same signal, from the other side: a sweep where EVERY repository failed
+    // throws rather than returning, and a workspace down to its last repository
+    // reaches exactly that path when it loses it.
+    void workspace.rediscoverRepos();
   }
 }
 
@@ -2881,7 +2893,7 @@ async function handleGitDiff(workspace: Workspace, socket: WebSocket, filePath: 
 async function handleGitLog(workspace: Workspace, socket: WebSocket, repo: string, limit: number, requestId: string): Promise<void> {
   if (workspace.repos.length === 0) return send(socket, { type: "git_error", requestId, message: "git is not available" });
   try {
-    send(socket, { type: "git_log", requestId, entries: await gitLog(repoById(workspace, repo), limit) });
+    send(socket, { type: "git_log", requestId, repo, entries: await gitLog(repoById(workspace, repo), limit) });
   } catch (error) {
     send(socket, { type: "git_error", requestId, message: gitErrorMessage(error) });
   }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -100,7 +100,7 @@ import {
   uploadFileFromBrowser,
   writeFileFromBrowser,
 } from "./fileBrowser.ts";
-import { GitError, gitFileLog, gitHeadContent, gitLog, gitRevisionContent, gitShow, gitStatus } from "./git.ts";
+import { GitError, gitFileLog, gitHeadContent, gitLog, gitRevisionContent, gitShow, gitStatus, repoFor, type GitRepo } from "./git.ts";
 import { createDocxExtractToolDefinition } from "./docxTool.ts";
 import { createXlsxExtractToolDefinition } from "./xlsxTool.ts";
 import { createPptxExtractToolDefinition } from "./pptxTool.ts";
@@ -350,7 +350,10 @@ function workspaceOptions(settings: WorkspaceSettings): Omit<WorkspaceOptions, "
  */
 const workspace = await Workspace.create({
   ...workspaceOptions({ cwd: config.cwd, ...(config.sandbox ? { sandbox: config.sandbox } : {}) }),
-  onDirectoryChanged: (relPath) => broadcast(workspace, { type: "directory_changed", path: relPath }),
+  onDirectoryChanged: (relPath) => {
+    workspace.noteDirectoryChange();
+    broadcast(workspace, { type: "directory_changed", path: relPath });
+  },
   createRuntime: () => {
     throw new Error("the boot workspace's runtime is built in index.ts and attached");
   },
@@ -1036,7 +1039,10 @@ for (const root of config.openProjects) {
   try {
     const restored = await Workspace.create({
       ...workspaceOptions({ cwd: root }),
-      onDirectoryChanged: (relPath) => broadcast(restored, { type: "directory_changed", path: relPath }),
+      onDirectoryChanged: (relPath) => {
+        restored.noteDirectoryChange();
+        broadcast(restored, { type: "directory_changed", path: relPath });
+      },
       createRuntime: () => { throw new Error("unused: runtimes are built through ensureStarted"); },
     });
     workspaces.add(restored);
@@ -1260,7 +1266,7 @@ function snapshot(workspace: Workspace): SessionSnapshot {
     // combine the new transcript/session id with the previous session's plan.
     workPlan: sameSessionFile(state.sessionFile, workspace.workPlanSessionFile) ? workspace.workPlan : null,
     writableRoot: workspace.writableRoot,
-    gitAvailable: workspace.git !== null,
+    gitAvailable: workspace.repos.length > 0,
     credentials: credentialStatus(workspace),
     // Omitted, not emptied, when the runtime cannot report an inventory: "none
     // loaded" and "this runtime never sees them" are different facts, and only one
@@ -1946,7 +1952,10 @@ async function handleOpenProject(socket: WebSocket, rawRoot: string): Promise<vo
     // the persisted set start the same way, and share the same in-flight guard.
     opened = await Workspace.create({
       ...workspaceOptions({ cwd: root }),
-      onDirectoryChanged: (relPath) => broadcast(opened, { type: "directory_changed", path: relPath }),
+      onDirectoryChanged: (relPath) => {
+        opened.noteDirectoryChange();
+        broadcast(opened, { type: "directory_changed", path: relPath });
+      },
       createRuntime: () => { throw new Error("unused: runtimes are built through ensureStarted"); },
     });
   } catch (error) {
@@ -2812,11 +2821,36 @@ function gitErrorMessage(error: unknown): string {
     : `Unexpected error: ${(error as Error).message}`;
 }
 
-async function handleGitStatus(workspace: Workspace, socket: WebSocket, requestId: string): Promise<void> {
-  if (workspace.git === null) return send(socket, { type: "git_error", requestId, message: "git is not available" });
+/**
+ * The repository owning a path.
+ *
+ * A file under no repository is not an error of the client's making — a workspace
+ * can hold both versioned projects and loose notes — but it has no HEAD, no history
+ * and no branch, so a request naming one has nothing to answer with.
+ */
+function repoForPath(workspace: Workspace, relPath: string): GitRepo {
+  const repo = repoFor(workspace.repos, relPath);
+  if (repo === null) throw new GitError(`"${relPath}" is not in a git repository`);
+  return repo;
+}
+
+/**
+ * The repository a client named, by the same id `git_status` reported it under.
+ *
+ * Never falls back to another: a commit id from one repository resolved against a
+ * second would answer with somebody else's history, and silently.
+ */
+function repoById(workspace: Workspace, id: string): GitRepo {
+  const repo = workspace.repos.find((candidate) => candidate.id === id);
+  if (repo === undefined) throw new GitError(`No repository at "${id === "" ? "." : id}"`);
+  return repo;
+}
+
+async function handleGitStatus(workspace: Workspace, socket: WebSocket, scope: string | undefined, requestId: string): Promise<void> {
+  if (workspace.repos.length === 0) return send(socket, { type: "git_error", requestId, message: "git is not available" });
   try {
-    const { branch, ahead, behind, files } = await gitStatus(workspace.browserRoot);
-    send(socket, { type: "git_status", requestId, branch, ahead, behind, files });
+    const { repos, files } = await gitStatus(workspace.repos, scope === undefined ? undefined : repoById(workspace, scope));
+    send(socket, { type: "git_status", requestId, ...(scope === undefined ? {} : { repo: scope }), repos, files });
   } catch (error) {
     send(socket, { type: "git_error", requestId, message: gitErrorMessage(error) });
   }
@@ -2824,7 +2858,7 @@ async function handleGitStatus(workspace: Workspace, socket: WebSocket, requestI
 
 /** Worktree-vs-HEAD contents of one file; missing sides (untracked/deleted) are "". */
 async function handleGitDiff(workspace: Workspace, socket: WebSocket, filePath: string, requestId: string): Promise<void> {
-  if (workspace.git === null) return send(socket, { type: "git_error", requestId, message: "git is not available" });
+  if (workspace.repos.length === 0) return send(socket, { type: "git_error", requestId, message: "git is not available" });
   try {
     let after = "";
     try {
@@ -2833,7 +2867,7 @@ async function handleGitDiff(workspace: Workspace, socket: WebSocket, filePath: 
       // A deleted file legitimately has no worktree side; confinement/size/binary still refuse
       if (!(error instanceof FileBrowserError) || error.reason !== "not-found") throw error;
     }
-    const before = await gitHeadContent(workspace.browserRoot, workspace.git.toplevel, filePath);
+    const before = await gitHeadContent(repoForPath(workspace, filePath), filePath);
     if (before.includes("\0")) throw new FileBrowserError("binary", "Binary file — diff not supported");
     if (Buffer.byteLength(before, "utf8") > 1_048_576) {
       throw new FileBrowserError("too-large", "HEAD version is larger than the 1 MB limit");
@@ -2844,10 +2878,10 @@ async function handleGitDiff(workspace: Workspace, socket: WebSocket, filePath: 
   }
 }
 
-async function handleGitLog(workspace: Workspace, socket: WebSocket, limit: number, requestId: string): Promise<void> {
-  if (workspace.git === null) return send(socket, { type: "git_error", requestId, message: "git is not available" });
+async function handleGitLog(workspace: Workspace, socket: WebSocket, repo: string, limit: number, requestId: string): Promise<void> {
+  if (workspace.repos.length === 0) return send(socket, { type: "git_error", requestId, message: "git is not available" });
   try {
-    send(socket, { type: "git_log", requestId, entries: await gitLog(workspace.browserRoot, limit) });
+    send(socket, { type: "git_log", requestId, entries: await gitLog(repoById(workspace, repo), limit) });
   } catch (error) {
     send(socket, { type: "git_error", requestId, message: gitErrorMessage(error) });
   }
@@ -2860,12 +2894,12 @@ function isGitRevision(value: unknown): value is GitRevision {
 
 /** Commits touching one file, for the history graph. */
 async function handleGitFileLog(workspace: Workspace, socket: WebSocket, filePath: string, limit: number, requestId: string): Promise<void> {
-  if (workspace.git === null) return send(socket, { type: "git_error", requestId, message: "git is not available" });
+  if (workspace.repos.length === 0) return send(socket, { type: "git_error", requestId, message: "git is not available" });
   try {
     // Confine before spawning: this path goes straight into a pathspec. Only
     // confinement applies — a deleted or oversized file still has a history.
     await assertWithinRoot(workspace.browserRoot, filePath);
-    const entries = await gitFileLog(workspace.browserRoot, workspace.git.toplevel, filePath, limit);
+    const entries = await gitFileLog(repoForPath(workspace, filePath), filePath, limit);
     send(socket, { type: "git_file_log", requestId, path: filePath, entries });
   } catch (error) {
     send(socket, { type: "git_error", requestId, message: gitErrorMessage(error) });
@@ -2878,7 +2912,7 @@ async function handleGitFileLog(workspace: Workspace, socket: WebSocket, filePat
  * and its size and binary limits, so a pair can never smuggle out an oversized
  * blob or a path outside the browser root.
  */
-async function readRevisionSide(workspace: Workspace, revision: GitRevision, toplevel: string): Promise<string> {
+async function readRevisionSide(workspace: Workspace, revision: GitRevision): Promise<string> {
   if (revision.rev === WORKTREE_REVISION) {
     try {
       return (await readFileForPreview(workspace.browserRoot, revision.path)).content;
@@ -2890,7 +2924,7 @@ async function readRevisionSide(workspace: Workspace, revision: GitRevision, top
   }
   // Confine before spawning: the path becomes part of a `<rev>:<path>` argument
   await assertWithinRoot(workspace.browserRoot, revision.path);
-  const content = await gitRevisionContent(workspace.browserRoot, toplevel, revision.rev, revision.path);
+  const content = await gitRevisionContent(repoForPath(workspace, revision.path), revision.rev, revision.path);
   if (content.includes("\0")) throw new FileBrowserError("binary", "Binary file — diff not supported");
   if (Buffer.byteLength(content, "utf8") > MAX_PREVIEW_BYTES) {
     throw new FileBrowserError("too-large", `${revision.rev.slice(0, 7)} is larger than the 1 MB limit`);
@@ -2899,19 +2933,19 @@ async function readRevisionSide(workspace: Workspace, revision: GitRevision, top
 }
 
 async function handleGitFileDiff(workspace: Workspace, socket: WebSocket, base: GitRevision, target: GitRevision, requestId: string): Promise<void> {
-  if (workspace.git === null) return send(socket, { type: "git_error", requestId, message: "git is not available" });
+  if (workspace.repos.length === 0) return send(socket, { type: "git_error", requestId, message: "git is not available" });
   try {
-    const [beforeText, afterText] = await Promise.all([readRevisionSide(workspace, base, workspace.git.toplevel), readRevisionSide(workspace, target, workspace.git.toplevel)]);
+    const [beforeText, afterText] = await Promise.all([readRevisionSide(workspace, base), readRevisionSide(workspace, target)]);
     send(socket, { type: "git_file_diff", requestId, base, target, beforeText, afterText });
   } catch (error) {
     send(socket, { type: "git_error", requestId, message: gitErrorMessage(error) });
   }
 }
 
-async function handleGitShow(workspace: Workspace, socket: WebSocket, sha: string, requestId: string): Promise<void> {
-  if (workspace.git === null) return send(socket, { type: "git_error", requestId, message: "git is not available" });
+async function handleGitShow(workspace: Workspace, socket: WebSocket, repo: string, sha: string, requestId: string): Promise<void> {
+  if (workspace.repos.length === 0) return send(socket, { type: "git_error", requestId, message: "git is not available" });
   try {
-    const { patch, truncated } = await gitShow(workspace.browserRoot, sha);
+    const { patch, truncated } = await gitShow(repoById(workspace, repo), sha);
     send(socket, { type: "git_show", requestId, sha, patch, truncated });
   } catch (error) {
     send(socket, { type: "git_error", requestId, message: gitErrorMessage(error) });
@@ -3219,20 +3253,22 @@ function handleClientMessage(socket: WebSocket, raw: string): void {
     }
     case "git_status":
       if (typeof message.requestId !== "string") return;
-      handleGitStatus(workspace, socket, message.requestId).catch(reportError);
+      if (message.repo !== undefined && typeof message.repo !== "string") return;
+      handleGitStatus(workspace, socket, message.repo, message.requestId).catch(reportError);
       break;
     case "git_diff":
       if (typeof message.path !== "string" || typeof message.requestId !== "string") return;
       handleGitDiff(workspace, socket, message.path, message.requestId).catch(reportError);
       break;
     case "git_log":
-      if (typeof message.requestId !== "string") return;
+      if (typeof message.requestId !== "string" || typeof message.repo !== "string") return;
       if (message.limit !== undefined && typeof message.limit !== "number") return;
-      handleGitLog(workspace, socket, message.limit ?? 30, message.requestId).catch(reportError);
+      handleGitLog(workspace, socket, message.repo, message.limit ?? 30, message.requestId).catch(reportError);
       break;
     case "git_show":
       if (typeof message.sha !== "string" || typeof message.requestId !== "string") return;
-      handleGitShow(workspace, socket, message.sha, message.requestId).catch(reportError);
+      if (typeof message.repo !== "string") return;
+      handleGitShow(workspace, socket, message.repo, message.sha, message.requestId).catch(reportError);
       break;
     case "git_file_log":
       if (typeof message.path !== "string" || typeof message.requestId !== "string") return;

--- a/server/src/workspace.ts
+++ b/server/src/workspace.ts
@@ -93,6 +93,11 @@ export interface WorkspaceOptions {
    */
   onDirectoryChanged: (relPath: string) => void;
   /**
+   * Where "this workspace's repository set changed" goes. Called only when the set
+   * differs from the one it replaces, so a quiet re-scan says nothing.
+   */
+  onRepositoriesChanged?: () => void;
+  /**
    * Builds the agent runtime for this workspace. Injected because the two runtime
    * flavours are assembled from configuration this object deliberately cannot see
    * (extensions, skills, prompt templates, RPC arguments).
@@ -316,12 +321,22 @@ export class Workspace {
     this.repoRescan.unref?.();
   }
 
-  /** Rebuild the repository set from disk. A failed scan leaves the old set in place. */
+  /**
+   * Rebuild the repository set from disk. A failed scan leaves the old set in place.
+   *
+   * Announces a set that actually changed. Silence would strand a client that was
+   * told at connect there was no repository here: it suppresses every git request
+   * from then on, so the first repository cloned into an empty workspace would stay
+   * invisible however many times the tree changed afterwards.
+   */
   async rediscoverRepos(): Promise<void> {
     if (this.stopped) return;
     try {
       const repos = await discoverRepos(this.browserRoot);
-      if (!this.stopped) this.repos = repos;
+      if (this.stopped) return;
+      const before = this.repos.map((repo) => repo.toplevel).join("\n");
+      this.repos = repos;
+      if (repos.map((repo) => repo.toplevel).join("\n") !== before) this.options.onRepositoriesChanged?.();
     } catch {
       // A scan that cannot read the tree is not a reason to forget the repositories
     }

--- a/server/src/workspace.ts
+++ b/server/src/workspace.ts
@@ -21,7 +21,7 @@ import type { AgentRuntime } from "./agentRuntime.ts";
 import type { SandboxConfig } from "./config.ts";
 import { type DirectoryWatcher, createDirectoryWatcher } from "./fileWatcher.ts";
 import { resolveBrowserRoot, resolveWritableRoot } from "./fileBrowser.ts";
-import { probeGit } from "./git.ts";
+import { discoverRepos, type GitRepo } from "./git.ts";
 import { ExtensionRenderer } from "./extensionRender.ts";
 import { createSandboxedTools } from "./sandbox.ts";
 import type { ExtensionUIRequest, WorkPlan } from "@pi-outpost/shared";
@@ -37,6 +37,13 @@ export interface WorkspaceSettings {
   cwd: string;
   sandbox?: SandboxConfig;
 }
+
+/**
+ * How long a burst of disk activity is collected before the repository set is
+ * scanned again. The window opens on the first change and is not extended: a clone
+ * writes continuously, and a resetting debounce would never fire while it did.
+ */
+const REPO_RESCAN_DEBOUNCE_MS = 500;
 
 /** Server-wide limits a workspace passes through when it builds its toolset. */
 export interface WorkspaceToolLimits {
@@ -113,7 +120,12 @@ export class Workspace {
 
   browserRoot: string;
   writableRoot: string | null | undefined;
-  git: { toplevel: string } | null;
+  /**
+   * Every repository serving this workspace, deepest-first. A set rather than one:
+   * a project directory may be inside a repository, hold several underneath it, or
+   * both, and a path is answered by whichever owns it.
+   */
+  repos: GitRepo[];
   fileWatcher: DirectoryWatcher | undefined;
   sandboxedTools: ToolDefinition[] | undefined;
 
@@ -181,6 +193,8 @@ export class Workspace {
   private _runtime: AgentRuntime | undefined;
 
   private readonly options: WorkspaceOptions;
+  /** Pending repository re-scan, if a debounce window is open. */
+  private repoRescan: NodeJS.Timeout | undefined;
   private stopped = false;
   /** Retired: session and watcher released, project still open. Cleared on rebuild. */
   retired = false;
@@ -196,7 +210,7 @@ export class Workspace {
     this.settings = options.settings;
     this.browserRoot = resources.browserRoot;
     this.writableRoot = resources.writableRoot;
-    this.git = resources.git;
+    this.repos = resources.repos;
     this.fileWatcher = resources.fileWatcher;
     this.sandboxedTools = resources.sandboxedTools;
     this.options = options;
@@ -274,9 +288,43 @@ export class Workspace {
     this.fileWatcher?.close();
     this.browserRoot = resources.browserRoot;
     this.writableRoot = resources.writableRoot;
-    this.git = resources.git;
+    this.repos = resources.repos;
     this.fileWatcher = resources.fileWatcher;
     this.sandboxedTools = resources.sandboxedTools;
+  }
+
+  /**
+   * A watched directory changed on disk.
+   *
+   * The repository set was discovered once, and a workspace whose whole purpose is
+   * holding many projects meets `git clone` and `git init` daily - so a set that
+   * only refreshes on restart is wrong within the hour. The watcher announces the
+   * DIRECTORY that changed, never the file, so a new repository shows up as a
+   * change to its parent: there is nothing finer to key on than "something moved",
+   * and the answer is to look again.
+   *
+   * Debounced because a clone writes thousands of files, and the whole scan is
+   * bounded and stops at every repository it finds - in the layout that motivates
+   * this, a handful of directories.
+   */
+  noteDirectoryChange(): void {
+    if (this.stopped || this.repoRescan !== undefined) return;
+    this.repoRescan = setTimeout(() => {
+      this.repoRescan = undefined;
+      void this.rediscoverRepos();
+    }, REPO_RESCAN_DEBOUNCE_MS);
+    this.repoRescan.unref?.();
+  }
+
+  /** Rebuild the repository set from disk. A failed scan leaves the old set in place. */
+  async rediscoverRepos(): Promise<void> {
+    if (this.stopped) return;
+    try {
+      const repos = await discoverRepos(this.browserRoot);
+      if (!this.stopped) this.repos = repos;
+    } catch {
+      // A scan that cannot read the tree is not a reason to forget the repositories
+    }
   }
 
   /**
@@ -286,6 +334,8 @@ export class Workspace {
   async stop(): Promise<void> {
     if (this.stopped) return;
     this.stopped = true;
+    if (this.repoRescan !== undefined) clearTimeout(this.repoRescan);
+    this.repoRescan = undefined;
     this.fileWatcher?.close();
     this.fileWatcher = undefined;
     this.renderer.configure(undefined);
@@ -321,7 +371,12 @@ export class Workspace {
 interface WorkspaceResources {
   browserRoot: string;
   writableRoot: string | null | undefined;
-  git: { toplevel: string } | null;
+  /**
+   * Every repository serving this workspace, deepest-first. A set rather than one:
+   * a project directory may be inside a repository, hold several underneath it, or
+   * both, and a path is answered by whichever owns it.
+   */
+  repos: GitRepo[];
   fileWatcher: DirectoryWatcher | undefined;
   sandboxedTools: ToolDefinition[] | undefined;
 }
@@ -330,7 +385,7 @@ async function buildResources(options: WorkspaceOptions): Promise<WorkspaceResou
   const { settings, limits } = options;
   const browserRoot = await resolveBrowserRoot(settings);
   const writableRoot = await resolveWritableRoot(settings, browserRoot);
-  const git = await probeGit(browserRoot);
+  const repos = await discoverRepos(browserRoot);
   const sandboxedTools = settings.sandbox
     ? [
         ...(await createSandboxedTools(
@@ -347,5 +402,5 @@ async function buildResources(options: WorkspaceOptions): Promise<WorkspaceResou
   const fileWatcher = options.watchFiles
     ? createDirectoryWatcher({ root: browserRoot, onChange: options.onDirectoryChanged })
     : undefined;
-  return { browserRoot, writableRoot, git, fileWatcher, sandboxedTools };
+  return { browserRoot, writableRoot, repos, fileWatcher, sandboxedTools };
 }

--- a/server/test/git-multi-repo.test.mjs
+++ b/server/test/git-multi-repo.test.mjs
@@ -218,6 +218,97 @@ describe("repositories that appear and vanish while the server runs", () => {
 });
 
 // ---------------------------------------------------------------------------
+// openlore: scenario=ARepositoryClonedWhileRunning spec=git
+describe("a workspace that had no repository at all, and gains one", () => {
+  let server;
+  let client;
+  let root;
+  let requestCounter = 0;
+
+  async function ask(message) {
+    const requestId = `empty-${++requestCounter}`;
+    client.send({ ...message, requestId });
+    return client.waitFor((m) => m.requestId === requestId, 20_000);
+  }
+
+  before(async () => {
+    root = await makeWorkspace({ "notes.md": "no repository here yet\n" });
+    server = await startServer(root);
+    client = connect(server.wsUrl());
+  });
+
+  after(async () => {
+    client?.close();
+    await server?.stop();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test("tells the client, which was told at connect there was none", async () => {
+    const hello = await client.waitFor("hello");
+    assert.equal(hello.gitAvailable, false);
+    // The watcher only watches what a client has listed
+    await ask({ type: "list_directory", path: "" });
+
+    await makeRepo(path.join(root, "arrived"), "main", "arrived initial");
+
+    const announced = await client.waitFor((m) => m.type === "git_repositories_changed", 20_000);
+    assert.equal(announced.available, true, "a client that stopped asking must be told, not left to ask again");
+
+    const status = await ask({ type: "git_status" });
+    assert.equal(status.type, "git_status");
+    assert.deepEqual(
+      status.repos.map((repo) => repo.repo),
+      ["arrived"],
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// openlore: scenario=ARepositoryThatStopsBeingOne spec=git
+describe("a workspace that loses its last repository", () => {
+  let server;
+  let client;
+  let root;
+  let requestCounter = 0;
+
+  async function ask(message) {
+    const requestId = `lost-${++requestCounter}`;
+    client.send({ ...message, requestId });
+    return client.waitFor((m) => m.requestId === requestId, 20_000);
+  }
+
+  before(async () => {
+    root = await makeWorkspace({});
+    await makeRepo(path.join(root, "only"), "main", "only initial");
+    server = await startServer(root);
+    client = connect(server.wsUrl());
+  });
+
+  after(async () => {
+    client?.close();
+    await server?.stop();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test("says git is gone, rather than leaving stale badges on screen", async () => {
+    const hello = await client.waitFor("hello");
+    assert.equal(hello.gitAvailable, true);
+    await ask({ type: "list_directory", path: "" });
+
+    // `rm -rf only/.git` changes `only`, which nobody expanded, so the watcher hears
+    // nothing at all. The next status is what finds out: the repository cannot answer.
+    await rm(path.join(root, "only", ".git"), { recursive: true, force: true });
+    await ask({ type: "git_status" });
+
+    const announced = await client.waitFor((m) => m.type === "git_repositories_changed", 20_000);
+    assert.equal(announced.available, false);
+
+    const answer = await ask({ type: "git_status" });
+    assert.equal(answer.type, "git_error");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // openlore: scenario=NoRepository spec=git
 describe("a workspace with no repository at all", () => {
   let server;

--- a/server/test/git-multi-repo.test.mjs
+++ b/server/test/git-multi-repo.test.mjs
@@ -1,0 +1,304 @@
+/**
+ * A workspace rooted at a directory that is NOT a repository, holding one per child.
+ *
+ * The layout this whole change exists for: the git surface used to go dark here,
+ * because the workspace held one repository or none. Over the socket, because what
+ * matters is what a client can actually get after clicking a tracked leaf.
+ */
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdir, realpath, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { after, before, describe, test } from "node:test";
+import { connect, makeWorkspace, startServer } from "./harness.mjs";
+
+function git(cwd, ...args) {
+  execFileSync("git", args, { cwd, stdio: "pipe" });
+}
+
+async function makeRepo(dir, branch, subject) {
+  await mkdir(dir, { recursive: true });
+  git(dir, "init", "-b", branch);
+  git(dir, "config", "user.email", "test@test");
+  git(dir, "config", "user.name", "Test");
+  git(dir, "config", "commit.gpgsign", "false");
+  await writeFile(path.join(dir, "README.md"), "# project\n");
+  git(dir, "add", "--", "README.md");
+  git(dir, "commit", "-m", subject);
+}
+
+describe("a workspace holding a repository per child directory", () => {
+  let server;
+  let client;
+  let root;
+  let hello;
+  let requestCounter = 0;
+
+  async function ask(message) {
+    const requestId = `req-${++requestCounter}`;
+    client.send({ ...message, requestId });
+    return client.waitFor((m) => m.requestId === requestId, 20_000);
+  }
+
+  before(async () => {
+    root = await makeWorkspace({});
+    await makeRepo(path.join(root, "projA"), "main", "projA initial");
+    await makeRepo(path.join(root, "projB"), "release", "projB initial");
+    // A change in each, so both have something to badge
+    await writeFile(path.join(root, "projA", "README.md"), "# projA changed\n");
+    await writeFile(path.join(root, "projB", "fresh.txt"), "new\n");
+    // A file belonging to no repository at all
+    await writeFile(path.join(root, "notes.md"), "loose\n");
+
+    server = await startServer(root);
+    client = connect(server.wsUrl());
+    hello = await client.waitFor("hello");
+  });
+
+  after(async () => {
+    client?.close();
+    await server?.stop();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  // openlore: scenario=RepositoriesOnlyUnderneath spec=git
+  test("advertises git as available, though the root is no repository", () => {
+    assert.equal(hello.gitAvailable, true);
+  });
+
+  // openlore: scenario=StatusSpansRepositories spec=git
+  test("reports both repositories, each with its own branch", async () => {
+    const status = await ask({ type: "git_status" });
+    assert.equal(status.type, "git_status");
+    const branches = Object.fromEntries(status.repos.map((repo) => [repo.repo, repo.branch]));
+    assert.deepEqual(branches, { projA: "main", projB: "release" });
+  });
+
+  // openlore: scenario=NestedRepositoriesUnderANonRepositoryRoot spec=git
+  test("badges files from both, keyed from the browser root", async () => {
+    const status = await ask({ type: "git_status" });
+    const byPath = Object.fromEntries(status.files.map((file) => [file.path, file.status]));
+    assert.equal(byPath["projA/README.md"], "modified");
+    assert.equal(byPath["projB/fresh.txt"], "untracked");
+  });
+
+  test("diffs a file against the HEAD of ITS repository", async () => {
+    const diff = await ask({ type: "git_diff", path: "projA/README.md" });
+    assert.equal(diff.type, "git_diff");
+    assert.equal(diff.before, "# project\n");
+    assert.equal(diff.after, "# projA changed\n");
+  });
+
+  // openlore: scenario=FullGitSurfaceOnClickingATrackedLeaf spec=git
+  test("gives a file its own repository's history", async () => {
+    const log = await ask({ type: "git_file_log", path: "projA/README.md" });
+    assert.equal(log.type, "git_file_log");
+    assert.deepEqual(
+      log.entries.map((entry) => entry.subject),
+      ["projA initial"],
+    );
+    assert.deepEqual([...new Set(log.entries.map((entry) => entry.path))], ["projA/README.md"]);
+  });
+
+  // openlore: scenario=LogIsScopedToTheNamedRepository spec=git
+  test("scopes the commit log to the repository the client names", async () => {
+    const a = await ask({ type: "git_log", repo: "projA" });
+    const b = await ask({ type: "git_log", repo: "projB" });
+    assert.deepEqual(
+      a.entries.map((entry) => entry.subject),
+      ["projA initial"],
+    );
+    assert.deepEqual(
+      b.entries.map((entry) => entry.subject),
+      ["projB initial"],
+    );
+  });
+
+  // openlore: scenario=CommitIdFromAnotherRepository spec=git
+  test("refuses a commit id against a repository that does not have it", async () => {
+    const b = await ask({ type: "git_log", repo: "projB" });
+    const answer = await ask({ type: "git_show", repo: "projA", sha: b.entries[0].sha });
+    assert.equal(answer.type, "git_error");
+  });
+
+  test("refuses a repository it does not hold, rather than picking one", async () => {
+    const answer = await ask({ type: "git_log", repo: "projZ" });
+    assert.equal(answer.type, "git_error");
+    assert.match(answer.message, /projZ/);
+  });
+
+  // openlore: scenario=AFileOwnedByNoRepository spec=git
+  test("says so for a file under no repository, and keeps its siblings' status", async () => {
+    const answer = await ask({ type: "git_diff", path: "notes.md" });
+    assert.equal(answer.type, "git_error");
+    assert.match(answer.message, /not in a git repository/i);
+
+    const status = await ask({ type: "git_status" });
+    assert.equal(status.type, "git_status");
+    assert.ok(status.files.some((file) => file.path === "projA/README.md"));
+  });
+
+  test("reads one repository when the client scopes the request", async () => {
+    const status = await ask({ type: "git_status", repo: "projB" });
+    assert.equal(status.repo, "projB");
+    assert.deepEqual(
+      status.repos.map((repo) => repo.repo),
+      ["projB"],
+    );
+    assert.equal(
+      status.files.some((file) => file.path.startsWith("projA/")),
+      false,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe("repositories that appear and vanish while the server runs", () => {
+  let server;
+  let client;
+  let root;
+  let requestCounter = 0;
+
+  async function ask(message) {
+    const requestId = `fresh-${++requestCounter}`;
+    client.send({ ...message, requestId });
+    return client.waitFor((m) => m.requestId === requestId, 20_000);
+  }
+
+  /** Poll the status until `predicate` holds, or give up — the re-scan is debounced. */
+  async function until(predicate, what) {
+    for (let attempt = 0; attempt < 60; attempt++) {
+      const status = await ask({ type: "git_status" });
+      if (status.type === "git_status" && predicate(status)) return status;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    assert.fail(`timed out waiting for ${what}`);
+  }
+
+  before(async () => {
+    root = await makeWorkspace({});
+    await makeRepo(path.join(root, "first"), "main", "first initial");
+    server = await startServer(root);
+    client = connect(server.wsUrl());
+    await client.waitFor("hello");
+    // The watcher only watches what a client has listed — that is where a new
+    // repository will be noticed appearing
+    await ask({ type: "list_directory", path: "" });
+  });
+
+  after(async () => {
+    client?.close();
+    await server?.stop();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  // openlore: scenario=ARepositoryClonedWhileRunning spec=git
+  test("a repository created after startup becomes usable without a restart", async () => {
+    await makeRepo(path.join(root, "second"), "later", "second initial");
+    await writeFile(path.join(root, "second", "fresh.txt"), "new\n");
+
+    const status = await until((s) => s.repos.some((repo) => repo.repo === "second"), "the new repository to appear");
+    assert.equal(status.repos.find((repo) => repo.repo === "second").branch, "later");
+
+    const log = await ask({ type: "git_log", repo: "second" });
+    assert.deepEqual(
+      log.entries.map((entry) => entry.subject),
+      ["second initial"],
+    );
+  });
+
+  // openlore: scenario=ARepositoryThatStopsBeingOne spec=git
+  test("a directory that stops being a repository stops being consulted", async () => {
+    await rm(path.join(root, "second", ".git"), { recursive: true, force: true });
+
+    await until((s) => !s.repos.some((repo) => repo.repo === "second"), "the repository to leave the set");
+    const answer = await ask({ type: "git_log", repo: "second" });
+    assert.equal(answer.type, "git_error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// openlore: scenario=NoRepository spec=git
+describe("a workspace with no repository at all", () => {
+  let server;
+  let client;
+  let root;
+
+  before(async () => {
+    root = await makeWorkspace({ "notes.md": "no git here\n" });
+    server = await startServer(root);
+    client = connect(server.wsUrl());
+  });
+
+  after(async () => {
+    client?.close();
+    await server?.stop();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test("says git is unavailable, and refuses git requests", async () => {
+    const hello = await client.waitFor("hello");
+    assert.equal(hello.gitAvailable, false);
+    client.send({ type: "git_status", requestId: "none-1" });
+    const answer = await client.waitFor((m) => m.requestId === "none-1", 20_000);
+    assert.equal(answer.type, "git_error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// openlore: scenario=RepositoriesArePerWorkspace spec=multi-project-workspaces
+describe("two open projects, each with its own repositories", () => {
+  let server;
+  let client;
+  let alpha;
+  let beta;
+  let requestCounter = 0;
+
+  async function ask(message) {
+    const requestId = `per-ws-${++requestCounter}`;
+    client.send({ ...message, requestId });
+    return client.waitFor((m) => m.requestId === requestId, 20_000);
+  }
+
+  before(async () => {
+    alpha = await realpath(await makeWorkspace({}));
+    beta = await realpath(await makeWorkspace({}));
+    await makeRepo(path.join(alpha, "inAlpha"), "alpha-branch", "alpha initial");
+    await makeRepo(path.join(beta, "inBeta"), "beta-branch", "beta initial");
+
+    server = await startServer(alpha, { openProjects: [alpha, beta] });
+    client = connect(server.wsUrl());
+    await client.waitFor("hello");
+  });
+
+  after(async () => {
+    client?.close();
+    await server?.stop();
+    await rm(alpha, { recursive: true, force: true });
+    await rm(beta, { recursive: true, force: true });
+  });
+
+  test("answers a git request from the subscribed project's repositories only", async () => {
+    const inAlpha = await ask({ type: "git_status" });
+    assert.deepEqual(
+      inAlpha.repos.map((repo) => repo.repo),
+      ["inAlpha"],
+    );
+
+    client.send({ type: "switch_workspace", root: beta });
+    const switched = await client.waitFor((m) => m.type === "workspace_switched", 20_000);
+    assert.equal(switched.workspace.root, beta);
+
+    const inBeta = await ask({ type: "git_status" });
+    assert.deepEqual(
+      inBeta.repos.map((repo) => repo.repo),
+      ["inBeta"],
+    );
+    assert.equal(inBeta.repos[0].branch, "beta-branch");
+  });
+
+  test("refuses the other project's repository by name", async () => {
+    const answer = await ask({ type: "git_log", repo: "inAlpha" });
+    assert.equal(answer.type, "git_error");
+  });
+});

--- a/server/test/git-repos.test.ts
+++ b/server/test/git-repos.test.ts
@@ -8,7 +8,12 @@
  */
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync, realpathSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+// `realpath` from the promises API, never `realpathSync`: on Windows only the former
+// expands a short path (`RUNNER~1` for `runneradmin`), and the code under test
+// canonicalises with it - a fixture built the other way compares two names of one
+// directory and fails on a difference that is not there.
+import { realpath } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { after, before, describe, test } from "node:test";
@@ -42,8 +47,8 @@ const ids = (repos: readonly GitRepo[]) => repos.map((repo) => repo.id).sort();
 describe("discovering the repositories under a workspace", () => {
   let root: string;
 
-  before(() => {
-    root = realpathSync(mkdtempSync(path.join(tmpdir(), "pi-repos-")));
+  before(async () => {
+    root = await realpath(mkdtempSync(path.join(tmpdir(), "pi-repos-")));
     makeRepo(path.join(root, "projA"));
     makeRepo(path.join(root, "projB"), "release");
     // Not a repository, and not in the way
@@ -105,8 +110,8 @@ describe("discovering the repositories under a workspace", () => {
 describe("a repository marker that is a file, not a directory", () => {
   let root: string;
 
-  before(() => {
-    root = realpathSync(mkdtempSync(path.join(tmpdir(), "pi-repos-linked-")));
+  before(async () => {
+    root = await realpath(mkdtempSync(path.join(tmpdir(), "pi-repos-linked-")));
     makeRepo(path.join(root, "main-repo"));
     // A linked work tree writes a `.git` FILE holding a gitdir: pointer
     git(path.join(root, "main-repo"), "worktree", "add", path.join(root, "linked"), "-b", "side");
@@ -132,10 +137,10 @@ describe("a repository reachable only through a symlink out of the root", () => 
   let outside: string;
   let root: string;
 
-  before(() => {
-    outside = realpathSync(mkdtempSync(path.join(tmpdir(), "pi-repos-outside-")));
+  before(async () => {
+    outside = await realpath(mkdtempSync(path.join(tmpdir(), "pi-repos-outside-")));
     makeRepo(path.join(outside, "secret"));
-    root = realpathSync(mkdtempSync(path.join(tmpdir(), "pi-repos-linkroot-")));
+    root = await realpath(mkdtempSync(path.join(tmpdir(), "pi-repos-linkroot-")));
     symlinkSync(path.join(outside, "secret"), path.join(root, "secret"));
   });
 
@@ -155,14 +160,14 @@ describe("a root the filesystem knows by another name", () => {
   let real: string;
   let alias: string;
 
-  before(() => {
+  before(async () => {
     // The shape that took CI down on Windows only: `%TEMP%` is a short name there
     // (`RUNNER~1` for `runneradmin`), so a root passed in one form and a child
     // realpath-resolved into the other compared as different trees, and discovery
     // quietly found nothing. A symlinked root reproduces it on any platform.
-    real = realpathSync(mkdtempSync(path.join(tmpdir(), "pi-repos-real-")));
+    real = await realpath(mkdtempSync(path.join(tmpdir(), "pi-repos-real-")));
     makeRepo(path.join(real, "projA"));
-    alias = path.join(realpathSync(mkdtempSync(path.join(tmpdir(), "pi-repos-alias-"))), "link");
+    alias = path.join(await realpath(mkdtempSync(path.join(tmpdir(), "pi-repos-alias-"))), "link");
     symlinkSync(real, alias);
   });
 
@@ -215,7 +220,7 @@ describe("status across several repositories", () => {
   let repos: GitRepo[];
 
   before(async () => {
-    root = realpathSync(mkdtempSync(path.join(tmpdir(), "pi-repos-status-")));
+    root = await realpath(mkdtempSync(path.join(tmpdir(), "pi-repos-status-")));
     makeRepo(path.join(root, "projA"));
     makeRepo(path.join(root, "projB"), "release");
     write(path.join(root, "projA", "README.md"), "# changed\n");
@@ -283,9 +288,9 @@ describe("status across several repositories", () => {
 describe("a repository inside the workspace's own repository", () => {
   let root: string;
 
-  before(() => {
-    root = realpathSync(mkdtempSync(path.join(tmpdir(), "pi-repos-sub-")));
-    const inner = realpathSync(mkdtempSync(path.join(tmpdir(), "pi-repos-subsrc-")));
+  before(async () => {
+    root = await realpath(mkdtempSync(path.join(tmpdir(), "pi-repos-sub-")));
+    const inner = await realpath(mkdtempSync(path.join(tmpdir(), "pi-repos-subsrc-")));
     makeRepo(inner);
     makeRepo(root);
     git(root, "-c", "protocol.file.allow=always", "submodule", "add", inner, "vendor");
@@ -314,7 +319,7 @@ describe("a repository embedded under a browser root that sits inside another", 
 
   before(async () => {
     // The workspace is a subdirectory of a repository, and holds a repository of its own
-    outer = realpathSync(mkdtempSync(path.join(tmpdir(), "pi-repos-outer-")));
+    outer = await realpath(mkdtempSync(path.join(tmpdir(), "pi-repos-outer-")));
     makeRepo(outer);
     root = path.join(outer, "workspace");
     mkdirSync(root);
@@ -359,7 +364,7 @@ describe("history is read from the repository owning the path", () => {
   let repos: GitRepo[];
 
   before(async () => {
-    root = realpathSync(mkdtempSync(path.join(tmpdir(), "pi-repos-log-")));
+    root = await realpath(mkdtempSync(path.join(tmpdir(), "pi-repos-log-")));
     makeRepo(path.join(root, "projA"));
     makeRepo(path.join(root, "projB"), "release");
     write(path.join(root, "projB", "only-here.txt"), "b\n");

--- a/server/test/git-repos.test.ts
+++ b/server/test/git-repos.test.ts
@@ -1,0 +1,366 @@
+/**
+ * A workspace holding a SET of repositories.
+ *
+ * The motivating layout has none at the root: a directory of independently
+ * versioned projects, one repository per child. Everything here is about finding
+ * them, attributing a path to one, and keeping git's output inside the root while
+ * the working directory is no longer a single fixed place.
+ */
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { after, before, describe, test } from "node:test";
+import { discoverRepos, gitFileLog, gitLog, gitShow, gitStatus, repoFor, type GitRepo } from "../src/git.ts";
+
+function git(cwd: string, ...args: string[]) {
+  execFileSync("git", args, { cwd });
+}
+
+/** A repository with one commit, at `dir`. */
+function makeRepo(dir: string, branch = "main") {
+  mkdirSync(dir, { recursive: true });
+  git(dir, "init");
+  git(dir, "branch", "-M", branch);
+  git(dir, "config", "user.email", "test@test");
+  git(dir, "config", "user.name", "Test");
+  git(dir, "config", "commit.gpgsign", "false");
+  writeFileSync(path.join(dir, "README.md"), "# project\n");
+  git(dir, "add", ".");
+  git(dir, "commit", "-m", `initial commit in ${path.basename(dir)}`);
+}
+
+function write(full: string, content: string) {
+  mkdirSync(path.dirname(full), { recursive: true });
+  writeFileSync(full, content);
+}
+
+const ids = (repos: readonly GitRepo[]) => repos.map((repo) => repo.id).sort();
+
+// ---------------------------------------------------------------------------
+describe("discovering the repositories under a workspace", () => {
+  let root: string;
+
+  before(() => {
+    root = realpathSync(mkdtempSync(path.join(tmpdir(), "pi-repos-")));
+    makeRepo(path.join(root, "projA"));
+    makeRepo(path.join(root, "projB"), "release");
+    // Not a repository, and not in the way
+    write(path.join(root, "notes.md"), "loose\n");
+    // Excluded by name, repository or not
+    makeRepo(path.join(root, "node_modules", "vendored"));
+    // Below the depth bound (root/1/2/3/4/deep)
+    makeRepo(path.join(root, "a", "b", "c", "d", "deep"));
+  });
+
+  after(() => rmSync(root, { recursive: true, force: true }));
+
+  test("finds a repository in each child directory of a root that is not one", async () => {
+    const repos = await discoverRepos(root);
+    assert.ok(ids(repos).includes("projA"));
+    assert.ok(ids(repos).includes("projB"));
+  });
+
+  test("leaves the root itself out when it is no repository", async () => {
+    const repos = await discoverRepos(root);
+    assert.equal(
+      repos.some((repo) => repo.id === ""),
+      false,
+    );
+  });
+
+  test("does not walk into a directory the file browser already excludes", async () => {
+    const repos = await discoverRepos(root);
+    assert.equal(
+      repos.some((repo) => repo.id.startsWith("node_modules")),
+      false,
+    );
+  });
+
+  test("stops at the depth bound rather than walking the whole tree", async () => {
+    const repos = await discoverRepos(root);
+    assert.equal(
+      repos.some((repo) => repo.id.endsWith("deep")),
+      false,
+    );
+  });
+
+  test("orders them deepest first, which is what longest-match reads", async () => {
+    const repos = await discoverRepos(root);
+    const lengths = repos.map((repo) => repo.id.length);
+    assert.deepEqual(lengths, [...lengths].sort((a, b) => b - a));
+  });
+
+  test("runs git from the repository itself when it lies under the root", async () => {
+    const repos = await discoverRepos(root);
+    const projA = repos.find((repo) => repo.id === "projA");
+    assert.ok(projA);
+    assert.equal(projA!.cwd, projA!.toplevel);
+    assert.equal(projA!.toplevel, path.join(root, "projA"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe("a repository marker that is a file, not a directory", () => {
+  let root: string;
+
+  before(() => {
+    root = realpathSync(mkdtempSync(path.join(tmpdir(), "pi-repos-linked-")));
+    makeRepo(path.join(root, "main-repo"));
+    // A linked work tree writes a `.git` FILE holding a gitdir: pointer
+    git(path.join(root, "main-repo"), "worktree", "add", path.join(root, "linked"), "-b", "side");
+  });
+
+  after(() => rmSync(root, { recursive: true, force: true }));
+
+  test("counts a linked work tree as a repository of its own", async () => {
+    const repos = await discoverRepos(root);
+    assert.ok(ids(repos).includes("linked"), `expected "linked" among ${JSON.stringify(ids(repos))}`);
+  });
+
+  test("reports the branch checked out in it, not the one next door", async () => {
+    const repos = await discoverRepos(root);
+    const status = await gitStatus(repos);
+    const linked = status.repos.find((repo) => repo.repo === "linked");
+    assert.equal(linked?.branch, "side");
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe("a repository reachable only through a symlink out of the root", () => {
+  let outside: string;
+  let root: string;
+
+  before(() => {
+    outside = realpathSync(mkdtempSync(path.join(tmpdir(), "pi-repos-outside-")));
+    makeRepo(path.join(outside, "secret"));
+    root = realpathSync(mkdtempSync(path.join(tmpdir(), "pi-repos-linkroot-")));
+    symlinkSync(path.join(outside, "secret"), path.join(root, "secret"));
+  });
+
+  after(() => {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+  });
+
+  test("is never admitted to the set, so it is never a working directory", async () => {
+    const repos = await discoverRepos(root);
+    assert.deepEqual(repos, []);
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe("attributing a path to a repository", () => {
+  const repos: GitRepo[] = [
+    { toplevel: "/w/projA/nested", cwd: "/w/projA/nested", id: "projA/nested" },
+    { toplevel: "/w/projA", cwd: "/w/projA", id: "projA" },
+    { toplevel: "/above", cwd: "/w", id: "" },
+  ];
+
+  test("gives a file to the deepest repository containing it", () => {
+    assert.equal(repoFor(repos, "projA/nested/x.ts")?.id, "projA/nested");
+    assert.equal(repoFor(repos, "projA/x.ts")?.id, "projA");
+  });
+
+  test("falls back to the repository containing the root", () => {
+    assert.equal(repoFor(repos, "loose.md")?.id, "");
+  });
+
+  test("does not mistake a sibling whose name starts the same way", () => {
+    assert.equal(repoFor(repos, "projAlpha/x.ts")?.id, "");
+  });
+
+  test("answers null when nothing owns the path and no repository holds the root", () => {
+    const nested = repos.filter((repo) => repo.id !== "");
+    assert.equal(repoFor(nested, "notes.md"), null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe("status across several repositories", () => {
+  let root: string;
+  let repos: GitRepo[];
+
+  before(async () => {
+    root = realpathSync(mkdtempSync(path.join(tmpdir(), "pi-repos-status-")));
+    makeRepo(path.join(root, "projA"));
+    makeRepo(path.join(root, "projB"), "release");
+    write(path.join(root, "projA", "README.md"), "# changed\n");
+    write(path.join(root, "projB", "fresh.txt"), "new\n");
+    repos = await discoverRepos(root);
+  });
+
+  after(() => rmSync(root, { recursive: true, force: true }));
+
+  test("reports files from every repository, in browser-root terms", async () => {
+    const status = await gitStatus(repos);
+    const byPath = Object.fromEntries(status.files.map((file) => [file.path, file.status]));
+    assert.equal(byPath["projA/README.md"], "modified");
+    assert.equal(byPath["projB/fresh.txt"], "untracked");
+  });
+
+  test("reports each repository's own branch", async () => {
+    const status = await gitStatus(repos);
+    const branches = Object.fromEntries(status.repos.map((repo) => [repo.repo, repo.branch]));
+    assert.deepEqual(branches, { projA: "main", projB: "release" });
+  });
+
+  test("a scoped read speaks for one repository and says nothing of the other", async () => {
+    const projB = repos.find((repo) => repo.id === "projB");
+    assert.ok(projB);
+    const status = await gitStatus(repos, projB!);
+    assert.deepEqual(
+      status.repos.map((repo) => repo.repo),
+      ["projB"],
+    );
+    assert.deepEqual(
+      status.files.map((file) => file.path),
+      ["projB/fresh.txt"],
+    );
+  });
+
+  test("a single-repository workspace reports exactly one repository, as it always did", async () => {
+    const single = await discoverRepos(path.join(root, "projA"));
+    const status = await gitStatus(single);
+    assert.equal(status.repos.length, 1);
+    assert.equal(status.repos[0].repo, "");
+    assert.deepEqual(
+      status.files.map((file) => file.path),
+      ["README.md"],
+    );
+  });
+
+  test("one repository failing does not blank the others", async () => {
+    const broken: GitRepo = { toplevel: path.join(root, "gone"), cwd: path.join(root, "gone"), id: "gone" };
+    const status = await gitStatus([...repos, broken]);
+    assert.ok(status.files.some((file) => file.path === "projA/README.md"));
+    assert.equal(
+      status.repos.some((repo) => repo.repo === "gone"),
+      false,
+    );
+  });
+
+  test("but a workspace where every repository fails still surfaces the error", async () => {
+    const broken: GitRepo = { toplevel: path.join(root, "gone"), cwd: path.join(root, "gone"), id: "gone" };
+    await assert.rejects(() => gitStatus([broken]));
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe("a repository inside the workspace's own repository", () => {
+  let root: string;
+
+  before(() => {
+    root = realpathSync(mkdtempSync(path.join(tmpdir(), "pi-repos-sub-")));
+    const inner = realpathSync(mkdtempSync(path.join(tmpdir(), "pi-repos-subsrc-")));
+    makeRepo(inner);
+    makeRepo(root);
+    git(root, "-c", "protocol.file.allow=always", "submodule", "add", inner, "vendor");
+    git(root, "-c", "protocol.file.allow=always", "commit", "-m", "add submodule");
+    rmSync(inner, { recursive: true, force: true });
+  });
+
+  after(() => rmSync(root, { recursive: true, force: true }));
+
+  test("is left to its parent: discovery stops at the work tree it is inside", async () => {
+    const repos = await discoverRepos(root);
+    assert.deepEqual(ids(repos), [""]);
+  });
+
+  test("so the workspace answers for the submodule's files as one repository", async () => {
+    const repos = await discoverRepos(root);
+    assert.equal(repoFor(repos, "vendor/README.md")?.id, "");
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe("a repository embedded under a browser root that sits inside another", () => {
+  let outer: string;
+  let root: string;
+  let repos: GitRepo[];
+
+  before(async () => {
+    // The workspace is a subdirectory of a repository, and holds a repository of its own
+    outer = realpathSync(mkdtempSync(path.join(tmpdir(), "pi-repos-outer-")));
+    makeRepo(outer);
+    root = path.join(outer, "workspace");
+    mkdirSync(root);
+    write(path.join(root, "loose.md"), "not versioned by the child\n");
+    makeRepo(path.join(root, "embedded"));
+    repos = await discoverRepos(root);
+  });
+
+  after(() => rmSync(outer, { recursive: true, force: true }));
+
+  test("holds both: the one containing the root, and the one under it", () => {
+    assert.deepEqual(ids(repos), ["", "embedded"]);
+  });
+
+  test("runs the containing repository from the browser root, never above it", () => {
+    const containing = repos.find((repo) => repo.id === "");
+    assert.equal(containing!.cwd, root);
+    assert.equal(containing!.toplevel, outer);
+  });
+
+  test("gives a file to the embedded repository, and the rest to the container", () => {
+    assert.equal(repoFor(repos, "embedded/README.md")?.id, "embedded");
+    assert.equal(repoFor(repos, "loose.md")?.id, "");
+  });
+
+  test("reports the embedded repository's own files, not one entry standing for it", async () => {
+    write(path.join(root, "embedded", "README.md"), "# changed inside\n");
+    const status = await gitStatus(repos);
+    const paths = status.files.map((file) => file.path);
+    assert.ok(paths.includes("embedded/README.md"), `expected the file itself among ${JSON.stringify(paths)}`);
+    assert.equal(
+      paths.some((entry) => entry === "embedded" || entry === "embedded/"),
+      false,
+      "the container's single entry for the embedded repository must not read as a file",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe("history is read from the repository owning the path", () => {
+  let root: string;
+  let repos: GitRepo[];
+
+  before(async () => {
+    root = realpathSync(mkdtempSync(path.join(tmpdir(), "pi-repos-log-")));
+    makeRepo(path.join(root, "projA"));
+    makeRepo(path.join(root, "projB"), "release");
+    write(path.join(root, "projB", "only-here.txt"), "b\n");
+    git(path.join(root, "projB"), "add", ".");
+    git(path.join(root, "projB"), "commit", "-m", "a commit only projB has");
+    repos = await discoverRepos(root);
+  });
+
+  after(() => rmSync(root, { recursive: true, force: true }));
+
+  const repo = (id: string) => {
+    const found = repos.find((candidate) => candidate.id === id);
+    assert.ok(found, `no repository ${id}`);
+    return found!;
+  };
+
+  test("the log of one repository carries none of the other's commits", async () => {
+    const subjects = (await gitLog(repo("projA"), 20)).map((entry) => entry.subject);
+    assert.ok(subjects.some((subject) => subject.includes("projA")));
+    assert.equal(
+      subjects.some((subject) => subject.includes("only projB has")),
+      false,
+    );
+  });
+
+  test("a commit id from one repository is not resolved against another", async () => {
+    const [onlyInB] = await gitLog(repo("projB"), 1);
+    await assert.rejects(() => gitShow(repo("projA"), onlyInB.sha));
+  });
+
+  test("a file's history comes back in browser-root paths", async () => {
+    const entries = await gitFileLog(repo("projB"), "projB/only-here.txt", 20);
+    assert.ok(entries.length > 0);
+    assert.deepEqual([...new Set(entries.map((entry) => entry.path))], ["projB/only-here.txt"]);
+  });
+});

--- a/server/test/git-repos.test.ts
+++ b/server/test/git-repos.test.ts
@@ -151,6 +151,38 @@ describe("a repository reachable only through a symlink out of the root", () => 
 });
 
 // ---------------------------------------------------------------------------
+describe("a root the filesystem knows by another name", () => {
+  let real: string;
+  let alias: string;
+
+  before(() => {
+    // The shape that took CI down on Windows only: `%TEMP%` is a short name there
+    // (`RUNNER~1` for `runneradmin`), so a root passed in one form and a child
+    // realpath-resolved into the other compared as different trees, and discovery
+    // quietly found nothing. A symlinked root reproduces it on any platform.
+    real = realpathSync(mkdtempSync(path.join(tmpdir(), "pi-repos-real-")));
+    makeRepo(path.join(real, "projA"));
+    alias = path.join(realpathSync(mkdtempSync(path.join(tmpdir(), "pi-repos-alias-"))), "link");
+    symlinkSync(real, alias);
+  });
+
+  after(() => {
+    rmSync(path.dirname(alias), { recursive: true, force: true });
+    rmSync(real, { recursive: true, force: true });
+  });
+
+  test("still finds the repositories under it", async () => {
+    const repos = await discoverRepos(alias);
+    assert.deepEqual(ids(repos), ["projA"]);
+  });
+
+  test("and runs git from a directory the filesystem agrees is that repository", async () => {
+    const [projA] = await discoverRepos(alias);
+    assert.equal(projA.cwd, path.join(real, "projA"));
+  });
+});
+
+// ---------------------------------------------------------------------------
 describe("attributing a path to a repository", () => {
   const repos: GitRepo[] = [
     { toplevel: "/w/projA/nested", cwd: "/w/projA/nested", id: "projA/nested" },

--- a/server/test/git.test.ts
+++ b/server/test/git.test.ts
@@ -4,7 +4,16 @@ import { mkdtempSync, existsSync, rmSync, writeFileSync, mkdirSync } from "node:
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { before, after, describe, test } from "node:test";
-import { probeGit, gitStatus, gitLog, gitShow, gitHeadContent, gitFileLog, gitRevisionContent, unquote } from "../src/git.ts";
+import { probeGit, gitStatus, gitLog, gitShow, gitHeadContent, gitFileLog, gitRevisionContent, unquote, MAX_PATCH_BYTES, type GitRepo } from "../src/git.ts";
+
+/**
+ * The browser root IS the repository - the shape a single-project workspace has,
+ * and the one every assertion below was written against.
+ */
+const selfRepo = (root: string): GitRepo => ({ toplevel: root, cwd: root, id: "" });
+
+/** A browser root sitting inside a larger repository: git still runs from the root. */
+const ancestorRepo = (root: string, toplevel: string): GitRepo => ({ toplevel, cwd: root, id: "" });
 
 // ---------------------------------------------------------------------------
 // unquote — C-style path unquoting (pure, no git needed)
@@ -100,10 +109,12 @@ describe("git operations", () => {
   });
 
   test("gitStatus reports branch and tracked files", async () => {
-    const status = await gitStatus(root);
-    assert.equal(status.branch, "main");
-    assert.equal(status.ahead, 0);
-    assert.equal(status.behind, 0);
+    const status = await gitStatus([selfRepo(root)]);
+    assert.equal(status.repos.length, 1);
+    assert.equal(status.repos[0].repo, "");
+    assert.equal(status.repos[0].branch, "main");
+    assert.equal(status.repos[0].ahead, 0);
+    assert.equal(status.repos[0].behind, 0);
     // After the second commit, everything is committed — no pending changes
     assert.equal(status.files.length, 0);
   });
@@ -111,7 +122,7 @@ describe("git operations", () => {
   test("gitStatus detects untracked files", async () => {
     write("new.txt", "new file");
     try {
-      const status = await gitStatus(root);
+      const status = await gitStatus([selfRepo(root)]);
       const untracked = status.files.find((f) => f.path === "new.txt");
       assert.ok(untracked, "expected new.txt to appear as untracked");
       assert.equal(untracked!.status, "untracked");
@@ -123,7 +134,7 @@ describe("git operations", () => {
   test("gitStatus detects modified files", async () => {
     write("README.md", "# Modified\n");
     try {
-      const status = await gitStatus(root);
+      const status = await gitStatus([selfRepo(root)]);
       const modified = status.files.find((f) => f.path === "README.md");
       assert.ok(modified, "expected README.md to appear");
       assert.equal(modified!.status, "modified");
@@ -133,7 +144,7 @@ describe("git operations", () => {
   });
 
   test("gitLog returns commit history in reverse order", async () => {
-    const log = await gitLog(root, 10);
+    const log = await gitLog(selfRepo(root), 10);
     assert.equal(log.length, 2);
     assert.equal(log[0].subject, "add main.ts and update readme");
     assert.equal(log[1].subject, "initial commit");
@@ -143,51 +154,66 @@ describe("git operations", () => {
   });
 
   test("gitLog respects the limit", async () => {
-    const log = await gitLog(root, 1);
+    const log = await gitLog(selfRepo(root), 1);
     assert.equal(log.length, 1);
   });
 
   test("gitShow returns a commit patch", async () => {
-    const log = await gitLog(root, 1);
-    const result = await gitShow(root, log[0].sha);
+    const log = await gitLog(selfRepo(root), 1);
+    const result = await gitShow(selfRepo(root), log[0].sha);
     assert.ok(result.patch.length > 0);
     assert.equal(result.truncated, false);
     // Should show the diff for src/main.ts and README.md
     assert.ok(result.patch.includes("src/main.ts"));
   });
 
+  test("gitShow truncates an oversized patch instead of refusing it", async () => {
+    // A commit whose patch is comfortably past MAX_PATCH_BYTES (256 KiB)
+    write("huge.txt", "x".repeat(MAX_PATCH_BYTES * 2));
+    git("add", "--", "huge.txt");
+    git("commit", "-m", "add a huge file");
+    try {
+      const [head] = await gitLog(selfRepo(root), 1);
+      const result = await gitShow(selfRepo(root), head.sha);
+      assert.equal(result.truncated, true, "an oversized patch is flagged, not thrown away");
+      assert.ok(Buffer.byteLength(result.patch, "utf8") <= MAX_PATCH_BYTES);
+    } finally {
+      git("reset", "--hard", "HEAD~1");
+    }
+  });
+
   test("gitShow rejects an invalid sha", async () => {
     await assert.rejects(
-      () => gitShow(root, "not-a-sha"),
+      () => gitShow(selfRepo(root), "not-a-sha"),
       /Invalid commit id/,
     );
   });
 
   test("gitShow rejects a very short sha", async () => {
     await assert.rejects(
-      () => gitShow(root, "abc"),
+      () => gitShow(selfRepo(root), "abc"),
       /Invalid commit id/,
     );
   });
 
   test("gitHeadContent returns HEAD content for a tracked file", async () => {
-    const content = await gitHeadContent(root, root, "README.md");
+    const content = await gitHeadContent(selfRepo(root), "README.md");
     assert.ok(content.includes("Updated"));
   });
 
   test("gitHeadContent returns empty string for an untracked file", async () => {
     write("untracked.txt", "fresh");
-    const content = await gitHeadContent(root, root, "untracked.txt");
+    const content = await gitHeadContent(selfRepo(root), "untracked.txt");
     assert.equal(content, "");
   });
 
   test("gitHeadContent returns empty for a non-existent file", async () => {
-    const content = await gitHeadContent(root, root, "no-such-file.ts");
+    const content = await gitHeadContent(selfRepo(root), "no-such-file.ts");
     assert.equal(content, "");
   });
 
   test("gitHeadContent works with nested paths", async () => {
-    const content = await gitHeadContent(root, root, "src/main.ts");
+    const content = await gitHeadContent(selfRepo(root), "src/main.ts");
     assert.ok(content.includes('console.log("hi")'));
   });
 });
@@ -264,7 +290,7 @@ describe("file history", () => {
   });
 
   test("lists the file's commits newest first", async () => {
-    const log = await gitFileLog(root, root, "docs/notes.txt", 50);
+    const log = await gitFileLog(selfRepo(root), "docs/notes.txt", 50);
     assert.equal(log[0].subject, SEP_SUBJECT);
     assert.equal(log[0].sha, sha[SEP_SUBJECT]);
     assert.ok(log[0].author.length > 0);
@@ -272,14 +298,14 @@ describe("file history", () => {
   });
 
   test("reports per-file line counts", async () => {
-    const log = await gitFileLog(root, root, "docs/notes.txt", 50);
+    const log = await gitFileLog(selfRepo(root), "docs/notes.txt", 50);
     const latest = log.find((entry) => entry.subject === SEP_SUBJECT);
     assert.equal(latest!.added, 1);
     assert.equal(latest!.deleted, 0);
   });
 
   test("keeps a record separator inside a subject", async () => {
-    const log = await gitFileLog(root, root, "docs/notes.txt", 50);
+    const log = await gitFileLog(selfRepo(root), "docs/notes.txt", 50);
     assert.ok(
       log.some((entry) => entry.subject === SEP_SUBJECT),
       `expected the \\x1e subject to survive parsing, got ${JSON.stringify(log.map((e) => e.subject))}`,
@@ -287,7 +313,7 @@ describe("file history", () => {
   });
 
   test("keeps the merge commit and both its parents", async () => {
-    const log = await gitFileLog(root, root, "docs/notes.txt", 50);
+    const log = await gitFileLog(selfRepo(root), "docs/notes.txt", 50);
     const merge = log.find((entry) => entry.subject === "merge side");
     assert.ok(merge, "expected the merge commit in the history");
     assert.equal(merge!.parents.length, 2);
@@ -295,20 +321,20 @@ describe("file history", () => {
   });
 
   test("follows the rename past the point --full-history stops at", async () => {
-    const log = await gitFileLog(root, root, "docs/notes.txt", 50);
+    const log = await gitFileLog(selfRepo(root), "docs/notes.txt", 50);
     const subjects = log.map((entry) => entry.subject);
     assert.ok(subjects.includes("extend notes"), `expected pre-rename history, got ${JSON.stringify(subjects)}`);
     assert.ok(subjects.includes("create notes"));
   });
 
   test("reports the path the file had at each commit", async () => {
-    const log = await gitFileLog(root, root, "docs/notes.txt", 50);
+    const log = await gitFileLog(selfRepo(root), "docs/notes.txt", 50);
     assert.equal(log.find((entry) => entry.subject === "create notes")!.path, "notes.txt");
     assert.equal(log.find((entry) => entry.subject === "main edit")!.path, "docs/notes.txt");
   });
 
   test("leaves every entry connected to one already in the list", async () => {
-    const log = await gitFileLog(root, root, "docs/notes.txt", 50);
+    const log = await gitFileLog(selfRepo(root), "docs/notes.txt", 50);
     const present = new Set(log.map((entry) => entry.sha));
     for (const entry of log.slice(0, -1)) {
       assert.ok(entry.parents.length > 0, `${entry.subject} has no parent to draw a rail to`);
@@ -318,38 +344,38 @@ describe("file history", () => {
   });
 
   test("clamps the limit", async () => {
-    assert.equal((await gitFileLog(root, root, "docs/notes.txt", 2)).length, 2);
-    assert.equal((await gitFileLog(root, root, "docs/notes.txt", 0)).length, 1);
+    assert.equal((await gitFileLog(selfRepo(root), "docs/notes.txt", 2)).length, 2);
+    assert.equal((await gitFileLog(selfRepo(root), "docs/notes.txt", 0)).length, 1);
   });
 
   test("returns an empty list for an untracked file", async () => {
     write("scratch.txt", "not committed\n");
     try {
-      assert.deepEqual(await gitFileLog(root, root, "scratch.txt", 50), []);
+      assert.deepEqual(await gitFileLog(selfRepo(root), "scratch.txt", 50), []);
     } finally {
       rmSync(`${root}/scratch.txt`);
     }
   });
 
   test("gitRevisionContent reads the file at a commit", async () => {
-    const content = await gitRevisionContent(root, root, sha["main edit"], "docs/notes.txt");
+    const content = await gitRevisionContent(selfRepo(root), sha["main edit"], "docs/notes.txt");
     assert.equal(content, "1\n2\nmain\n");
   });
 
   test("gitRevisionContent reads the pre-rename path at an old commit", async () => {
-    const content = await gitRevisionContent(root, root, sha["extend notes"], "notes.txt");
+    const content = await gitRevisionContent(selfRepo(root), sha["extend notes"], "notes.txt");
     assert.equal(content, "1\n2\n");
   });
 
   test("gitRevisionContent returns empty where the file did not exist yet", async () => {
-    const content = await gitRevisionContent(root, root, sha["create notes"], "docs/notes.txt");
+    const content = await gitRevisionContent(selfRepo(root), sha["create notes"], "docs/notes.txt");
     assert.equal(content, "");
   });
 
   test("gitRevisionContent peels an annotated tag", async () => {
     git("tag", "-a", "v1", "-m", "release", sha["main edit"]);
     const tagId = execFileSync("git", ["rev-parse", "v1"], { cwd: root, encoding: "utf8" }).trim();
-    const content = await gitRevisionContent(root, root, tagId, "docs/notes.txt");
+    const content = await gitRevisionContent(selfRepo(root), tagId, "docs/notes.txt");
     assert.equal(content, "1\n2\nmain\n");
   });
 
@@ -357,17 +383,17 @@ describe("file history", () => {
     const blob = execFileSync("git", ["rev-parse", `${sha["main edit"]}:docs/notes.txt`], { cwd: root, encoding: "utf8" }).trim();
     // ^{commit} refuses a blob outright, and that must surface rather than read as
     // an empty file — an empty side would silently render as an all-added diff
-    await assert.rejects(() => gitRevisionContent(root, root, blob, "docs/notes.txt"), /blob/i);
+    await assert.rejects(() => gitRevisionContent(selfRepo(root), blob, "docs/notes.txt"), /blob/i);
   });
 
   test("gitRevisionContent refuses a malformed revision", async () => {
-    await assert.rejects(() => gitRevisionContent(root, root, "main", "docs/notes.txt"), /Invalid commit id/);
-    await assert.rejects(() => gitRevisionContent(root, root, "HEAD@{0}", "docs/notes.txt"), /Invalid commit id/);
-    await assert.rejects(() => gitRevisionContent(root, root, "--upload-pack=evil", "docs/notes.txt"), /Invalid commit id/);
+    await assert.rejects(() => gitRevisionContent(selfRepo(root), "main", "docs/notes.txt"), /Invalid commit id/);
+    await assert.rejects(() => gitRevisionContent(selfRepo(root), "HEAD@{0}", "docs/notes.txt"), /Invalid commit id/);
+    await assert.rejects(() => gitRevisionContent(selfRepo(root), "--upload-pack=evil", "docs/notes.txt"), /Invalid commit id/);
   });
 
   test("gitRevisionContent refuses the working-tree marker", async () => {
-    await assert.rejects(() => gitRevisionContent(root, root, "worktree", "docs/notes.txt"), /read from disk/);
+    await assert.rejects(() => gitRevisionContent(selfRepo(root), "worktree", "docs/notes.txt"), /read from disk/);
   });
 });
 
@@ -415,7 +441,7 @@ describe("file history below the repository toplevel", () => {
   });
 
   test("reports paths relative to the browser root, not the toplevel", async () => {
-    const log = await gitFileLog(root, toplevel, "index.ts", 50);
+    const log = await gitFileLog(ancestorRepo(root, toplevel), "index.ts", 50);
     assert.equal(log.length, 2, `expected both commits, got ${JSON.stringify(log.map((e) => e.subject))}`);
     // Not "workspace/app/index.ts": the UI speaks browser-root paths
     assert.deepEqual(
@@ -425,17 +451,17 @@ describe("file history below the repository toplevel", () => {
   });
 
   test("does not list commits that only touched files outside the browser root", async () => {
-    const subjects = (await gitFileLog(root, toplevel, "index.ts", 50)).map((entry) => entry.subject);
+    const subjects = (await gitFileLog(ancestorRepo(root, toplevel), "index.ts", 50)).map((entry) => entry.subject);
     assert.ok(!subjects.includes("add a file outside the root"), `unexpected outside commit in ${JSON.stringify(subjects)}`);
   });
 
   test("reads a revision's content through the toplevel prefix", async () => {
-    assert.equal(await gitRevisionContent(root, toplevel, sha["create index"], "index.ts"), "one\n");
-    assert.equal(await gitRevisionContent(root, toplevel, sha["extend index"], "index.ts"), "one\ntwo\n");
+    assert.equal(await gitRevisionContent(ancestorRepo(root, toplevel), sha["create index"], "index.ts"), "one\n");
+    assert.equal(await gitRevisionContent(ancestorRepo(root, toplevel), sha["extend index"], "index.ts"), "one\ntwo\n");
   });
 
   test("gitHeadContent agrees with it", async () => {
-    assert.equal(await gitHeadContent(root, toplevel, "index.ts"), "one\ntwo\n");
+    assert.equal(await gitHeadContent(ancestorRepo(root, toplevel), "index.ts"), "one\ntwo\n");
   });
 });
 
@@ -496,13 +522,13 @@ describe("file history edge cases", () => {
   });
 
   test("follows a chain of two renames", async () => {
-    const log = await gitFileLog(root, root, "c.txt", 50);
+    const log = await gitFileLog(selfRepo(root), "c.txt", 50);
     const subjects = log.map((entry) => entry.subject);
     assert.deepEqual(subjects, ["edit under the third name", "third name", "second name", "first name"]);
   });
 
   test("reports the name the file had at each link of the chain", async () => {
-    const log = await gitFileLog(root, root, "c.txt", 50);
+    const log = await gitFileLog(selfRepo(root), "c.txt", 50);
     const bySubject = Object.fromEntries(log.map((entry) => [entry.subject, entry.path]));
     assert.equal(bySubject["third name"], "c.txt");
     assert.equal(bySubject["second name"], "b.txt");
@@ -510,18 +536,18 @@ describe("file history edge cases", () => {
   });
 
   test("spends the limit across the whole chain, not per pass", async () => {
-    assert.equal((await gitFileLog(root, root, "c.txt", 3)).length, 3);
-    assert.equal((await gitFileLog(root, root, "c.txt", 1)).length, 1);
+    assert.equal((await gitFileLog(selfRepo(root), "c.txt", 3)).length, 3);
+    assert.equal((await gitFileLog(selfRepo(root), "c.txt", 1)).length, 1);
   });
 
   test("reads content from before both renames", async () => {
-    const log = await gitFileLog(root, root, "c.txt", 50);
+    const log = await gitFileLog(selfRepo(root), "c.txt", 50);
     const first = log.find((entry) => entry.subject === "first name")!;
-    assert.equal(await gitRevisionContent(root, root, first.sha, first.path), "1\n");
+    assert.equal(await gitRevisionContent(selfRepo(root), first.sha, first.path), "1\n");
   });
 
   test("reports a binary file's counts as zero rather than NaN", async () => {
-    const [entry] = await gitFileLog(root, root, "logo.bin", 50);
+    const [entry] = await gitFileLog(selfRepo(root), "logo.bin", 50);
     assert.equal(entry.subject, "add a binary file");
     // git prints "-" for a binary file's added/deleted
     assert.equal(entry.added, 0);
@@ -529,9 +555,9 @@ describe("file history edge cases", () => {
   });
 
   test("treats a leading-dash filename as a path, not an option", async () => {
-    const log = await gitFileLog(root, root, "-weird.txt", 50);
+    const log = await gitFileLog(selfRepo(root), "-weird.txt", 50);
     assert.equal(log.length, 1);
     assert.equal(log[0].subject, "add a file whose name starts with a dash");
-    assert.equal(await gitRevisionContent(root, root, log[0].sha, "-weird.txt"), "dashed\n");
+    assert.equal(await gitRevisionContent(selfRepo(root), log[0].sha, "-weird.txt"), "dashed\n");
   });
 });

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -636,6 +636,15 @@ export type ServerMessage =
     }
   | { type: "file_changed"; path: string }
   /**
+   * The workspace's repository set changed on disk — one was cloned, initialised or
+   * removed. `available` is the new `gitAvailable`.
+   *
+   * Broadcast rather than waited for: a client told at connect that the workspace has
+   * no repository stops asking about git entirely, so nothing short of being told
+   * would ever bring the surface back.
+   */
+  | { type: "git_repositories_changed"; available: boolean }
+  /**
    * A watched directory's entries changed on disk, whatever caused it — this
    * server, the agent through bash, or nothing in this process at all.
    *
@@ -657,7 +666,8 @@ export type ServerMessage =
    */
   | { type: "git_status"; requestId: string; repo?: string; repos: GitRepoStatus[]; files: GitFileStatus[] }
   | { type: "git_diff"; requestId: string; path: string; before: string; after: string }
-  | { type: "git_log"; requestId: string; entries: GitLogEntry[] }
+  /** `repo` is echoed: a log rendered under another repository's chip is a lie. */
+  | { type: "git_log"; requestId: string; repo: string; entries: GitLogEntry[] }
   | { type: "git_show"; requestId: string; sha: string; patch: string; truncated: boolean }
   | { type: "git_file_log"; requestId: string; path: string; entries: GitFileLogEntry[] }
   /** Both revisions are echoed so the client can drop a reply its selection has moved past. */

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -258,6 +258,22 @@ export interface GitFileStatus {
   status: GitFileState;
 }
 
+/**
+ * Branch state of one repository serving the workspace.
+ *
+ * A workspace holds a set of repositories - a directory of independently
+ * versioned projects has one per child - so there is no single branch to report.
+ * The client attributes a file to a repository by longest matching `repo`, the
+ * same rule the server resolves with.
+ */
+export interface GitRepoStatus {
+  /** Path from the browser root to the repository (posix); "" for the root itself or an ancestor. */
+  repo: string;
+  branch: string;
+  ahead: number;
+  behind: number;
+}
+
 export interface GitLogEntry {
   sha: string;
   author: string;
@@ -634,7 +650,12 @@ export type ServerMessage =
   | { type: "file_search_results"; requestId: string; query: string; results: FileSearchEntry[] }
   | { type: "tree"; roots: TreeNode[] }
   | { type: "editor_prefill"; text: string }
-  | { type: "git_status"; requestId: string; branch: string; ahead: number; behind: number; files: GitFileStatus[] }
+  /**
+   * `files` spans every repository in the workspace and `repos` carries each one's
+   * branch — unless `repo` echoes a scoped request, in which case both describe that
+   * repository alone and replace only its slice of what the client holds.
+   */
+  | { type: "git_status"; requestId: string; repo?: string; repos: GitRepoStatus[]; files: GitFileStatus[] }
   | { type: "git_diff"; requestId: string; path: string; before: string; after: string }
   | { type: "git_log"; requestId: string; entries: GitLogEntry[] }
   | { type: "git_show"; requestId: string; sha: string; patch: string; truncated: boolean }
@@ -760,10 +781,13 @@ export type ClientMessage =
    * (the old exchange stays reachable through the tree).
    */
   | { type: "edit_prompt"; entryId: string; text: string; images?: WireImage[] }
-  | { type: "git_status"; requestId: string }
-  | { type: "git_log"; limit?: number; requestId: string }
+  /** `repo` reads one repository instead of sweeping every one of them. */
+  | { type: "git_status"; repo?: string; requestId: string }
+  /** `repo` names which repository of the workspace to read, as `GitRepoStatus.repo` does. */
+  | { type: "git_log"; repo: string; limit?: number; requestId: string }
   | { type: "git_diff"; path: string; requestId: string }
-  | { type: "git_show"; sha: string; requestId: string }
+  /** `sha` is resolved only against `repo`; there is no fallback to another. */
+  | { type: "git_show"; repo: string; sha: string; requestId: string }
   /** Commits touching one file, renames followed; limit clamped to [1, 200] server-side. */
   | { type: "git_file_log"; path: string; limit?: number; requestId: string }
   | { type: "git_file_diff"; base: GitRevision; target: GitRevision; requestId: string }

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -369,9 +369,43 @@ describe("App — panes and handovers", () => {
     expect(screen.getByRole("button", { name: "Close file viewer" })).toBeInTheDocument();
   });
 
+  it("offers no history for a file under no repository, though the workspace has git", () => {
+    // A directory of projects: two repositories, and a loose file beside them. The
+    // workspace has git; this file has no history, and the affordance would 404.
+    mount({
+      gitAvailable: true,
+      gitStatus: {
+        repos: [
+          { repo: "projA", branch: "main", ahead: 0, behind: 0 },
+          { repo: "projB", branch: "release", ahead: 0, behind: 0 },
+        ],
+        files: {},
+      },
+      openFile: { status: "loaded", path: "notes.md", content: "x", size: 1, mtimeMs: 1 },
+    });
+    expect(screen.queryByRole("button", { name: /history/ })).not.toBeInTheDocument();
+  });
+
+  it("offers history for a file inside one of several repositories", () => {
+    const { api } = mount({
+      gitAvailable: true,
+      gitStatus: {
+        repos: [
+          { repo: "projA", branch: "main", ahead: 0, behind: 0 },
+          { repo: "projB", branch: "release", ahead: 0, behind: 0 },
+        ],
+        files: {},
+      },
+      openFile: { status: "loaded", path: "projB/src/main.ts", content: "x", size: 1, mtimeMs: 1 },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /history/ }));
+    expect(api.fetchGitFileHistory).toHaveBeenCalledWith("projB/src/main.ts");
+  });
+
   it("asks for a file's history from the viewer", () => {
     const { api } = mount({
       gitAvailable: true,
+      gitStatus: { repos: [{ repo: "", branch: "main", ahead: 0, behind: 0 }], files: {} },
       openFile: { status: "loaded", path: "src/main.ts", content: "x", size: 1, mtimeMs: 1 },
     });
     fireEvent.click(screen.getByRole("button", { name: /history/ }));
@@ -381,6 +415,7 @@ describe("App — panes and handovers", () => {
   it("shows the history pane once the answer arrives", () => {
     mount({
       gitAvailable: true,
+      gitStatus: { repos: [{ repo: "", branch: "main", ahead: 0, behind: 0 }], files: {} },
       openFile: { status: "loaded", path: "src/main.ts", content: "x", size: 1, mtimeMs: 1 },
       gitFileHistory: { path: "src/main.ts", status: "loaded", entries: [], requestId: "r1" },
     });
@@ -780,7 +815,7 @@ describe("App — model bar and tree", () => {
   it("opens a file from the tree straight onto its diff", () => {
     const api = mount({
       fileTree: { "": [{ name: "readme.md", type: "file" }] },
-      gitStatus: { branch: "main", ahead: 0, behind: 0, files: { "readme.md": "modified" } },
+      gitStatus: { repos: [{ repo: "", branch: "main", ahead: 0, behind: 0 }], files: { "readme.md": "modified" } },
       gitAvailable: true,
     });
     fireEvent.click(screen.getByRole("button", { name: /[◨◧]\s*files/ }));

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -369,6 +369,38 @@ describe("App — panes and handovers", () => {
     expect(screen.getByRole("button", { name: "Close file viewer" })).toBeInTheDocument();
   });
 
+  // openlore: scenario=TheChipFollowsADirectoryToo spec=git
+  it("moves the branch chip when the user walks into another project's directory", () => {
+    // The gap a component test could not see: GitMenu was right, and App fed it the
+    // open FILE, so clicking a project's folder moved nothing.
+    mount({
+      gitAvailable: true,
+      fileTree: {
+        "": [
+          { name: "projA", type: "directory" },
+          { name: "projB", type: "directory" },
+        ],
+      },
+      gitStatus: {
+        repos: [
+          { repo: "projA", branch: "main", ahead: 0, behind: 0 },
+          { repo: "projB", branch: "release", ahead: 0, behind: 0 },
+        ],
+        files: {},
+      },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /[◨◧]\s*files/ }));
+
+    const chip = () => screen.getByRole("button", { name: /⎇/ });
+    expect(chip()).toHaveTextContent("—");
+
+    fireEvent.click(screen.getByRole("button", { name: /^[▸▾]\s*projB\s*\d*$/ }));
+    expect(chip()).toHaveTextContent("release");
+
+    fireEvent.click(screen.getByRole("button", { name: /^[▸▾]\s*projA\s*\d*$/ }));
+    expect(chip()).toHaveTextContent("main");
+  });
+
   it("offers no history for a file under no repository, though the workspace has git", () => {
     // A directory of projects: two repositories, and a loose file beside them. The
     // workspace has git; this file has no history, and the affordance would 404.

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -174,6 +174,13 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
    * would close the listing the other is still reading.
    */
   const [headerPicker, setHeaderPicker] = useState<"project" | "root" | "settings" | null>(null);
+  /**
+   * The last path the user touched in the tree, file or directory — what the branch
+   * chip names a repository from. Not `openFile`: walking into a project without
+   * opening anything is still saying which project you are in, and closing the viewer
+   * is not saying you have left it.
+   */
+  const [treeSelection, setTreeSelection] = useState<string | null>(null);
   const projectPicker = headerPicker === "project";
   const setProjectPicker = (open: boolean) => setHeaderPicker(open ? "project" : null);
   /**
@@ -702,13 +709,16 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
             gitFiles={state.gitStatus?.files}
             attachedPaths={attachedPaths}
             onExpand={listDirectory}
+            onSelectDirectory={setTreeSelection}
             onRefresh={refreshFileTree}
             onSelectFile={(path) => {
               setDiffOnOpen(false);
+              setTreeSelection(path);
               readFile(path);
             }}
             onSelectDiff={(path) => {
               setDiffOnOpen(true);
+              setTreeSelection(path);
               readFile(path);
             }}
             onToggleAttachPath={toggleAttachPath}
@@ -814,7 +824,7 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
             onForkSession={forkSession}
             gitAvailable={state.gitAvailable}
             gitStatus={state.gitStatus}
-            gitSelectedPath={state.openFile?.path ?? null}
+            gitSelectedPath={treeSelection}
             gitLog={state.gitLog}
             extensionPaths={state.extensionPaths}
             configuredExtensionPaths={state.configuredExtensionPaths}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -7,6 +7,7 @@ import { ThemeContext } from "./theme/ThemeContext";
 import { useConversationJump } from "./useConversationJump";
 import { analyzeSession } from "./util/sessionAnalysis";
 import { sessionUsage } from "./util/sessionUsage";
+import { repoForPath } from "./util/gitRepos";
 import { ToolCard } from "./components/ToolCard";
 import { createActionDispatch } from "./presentations/actions";
 import { UserMessage } from "./components/UserMessage";
@@ -813,6 +814,7 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
             onForkSession={forkSession}
             gitAvailable={state.gitAvailable}
             gitStatus={state.gitStatus}
+            gitSelectedPath={state.openFile?.path ?? null}
             gitLog={state.gitLog}
             extensionPaths={state.extensionPaths}
             configuredExtensionPaths={state.configuredExtensionPaths}
@@ -862,7 +864,7 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
               gitDiff={state.gitDiff}
               onFetchGitDiff={fetchGitDiff}
               onClearGitDiff={clearGitDiff}
-              gitAvailable={state.gitAvailable}
+              inRepository={repoForPath(state.gitStatus?.repos ?? [], state.openFile.path) !== null}
               onOpenGitHistory={fetchGitFileHistory}
               onClose={closePreview}
               onReload={readFile}

--- a/ui/src/components/FileTree.test.tsx
+++ b/ui/src/components/FileTree.test.tsx
@@ -215,6 +215,24 @@ describe("FileTree", () => {
         expect(within(dirToggle("projB")).getByTitle("1 changed file(s) inside")).toBeInTheDocument();
       });
 
+      it("reports the directory the user touched, opening it, closing it, or reopening it", () => {
+        const onSelectDirectory = vi.fn();
+        setup({ tree: projects, gitFiles: across, onSelectDirectory });
+
+        fireEvent.click(dirToggle("projA"));
+        expect(onSelectDirectory).toHaveBeenLastCalledWith("projA");
+
+        // Collapsing is still saying which project you are looking at
+        fireEvent.click(dirToggle("projA"));
+        expect(onSelectDirectory).toHaveBeenCalledTimes(2);
+
+        // And reopening a directory already listed fetches nothing, so onExpand is
+        // silent — this is the case the branch chip used to miss entirely
+        fireEvent.click(dirToggle("projA"));
+        expect(onSelectDirectory).toHaveBeenCalledTimes(3);
+        expect(onSelectDirectory).toHaveBeenLastCalledWith("projA");
+      });
+
       it("leaves a file under no repository unbadged", () => {
         setup({ tree: projects, gitFiles: across });
         expect(screen.queryByRole("button", { name: "Show diff of notes.md" })).not.toBeInTheDocument();

--- a/ui/src/components/FileTree.test.tsx
+++ b/ui/src/components/FileTree.test.tsx
@@ -188,6 +188,38 @@ describe("FileTree", () => {
       expect(within(dirToggle("src")).queryByTitle(/changed file/)).not.toBeInTheDocument();
       expect(within(dirToggle("src-gen")).getByTitle("1 changed file(s) inside")).toBeInTheDocument();
     });
+
+    describe("a workspace whose root is no repository and whose children are", () => {
+      /** Two projects side by side, each a repository, each with one change. */
+      const projects: Record<string, DirState> = {
+        "": [dir("projA"), dir("projB"), file("notes.md")],
+        projA: [file("a.ts")],
+        projB: [file("b.ts")],
+      };
+      const across: Record<string, GitFileState> = {
+        "projA/a.ts": "modified",
+        "projB/b.ts": "untracked",
+      };
+
+      it("badges files from both repositories, not just one", () => {
+        setup({ tree: projects, gitFiles: across });
+        fireEvent.click(dirToggle("projA"));
+        fireEvent.click(dirToggle("projB"));
+        expect(screen.getByRole("button", { name: "Show diff of a.ts" })).toHaveTextContent("M");
+        expect(screen.getByRole("button", { name: "Show diff of b.ts" })).toHaveTextContent("U");
+      });
+
+      it("puts a change count on each collapsed project", () => {
+        setup({ tree: projects, gitFiles: across });
+        expect(within(dirToggle("projA")).getByTitle("1 changed file(s) inside")).toBeInTheDocument();
+        expect(within(dirToggle("projB")).getByTitle("1 changed file(s) inside")).toBeInTheDocument();
+      });
+
+      it("leaves a file under no repository unbadged", () => {
+        setup({ tree: projects, gitFiles: across });
+        expect(screen.queryByRole("button", { name: "Show diff of notes.md" })).not.toBeInTheDocument();
+      });
+    });
   });
 
   describe("prompt references", () => {

--- a/ui/src/components/FileTree.tsx
+++ b/ui/src/components/FileTree.tsx
@@ -43,6 +43,14 @@ interface TreeProps {
   /** Paths currently attached to the composer as references (from the tree or the open preview). */
   attachedPaths?: string[];
   onExpand: (path: string) => void;
+  /**
+   * A directory the user touched, opened or closed.
+   *
+   * Distinct from `onExpand`, which fires once per directory and only to fetch it:
+   * re-opening a cached directory, or collapsing one, tells the tree nothing while
+   * telling the user's eye a great deal about which project they are looking at.
+   */
+  onSelectDirectory?: (path: string) => void;
   onSelectFile: (path: string) => void;
   /** Open the file directly on its uncommitted diff (badge click). */
   onSelectDiff?: (path: string) => void;
@@ -296,6 +304,7 @@ function TreeNode({
               const next = !open;
               setOpen(next);
               if (next && props.tree[fullPath] === undefined) props.onExpand(fullPath);
+              props.onSelectDirectory?.(fullPath);
             }}
             style={{ paddingLeft: depth * 12 }}
             className="flex min-w-0 flex-1 items-center gap-1 rounded py-0.5 text-left"

--- a/ui/src/components/FileViewer.test.tsx
+++ b/ui/src/components/FileViewer.test.tsx
@@ -24,7 +24,7 @@ function setup(overrides: Partial<Props> = {}) {
     file: loaded(),
     isStreaming: false,
     gitDiff: null,
-    gitAvailable: false,
+    inRepository: false,
     ...handlers,
     ...overrides,
   };
@@ -346,18 +346,18 @@ describe("FileViewer", () => {
     });
 
     it("offers the history affordance for any tracked file, changed or not", () => {
-      const { onOpenGitHistory } = setup({ gitAvailable: true, gitState: undefined });
+      const { onOpenGitHistory } = setup({ inRepository: true, gitState: undefined });
       fireEvent.click(button("⎇ history"));
       expect(onOpenGitHistory).toHaveBeenCalledWith("src/main.ts");
     });
 
-    it("hides the history affordance when git is unavailable", () => {
-      setup({ gitAvailable: false });
+    it("hides the history affordance for a file under no repository", () => {
+      setup({ inRepository: false });
       expect(queryButton("⎇ history")).not.toBeInTheDocument();
     });
 
     it("hides both git affordances while editing", () => {
-      setup({ gitAvailable: true, gitState: "modified" });
+      setup({ inRepository: true, gitState: "modified" });
       fireEvent.click(button("✎ edit"));
       expect(queryButton("⎇ history")).not.toBeInTheDocument();
       expect(queryButton("± diff")).not.toBeInTheDocument();

--- a/ui/src/components/FileViewer.tsx
+++ b/ui/src/components/FileViewer.tsx
@@ -36,8 +36,14 @@ interface FileViewerProps {
   gitDiff: GitDiffState | null;
   onFetchGitDiff: (path: string) => void;
   onClearGitDiff: () => void;
-  /** Enables the history affordance — for any tracked file, changed or not. */
-  gitAvailable: boolean;
+  /**
+   * Whether this file is inside one of the workspace's repositories — which enables
+   * the history affordance, for any file in one, changed or not.
+   *
+   * Not "does the workspace have git": a directory of projects can hold loose files
+   * beside versioned ones, and a file under no repository has no history to show.
+   */
+  inRepository: boolean;
   onOpenGitHistory: (path: string) => void;
   onClose: () => void;
   /** Refetch the file from disk (discards the edit baseline). */
@@ -143,7 +149,7 @@ export function FileViewer({
   gitDiff,
   onFetchGitDiff,
   onClearGitDiff,
-  gitAvailable,
+  inRepository,
   onOpenGitHistory,
   onClose,
   onReload,
@@ -538,7 +544,7 @@ export function FileViewer({
             ± diff
           </button>
         )}
-        {gitAvailable && edit === null && (
+        {inRepository && edit === null && (
           <button
             type="button"
             onClick={() => onOpenGitHistory(file.path)}

--- a/ui/src/components/GitMenu.test.tsx
+++ b/ui/src/components/GitMenu.test.tsx
@@ -1,11 +1,20 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent, within } from "@testing-library/react";
-import type { GitLogEntry } from "@pi-outpost/shared";
+import type { GitLogEntry, GitRepoStatus } from "@pi-outpost/shared";
 import { GitMenu } from "./GitMenu";
 import type { GitStatusState } from "../useAgent";
 
-function status(overrides: Partial<GitStatusState> = {}): GitStatusState {
-  return { branch: "main", ahead: 0, behind: 0, files: {}, ...overrides };
+/** One repository at the browser root — the shape a single-project workspace has. */
+const ONE: GitRepoStatus[] = [{ repo: "", branch: "main", ahead: 0, behind: 0 }];
+
+/** A directory of projects: the root is no repository, each child is one. */
+const TWO: GitRepoStatus[] = [
+  { repo: "projA", branch: "main", ahead: 0, behind: 0 },
+  { repo: "projB", branch: "release", ahead: 1, behind: 2 },
+];
+
+function status(repos: GitRepoStatus[] = ONE): GitStatusState {
+  return { repos, files: {} };
 }
 
 const LOG: GitLogEntry[] = [
@@ -16,7 +25,9 @@ const LOG: GitLogEntry[] = [
 function setup(props: Partial<React.ComponentProps<typeof GitMenu>> = {}) {
   const onFetchLog = vi.fn();
   const onShowCommit = vi.fn();
-  const view = render(<GitMenu status={status()} log={LOG} onFetchLog={onFetchLog} onShowCommit={onShowCommit} {...props} />);
+  const view = render(
+    <GitMenu status={status()} selected={null} log={LOG} onFetchLog={onFetchLog} onShowCommit={onShowCommit} {...props} />,
+  );
   return { onFetchLog, onShowCommit, ...view };
 }
 
@@ -39,7 +50,15 @@ describe("GitMenu", () => {
   it("shows ahead and behind counts only when there is something to report", () => {
     const { rerender } = setup();
     expect(chip()).not.toHaveTextContent("↑");
-    rerender(<GitMenu status={status({ ahead: 2, behind: 3 })} log={LOG} onFetchLog={vi.fn()} onShowCommit={vi.fn()} />);
+    rerender(
+      <GitMenu
+        status={status([{ repo: "", branch: "main", ahead: 2, behind: 3 }])}
+        selected={null}
+        log={LOG}
+        onFetchLog={vi.fn()}
+        onShowCommit={vi.fn()}
+      />,
+    );
     expect(chip()).toHaveTextContent("↑2");
     expect(chip()).toHaveTextContent("↓3");
   });
@@ -54,7 +73,7 @@ describe("GitMenu", () => {
     expect(onFetchLog).not.toHaveBeenCalled();
     fireEvent.click(chip());
     expect(onFetchLog).toHaveBeenCalledTimes(1);
-    rerender(<GitMenu status={status()} log={LOG} onFetchLog={onFetchLog} onShowCommit={vi.fn()} />);
+    rerender(<GitMenu status={status()} selected={null} log={LOG} onFetchLog={onFetchLog} onShowCommit={vi.fn()} />);
     expect(onFetchLog).toHaveBeenCalledTimes(1);
   });
 
@@ -83,7 +102,7 @@ describe("GitMenu", () => {
     const { onShowCommit } = setup();
     fireEvent.click(chip());
     fireEvent.click(screen.getByText("three days back"));
-    expect(onShowCommit).toHaveBeenCalledWith("bbbbbbb2222");
+    expect(onShowCommit).toHaveBeenCalledWith("", "bbbbbbb2222");
     expect(screen.queryByText("three days back")).not.toBeInTheDocument();
   });
 
@@ -120,5 +139,58 @@ describe("GitMenu", () => {
     fireEvent.click(chip());
 
     expect(screen.getByText("most recent")).toHaveAttribute("title", "most recent");
+  });
+
+  describe("a workspace holding several repositories", () => {
+    const render2 = (selected: string | null, handlers: Partial<React.ComponentProps<typeof GitMenu>> = {}) =>
+      setup({ status: status(TWO), selected, ...handlers });
+
+    it("names the branch of the repository owning the selected file", () => {
+      const { rerender, onFetchLog, onShowCommit } = render2("projA/src/main.ts");
+      expect(chip()).toHaveTextContent("main");
+      expect(chip()).not.toHaveTextContent("release");
+
+      rerender(
+        <GitMenu status={status(TWO)} selected="projB/README.md" log={LOG} onFetchLog={onFetchLog} onShowCommit={onShowCommit} />,
+      );
+      expect(chip()).toHaveTextContent("release");
+      expect(chip()).toHaveTextContent("↑1");
+      expect(chip()).toHaveTextContent("↓2");
+    });
+
+    it("names the project too, since one branch name no longer says which", () => {
+      render2("projB/README.md");
+      expect(chip()).toHaveTextContent("projB");
+    });
+
+    it("names no branch while nothing is selected, and stays on screen", () => {
+      render2(null);
+      expect(chip()).toBeInTheDocument();
+      expect(chip()).toHaveTextContent("—");
+      expect(chip()).not.toHaveTextContent("main");
+      expect(chip()).not.toHaveTextContent("release");
+    });
+
+    it("leaves the chip where it was when the selection is under no repository", () => {
+      const { rerender, onFetchLog, onShowCommit } = render2("projA/src/main.ts");
+      expect(chip()).toHaveTextContent("main");
+      rerender(<GitMenu status={status(TWO)} selected="notes.md" log={LOG} onFetchLog={onFetchLog} onShowCommit={onShowCommit} />);
+      expect(chip()).toHaveTextContent("main");
+    });
+
+    it("asks for the selected repository's log, and reports a commit against it", () => {
+      const { onFetchLog, onShowCommit } = render2("projB/README.md");
+      fireEvent.click(chip());
+      expect(onFetchLog).toHaveBeenCalledWith("projB");
+      fireEvent.click(screen.getByText("three days back"));
+      expect(onShowCommit).toHaveBeenCalledWith("projB", "bbbbbbb2222");
+    });
+
+    it("offers no history to open while no repository is named", () => {
+      const { onFetchLog } = render2(null);
+      fireEvent.click(chip());
+      expect(onFetchLog).not.toHaveBeenCalled();
+      expect(screen.queryByText("most recent")).not.toBeInTheDocument();
+    });
   });
 });

--- a/ui/src/components/GitMenu.test.tsx
+++ b/ui/src/components/GitMenu.test.tsx
@@ -17,10 +17,19 @@ function status(repos: GitRepoStatus[] = ONE): GitStatusState {
   return { repos, files: {} };
 }
 
-const LOG: GitLogEntry[] = [
+const ENTRIES: GitLogEntry[] = [
   { sha: "aaaaaaa1111", author: "Ada", date: new Date().toISOString(), subject: "most recent" },
   { sha: "bbbbbbb2222", author: "Grace", date: new Date(Date.now() - 3 * 86400_000).toISOString(), subject: "three days back" },
 ];
+
+/** A log answered BY `repo` — the menu shows it only under that repository's chip. */
+const logFor = (repo: string, entries: GitLogEntry[] | null = ENTRIES) =>
+  entries === null ? null : { repo, entries };
+
+/** The repository a browser-root-relative path belongs to, for the fixtures below. */
+const repoOf = (selected: string | null) => (selected === null ? "" : selected.split("/")[0]);
+
+const LOG = logFor("");
 
 function setup(props: Partial<React.ComponentProps<typeof GitMenu>> = {}) {
   const onFetchLog = vi.fn();
@@ -113,7 +122,7 @@ describe("GitMenu", () => {
   });
 
   it("distinguishes a repository with no commits from one still loading", () => {
-    setup({ log: [] });
+    setup({ log: logFor("", []) });
     fireEvent.click(chip());
     expect(screen.getByText("no commits")).toBeInTheDocument();
     expect(screen.queryByText("loading…")).not.toBeInTheDocument();
@@ -143,7 +152,7 @@ describe("GitMenu", () => {
 
   describe("a workspace holding several repositories", () => {
     const render2 = (selected: string | null, handlers: Partial<React.ComponentProps<typeof GitMenu>> = {}) =>
-      setup({ status: status(TWO), selected, ...handlers });
+      setup({ status: status(TWO), selected, log: logFor(repoOf(selected)), ...handlers });
 
     it("names the branch of the repository owning the selected file", () => {
       const { rerender, onFetchLog, onShowCommit } = render2("projA/src/main.ts");
@@ -151,7 +160,7 @@ describe("GitMenu", () => {
       expect(chip()).not.toHaveTextContent("release");
 
       rerender(
-        <GitMenu status={status(TWO)} selected="projB/README.md" log={LOG} onFetchLog={onFetchLog} onShowCommit={onShowCommit} />,
+        <GitMenu status={status(TWO)} selected="projB/README.md" log={logFor("projB")} onFetchLog={onFetchLog} onShowCommit={onShowCommit} />,
       );
       expect(chip()).toHaveTextContent("release");
       expect(chip()).toHaveTextContent("↑1");
@@ -175,7 +184,7 @@ describe("GitMenu", () => {
     it("names no branch when the selection is under no repository", () => {
       const { rerender, onFetchLog, onShowCommit } = render2("projA/src/main.ts");
       expect(chip()).toHaveTextContent("main");
-      rerender(<GitMenu status={status(TWO)} selected="notes.md" log={LOG} onFetchLog={onFetchLog} onShowCommit={onShowCommit} />);
+      rerender(<GitMenu status={status(TWO)} selected="notes.md" log={logFor("")} onFetchLog={onFetchLog} onShowCommit={onShowCommit} />);
       expect(chip()).toBeInTheDocument();
       expect(chip()).toHaveTextContent("—");
       expect(chip()).not.toHaveTextContent("main");
@@ -185,7 +194,7 @@ describe("GitMenu", () => {
     it("follows a directory, not only a file", () => {
       const { rerender, onFetchLog, onShowCommit } = render2("projA/src/main.ts");
       expect(chip()).toHaveTextContent("main");
-      rerender(<GitMenu status={status(TWO)} selected="projB" log={LOG} onFetchLog={onFetchLog} onShowCommit={onShowCommit} />);
+      rerender(<GitMenu status={status(TWO)} selected="projB" log={logFor("projB")} onFetchLog={onFetchLog} onShowCommit={onShowCommit} />);
       expect(chip()).toHaveTextContent("release");
       expect(chip()).toHaveTextContent("projB");
     });
@@ -196,6 +205,39 @@ describe("GitMenu", () => {
       expect(onFetchLog).toHaveBeenCalledWith("projB");
       fireEvent.click(screen.getByText("three days back"));
       expect(onShowCommit).toHaveBeenCalledWith("projB", "bbbbbbb2222");
+    });
+
+    it("asks for the new repository's log when the selection moves under an open menu", () => {
+      // The menu stays open while the user walks the tree. Asking only on the toggle
+      // left it saying "loading…" for a request nobody had made.
+      const { onFetchLog, rerender, onShowCommit } = setup({
+        status: status(TWO),
+        selected: "projA/src/main.ts",
+        log: logFor("projA"),
+      });
+      fireEvent.click(chip());
+      expect(onFetchLog).toHaveBeenLastCalledWith("projA");
+
+      rerender(
+        <GitMenu status={status(TWO)} selected="projB" log={logFor("projA")} onFetchLog={onFetchLog} onShowCommit={onShowCommit} />,
+      );
+      expect(onFetchLog).toHaveBeenLastCalledWith("projB");
+      expect(screen.getByText("loading…")).toBeInTheDocument();
+
+      rerender(
+        <GitMenu status={status(TWO)} selected="projB" log={logFor("projB")} onFetchLog={onFetchLog} onShowCommit={onShowCommit} />,
+      );
+      expect(screen.getByText("most recent")).toBeInTheDocument();
+    });
+
+    it("shows no commits under a repository whose answer has not arrived", () => {
+      // Opening projA's history, then projB's: projA's entries must not render under
+      // projB's chip, and must not be clickable into a git_show against projB
+      const { onShowCommit } = setup({ status: status(TWO), selected: "projB/README.md", log: logFor("projA") });
+      fireEvent.click(chip());
+      expect(screen.getByText("loading…")).toBeInTheDocument();
+      expect(screen.queryByText("most recent")).not.toBeInTheDocument();
+      expect(onShowCommit).not.toHaveBeenCalled();
     });
 
     it("offers no history to open while no repository is named", () => {

--- a/ui/src/components/GitMenu.test.tsx
+++ b/ui/src/components/GitMenu.test.tsx
@@ -171,11 +171,23 @@ describe("GitMenu", () => {
       expect(chip()).not.toHaveTextContent("release");
     });
 
-    it("leaves the chip where it was when the selection is under no repository", () => {
+    // openlore: scenario=ASelectionUnderNoRepositoryNamesNothing spec=git
+    it("names no branch when the selection is under no repository", () => {
       const { rerender, onFetchLog, onShowCommit } = render2("projA/src/main.ts");
       expect(chip()).toHaveTextContent("main");
       rerender(<GitMenu status={status(TWO)} selected="notes.md" log={LOG} onFetchLog={onFetchLog} onShowCommit={onShowCommit} />);
+      expect(chip()).toBeInTheDocument();
+      expect(chip()).toHaveTextContent("—");
+      expect(chip()).not.toHaveTextContent("main");
+    });
+
+    // openlore: scenario=TheChipFollowsADirectoryToo spec=git
+    it("follows a directory, not only a file", () => {
+      const { rerender, onFetchLog, onShowCommit } = render2("projA/src/main.ts");
       expect(chip()).toHaveTextContent("main");
+      rerender(<GitMenu status={status(TWO)} selected="projB" log={LOG} onFetchLog={onFetchLog} onShowCommit={onShowCommit} />);
+      expect(chip()).toHaveTextContent("release");
+      expect(chip()).toHaveTextContent("projB");
     });
 
     it("asks for the selected repository's log, and reports a commit against it", () => {

--- a/ui/src/components/GitMenu.tsx
+++ b/ui/src/components/GitMenu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import type { GitLogEntry, GitRepoStatus } from "@pi-outpost/shared";
 import type { GitStatusState } from "../useAgent";
 import { useClickOutside } from "../util/clickOutside";
@@ -6,7 +6,10 @@ import { repoForPath } from "../util/gitRepos";
 
 interface GitMenuProps {
   status: GitStatusState | null;
-  /** Browser-root-relative path of what the user has open, or null when nothing is. */
+  /**
+   * Browser-root-relative path of the last thing the user touched in the tree — a file
+   * or a directory — or null when they have touched nothing yet.
+   */
   selected: string | null;
   log: GitLogEntry[] | null;
   onFetchLog: (repo: string) => void;
@@ -30,25 +33,23 @@ function repoName(repo: string): string {
  * Header branch chip; opens that repository's recent commits, click one for its diff.
  *
  * A workspace holds a set of repositories, so there is no single branch to show and
- * the chip follows the selection instead: opening a file in one project names that
- * project's branch. No picker — the user already chose by clicking a file, and a
- * control for choosing again would be asking twice.
+ * the chip follows the selection instead — a file OR a directory, since walking into
+ * a project is how you say which one you are in. No picker: the user already chose by
+ * clicking, and a control for choosing again would be asking twice.
+ *
+ * A selection under no repository names nothing. The chip stays on screen and says
+ * `—`, rather than going on claiming the last repository it knew: in a directory of
+ * projects the loose files at the root are exactly where a README lives, and a chip
+ * naming a project the user has left is worse than one admitting it has none.
  */
 export function GitMenu({ status, selected, log, onFetchLog, onShowCommit }: GitMenuProps) {
   const [open, setOpen] = useState(false);
   const ref = useClickOutside(() => setOpen(false));
   const repos = status?.repos ?? [];
   const owner = selected === null ? null : repoForPath(repos, selected);
-
-  // A file under no repository — a loose note beside three projects — leaves the chip
-  // where it was rather than blanking it: it would flicker on every click into one.
-  const [sticky, setSticky] = useState<string | null>(null);
-  useEffect(() => {
-    if (owner !== null) setSticky(owner.repo);
-  }, [owner]);
-
-  const current: GitRepoStatus | null =
-    owner ?? repos.find((repo) => repo.repo === sticky) ?? (repos.length === 1 ? repos[0] : null);
+  // Nothing touched yet: a workspace with one repository has only one answer, and a
+  // workspace with several has none worth guessing at
+  const current: GitRepoStatus | null = owner ?? (selected === null && repos.length === 1 ? repos[0] : null);
   const counts =
     current && (current.ahead > 0 || current.behind > 0)
       ? ` ${current.ahead > 0 ? `↑${current.ahead}` : ""}${current.behind > 0 ? `↓${current.behind}` : ""}`

--- a/ui/src/components/GitMenu.tsx
+++ b/ui/src/components/GitMenu.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
-import type { GitLogEntry, GitRepoStatus } from "@pi-outpost/shared";
-import type { GitStatusState } from "../useAgent";
+import { useEffect, useState } from "react";
+import type { GitRepoStatus } from "@pi-outpost/shared";
+import type { GitLogState, GitStatusState } from "../useAgent";
 import { useClickOutside } from "../util/clickOutside";
 import { repoForPath } from "../util/gitRepos";
 
@@ -11,7 +11,7 @@ interface GitMenuProps {
    * or a directory — or null when they have touched nothing yet.
    */
   selected: string | null;
-  log: GitLogEntry[] | null;
+  log: GitLogState | null;
   onFetchLog: (repo: string) => void;
   onShowCommit: (repo: string, sha: string) => void;
 }
@@ -57,6 +57,21 @@ export function GitMenu({ status, selected, log, onFetchLog, onShowCommit }: Git
   // Naming the project matters only when there is more than one to confuse it with
   const prefix = repos.length > 1 && current !== null && current.repo !== "" ? `${repoName(current.repo)} ` : "";
   const label = status === null ? "…" : (current?.branch ?? "—");
+  // Only this repository's own log. Switching projects with the menu open, or a
+  // slower answer landing after a newer one, would otherwise put one project's
+  // commits under another's name - and clicking one asks for a commit id the named
+  // repository has never heard of.
+  const entries = current !== null && log?.repo === current.repo ? log.entries : null;
+
+  // The menu is a panel, not a dialog: it stays open while the user walks the tree,
+  // so the repository under it can change without it ever being reopened. Asking only
+  // on the toggle left it saying "loading…" for a request nobody had made.
+  useEffect(() => {
+    if (open && current !== null && log?.repo !== current.repo) onFetchLog(current.repo);
+    // `log` is deliberately absent: it is the ANSWER to this request, and depending on
+    // it would ask again on every reply that is not the one being waited for.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, current?.repo, onFetchLog]);
 
   return (
     <div className="relative" ref={ref}>
@@ -76,9 +91,9 @@ export function GitMenu({ status, selected, log, onFetchLog, onShowCommit }: Git
       </button>
       {open && current !== null && (
         <div className="absolute left-0 top-full z-20 mt-1 max-h-96 w-[26rem] max-w-[80vw] overflow-y-auto rounded-lg border border-zinc-200 bg-white py-1 shadow-xl dark:border-zinc-700 dark:bg-zinc-900">
-          {log === null && <div className="px-3 py-2 text-xs text-zinc-500">loading…</div>}
-          {log?.length === 0 && <div className="px-3 py-2 text-xs text-zinc-500">no commits</div>}
-          {log?.map((entry) => (
+          {entries === null && <div className="px-3 py-2 text-xs text-zinc-500">loading…</div>}
+          {entries?.length === 0 && <div className="px-3 py-2 text-xs text-zinc-500">no commits</div>}
+          {entries?.map((entry) => (
             <button
               key={entry.sha}
               type="button"

--- a/ui/src/components/GitMenu.tsx
+++ b/ui/src/components/GitMenu.tsx
@@ -1,13 +1,16 @@
-import { useState } from "react";
-import type { GitLogEntry } from "@pi-outpost/shared";
+import { useEffect, useState } from "react";
+import type { GitLogEntry, GitRepoStatus } from "@pi-outpost/shared";
 import type { GitStatusState } from "../useAgent";
 import { useClickOutside } from "../util/clickOutside";
+import { repoForPath } from "../util/gitRepos";
 
 interface GitMenuProps {
   status: GitStatusState | null;
+  /** Browser-root-relative path of what the user has open, or null when nothing is. */
+  selected: string | null;
   log: GitLogEntry[] | null;
-  onFetchLog: () => void;
-  onShowCommit: (sha: string) => void;
+  onFetchLog: (repo: string) => void;
+  onShowCommit: (repo: string, sha: string) => void;
 }
 
 function relativeDate(iso: string): string {
@@ -18,30 +21,59 @@ function relativeDate(iso: string): string {
   return `${Math.round(seconds / 86400)}d ago`;
 }
 
-/** Header branch chip; opens the recent-commit history, click a commit for its diff. */
-export function GitMenu({ status, log, onFetchLog, onShowCommit }: GitMenuProps) {
+/** Last path segment: what a person calls the project, rather than where it sits. */
+function repoName(repo: string): string {
+  return repo.slice(repo.lastIndexOf("/") + 1);
+}
+
+/**
+ * Header branch chip; opens that repository's recent commits, click one for its diff.
+ *
+ * A workspace holds a set of repositories, so there is no single branch to show and
+ * the chip follows the selection instead: opening a file in one project names that
+ * project's branch. No picker — the user already chose by clicking a file, and a
+ * control for choosing again would be asking twice.
+ */
+export function GitMenu({ status, selected, log, onFetchLog, onShowCommit }: GitMenuProps) {
   const [open, setOpen] = useState(false);
   const ref = useClickOutside(() => setOpen(false));
+  const repos = status?.repos ?? [];
+  const owner = selected === null ? null : repoForPath(repos, selected);
+
+  // A file under no repository — a loose note beside three projects — leaves the chip
+  // where it was rather than blanking it: it would flicker on every click into one.
+  const [sticky, setSticky] = useState<string | null>(null);
+  useEffect(() => {
+    if (owner !== null) setSticky(owner.repo);
+  }, [owner]);
+
+  const current: GitRepoStatus | null =
+    owner ?? repos.find((repo) => repo.repo === sticky) ?? (repos.length === 1 ? repos[0] : null);
   const counts =
-    status && (status.ahead > 0 || status.behind > 0)
-      ? ` ${status.ahead > 0 ? `↑${status.ahead}` : ""}${status.behind > 0 ? `↓${status.behind}` : ""}`
+    current && (current.ahead > 0 || current.behind > 0)
+      ? ` ${current.ahead > 0 ? `↑${current.ahead}` : ""}${current.behind > 0 ? `↓${current.behind}` : ""}`
       : "";
+  // Naming the project matters only when there is more than one to confuse it with
+  const prefix = repos.length > 1 && current !== null && current.repo !== "" ? `${repoName(current.repo)} ` : "";
+  const label = status === null ? "…" : (current?.branch ?? "—");
 
   return (
     <div className="relative" ref={ref}>
       <button
         type="button"
+        disabled={current === null}
         onClick={() => {
+          if (current === null) return;
           setOpen(!open);
-          if (!open) onFetchLog();
+          if (!open) onFetchLog(current.repo);
         }}
-        title="git history"
-        className="rounded-md border border-zinc-300 px-2 py-1 font-mono text-xs text-zinc-500 hover:border-zinc-400 hover:text-zinc-700 dark:border-zinc-800 dark:text-zinc-400 dark:hover:border-zinc-600 dark:hover:text-zinc-200"
+        title={current === null ? "no repository selected" : `git history — ${current.repo === "" ? "this project" : current.repo}`}
+        className="rounded-md border border-zinc-300 px-2 py-1 font-mono text-xs text-zinc-500 hover:border-zinc-400 hover:text-zinc-700 disabled:cursor-default disabled:hover:border-zinc-300 disabled:hover:text-zinc-500 dark:border-zinc-800 dark:text-zinc-400 dark:hover:border-zinc-600 dark:hover:text-zinc-200 dark:disabled:hover:border-zinc-800 dark:disabled:hover:text-zinc-400"
       >
-        ⎇ {status?.branch ?? "…"}
+        {prefix}⎇ {label}
         {counts}
       </button>
-      {open && (
+      {open && current !== null && (
         <div className="absolute left-0 top-full z-20 mt-1 max-h-96 w-[26rem] max-w-[80vw] overflow-y-auto rounded-lg border border-zinc-200 bg-white py-1 shadow-xl dark:border-zinc-700 dark:bg-zinc-900">
           {log === null && <div className="px-3 py-2 text-xs text-zinc-500">loading…</div>}
           {log?.length === 0 && <div className="px-3 py-2 text-xs text-zinc-500">no commits</div>}
@@ -50,7 +82,7 @@ export function GitMenu({ status, log, onFetchLog, onShowCommit }: GitMenuProps)
               key={entry.sha}
               type="button"
               onClick={() => {
-                onShowCommit(entry.sha);
+                onShowCommit(current.repo, entry.sha);
                 setOpen(false);
               }}
               className="flex w-full items-baseline gap-2 px-3 py-1.5 text-left text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800"

--- a/ui/src/components/Header.test.tsx
+++ b/ui/src/components/Header.test.tsx
@@ -122,7 +122,7 @@ describe("Header", () => {
     it("shows the branch chip only when git is available", () => {
       const { rerenderWith } = setup({ gitAvailable: false });
       expect(screen.queryByRole("button", { name: /⎇/ })).not.toBeInTheDocument();
-      rerenderWith({ gitAvailable: true, gitStatus: { branch: "main", ahead: 0, behind: 0, files: {} } });
+      rerenderWith({ gitAvailable: true, gitStatus: { repos: [{ repo: "", branch: "main", ahead: 0, behind: 0 }], files: {} } });
       expect(screen.getByRole("button", { name: /main/ })).toBeInTheDocument();
     });
 

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
-import { MIN_SESSION_QUERY_LENGTH, type GitLogEntry, type SessionSummary, type TreeNode, type WorkspaceInfo } from "@pi-outpost/shared";
+import { MIN_SESSION_QUERY_LENGTH, type SessionSummary, type TreeNode, type WorkspaceInfo } from "@pi-outpost/shared";
 import { ProjectMenu } from "./ProjectMenu";
 import { WorkspaceRootControl, type WorkspaceRootSandbox } from "./WorkspaceRootControl";
-import type { GitStatusState, ServerBrowseState, SessionSearch, SettingsApplyState } from "../useAgent";
+import type { GitLogState, GitStatusState, ServerBrowseState, SessionSearch, SettingsApplyState } from "../useAgent";
 import { stripAnsi } from "../util/ansi";
 import { useClickOutside } from "../util/clickOutside";
 import { GitMenu } from "./GitMenu";
@@ -50,7 +50,7 @@ interface HeaderProps {
   hideTools: boolean;
   gitAvailable: boolean;
   gitStatus: GitStatusState | null;
-  gitLog: GitLogEntry[] | null;
+  gitLog: GitLogState | null;
   extensionPaths: string[] | null;
   configuredExtensionPaths: string[];
   userExtensionPaths: string[];

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -89,8 +89,10 @@ interface HeaderProps {
   onListTree: () => void;
   onNavigateTree: (entryId: string) => void;
   onForkSession: (entryId: string) => void;
-  onFetchGitLog: () => void;
-  onShowCommit: (sha: string) => void;
+  onFetchGitLog: (repo: string) => void;
+  onShowCommit: (repo: string, sha: string) => void;
+  /** What the viewer has open, so the branch chip can name that project's repository. */
+  gitSelectedPath: string | null;
 }
 
 const SESSION_SEARCH_DEBOUNCE_MS = 200;
@@ -380,6 +382,7 @@ export function Header(props: HeaderProps) {
       {props.gitAvailable && (
         <GitMenu
           status={props.gitStatus}
+          selected={props.gitSelectedPath}
           log={props.gitLog}
           onFetchLog={props.onFetchGitLog}
           onShowCommit={props.onShowCommit}

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -15,6 +15,7 @@ interface SidebarProps {
   /** Paths already referenced by the composer, so the tree can show the toggle as active. */
   attachedPaths?: string[];
   onExpand: (path: string) => void;
+  onSelectDirectory?: (path: string) => void;
   /** Re-list every directory the tree is holding. */
   onRefresh?: () => void;
   onSelectFile: (path: string) => void;
@@ -43,6 +44,7 @@ export function Sidebar({
   gitFiles,
   attachedPaths,
   onExpand,
+  onSelectDirectory,
   onRefresh,
   onSelectFile,
   onSelectDiff,
@@ -86,6 +88,7 @@ export function Sidebar({
           gitFiles={gitFiles}
           attachedPaths={attachedPaths}
           onExpand={onExpand}
+          onSelectDirectory={onSelectDirectory}
           onRefresh={onRefresh}
           onSelectFile={onSelectFile}
           onSelectDiff={onSelectDiff}

--- a/ui/src/useAgent.test.ts
+++ b/ui/src/useAgent.test.ts
@@ -84,7 +84,7 @@ afterEach(() => {
 // Shared harness: a connected hook with a session already established.
 // ---------------------------------------------------------------------------
 /** Renders the hook, opens the socket, and replays a `hello` with `items`. */
-async function connected(items: unknown[] = []) {
+async function connected(items: unknown[] = [], hello: Record<string, unknown> = {}) {
   const { result } = renderHook(() => useAgent());
   act(() => mockWs!.open());
   await waitFor(() => expect(result.current.state.connected).toBe(true));
@@ -101,6 +101,7 @@ async function connected(items: unknown[] = []) {
       items,
       contextUsage: null,
       gitAvailable: false,
+      ...hello,
     }),
   );
   await waitFor(() => expect(result.current.state.sessionId).toBe("sess_1"));
@@ -1095,15 +1096,112 @@ describe("git messages", () => {
     act(() =>
       mockWs!.receive({
         type: "git_status",
-        branch: "main",
-        ahead: 1,
-        behind: 0,
+        repos: [{ repo: "", branch: "main", ahead: 1, behind: 0 }],
         files: [{ path: "a.ts", status: "modified" }],
       }),
     );
 
     await waitFor(() => expect(result.current.state.gitStatus?.files["a.ts"]).toBe("modified"));
-    expect(result.current.state.gitStatus?.branch).toBe("main");
+    expect(result.current.state.gitStatus?.repos[0]?.branch).toBe("main");
+  });
+
+  it("carries every repository's branch, and files from all of them", async () => {
+    const result = await connected();
+
+    act(() =>
+      mockWs!.receive({
+        type: "git_status",
+        repos: [
+          { repo: "projA", branch: "main", ahead: 0, behind: 0 },
+          { repo: "projB", branch: "release", ahead: 2, behind: 0 },
+        ],
+        files: [
+          { path: "projA/a.ts", status: "modified" },
+          { path: "projB/b.ts", status: "untracked" },
+        ],
+      }),
+    );
+
+    await waitFor(() => expect(result.current.state.gitStatus?.files["projA/a.ts"]).toBe("modified"));
+    expect(result.current.state.gitStatus?.files["projB/b.ts"]).toBe("untracked");
+    expect(result.current.state.gitStatus?.repos.map((repo) => repo.branch)).toEqual(["main", "release"]);
+  });
+
+  it("lets a scoped answer replace one repository's slice and leave the rest standing", async () => {
+    const result = await connected();
+    act(() =>
+      mockWs!.receive({
+        type: "git_status",
+        repos: [
+          { repo: "projA", branch: "main", ahead: 0, behind: 0 },
+          { repo: "projB", branch: "release", ahead: 0, behind: 0 },
+        ],
+        files: [
+          { path: "projA/a.ts", status: "modified" },
+          { path: "projB/b.ts", status: "modified" },
+        ],
+      }),
+    );
+    await waitFor(() => expect(result.current.state.gitStatus?.files["projA/a.ts"]).toBe("modified"));
+
+    // projA is now clean and one commit ahead; projB was not asked about at all
+    act(() =>
+      mockWs!.receive({
+        type: "git_status",
+        repo: "projA",
+        repos: [{ repo: "projA", branch: "main", ahead: 1, behind: 0 }],
+        files: [],
+      }),
+    );
+
+    await waitFor(() => expect(result.current.state.gitStatus?.files["projA/a.ts"]).toBeUndefined());
+    expect(result.current.state.gitStatus?.files["projB/b.ts"]).toBe("modified");
+    expect(result.current.state.gitStatus?.repos).toEqual([
+      { repo: "projA", branch: "main", ahead: 1, behind: 0 },
+      { repo: "projB", branch: "release", ahead: 0, behind: 0 },
+    ]);
+  });
+
+  it("sweeps every repository when a turn ends, since bash can touch any of them", async () => {
+    await connected([], { gitAvailable: true });
+    // Connecting already asked once; settle it, or the next request coalesces into it
+    act(() => mockWs!.receive({ type: "git_status", repos: [], files: [] }));
+    const before = mockWs.sent.length;
+
+    act(() => mockWs!.receive({ type: "agent_end" }));
+
+    await waitFor(() => {
+      const statuses = mockWs.sent
+        .slice(before)
+        .map((raw) => JSON.parse(raw) as { type: string; repo?: string })
+        .filter((frame) => frame.type === "git_status");
+      expect(statuses).toHaveLength(1);
+      expect(statuses[0].repo).toBeUndefined();
+    });
+  });
+
+  it("asks only the changed file's repository for a fresh status", async () => {
+    const result = await connected([], { gitAvailable: true });
+    act(() =>
+      mockWs!.receive({
+        type: "git_status",
+        repos: [
+          { repo: "projA", branch: "main", ahead: 0, behind: 0 },
+          { repo: "projB", branch: "release", ahead: 0, behind: 0 },
+        ],
+        files: [],
+      }),
+    );
+    await waitFor(() => expect(result.current.state.gitStatus?.repos).toHaveLength(2));
+
+    act(() => mockWs!.receive({ type: "file_changed", path: "projB/b.ts" }));
+
+    await waitFor(() => {
+      const statuses = mockWs!.sent
+        .map((raw) => JSON.parse(raw) as { type: string; repo?: string })
+        .filter((frame) => frame.type === "git_status");
+      expect(statuses.at(-1)?.repo).toBe("projB");
+    });
   });
 
   it("shows a diff failure in the diff pane, where the viewer covers the banner", async () => {
@@ -1713,8 +1811,8 @@ describe("commands on the wire", () => {
     ["forkSession", (api) => api.forkSession("e1"), { type: "fork_session", entryId: "e1" }],
     ["editPrompt", (api) => api.editPrompt("e1", "again"), { type: "edit_prompt", entryId: "e1", text: "again" }],
     ["compact", (api) => api.compact(), { type: "compact" }],
-    ["fetchGitLog", (api) => api.fetchGitLog(20), { type: "git_log", limit: 20 }],
-    ["fetchGitShow", (api) => api.fetchGitShow("abc1234"), { type: "git_show", sha: "abc1234" }],
+    ["fetchGitLog", (api) => api.fetchGitLog("projA", 20), { type: "git_log", repo: "projA", limit: 20 }],
+    ["fetchGitShow", (api) => api.fetchGitShow("projA", "abc1234"), { type: "git_show", repo: "projA", sha: "abc1234" }],
     ["setCredential", (api) => api.setCredential("openai", "sk-x"), { type: "set_credential", provider: "openai", apiKey: "sk-x" }],
     [
       "declareProvider",
@@ -1749,7 +1847,7 @@ describe("commands on the wire", () => {
 
   it("omits the limit when none was asked for", async () => {
     const result = await connected();
-    act(() => result.current.fetchGitLog());
+    act(() => result.current.fetchGitLog(""));
     expect(lastFrame()).not.toHaveProperty("limit");
   });
 

--- a/ui/src/useAgent.test.ts
+++ b/ui/src/useAgent.test.ts
@@ -1162,6 +1162,54 @@ describe("git messages", () => {
     ]);
   });
 
+  it("starts asking about git when a workspace that had no repository gains one", async () => {
+    // The gate that makes this message necessary: told at connect there was no
+    // repository, the client suppresses every git request from then on
+    const result = await connected([], { gitAvailable: false });
+    const before = mockWs.sent.length;
+    act(() => mockWs!.receive({ type: "file_changed", path: "projA/README.md" }));
+    expect(mockWs.sent.slice(before).filter((raw) => JSON.parse(raw).type === "git_status")).toHaveLength(0);
+
+    act(() => mockWs!.receive({ type: "git_repositories_changed", available: true }));
+
+    await waitFor(() => expect(result.current.state.gitAvailable).toBe(true));
+    await waitFor(() =>
+      expect(mockWs.sent.slice(before).filter((raw) => JSON.parse(raw).type === "git_status").length).toBeGreaterThan(0),
+    );
+  });
+
+  it("stops describing repositories the workspace no longer has", async () => {
+    const result = await connected([], { gitAvailable: true });
+    act(() =>
+      mockWs!.receive({
+        type: "git_status",
+        repos: [{ repo: "only", branch: "main", ahead: 0, behind: 0 }],
+        files: [{ path: "only/a.ts", status: "modified" }],
+      }),
+    );
+    await waitFor(() => expect(result.current.state.gitStatus?.files["only/a.ts"]).toBe("modified"));
+
+    act(() => mockWs!.receive({ type: "git_repositories_changed", available: false }));
+
+    await waitFor(() => expect(result.current.state.gitAvailable).toBe(false));
+    // The badges and the branch chip would otherwise go on describing what is gone
+    expect(result.current.state.gitStatus).toBeNull();
+  });
+
+  it("keeps one repository's commits from rendering as another's", async () => {
+    const result = await connected([], { gitAvailable: true });
+    act(() =>
+      mockWs!.receive({
+        type: "git_log",
+        requestId: "gitlog:1",
+        repo: "projA",
+        entries: [{ sha: "aaaaaaa", author: "Ada", date: new Date().toISOString(), subject: "in projA" }],
+      }),
+    );
+    await waitFor(() => expect(result.current.state.gitLog?.repo).toBe("projA"));
+    expect(result.current.state.gitLog?.entries).toHaveLength(1);
+  });
+
   it("sweeps every repository when a turn ends, since bash can touch any of them", async () => {
     await connected([], { gitAvailable: true });
     // Connecting already asked once; settle it, or the next request coalesces into it

--- a/ui/src/useAgent.ts
+++ b/ui/src/useAgent.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { bootstrapToken, storedToken, storeToken } from "./authToken";
+import { repoForPath } from "./util/gitRepos";
 import type {
   Branding,
   ChatItem,
@@ -15,6 +16,7 @@ import type {
   GitFileLogEntry,
   GitFileState,
   GitLogEntry,
+  GitRepoStatus,
   GitRevision,
   ModelChoice,
   ProviderCompat,
@@ -99,10 +101,9 @@ export type SessionSearch = {
 
 /** Latest git working-tree status; null until the first git_status answer. */
 export interface GitStatusState {
-  branch: string;
-  ahead: number;
-  behind: number;
-  /** Browser-root-relative path → state. */
+  /** Every repository serving the workspace, each with its own branch. */
+  repos: GitRepoStatus[];
+  /** Browser-root-relative path → state, across all of them. */
   files: Record<string, GitFileState>;
 }
 
@@ -976,7 +977,18 @@ function reduce(state: AgentState, action: Action): AgentState {
     case "git_status": {
       const files: Record<string, GitFileState> = {};
       for (const file of message.files) files[file.path] = file.status;
-      return { ...state, gitStatus: { branch: message.branch, ahead: message.ahead, behind: message.behind, files } };
+      const previous = state.gitStatus;
+      // A full sweep is authoritative: it is also how a repository that appeared or
+      // vanished enters and leaves the list
+      if (message.repo === undefined || previous === null) return { ...state, gitStatus: { repos: message.repos, files } };
+      // A scoped answer speaks for one repository only — drop that repository's old
+      // files, keep everyone else's, and refresh its branch in place
+      const kept: Record<string, GitFileState> = {};
+      for (const [path, status] of Object.entries(previous.files)) {
+        if (repoForPath(previous.repos, path)?.repo !== message.repo) kept[path] = status;
+      }
+      const repos = previous.repos.map((repo) => message.repos.find((one) => one.repo === repo.repo) ?? repo);
+      return { ...state, gitStatus: { repos, files: { ...kept, ...files } } };
     }
     case "git_diff":
       return { ...state, gitDiff: { path: message.path, before: message.before, after: message.after } };
@@ -1140,26 +1152,43 @@ export function useAgent(serverUrl = "", explicitToken?: string, embedded = fals
   );
 
   // Git status refetches are event-driven (connect, file_changed, agent_end) and can
-  // burst — coalesce to one in flight with a single trailing rerun.
+  // burst — coalesce to one in flight with a single trailing rerun. Coalescing is per
+  // scope: a workspace holding thirty repositories would otherwise let one project's
+  // refresh swallow another's, and they are answers to different questions.
   const gitAvailableRef = useRef(false);
-  const gitStatusInFlight = useRef(false);
-  const gitStatusQueued = useRef(false);
-  const refreshGitStatus = useCallback(() => {
-    if (!gitAvailableRef.current) return;
-    if (gitStatusInFlight.current) {
-      gitStatusQueued.current = true;
-      return;
-    }
-    gitStatusInFlight.current = true;
-    sendMessage({ type: "git_status", requestId: `git:${crypto.randomUUID()}` });
-  }, [sendMessage]);
-  const gitStatusSettled = useCallback(() => {
-    gitStatusInFlight.current = false;
-    if (gitStatusQueued.current) {
-      gitStatusQueued.current = false;
-      refreshGitStatus();
-    }
-  }, [refreshGitStatus]);
+  /** The repository list as of the last status, for attributing a changed path. */
+  const gitReposRef = useRef<GitRepoStatus[]>([]);
+  useEffect(() => {
+    gitReposRef.current = state.gitStatus?.repos ?? [];
+  }, [state.gitStatus]);
+  const gitStatusInFlight = useRef(new Set<string>());
+  const gitStatusQueued = useRef(new Set<string>());
+  /** requestId → scope, so an error (which carries no repo) settles the right one. */
+  const gitStatusScopes = useRef(new Map<string, string>());
+  const refreshGitStatus = useCallback(
+    (repo?: string) => {
+      if (!gitAvailableRef.current) return;
+      const scope = repo ?? "";
+      if (gitStatusInFlight.current.has(scope)) {
+        gitStatusQueued.current.add(scope);
+        return;
+      }
+      gitStatusInFlight.current.add(scope);
+      const requestId = `git:${crypto.randomUUID()}`;
+      gitStatusScopes.current.set(requestId, scope);
+      sendMessage({ type: "git_status", ...(repo === undefined ? {} : { repo }), requestId });
+    },
+    [sendMessage],
+  );
+  const gitStatusSettled = useCallback(
+    (requestId: string) => {
+      const scope = gitStatusScopes.current.get(requestId) ?? "";
+      gitStatusScopes.current.delete(requestId);
+      gitStatusInFlight.current.delete(scope);
+      if (gitStatusQueued.current.delete(scope)) refreshGitStatus(scope === "" ? undefined : scope);
+    },
+    [refreshGitStatus],
+  );
 
   /**
    * Re-list a directory — but only one the tree is actually holding.
@@ -1294,7 +1323,9 @@ export function useAgent(serverUrl = "", explicitToken?: string, embedded = fals
           if (gitDiffPathRef.current === message.path) {
             sendMessage({ type: "git_diff", path: message.path, requestId: `gitdiff:${crypto.randomUUID()}` });
           }
-          refreshGitStatus();
+          // One file moved: only its repository has anything new to say. Re-reading
+          // thirty of them to learn that is thirty processes for one fact.
+          refreshGitStatus(repoForPath(gitReposRef.current, message.path)?.repo);
           return;
         }
         if (message.type === "directory_changed") {
@@ -1327,7 +1358,7 @@ export function useAgent(serverUrl = "", explicitToken?: string, embedded = fals
         // Bash commands can change git state without any file_changed broadcast
         if (message.type === "agent_end") refreshGitStatus();
         if (message.type === "git_status" || (message.type === "git_error" && message.requestId.startsWith("git:"))) {
-          gitStatusSettled();
+          gitStatusSettled(message.requestId);
         }
         if (message.type === "file_operation_result") {
           // `file_changed` notifications follow the acknowledgement immediately.
@@ -1352,8 +1383,9 @@ export function useAgent(serverUrl = "", explicitToken?: string, embedded = fals
         if (socketRef.current !== socket) return;
         // An in-flight git_status will never be answered on this socket — clear the
         // coalescing flags or the branch chip/badges freeze until a page reload
-        gitStatusInFlight.current = false;
-        gitStatusQueued.current = false;
+        gitStatusInFlight.current.clear();
+        gitStatusQueued.current.clear();
+        gitStatusScopes.current.clear();
         // Same reasoning, but a stuck upload is worse than a stale badge: the
         // composer blocks submission while one is in flight, so an unanswered
         // promise would wedge the whole editor rather than one indicator.
@@ -1546,7 +1578,7 @@ export function useAgent(serverUrl = "", explicitToken?: string, embedded = fals
     },
     clearFileSearch: () => dispatch({ type: "file_search_cleared" }),
     /** Manual git status refresh (event-driven refreshes are automatic). */
-    fetchGitStatus: refreshGitStatus,
+    fetchGitStatus: () => refreshGitStatus(),
     /** Worktree-vs-HEAD contents for one file (answers land in state.gitDiff). */
     fetchGitDiff: (path: string) => {
       const requestId = `gitdiff:${crypto.randomUUID()}`;
@@ -1554,8 +1586,9 @@ export function useAgent(serverUrl = "", explicitToken?: string, embedded = fals
       sendMessage({ type: "git_diff", path, requestId });
     },
     clearGitDiff: () => dispatch({ type: "git_diff_cleared" }),
-    fetchGitLog: (limit?: number) => sendMessage({ type: "git_log", ...(limit ? { limit } : {}), requestId: `gitlog:${crypto.randomUUID()}` }),
-    fetchGitShow: (sha: string) => sendMessage({ type: "git_show", sha, requestId: `gitshow:${crypto.randomUUID()}` }),
+    fetchGitLog: (repo: string, limit?: number) =>
+      sendMessage({ type: "git_log", repo, ...(limit ? { limit } : {}), requestId: `gitlog:${crypto.randomUUID()}` }),
+    fetchGitShow: (repo: string, sha: string) => sendMessage({ type: "git_show", repo, sha, requestId: `gitshow:${crypto.randomUUID()}` }),
     clearGitShow: () => dispatch({ type: "git_show_cleared" }),
     /** Open the history pane for one file (answers land in state.gitFileHistory). */
     fetchGitFileHistory: (path: string, limit?: number) => {

--- a/ui/src/useAgent.ts
+++ b/ui/src/useAgent.ts
@@ -99,6 +99,18 @@ export type SessionSearch = {
   results: SessionSummary[];
 };
 
+/**
+ * The last commit log answered, and which repository answered it.
+ *
+ * A workspace holds several, so entries alone are not enough: rendered under
+ * another repository's chip they read as that repository's history, and clicking one
+ * would ask for a commit id the named repository has never heard of.
+ */
+export interface GitLogState {
+  repo: string;
+  entries: GitLogEntry[];
+}
+
 /** Latest git working-tree status; null until the first git_status answer. */
 export interface GitStatusState {
   /** Every repository serving the workspace, each with its own branch. */
@@ -287,7 +299,8 @@ export interface AgentState {
   gitStatus: GitStatusState | null;
   /** Worktree-vs-HEAD contents for the viewer's diff toggle. */
   gitDiff: GitDiffState | null;
-  gitLog: GitLogEntry[] | null;
+  /** The last commit log, with the repository it belongs to — see `GitLogState`. */
+  gitLog: GitLogState | null;
   gitShow: GitShowState | null;
   /** The open file's history, and the diff between the two revisions picked in it. */
   gitFileHistory: GitFileHistoryState | null;
@@ -990,10 +1003,14 @@ function reduce(state: AgentState, action: Action): AgentState {
       const repos = previous.repos.map((repo) => message.repos.find((one) => one.repo === repo.repo) ?? repo);
       return { ...state, gitStatus: { repos, files: { ...kept, ...files } } };
     }
+    case "git_repositories_changed":
+      // A workspace that has lost its last repository keeps no status to show: the
+      // badges and the branch chip would otherwise go on describing what is gone
+      return { ...state, gitAvailable: message.available, gitStatus: message.available ? state.gitStatus : null };
     case "git_diff":
       return { ...state, gitDiff: { path: message.path, before: message.before, after: message.after } };
     case "git_log":
-      return { ...state, gitLog: message.entries };
+      return { ...state, gitLog: { repo: message.repo, entries: message.entries } };
     case "git_show":
       return { ...state, gitShow: { sha: message.sha, patch: message.patch, truncated: message.truncated } };
     case "git_file_log":
@@ -1357,6 +1374,12 @@ export function useAgent(serverUrl = "", explicitToken?: string, embedded = fals
         }
         // Bash commands can change git state without any file_changed broadcast
         if (message.type === "agent_end") refreshGitStatus();
+        if (message.type === "git_repositories_changed") {
+          // The gate this ref holds is why the message exists: a client told at
+          // connect that there was no repository here would otherwise never ask again
+          gitAvailableRef.current = message.available;
+          if (message.available) refreshGitStatus();
+        }
         if (message.type === "git_status" || (message.type === "git_error" && message.requestId.startsWith("git:"))) {
           gitStatusSettled(message.requestId);
         }

--- a/ui/src/util/gitRepos.ts
+++ b/ui/src/util/gitRepos.ts
@@ -1,0 +1,19 @@
+/**
+ * Which repository owns a path.
+ *
+ * A workspace holds a set of repositories — a directory of independently
+ * versioned projects has one per child — so a path only means something once it
+ * has been attributed to one. Longest match wins, exactly as the server resolves
+ * it, so a repository nested inside another answers for its own files.
+ *
+ * The empty id is the repository at the browser root, or the one containing it;
+ * it matches everything nothing deeper claims.
+ */
+export function repoForPath<T extends { repo: string }>(repos: readonly T[], relPath: string): T | null {
+  let best: T | null = null;
+  for (const repo of repos) {
+    const owns = repo.repo === "" || relPath === repo.repo || relPath.startsWith(`${repo.repo}/`);
+    if (owns && (best === null || repo.repo.length > best.repo.length)) best = repo;
+  }
+  return best;
+}


### PR DESCRIPTION
## Why

A workspace held one repository, probed once when its resources were built (`workspace.ts`, `probeGit(browserRoot)`). A colleague organises his work as a parent directory of independently versioned project folders: nothing at the root, one repository per child. `rev-parse --show-toplevel` at the root returns nothing, `gitAvailable` goes false, and the entire git surface goes dark — no branch chip, no tree badges, no worktree diff, no file history — while every repository sits right there, readable, one level down.

## What this does

The workspace owns a **set** of repositories and answers every path with the one that owns it (longest match). The surface splits in two, and only one half needed a decision:

- **File-scoped** — badges, worktree diff, file history, revision-pair diff. `toplevel` was already a parameter, so these only needed a resolver.
- **Repository-scoped** — branch with ahead/behind, commit log, commit patch. These follow **the selected file's repository**. No picker: the user chose by clicking a file, and a control for choosing again would ask twice.

Status spans every repository, so a tracked leaf already looks tracked *before* it is clicked — which is the point, since you cannot click "a leaf tracked by git" if nothing tells you which one is.

```
  BEFORE                              AFTER
  ======                              =====

  ~/work/          <- opened          ~/work/
    projA/ .git    dark                 projA/ .git   ⎇ main     badges, diff, history
    projB/ .git    dark                 projB/ .git   ⎇ release  badges, diff, history
    notes.md                            notes.md      no repository: no affordances

  workspace.git = null                workspace.repos = deepest-first set
  gitAvailable  = false               gitAvailable    = set is non-empty
```

## Notable

**Breaking protocol edit.** `git_status` loses the flat `branch`/`ahead`/`behind` and gains `repos: GitRepoStatus[]`; `git_log` and `git_show` gain a `repo`. The served UI ships with the server, so there is no compatibility window to keep.

**Confinement.** `git.ts` rested on one invariant: a fixed `cwd` at the browser root plus a trailing pathspec. With several repositories the cwd is no longer fixed, so every discovered toplevel is realpath-resolved and checked with the file browser's own `isWithin` before it may become one. A symlinked directory whose real repository lives outside the root is dropped from the set and never spawns anything. The header comment is rewritten to state the invariant in its new form.

**Cost.** A full sweep is one `git status` per repository, bounded at 4 concurrent. A single file changing re-reads only its own repository — the client sends `git_status` with a `repo`, and merges that slice. A one-repository workspace issues exactly one invocation, as it always did.

**Freshness.** The set is re-scanned, debounced, when a watched directory changes, so a `git clone` during a session is usable without a restart. This is coarser than "re-scan the affected subtree" as the design proposed: the watcher announces the *directory*, never the file, so there is nothing finer to key on. The scan is bounded and stops at every repository it finds.

**Submodules.** Two rules in the spec were in tension — recognise a `.git` *file* marker, and never descend into a work tree. The delta now settles it: a submodule of a repository the workspace already holds is answered by its parent; a repository nested under the root but outside every repository in the set (an embedded clone, or a submodule under a root whose toplevel is an ancestor) is found and answers for itself, and the container's single entry for it is not also reported as a file.

## A bug the unit tests could not see

`⎇ history` stayed on offer for a file under no repository. `FileViewer` gated it on `gitAvailable` — a workspace-wide boolean — when the real question is whether *this file* is in a repository. Found by driving the running app, not by a green suite. The prop is now `inRepository`, computed per path; two regression tests in `App.test.tsx`.

## Verification

Driven in a real browser against a workspace whose root is not a repository, reading back the DOM at each step: chip disabled with no selection → `projA ⎇ main` with diff and history on a tracked leaf → `projB ⎇ release` on switching projects → chip held and affordances gone on a loose file → the chip's history listing only that project's commits.

```
typecheck   green (shared, server, ui, web, embed, cli)
server      1714 pass / 0 fail   (+43 new)
ui          1414 pass / 0 fail   (+21 new)
lint        green
openspec    validate --strict: valid
```

All 35 scenarios across the `git` and `multi-project-workspaces` deltas have a named test, annotated `// openlore: scenario=…` for the new ones. New files: `server/test/git-repos.test.ts`, `server/test/git-multi-repo.test.mjs`, `ui/src/util/gitRepos.ts`.

`OversizedPatchTruncated` had only its negative side asserted — a gap that predates this change. Closed here.

## Not done

Cross-model review: the Codex quota was exhausted at the time of writing (`You've hit your usage limit`). Worth a run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JpDnwLWKe5zYdPdhzhvKde
