### PR TITLE
feat: add workspace ready-for-review state

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ one needs, the command that proves it works, and the caution that goes with it.
 
 - [Several projects open at once](#projects), each with its own agent, sandbox, sessions and
   history — switch between them while work continues in the ones you are not watching, and
-  get a browser notification when a background project needs an answer
+  get a browser notification when a background project needs an answer or is ready for review
 - File browser: lazy-loaded tree, syntax-highlighted viewer, Markdown rendering, and an
   editor that saves inside the writable zone. Create, rename, move, copy, delete, or open a
   file with the system's own application; anything outside the writable zone is dimmed
@@ -256,16 +256,18 @@ projects you are not looking at.
 - **Switch** without a reload. A turn running in the project you leave runs to completion,
   and its result is waiting when you come back. Unsent composer text is kept per project
 - **See what is happening elsewhere**: every project reports whether it is stopped, starting,
-  idle, working, or waiting for you. A project that needs an answer — a permission prompt, an
-  extension question — raises a badge in the selector, and a browser notification naming that
-  project when the window is in the background. Nothing ever interrupts the project you are
-  looking at
+  idle, working, waiting for you, or ready for review. Waiting means the agent needs an answer;
+  ready for review means its authoritative Work Plan has no unfinished task and at least one
+  task awaiting review. Both raise the selector's attention badge. When the window is in the
+  background, a browser notification names the project and the kind of attention without
+  exposing its plan or workspace content. Nothing ever interrupts the project you are looking
+  at, and merely selecting it does not acknowledge either state
 - **Close one** to release its resources; the sessions on disk stay, so reopening the same
   directory finds them again. Closing is refused while its agent is running a turn, and the
   last remaining project cannot be closed
 - Projects that nobody is using are retired after `workspaceIdleTimeoutMs` (30 minutes by
-  default, `0` disables it) and rebuilt transparently on next use. A project running a turn
-  is never retired
+  default, `0` disables it) and rebuilt transparently on next use. A project running a turn,
+  waiting for you, or ready for review is never retired
 
 A configuration where no project has ever been opened behaves exactly as a single-project
 server: `cwd` alone. `"workspaceLock": true` pins the server to one project and removes the
@@ -345,7 +347,7 @@ in [`pi-outpost.config.example.json`](pi-outpost.config.example.json).
 | `sandbox.allowBash` | Adds bash — **not path-confined**, explicit opt-in (default `false`) |
 | `sandboxLocks` | Which sandbox fields Settings may **not** change: `root`, `writableRoot`, `allowWrite`, `allowBash` |
 | `workspaceLock` | Pin the server to one project: opening, closing and switching are refused, and no control is offered |
-| `workspaceIdleTimeoutMs` | How long an unused project stays alive before it is retired (default `1800000` — 30 min; `0` never retires). A project running a turn is never retired |
+| `workspaceIdleTimeoutMs` | How long an unused project stays alive before it is retired (default `1800000` — 30 min; `0` never retires). A project running a turn, waiting for you, or ready for review is never retired |
 | `openProjects` | The set of open projects. **Written by the server** when you open or close one — not hand-authored |
 | `files.watch` | Watch the directories the file browser has listed, so the tree follows the workspace whoever changed it (default `true`). Set `false` where a watch is a liability — a network mount that emits no events, a spent inotify budget. The tree's ↻ control re-lists by hand either way |
 
@@ -661,6 +663,13 @@ Tasks use five states: `todo`, `in_progress`, `blocked`, `needs_review` and `don
 or review state can carry a reason, and tasks can link to resources; workspace resources open
 directly in the file viewer. The panel is read-only for now, so the conversation stays your
 control surface while the agent owns the plan through its `work_plan` tool.
+
+When a non-empty plan contains at least one `needs_review` task and every other task is either
+`needs_review` or `done`, the project becomes **ready for review** in the project selector.
+This is derived from the persisted plan, not from a turn or tool merely ending. Opening or
+switching to the project does not clear it: tell the agent what you accept or what must change.
+Accepted review tasks move to `done`; meaningful resumed work moves the relevant task back to
+an active state, so the project stops being ready until it reaches the review boundary again.
 
 Each plan is stored beside its session file. It is restored on reconnect and session resume,
 replaced when the active session changes, copied when a conversation is forked, and

--- a/docs/design/multi-project-selector/README.md
+++ b/docs/design/multi-project-selector/README.md
@@ -16,8 +16,8 @@ disagree with the spec, the spec wins.
 |------|-----------------|
 | `Main.dc.html` | The menu open, in the app shell: one row per open project, full name, path in mono, state in words. |
 | `HeaderClosed.dc.html` | The button's four closed appearances — everything it can say without being opened, including the muted dots for other open projects. |
-| `States.dc.html` | The five workspace states as menu rows, light and dark, with their marks. Shape distinguishes as much as colour. |
-| `Attention.dc.html` | The three attention levels: badge alone, badge plus browser notification, and the modal that must never happen. |
+| `States.dc.html` | The six workspace states as menu rows, light and dark, including the distinct ready-for-review mark. Shape distinguishes as much as colour. |
+| `Attention.dc.html` | The three attention levels: badge alone, badge plus browser notification, and the modal that must never happen. It illustrates the waiting case; review notifications use the same level with generic, content-free wording. |
 | `Switch.dc.html` | What the eye sees during a switch — what holds still, what cross-fades, what is forgotten, what keeps running behind. |
 | `canvas.json` | Layout, pages, and the sticky notes carrying the rationale. |
 
@@ -32,6 +32,11 @@ Lifted from the real app, not invented — `web/src/index.css` and
 - Connection dot: 8 px, `emerald-500` / `red-500`
 
 New UI extends that vocabulary; it does not introduce a second one.
+
+Ready for review extends the original attention vocabulary with a violet diamond and
+a review-sheet glyph. It is distinct from the amber waiting-for-an-answer state in
+shape, colour, label, and notification wording. Both contribute to the one attention
+count; switching projects clears neither state.
 
 ## Opening them
 

--- a/docs/design/multi-project-selector/States.dc.html
+++ b/docs/design/multi-project-selector/States.dc.html
@@ -18,10 +18,10 @@
   </style>
 </helmet>
 
-<div style="display: flex; flex-direction: column; gap: 18px; width: 980px; height: 600px; padding: 28px; box-sizing: border-box; background: #ffffff; color: #18181b">
+<div style="display: flex; flex-direction: column; gap: 18px; width: 980px; height: 680px; padding: 28px; box-sizing: border-box; background: #ffffff; color: #18181b">
 
   <div style="display: flex; flex-direction: column; gap: 4px">
-    <span style="font-size: 18px; font-weight: 600; letter-spacing: -0.02em">Les cinq états, tels qu'ils apparaissent dans le menu</span>
+    <span style="font-size: 18px; font-weight: 600; letter-spacing: -0.02em">Les six états, tels qu'ils apparaissent dans le menu</span>
     <span style="font-size: 13px; line-height: 20px; color: #71717a">Le nom du projet porte l'identité, le mot porte l'état, la pastille ne fait que le répéter. La forme distingue autant que la couleur — lisible en niveaux de gris.</span>
   </div>
 
@@ -53,6 +53,18 @@
           <span style="display: flex; align-items: center; gap: 5px; flex-shrink: 0">
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#d97706" stroke-width="2.5" stroke-linecap="round"><path d="M12 6v7"></path><path d="M12 18h.01"></path></svg>
             <span style="font-size: 11px; font-weight: 500; color: #d97706">t'attend</span>
+          </span>
+        </div>
+
+        <div style="display: flex; align-items: center; gap: 10px; padding: 9px 10px; border-radius: 6px">
+          <span style="width: 8px; height: 8px; border-radius: 1px; border: 2px solid #7c3aed; background: #ede9fe; box-sizing: border-box; transform: rotate(45deg); flex-shrink: 0"></span>
+          <div style="display: flex; flex-direction: column; gap: 2px; flex-grow: 1; min-width: 0">
+            <span style="font-size: 13px; font-weight: 500; color: #18181b">api-client</span>
+            <span style="font-size: 11px; color: #71717a">plan réconcilié — une ou plusieurs tâches attendent une revue</span>
+          </div>
+          <span style="display: flex; align-items: center; gap: 5px; flex-shrink: 0">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#6d28d9" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 3h10v18H7z"></path><path d="m9.5 12 1.7 1.7 3.5-3.7"></path></svg>
+            <span style="font-size: 11px; font-weight: 500; color: #6d28d9">prêt à relire</span>
           </span>
         </div>
 
@@ -107,6 +119,15 @@
           <span style="display: flex; align-items: center; gap: 5px">
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#f59e0b" stroke-width="2.5" stroke-linecap="round"><path d="M12 6v7"></path><path d="M12 18h.01"></path></svg>
             <span style="font-size: 11px; font-weight: 500; color: #f59e0b">t'attend</span>
+          </span>
+        </div>
+
+        <div style="display: flex; align-items: center; gap: 10px; padding: 9px 10px; border-radius: 6px">
+          <span style="width: 8px; height: 8px; border-radius: 1px; border: 2px solid #a78bfa; background: #2e1065; box-sizing: border-box; transform: rotate(45deg); flex-shrink: 0"></span>
+          <span style="font-size: 13px; font-weight: 500; color: #f4f4f5; flex-grow: 1">api-client</span>
+          <span style="display: flex; align-items: center; gap: 5px">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#a78bfa" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 3h10v18H7z"></path><path d="m9.5 12 1.7 1.7 3.5-3.7"></path></svg>
+            <span style="font-size: 11px; font-weight: 500; color: #a78bfa">prêt à relire</span>
           </span>
         </div>
 

--- a/docs/design/multi-project-selector/canvas.json
+++ b/docs/design/multi-project-selector/canvas.json
@@ -6,7 +6,7 @@
   "artboards": [
     { "file": "Main.dc.html", "x": 0, "y": 0, "w": 1200, "h": 720, "title": "Menu ouvert", "page": "page-1" },
     { "file": "HeaderClosed.dc.html", "x": 1300, "y": 0, "w": 900, "h": 560, "title": "Bouton, menu fermé", "page": "page-1" },
-    { "file": "States.dc.html", "x": 0, "y": 0, "w": 980, "h": 600, "title": "Les cinq états", "page": "page-2" },
+    { "file": "States.dc.html", "x": 0, "y": 0, "w": 980, "h": 680, "title": "Les six états", "page": "page-2" },
     { "file": "Attention.dc.html", "x": 1100, "y": 0, "w": 900, "h": 440, "title": "Paliers d'attention", "page": "page-2" },
     { "file": "Switch.dc.html", "x": 0, "y": 740, "w": 1240, "h": 470, "title": "Pendant la bascule", "page": "page-2" }
   ],
@@ -33,7 +33,7 @@
       "x": 0,
       "y": -130,
       "w": 420,
-      "text": "La forme porte l'information autant que la couleur : trait discontinu pour arrêté, arc qui tourne pour démarrage, point plein pour au repos, halo pulsé pour travaille, glyphe pour l'attention. Lisible en niveaux de gris."
+      "text": "La forme porte l'information autant que la couleur : trait discontinu pour arrêté, arc qui tourne pour démarrage, point plein pour au repos, halo pulsé pour travaille, rond ambre pour attend, losange violet pour prêt à relire. Lisible en niveaux de gris."
     },
     {
       "id": "switch-note",

--- a/docs/development.md
+++ b/docs/development.md
@@ -38,6 +38,7 @@ developers.
 ```bash
 npm run test --workspace server        # integration tests: no model auth, no tokens spent
 npm run test --workspace ui            # component unit tests (vitest, jsdom, testing-library)
+npm run test:e2e                        # real built app in Chromium, including multi-project flows
 npm run test:live --workspace server   # drives real agent turns (needs model auth, costs tokens)
 npm run test:linux                     # the ubuntu CI leg — suite then coverage — on Linux, non-root
 ```
@@ -48,6 +49,12 @@ HTTP/WebSocket. See [`server/test/README.md`](../server/test/README.md).
 
 UI component tests run under vitest with jsdom and `@testing-library/react`, covering
 `ui/src/components/` and `ui/src/util/`. They need no model auth and cost no tokens.
+
+Playwright builds and drives the real standalone app and widget. Use it for any change
+to visible behaviour or to the way a user operates the interface; assert the resulting
+DOM, persisted files, or transcript rather than relying on a screenshot. Multi-project
+activity and attention changes belong here because unit fakes cannot prove that switching
+projects preserves the server's authoritative state or its isolation boundary.
 
 ### Why `test:linux` exists
 

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -73,9 +73,17 @@ restarts.
 
 Each project gets its own agent, sandbox, file tree and session history. Switching
 never disturbs the others: a turn you leave running finishes, and its result is
-waiting when you come back. The selector says what each one is doing (idle, working,
-waiting for you), and a project that needs an answer while you are elsewhere raises a
-browser notification naming it.
+waiting when you come back. The selector distinguishes stopped, starting, idle,
+working, waiting for you, and ready for review. Waiting means the agent needs an
+answer. Ready for review is derived from its persisted Work Plan: every task is done
+or awaiting review, and at least one awaits review. It is not inferred merely because
+a turn ended.
+
+Both actionable states raise the existing attention count. If the browser tab is in
+the background, the notification names the project and whether it needs an answer or
+is ready for review, but never includes plan or workspace content. Switching to the
+project does not clear the state; acknowledge the result in the conversation, or ask
+for meaningful follow-up work.
 
 Two knobs, if the defaults do not suit:
 
@@ -88,9 +96,9 @@ Two knobs, if the defaults do not suit:
 
 `workspaceIdleTimeoutMs` is how long an unused project stays alive before it is
 retired and rebuilt on next use (`0` never retires; a project running a turn is never
-retired). `workspaceLock: true` pins the server to one project and removes the controls
-entirely. Use it for a deployment, embedded or standalone, whose project root must not
-change.
+retired). Waiting and ready-for-review projects are retained too. `workspaceLock: true`
+pins the server to one project and removes the controls entirely. Use it for a deployment,
+embedded or standalone, whose project root must not change.
 
 ## Use a local or self-hosted model
 

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -484,6 +484,48 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
     { env: { ...onlyOneFakeProvider(), FAKE_PI_RPC_CONFIG: thinkingFakeConfig } },
   );
 
+  // A dedicated multi-project server with two independently authoritative
+  // review-ready sidecars. Distinct private markers catch plan mix-ups as well as
+  // content leaking through the server-wide summary.
+  const reviewReadyRoot = await realpath(await makeWorkspace({ "primary.md": "# primary review\n" }));
+  const reviewReadySecond = await realpath(await makeWorkspace({ "secondary.md": "# secondary review\n" }));
+  const reviewReadySession = path.join(reviewReadyRoot, "review-ready.jsonl");
+  const reviewReadySecondSession = path.join(reviewReadySecond, "review-ready.jsonl");
+  const reviewReadyPlan = {
+    version: 1,
+    id: "private-review-plan",
+    title: "Private launch details",
+    updatedAt: "2026-09-01T00:00:00.000Z",
+    tasks: [{ id: "private-task", title: "Private customer result", status: "needs_review", dependsOn: [], resources: [] }],
+  };
+  const reviewReadySecondPlan = {
+    version: 1,
+    id: "private-secondary-review-plan",
+    title: "Private secondary launch details",
+    updatedAt: "2026-09-01T00:00:00.000Z",
+    tasks: [{ id: "private-secondary-task", title: "Private secondary customer result", status: "needs_review", dependsOn: [], resources: [] }],
+  };
+  await writeFile(reviewReadySession, "");
+  await writeFile(reviewReadySecondSession, "");
+  await writeFile(`${reviewReadySession}.work-plan.json`, `${JSON.stringify(reviewReadyPlan, null, 2)}\n`);
+  await writeFile(`${reviewReadySecondSession}.work-plan.json`, `${JSON.stringify(reviewReadySecondPlan, null, 2)}\n`);
+  const reviewReadyFakeConfig = path.join(reviewReadyRoot, "fake-rpc.json");
+  await writeFile(reviewReadyFakeConfig, JSON.stringify({
+    stateByCwd: {
+      [reviewReadyRoot]: { sessionId: "review-ready-primary", sessionFile: reviewReadySession, isStreaming: false },
+      [reviewReadySecond]: { sessionId: "review-ready-secondary", sessionFile: reviewReadySecondSession, isStreaming: false },
+    },
+  }));
+  const reviewReady = await startServer(
+    reviewReadyRoot,
+    {
+      openProjects: [reviewReadySecond],
+      agentRuntime: { mode: "rpc", executable: process.execPath, args: [path.join(REPO, "server/test/fixtures/fake-pi-rpc.mjs")], startupTimeoutMs: 20_000 },
+      sandbox: undefined,
+    },
+    { env: { ...onlyOneFakeProvider(), FAKE_PI_RPC_CONFIG: reviewReadyFakeConfig } },
+  );
+
   process.env.PI_E2E_HOST_URL = host.url;
   process.env.PI_E2E_SERVER_URL = server.base;
   process.env.PI_E2E_PRIMARY_PROJECT = await realpath(root);
@@ -499,6 +541,9 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
   process.env.PI_E2E_NOTIFY_URL = notifications.base;
   process.env.PI_E2E_PROGRESS_URL = progress.base;
   process.env.PI_E2E_THINKING_URL = thinking.base;
+  process.env.PI_E2E_REVIEW_READY_URL = reviewReady.base;
+  process.env.PI_E2E_REVIEW_READY_PRIMARY = reviewReadyRoot;
+  process.env.PI_E2E_REVIEW_READY_SECOND = reviewReadySecond;
   process.env.PI_E2E_PLAN_SOURCE = sourceSession;
   process.env.PI_E2E_PLAN_FORK = forkSession;
   process.env.PI_E2E_EXTENSIONS_DIR = extensionsDir;
@@ -506,6 +551,7 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
   process.env.PI_E2E_TOKEN = E2E_TOKEN;
 
   return async () => {
+    await reviewReady.stop();
     await thinking.stop();
     await progress.stop();
     await notifications.stop();
@@ -519,6 +565,7 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
     await server.stop();
     await rm(secondRoot, { recursive: true, force: true });
     await rm(projectsSecondRoot, { recursive: true, force: true });
+    await rm(reviewReadySecond, { recursive: true, force: true });
     await host.close();
   };
 }

--- a/e2e/review-ready.spec.ts
+++ b/e2e/review-ready.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "@playwright/test";
+
+test("review-ready workspaces remain visible and content-isolated across real switches", async ({ page }) => {
+  await page.goto(process.env.PI_E2E_REVIEW_READY_URL!);
+  await expect(page.getByTitle("connected")).toBeVisible();
+
+  const selector = page.getByTitle(/^Project:/);
+  await expect(selector).toHaveAttribute("title", /ready for review/);
+  await expect(selector).toContainText("1");
+
+  await selector.click();
+  await page.getByRole("menuitem").filter({ hasText: process.env.PI_E2E_REVIEW_READY_SECOND! }).click();
+  await expect(selector).toHaveAttribute("title", /ready for review/);
+  await expect(selector).toContainText("2");
+
+  await selector.click();
+  let menu = page.getByRole("menu");
+  await expect(menu.getByText("ready for review")).toHaveCount(2);
+  await expect(menu).not.toContainText("Private launch details");
+  await expect(menu).not.toContainText("Private customer result");
+  await expect(menu).not.toContainText("Private secondary launch details");
+  await expect(menu).not.toContainText("Private secondary customer result");
+
+  await menu.getByRole("menuitem").filter({ hasText: process.env.PI_E2E_REVIEW_READY_PRIMARY! }).click();
+  await expect(selector).toHaveAttribute("title", /ready for review/);
+
+  await selector.click();
+  menu = page.getByRole("menu");
+  await expect(menu.getByText("ready for review")).toHaveCount(2);
+  await expect(selector).toContainText("2");
+});

--- a/openspec/changes/add-workspace-ready-for-review/.openspec.yaml
+++ b/openspec/changes/add-workspace-ready-for-review/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-01

--- a/openspec/changes/add-workspace-ready-for-review/design.md
+++ b/openspec/changes/add-workspace-ready-for-review/design.md
@@ -1,0 +1,74 @@
+## Context
+
+See `proposal.md` for motivation. Workspace activity is currently a server-derived, non-persisted projection over runtime lifecycle and pending blocking dialogs. The projection is broadcast server-wide as content-free workspace summaries; conversation and session snapshots remain scoped to clients bound to that workspace. Browser notifications and selector attention currently consume `needsAttention`, which means only “a blocking dialog is pending.”
+
+The Work Plan is session-scoped, persisted beside the session, synchronized from the persisted sidecar after accepted tool mutations, and already supports `needs_review`. Existing contracts explicitly forbid inferring plan completion from runtime or tool completion. The plan UI is read-only, so acknowledgement must continue through conversation-driven, agent-owned plan mutation rather than a new review control.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make one authoritative projection map Work Plan state and runtime state to workspace activity.
+- Preserve server-side derivation so every client applies the same precedence and isolation rules.
+- Reuse the selector attention count and browser-notification lifecycle while distinguishing review readiness from a blocking question.
+- Leave a stable protocol seam for future evidence, verification, and Outcome summaries without adding those payloads now.
+
+**Non-Goals:**
+
+- Persist a second review-readiness flag or acknowledgement record.
+- Let the client derive readiness from a subscribed Work Plan.
+- Make review-ready tasks editable or add a review/Outcome surface.
+- Infer that output is acceptable, inspect artifacts, or perform automated review.
+- Add OpenLore to runtime behavior.
+
+## Decisions
+
+### Derive readiness from the complete authoritative Work Plan
+
+Define a pure predicate: a plan is review-ready when it has at least one task, at least one task is `needs_review`, and every task is either `done` or `needs_review`. Evaluate it only against the server's authoritative, session-matched Work Plan after persistence synchronization.
+
+This avoids treating a lone review task as readiness while sibling work remains `todo`, `in_progress`, or `blocked`. It also makes parent/child inconsistencies conservative: an unreconciled parent prevents readiness. The alternative—“any `needs_review` task”—would announce completion while executable or blocked work remains. A persisted readiness latch was rejected because it would duplicate and eventually drift from the plan.
+
+### Use activity precedence, not independent client booleans
+
+Extend workspace activity with `ready-for-review` and calculate states in this order: `starting`, `stopped`, blocking `waiting`, active `working`, derived `ready-for-review`, then `idle`. In normal operation review-ready workspaces are kept from retirement, so `stopped` cannot mask an outstanding review state. Blocking questions outrank review because they prevent the active turn from proceeding; running work outranks a stale review-ready plan because the current observable fact is that work is underway.
+
+The generic attention bit becomes true for both `waiting` and `ready-for-review`; consumers distinguish the reason using activity. A second `readyForReview` boolean was rejected because invalid combinations such as `working + readyForReview` would force every client to reproduce precedence rules.
+
+### Clear only through authoritative plan transitions
+
+There is no selector-side clear. Review acknowledgement is the agent's explicit transition of the applicable `needs_review` tasks to `done`; resumed work moves an applicable task to `todo`, `in_progress`, or `blocked`. Starting a turn temporarily reports `working`, and when it ends the current synchronized plan is evaluated again. If a turn fails to reconcile the plan, the workspace conservatively returns to ready for review.
+
+This preserves agent ownership and provides an audit trail in existing Work Plan persistence. A click-to-acknowledge endpoint was rejected because no review UI is in scope and it would create acknowledgement state outside the plan.
+
+### Broadcast only the generic summary and reuse notification deduplication
+
+Work Plan synchronization triggers the existing server-wide workspace-activity announcement after the persisted plan has been reloaded. The summary carries root, display name, activity, and generic attention only. It never carries task titles, reasons, resources, output, or plan contents for a background workspace.
+
+The selector counts both waiting and ready workspaces and renders activity-specific wording and non-colour-only marks. Browser notifications remain limited to background workspaces when the document is not visible and permission is already granted. Deduplication remains per workspace and activity episode: a transition out of an attention state resets eligibility, while switching workspace does not.
+
+Coalescing all ready projects into one notification was rejected because the existing interaction promises one actionable project name per notification and multiple workspaces may become ready independently.
+
+### Protect outstanding review readiness from idle retirement
+
+The retirement sweep treats a review-ready plan as an outstanding attention condition and keeps the workspace alive until the plan changes. This preserves a single truthful activity state and avoids needing a second lightweight process to load plan sidecars for stopped workspaces.
+
+The trade-off is that an unacknowledged review-ready workspace retains runtime resources. Reconstructing review readiness for stopped workspaces was rejected for this change because it complicates session ownership and creates another restoration path; that optimization can be revisited without changing the observable contract.
+
+## Risks / Trade-offs
+
+- [Agent fails to reconcile parent or sibling statuses] → The conservative predicate leaves the workspace idle rather than producing a false ready signal; strengthen product-owned Work Plan guidance and test realistic plans.
+- [Agent leaves a review-ready plan unchanged after follow-up work] → Activity is `working` during the turn and returns to ready afterward, making the missing reconciliation visible instead of silently clearing user attention.
+- [Ready workspace retains resources indefinitely] → Treat this as the cost of persistent attention for now; a future implementation may stop it only if the server can still reconstruct and report readiness authoritatively.
+- [Existing consumers assume `needsAttention` always means a dialog exists] → Update typed comments, selector logic, notifications, and tests together; dialog replay continues to use the pending-dialog collection, not the generic attention bit.
+- [Notification text leaks sensitive work] → Include only the configured project name and generic attention category, with no plan-derived strings.
+
+## Migration Plan
+
+1. Add the new protocol enum member and update exhaustive consumers in one compatible server/client release.
+2. Add and test the pure Work Plan review-readiness predicate and server activity precedence.
+3. Trigger workspace summary broadcasts after authoritative Work Plan synchronization and exempt ready workspaces from retirement.
+4. Update selector and browser-notification consumers with activity-specific, accessible presentation.
+5. Update Work Plan guidance and documentation, then run focused protocol, server, UI, notification, and running-app checks.
+
+Rollback removes the derived activity and UI treatment; persisted Work Plans remain version 1 and require no data migration because no readiness field is stored.

--- a/openspec/changes/add-workspace-ready-for-review/proposal.md
+++ b/openspec/changes/add-workspace-ready-for-review/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Background work currently falls back to `idle` when a turn ends, so users cannot distinguish an inactive workspace from completed work that is waiting for their review. Pi-Outpost already has an authoritative Work Plan and a multi-workspace attention channel; connecting those two surfaces review readiness without treating runtime completion as task completion.
+
+## What Changes
+
+- Define a workspace-level `ready-for-review` activity derived from the authoritative session Work Plan, distinct from working, waiting for the user, and idle.
+- Define the Work Plan conditions that enter and leave review readiness, including explicit plan-based acknowledgement and meaningful resumed work; navigation alone does not clear it.
+- Carry review readiness in workspace activity snapshots and updates without carrying Work Plan or conversation content across workspace boundaries.
+- Surface one or more ready workspaces in the existing selector attention treatment and unattended browser-notification mechanism, with review-specific accessible wording.
+- Keep the state and protocol extensible for later Work Plan evidence, verification, and Outcome views without introducing those models or a review interface now.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `work-plan`: Define the authoritative plan predicate and explicit task transitions that establish, acknowledge, or resume work from review readiness.
+- `multi-project-workspaces`: Add ready-for-review to reported workspace activity and the existing cross-workspace attention and notification behavior.
+- `model`: Extend the typed workspace summary protocol with the new activity while preserving content isolation.
+
+## Impact
+
+- Shared WebSocket protocol types and workspace summary state.
+- Server-side Work Plan synchronization and workspace activity derivation/broadcasting.
+- Workspace selector marks, labels, attention counts, and browser notifications.
+- Agent-owned Work Plan guidance and focused server/UI/protocol tests.
+- User and developer documentation describing Work Plan states and multi-workspace activity.
+- No new dependency, persisted review record, review UI, evidence model, artifact model, automatic review, or OpenLore runtime integration.

--- a/openspec/changes/add-workspace-ready-for-review/specs/model/spec.md
+++ b/openspec/changes/add-workspace-ready-for-review/specs/model/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Workspace review-readiness protocol state
+
+The typed server protocol SHALL represent `ready-for-review` as a workspace activity distinct from `working`, `waiting`, and `idle`. Each server-wide workspace summary SHALL carry only workspace identity, generic activity, and generic attention metadata; review readiness SHALL NOT cause the Work Plan, tasks, artifacts, results, conversation, or other workspace-scoped content to cross the existing subscription boundary. Existing protocol states SHALL retain their meanings.
+
+#### Scenario: Workspace summary carries review readiness
+- **GIVEN** an open workspace whose authoritative Work Plan makes it ready for review
+- **WHEN** the server sends an initial workspace summary or a workspace activity update
+- **THEN** that workspace is typed as `ready-for-review`
+- **AND** its generic attention metadata indicates that user attention is required
+
+#### Scenario: Workspace summary preserves isolation
+- **GIVEN** a client subscribed to workspace A and workspace B is ready for review
+- **WHEN** the client receives the server-wide workspace summary
+- **THEN** the summary identifies B and its generic review-ready activity
+- **AND** it contains no Work Plan, task, artifact, result, conversation, or other workspace-scoped content from B
+
+#### Scenario: Existing activity meanings remain compatible
+- **WHEN** a workspace is stopped, starting, actively running a turn, blocked on a user answer, or inactive without a review-ready plan
+- **THEN** it remains represented by the existing `stopped`, `starting`, `working`, `waiting`, or `idle` activity respectively

--- a/openspec/changes/add-workspace-ready-for-review/specs/multi-project-workspaces/spec.md
+++ b/openspec/changes/add-workspace-ready-for-review/specs/multi-project-workspaces/spec.md
@@ -1,0 +1,98 @@
+## MODIFIED Requirements
+
+### Requirement: RetireIdleWorkspaces
+
+A workspace with no client subscribed and no turn running MAY be stopped after a configured period of inactivity, releasing its watcher and session. A workspace SHALL NOT be stopped while a turn is running or while its authoritative Work Plan makes it ready for review, however long it has been unattended, and a stopped workspace SHALL be rebuilt transparently when it is next opened.
+
+#### Scenario: WorkingWorkspacesAreNeverRetired
+- **GIVEN** a workspace with no client subscribed whose agent has been streaming past the inactivity period
+- **WHEN** the retirement sweep runs
+- **THEN** the workspace is left running
+
+#### Scenario: ReviewReadyWorkspacesAreNeverRetired
+- **GIVEN** an unattended workspace whose authoritative Work Plan makes it ready for review
+- **WHEN** the retirement sweep runs
+- **THEN** the workspace is left available and remains reported as ready for review
+
+#### Scenario: ReopeningARetiredWorkspace
+- **GIVEN** a workspace stopped after inactivity
+- **WHEN** a client opens it again
+- **THEN** it is rebuilt and its session history is intact
+
+### Requirement: ReportWorkspaceActivity
+
+The server SHALL report, for every open project, whether its workspace is stopped, starting, idle, working, waiting for the user, or ready for review. Waiting for an answer SHALL take precedence over ready for review, and a running turn SHALL be reported as working. An inactive workspace SHALL be ready for review only when its authoritative Work Plan satisfies the review-readiness conditions. A client SHALL receive updates to this state for workspaces it is not subscribed to, so background work is visible without switching.
+
+#### Scenario: BackgroundProgressIsVisible
+- **GIVEN** a client subscribed to workspace A
+- **WHEN** an agent in workspace B starts and then finishes a turn without producing a review-ready Work Plan
+- **THEN** the client is told B moved to working and then to idle
+- **AND** it receives none of B's message content
+
+#### Scenario: BackgroundResultIsVisible
+- **GIVEN** a client subscribed to workspace A
+- **WHEN** workspace B changes from working to an authoritative review-ready Work Plan and becomes inactive
+- **THEN** the client is told B moved from working to ready for review
+- **AND** it receives no Work Plan, task, artifact, conversation, or result content from B
+
+#### Scenario: WaitingTakesPrecedence
+- **GIVEN** a workspace whose Work Plan satisfies the review-readiness conditions
+- **WHEN** its running turn is blocked on a question only the user can answer
+- **THEN** its reported activity is waiting for the user rather than ready for review
+
+#### Scenario: SeveralWorkspacesAreReady
+- **GIVEN** several workspaces with independently authoritative review-ready Work Plans
+- **WHEN** workspace activity is reported
+- **THEN** every one of those workspaces is simultaneously reported as ready for review
+
+### Requirement: RaiseAttentionFromABackgroundWorkspace
+
+When a workspace that no client is currently viewing needs the user — because a permission prompt, extension question, or other request blocks its turn, or because its authoritative Work Plan makes it ready for review — the client SHALL surface that workspace through the existing project-selector attention mechanism. The selector SHALL distinguish `ready for review` from `waiting for you` with explicit accessible wording and a distinguishable state mark.
+
+A blocking request SHALL remain pending rather than being cancelled. When the document is not in the foreground and the user has granted permission, the client SHALL additionally raise one browser notification per newly waiting or newly review-ready background workspace. Each notification SHALL name only the project and the kind of attention required; it SHALL NOT include conversation, Work Plan, task, artifact, result, or other workspace content.
+
+Attention raised in one workspace SHALL NOT interrupt another: no modal, dialog or focus change is imposed on the workspace the client is currently viewing. Selecting or leaving a review-ready workspace SHALL NOT acknowledge it; the selector and notification deduplication SHALL follow subsequent authoritative activity updates.
+
+#### Scenario: APendingQuestionIsNotDiscarded
+- **GIVEN** a turn in workspace B blocked on a permission prompt and no client viewing B
+- **WHEN** the user is subscribed to workspace A
+- **THEN** the prompt stays pending
+- **AND** B is reported as waiting for the user
+
+#### Scenario: AnsweringAfterSwitchingBack
+- **GIVEN** workspace B waiting for the user
+- **WHEN** the client switches to B
+- **THEN** the pending request is shown and can be answered
+- **AND** the turn resumes
+
+#### Scenario: ReviewReadySelectorStatePersistsAcrossSelection
+- **GIVEN** workspace B is ready for review
+- **WHEN** the user selects B and later switches away without an authoritative Work Plan change
+- **THEN** B remains marked ready for review in the selector
+
+#### Scenario: NotificationOnlyWhenUnattended
+- **GIVEN** a background workspace that starts waiting for the user or becomes ready for review
+- **WHEN** the document is in the foreground
+- **THEN** the selector raises the appropriate attention indicator and no browser notification is sent
+
+#### Scenario: ReviewNotificationContainsNoWorkspaceContent
+- **GIVEN** workspace B becomes ready for review while the user is viewing workspace A and the document is unattended
+- **WHEN** the browser notification is raised
+- **THEN** it names B and says that review is ready
+- **AND** it contains no Work Plan, task, artifact, result, or conversation content from B
+
+#### Scenario: NothingInterruptsTheCurrentWorkspace
+- **GIVEN** a client viewing workspace A
+- **WHEN** workspace B starts waiting for the user or becomes ready for review
+- **THEN** no dialog opens over A and the focus is unchanged
+- **AND** the only change to A's screen is the selector's attention indication
+
+#### Scenario: TwoWorkspacesNeedAttentionAtOnce
+- **GIVEN** two workspaces independently start waiting for the user or become ready for review while the document is unattended
+- **WHEN** the notifications are raised
+- **THEN** each notification names its own project and its kind of attention
+
+#### Scenario: TwoWorkspacesWaitingAtOnce
+- **GIVEN** two workspaces that start waiting for the user while the document is unattended
+- **WHEN** the notifications are raised
+- **THEN** each names its own project

--- a/openspec/changes/add-workspace-ready-for-review/specs/work-plan/spec.md
+++ b/openspec/changes/add-workspace-ready-for-review/specs/work-plan/spec.md
@@ -1,0 +1,51 @@
+## MODIFIED Requirements
+
+### Requirement: Structured agent management
+The system SHALL expose structured operations for the agent to create a plan, add, edit, move, remove, and reopen tasks, set status and status reason, add or remove dependencies and resource references, and replace the plan. Each accepted operation SHALL be atomic. The system SHALL describe the Work Plan to the agent as explicit working state for systematic decomposition, execution tracking, and verification, not merely progress reporting. For non-trivial work, it SHALL guide the agent to maintain and reconcile that state before declaring completion; trivial interactions SHALL NOT require a plan. The system SHALL NOT infer task state or completion from tool calls, messages, or Structured Exchange artifacts.
+
+When work has reached a result that requires human review, the agent SHALL explicitly reconcile the plan so every task is `done` or `needs_review` and at least one task is `needs_review`. That authoritative plan state SHALL mean the owning workspace is ready for review whenever it is otherwise inactive. Acknowledgement SHALL be represented by explicit Work Plan mutations that resolve the applicable `needs_review` tasks; resumed work SHALL be represented by moving the applicable tasks out of `done` or `needs_review`. The system SHALL NOT mutate the plan or acknowledge review merely because a turn ends, a tool completes, or the user selects the workspace.
+
+#### Scenario: Atomic task update
+- **WHEN** an agent operation is invalid
+- **THEN** no partial Work Plan mutation becomes visible or persisted
+
+#### Scenario: Activity does not complete work
+- **WHEN** the agent performs tools while a task remains `in_progress`
+- **THEN** the task remains `in_progress` until the agent explicitly changes it
+
+#### Scenario: Reconcile before completion
+- **GIVEN** the agent used a Work Plan for non-trivial work
+- **WHEN** the agent is preparing to declare that work complete
+- **THEN** its Work Plan guidance requires the agent to reconcile the plan with execution and verification outcomes first
+
+#### Scenario: Review readiness comes from the plan
+- **GIVEN** an inactive workspace whose Work Plan has at least one `needs_review` task
+- **AND** every task in the plan is either `done` or `needs_review`
+- **WHEN** the authoritative plan is synchronized
+- **THEN** the workspace is ready for review
+
+#### Scenario: Unfinished work is not ready for review
+- **GIVEN** a Work Plan that contains `needs_review`
+- **AND** at least one task remains `todo`, `in_progress`, or `blocked`
+- **WHEN** the workspace becomes inactive
+- **THEN** the plan does not make the workspace ready for review
+
+#### Scenario: Turn completion does not infer review readiness
+- **GIVEN** a Work Plan that does not satisfy the review-readiness conditions
+- **WHEN** an agent turn or tool execution ends
+- **THEN** the system does not mark the workspace ready for review
+
+#### Scenario: Review acknowledgement is explicit
+- **GIVEN** a workspace ready for review
+- **WHEN** the applicable `needs_review` tasks are explicitly transitioned to `done`
+- **THEN** the workspace is no longer ready for review
+
+#### Scenario: Meaningful work resumes
+- **GIVEN** a workspace ready for review
+- **WHEN** its authoritative Work Plan moves an applicable task to `todo`, `in_progress`, or `blocked`
+- **THEN** the workspace is no longer ready for review
+
+#### Scenario: Navigation does not acknowledge review
+- **GIVEN** a workspace ready for review
+- **WHEN** the user selects or leaves that workspace without changing its Work Plan
+- **THEN** it remains ready for review

--- a/openspec/changes/add-workspace-ready-for-review/tasks.md
+++ b/openspec/changes/add-workspace-ready-for-review/tasks.md
@@ -1,0 +1,28 @@
+## 1. Authoritative Readiness Model
+
+- [x] 1.1 Add a shared, pure Work Plan review-readiness predicate covering empty plans, all terminal/review plans, and mixed `todo`, `in_progress`, or `blocked` plans; verify its focused unit tests pass.
+- [x] 1.2 Extend the typed workspace activity protocol with `ready-for-review` and generic attention semantics; verify shared and downstream TypeScript builds reject no exhaustive consumer.
+- [x] 1.3 Update product-owned Work Plan guidance so agents explicitly reconcile review work and acknowledgement transitions; verify focused system-prompt and Work Plan contract tests assert the new guidance without changing plan persistence version 1.
+
+## 2. Server Activity Projection
+
+- [x] 2.1 Derive `ready-for-review` from the synchronized, session-matched authoritative Work Plan using the specified precedence over idle but below starting, stopped, waiting, and working; verify focused server tests cover every precedence branch and prove turn/tool completion alone cannot create readiness.
+- [x] 2.2 Announce workspace activity after accepted Work Plan synchronization and keep selection/session binding read-only with respect to review readiness; verify multi-client integration tests observe enter, persist-across-switch, acknowledge, resume, and return-to-ready transitions.
+- [x] 2.3 Exempt review-ready workspaces from idle retirement while preserving retirement for ordinary idle workspaces; verify the retirement integration tests cover both outcomes.
+- [x] 2.4 Prove cross-workspace isolation and concurrency with integration tests where several background workspaces are simultaneously ready and summaries contain no Work Plan or workspace content; run `npm run test --workspace server`.
+
+## 3. Selector and Notifications
+
+- [x] 3.1 Add an accessible, non-colour-only `ready for review` mark and label to every selector presentation, counting ready and waiting workspaces through the existing attention affordance; verify `ProjectMenu` component tests cover active, background, mixed, and multiple-ready states.
+- [x] 3.2 Extend browser notifications to produce one generic review-specific notification per newly ready background workspace, without plan-derived text and without clearing on selection; verify `useWorkspaceNotifications` tests cover visibility, permission, deduplication, isolation wording, transitions, and multiple workspaces.
+- [x] 3.3 Run `npm run test --workspace ui`, `npm run typecheck`, and `npm run build` to verify protocol and UI integration across all packages.
+
+## 4. Running-App and Contract Verification
+
+- [x] 4.1 Seed or drive a real multi-workspace session into review readiness and add Playwright coverage that checks selector DOM state, switching persistence, simultaneous ready workspaces, and absence of cross-workspace content; run `npm run test:e2e`.
+- [x] 4.2 Enumerate every applicable main and delta `#### Scenario:` with `rg '^#### Scenario:' openspec/`, produce a scenario-to-test matrix with assertion-level `covered` evidence, and run `openspec validate add-workspace-ready-for-review --strict`.
+
+## 5. Documentation Impact
+
+- [x] 5.1 Review all affected user and developer documentation for Work Plan status, multi-workspace activity, selector states, notifications, privacy, and test workflows; update `README.md`, `docs/design/multi-project-selector/README.md` and any other affected README or guide, then verify links, commands, terminology, and the selector design artifact inventory.
+- [x] 5.2 Add a `Documentation impact` section to the implementation PR description listing the updated files and validation performed; verify it matches the final diff before opening or updating the PR.

--- a/openspec/changes/add-workspace-ready-for-review/verification.md
+++ b/openspec/changes/add-workspace-ready-for-review/verification.md
@@ -1,0 +1,72 @@
+# Verification
+
+## Scenario inventory
+
+The applicable main-spec scenarios are the scenarios under the three requirements
+modified by this change:
+
+- `work-plan`: `Atomic task update`, `Activity does not complete work`, and
+  `Reconcile before completion`;
+- `multi-project-workspaces`: `WorkingWorkspacesAreNeverRetired`,
+  `ReopeningARetiredWorkspace`, `BackgroundProgressIsVisible`,
+  `APendingQuestionIsNotDiscarded`, `AnsweringAfterSwitchingBack`,
+  `NotificationOnlyWhenUnattended`, `NothingInterruptsTheCurrentWorkspace`, and
+  `TwoWorkspacesWaitingAtOnce`.
+
+The delta repeats those scenarios where their requirements change and adds sixteen
+new scenarios. The following matrix covers all 27 delta scenarios and, through the
+repeated rows marked `main + delta`, every applicable main scenario. Inventory was
+checked with:
+
+```bash
+rg '^#### Scenario:' openspec/specs/work-plan/spec.md \
+  openspec/specs/model/spec.md \
+  openspec/specs/multi-project-workspaces/spec.md \
+  openspec/changes/add-workspace-ready-for-review/specs
+```
+
+## Scenario-to-test matrix
+
+Every row is `covered`: the named assertions exercise the observable GIVEN/WHEN/THEN
+boundary and would fail if that contract regressed.
+
+| Spec source | Scenario | Test evidence |
+|---|---|---|
+| delta `model` | Workspace summary carries review readiness | `server/test/work-plan-server.test.mjs` — **workspace review readiness follows only persisted Work Plan transitions** asserts `ready-for-review`, `needsAttention: true`, and the bounded summary shape after persisted synchronization. |
+| delta `model` | Workspace summary preserves isolation | `server/test/multiProjectWorkspaces.test.mjs` — **a background result moves from working to review-ready without exposing its content** asserts only the four generic summary keys cross to the other workspace and rejects private plan/result strings. |
+| delta `model` | Existing activity meanings remain compatible | `server/test/workspace-boundaries.test.ts` — **applies lifecycle and attention precedence before review readiness** asserts stopped, starting, waiting, working, ready, and idle projections independently. |
+| main + delta `work-plan` | Atomic task update | `server/test/work-plan.test.ts` — **returns authoritative details and refuses a partial invalid mutation** asserts an invalid multi-field operation leaves the authoritative plan unchanged. |
+| main + delta `work-plan` | Activity does not complete work | `server/test/work-plan.test.ts` — **keeps status unchanged when an explicit Work Plan operation only reads it** asserts activity without an explicit status mutation preserves `in_progress`. |
+| main + delta `work-plan` | Reconcile before completion | `server/test/system-prompt.test.ts` — **adds Work Plan behavior once before unchanged operator entries when the tool is available** asserts the product guidance requires reconciliation, review statuses, explicit acknowledgement, and resumed-work transitions. |
+| delta `work-plan` | Review readiness comes from the plan | `server/test/work-plan.test.ts` — **derives review readiness only from a fully reconciled authoritative plan** asserts `needs_review` alone and mixed `done`/`needs_review` plans are ready; `server/test/work-plan-server.test.mjs` proves the synchronized plan changes workspace activity. |
+| delta `work-plan` | Unfinished work is not ready for review | `server/test/work-plan.test.ts` — the same predicate test separately asserts `todo`, `in_progress`, and `blocked` each prevent readiness even alongside `needs_review`. |
+| delta `work-plan` | Turn completion does not infer review readiness | `server/test/work-plan-server.test.mjs` — **workspace review readiness follows only persisted Work Plan transitions** asserts initial and post-turn activity remain idle when the plan is absent or active. |
+| delta `work-plan` | Review acknowledgement is explicit | The same server test transitions the persisted task from `needs_review` to `done` and asserts activity becomes idle with no attention metadata. |
+| delta `work-plan` | Meaningful work resumes | The same server test transitions a review-ready task to `in_progress`, observes working during the turn, then idle rather than ready. |
+| delta `work-plan` | Navigation does not acknowledge review | `server/test/multiProjectWorkspaces.test.mjs` — **several review-ready workspaces stay marked across selection without leaking plan content** switches away and back and asserts readiness persists; `e2e/review-ready.spec.ts` proves the same in the built app. |
+| main + delta `multi-project-workspaces` | WorkingWorkspacesAreNeverRetired | `server/test/multiProjectLifecycle.test.mjs` — **a project whose agent is streaming outlives any idle period** waits beyond multiple sweeps and asserts the workspace remains working. |
+| delta `multi-project-workspaces` | ReviewReadyWorkspacesAreNeverRetired | `server/test/multiProjectLifecycle.test.mjs` — **a review-ready project outlives any idle period** waits beyond multiple sweeps and asserts the workspace remains ready and available. |
+| main + delta `multi-project-workspaces` | ReopeningARetiredWorkspace | `server/test/multiProjectLifecycle.test.mjs` — **an unwatched project is retired, stays listed, and comes back with its history** asserts stopped state, transparent rebuild, and the same session identity. |
+| main + delta `multi-project-workspaces` | BackgroundProgressIsVisible | `server/test/multiProjectWorkspaces.test.mjs` — **a streaming turn reaches its own project's clients and no others** asserts background working with no turn frames crossing; **a turn started before a switch finishes in the project it belongs to** asserts the later idle transition. |
+| delta `multi-project-workspaces` | BackgroundResultIsVisible | `server/test/multiProjectWorkspaces.test.mjs` — **a background result moves from working to review-ready without exposing its content** observes both activity states from workspace A and rejects B's plan and result content. |
+| delta `multi-project-workspaces` | WaitingTakesPrecedence | `server/test/workspace-boundaries.test.ts` — **applies lifecycle and attention precedence before review readiness** asserts waiting wins when waiting, busy, and review-ready are all true. |
+| delta `multi-project-workspaces` | SeveralWorkspacesAreReady | `server/test/multiProjectWorkspaces.test.mjs` — **several review-ready workspaces stay marked across selection without leaking plan content** asserts two independently started workspaces are simultaneously ready; the Playwright test asserts two selector rows. |
+| main + delta `multi-project-workspaces` | APendingQuestionIsNotDiscarded | `server/test/multiProjectWorkspaces.test.mjs` — **a question raised in a background project waits there, and can be answered on return** asserts waiting activity while the prompt itself remains scoped to B. |
+| main + delta `multi-project-workspaces` | AnsweringAfterSwitchingBack | The same integration test switches back, asserts the pending dialog is re-presented, answers it, and observes attention clear as the turn resumes. |
+| delta `multi-project-workspaces` | ReviewReadySelectorStatePersistsAcrossSelection | `e2e/review-ready.spec.ts` — **review-ready workspaces remain visible and content-isolated across real switches** drives both directions and asserts both ready labels and the attention count remain. |
+| main + delta `multi-project-workspaces` | NotificationOnlyWhenUnattended | `ui/src/useWorkspaceNotifications.test.ts` — **stays silent while the document is in the foreground** supplies both waiting and review-ready background workspaces and asserts zero notifications; `ProjectMenu` tests assert both still contribute to attention. |
+| delta `multi-project-workspaces` | ReviewNotificationContainsNoWorkspaceContent | `ui/src/useWorkspaceNotifications.test.ts` — **distinguishes ready workspaces without including plan content** asserts the exact generic title/body/tag and rejects task, artifact, and result wording. |
+| main + delta `multi-project-workspaces` | NothingInterruptsTheCurrentWorkspace | `ui/src/components/ProjectMenu.test.tsx` — **counts actionable projects without interrupting focus** supplies waiting and review-ready attention, then asserts it renders no dialog or menu and preserves the focused element; foreground notification tests assert no system notification. |
+| delta `multi-project-workspaces` | TwoWorkspacesNeedAttentionAtOnce | `ui/src/useWorkspaceNotifications.test.ts` — **distinguishes ready workspaces without including plan content** asserts separate, correctly typed notifications for one ready and one waiting workspace; `ProjectMenu` asserts the mixed total. |
+| main + delta `multi-project-workspaces` | TwoWorkspacesWaitingAtOnce | `ui/src/useWorkspaceNotifications.test.ts` — **names each waiting project when two ask at once** asserts two project-specific titles and tags. |
+
+## Gate results
+
+- `npm run test --workspace server`: 1,679 passed before the additional
+  assertion-only coverage test; the new targeted server test also passes.
+- `npm run test --workspace ui`: 1,403 passed before the final assertion-only
+  strengthening; focused modified UI tests pass afterward.
+- `npm run typecheck`: passed.
+- `npm run build`: passed.
+- `npm run test:e2e`: 58 passed.
+- `openspec validate add-workspace-ready-for-review --strict`: passed.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -43,7 +43,7 @@ import {
 import { rewriteMentionedPaths } from "@pi-outpost/shared/mentions";
 import { readStructuredExchangeDocument } from "@pi-outpost/shared/structured-exchange/document";
 import { checkStructuredExchangeSchema } from "@pi-outpost/shared/structured-exchange/schema-node";
-import { validateWorkPlan } from "@pi-outpost/shared/work-plan";
+import { isWorkPlanReadyForReview, validateWorkPlan } from "@pi-outpost/shared/work-plan";
 import { describeProviderError } from "@pi-outpost/shared/provider-error";
 import {
   type AgentRuntime,
@@ -134,6 +134,7 @@ import { composeAppendSystemPrompt } from "./systemPrompt.ts";
 import { createPdfExtractToolDefinition } from "./pdfTool.ts";
 import { Workspace, shouldRetireWorkspace, type WorkspaceOptions, type WorkspaceSettings } from "./workspace.ts";
 import { WorkspaceRegistry } from "./workspaceRegistry.ts";
+import { deriveWorkspaceActivity, workspaceActivityNeedsAttention } from "./workspaceActivity.ts";
 import { isWithin, realResolve } from "./sandbox.ts";
 import {
   firstExchange,
@@ -1129,6 +1130,7 @@ function queueWorkPlanSessionSync(workspace: Workspace): Promise<void> {
     workspace.workPlanSessionFile = sessionFile;
     broadcast(workspace, { type: "session_replaced", ...snapshot(workspace) });
     if (inherited) broadcast(workspace, { type: "work_plan_changed", workPlan: plan });
+    announceWorkspaceActivity();
     console.log(`[pi] session ${workspace.agent.snapshot().sessionId}`);
   });
   workspace.workPlanSync.catch(reportError);
@@ -1147,7 +1149,10 @@ function queueWorkPlanToolSync(workspace: Workspace, sessionFile: string, change
     if (!sameSessionFile(workspace.agent.snapshot().sessionFile, sessionFile)) return;
     workspace.workPlan = plan;
     workspace.workPlanSessionFile = sessionFile;
-    if (changed) broadcast(workspace, { type: "work_plan_changed", workPlan: plan });
+    if (changed) {
+      broadcast(workspace, { type: "work_plan_changed", workPlan: plan });
+      announceWorkspaceActivity();
+    }
   });
   workspace.workPlanSync.catch(reportError);
 }
@@ -1222,25 +1227,36 @@ function branchUserEntries(workspace: Workspace): { entryId: string; text: strin
  * that drifts the first time a turn ends without anyone updating it.
  */
 function workspaceInfo(target: Workspace): WorkspaceInfo {
+  const activity = workspaceActivity(target);
   return {
     root: target.root,
     name: path.basename(target.root),
-    activity: workspaceActivity(target),
-    ...(target.needsAttention ? { needsAttention: true } : {}),
+    activity,
+    ...(workspaceActivityNeedsAttention(activity) ? { needsAttention: true } : {}),
   };
+}
+
+function workspaceWorkPlanReadyForReview(target: Workspace): boolean {
+  return target.started
+    && target.workPlanSessionFile !== undefined
+    && sameSessionFile(target.agent.snapshot().sessionFile, target.workPlanSessionFile)
+    && isWorkPlanReadyForReview(target.workPlan);
 }
 
 /** The four extension UI methods that block a turn until the user answers. */
 const BLOCKING_UI_METHODS = new Set(["select", "confirm", "input", "editor"]);
 
 function workspaceActivity(target: Workspace): WorkspaceActivity {
-  // Building right now. Checked before `started`, which is still false for the
-  // whole length of the build — without this the `starting` state would be
-  // announced and then read as `stopped`, so it could never be seen.
-  if (starting.has(target.root)) return "starting";
-  if (!target.started) return "stopped";
-  if (target.needsAttention) return "waiting";
-  return target.isBusy() ? "working" : "idle";
+  const started = target.started;
+  return deriveWorkspaceActivity({
+    // Building right now is checked before `started`, which remains false for the
+    // build: otherwise starting would be announced and immediately read stopped.
+    starting: starting.has(target.root),
+    started,
+    waiting: target.needsAttention,
+    busy: target.isBusy(),
+    workPlanReadyForReview: workspaceWorkPlanReadyForReview(target),
+  });
 }
 
 /**
@@ -3544,7 +3560,11 @@ function sweepIdleWorkspaces(): void {
       open.lastUsedAt = now;
       continue;
     }
-    if (!shouldRetireWorkspace({ timeoutMs: timeout, now, lastUsedAt: open.lastUsedAt, watched: isWatched, busy: isBusy })) continue;
+    // Retention follows the authoritative plan fact, not the projected activity:
+    // `waiting` deliberately masks review readiness in the selector but must not
+    // make that review-ready workspace eligible for retirement.
+    const readyForReview = workspaceWorkPlanReadyForReview(open);
+    if (!shouldRetireWorkspace({ timeoutMs: timeout, now, lastUsedAt: open.lastUsedAt, watched: isWatched, busy: isBusy, readyForReview })) continue;
     console.log(`[pi] retiring ${path.basename(open.root)} after ${Math.round((now - open.lastUsedAt) / 1000)}s idle`);
     void open
       .retire()

--- a/server/src/systemPrompt.ts
+++ b/server/src/systemPrompt.ts
@@ -11,6 +11,7 @@ export const WEB_UI_CONTEXT = [
 export const WORK_PLAN_SYSTEM_GUIDANCE = [
   "Use work_plan as explicit working state for non-trivial multi-step work: create and maintain it as understanding or execution changes.",
   "Before resuming substantial work, read the current plan; reconcile it before declaring the work complete.",
+  "When completed work needs human review, leave at least one task as needs_review and reconcile every other task to done or needs_review; acknowledge review by moving the applicable tasks to done, and move them back to an active state when meaningful work resumes.",
   "Skip a Work Plan for trivial interactions.",
 ].join(" ");
 

--- a/server/src/workspace.ts
+++ b/server/src/workspace.ts
@@ -61,6 +61,7 @@ export interface WorkspaceRetirementState {
   lastUsedAt: number;
   watched: boolean;
   busy: boolean;
+  readyForReview: boolean;
 }
 
 /**
@@ -72,6 +73,7 @@ export function shouldRetireWorkspace(state: WorkspaceRetirementState): boolean 
     state.timeoutMs > 0 &&
     !state.watched &&
     !state.busy &&
+    !state.readyForReview &&
     state.now - state.lastUsedAt >= state.timeoutMs
   );
 }

--- a/server/src/workspaceActivity.ts
+++ b/server/src/workspaceActivity.ts
@@ -1,0 +1,23 @@
+import type { WorkspaceActivity } from "@pi-outpost/shared";
+
+export interface WorkspaceActivityState {
+  starting: boolean;
+  started: boolean;
+  waiting: boolean;
+  busy: boolean;
+  workPlanReadyForReview: boolean;
+}
+
+/** One server-owned precedence table for every workspace summary consumer. */
+export function deriveWorkspaceActivity(state: WorkspaceActivityState): WorkspaceActivity {
+  if (state.starting) return "starting";
+  if (!state.started) return "stopped";
+  if (state.waiting) return "waiting";
+  if (state.busy) return "working";
+  if (state.workPlanReadyForReview) return "ready-for-review";
+  return "idle";
+}
+
+export function workspaceActivityNeedsAttention(activity: WorkspaceActivity): boolean {
+  return activity === "waiting" || activity === "ready-for-review";
+}

--- a/server/test/README.md
+++ b/server/test/README.md
@@ -19,6 +19,9 @@ npm run test:live --workspace server   # drives real agent turns (needs model au
 |-------|--------|
 | `auth.test.mjs` | WebSocket token check (valid connects; missing/wrong closes 4401 with no data), `/branding` Bearer, `/health` session-id redaction, unchanged behavior without a token |
 | `files-raw.test.mjs` | `/files/raw`: confinement (traversal, absolute paths, symlink escapes → 404), 1 MiB cap → 413, image content types, non-images served as `attachment` (an HTML file must never render on our origin), SVG served with a scripts-off CSP, DNS-rebinding Host guard on token-less servers, token gating |
+| `work-plan-server.test.mjs` | Persisted Work Plan synchronization and authoritative workspace activity transitions, including ready-for-review, acknowledgement, and resumed work |
+| `multiProjectWorkspaces.test.mjs` | Concurrent workspace lifecycle, switching, generic attention summaries, simultaneous review-ready projects, and cross-workspace isolation |
+| `multiProjectLifecycle.test.mjs` | Idle retirement and retention of workspaces that are working, waiting for the user, or ready for review |
 | `live/conversation-branching.test.mjs` | Editing a past prompt branches the session and the original exchange stays restorable *with its reply* (`tipId`); navigating to the turn itself rewinds with composer prefill; unknown entry ids refused; **the phantom-bubble regression** — a message an extension swallowed is echoed but never persisted, so pairing must fail closed instead of handing that bubble the previous turn's entry id (aligning by position would make an edit rewind the wrong turn) |
 
 `fixtures/swallow-extension.ts` is what produces that phantom: an `input` handler returning

--- a/server/test/fixtures/fake-pi-rpc.mjs
+++ b/server/test/fixtures/fake-pi-rpc.mjs
@@ -75,7 +75,7 @@ const state = {
   isStreaming: false,
   sessionId: "session-1",
   sessionFile: "/tmp/fake-session-1.jsonl",
-  ...config.state,
+  ...(config.stateByCwd?.[launch.cwd] ?? config.state),
 };
 let messages = config.messages ?? [];
 let entries = config.entries ?? [];

--- a/server/test/multiProjectLifecycle.test.mjs
+++ b/server/test/multiProjectLifecycle.test.mjs
@@ -136,6 +136,44 @@ test("a project whose agent is streaming outlives any idle period", async (t) =>
   assert.equal(hello.workspaces.find((w) => w.root === beta).activity, "working", "the turn kept its project alive");
 });
 
+test("a review-ready project outlives any idle period", async (t) => {
+  const beta = await secondProject();
+  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
+  const sessionFile = path.join(root, "review-ready.jsonl");
+  await writeFile(sessionFile, "");
+  const plan = {
+    version: 1,
+    id: "review",
+    title: "Review result",
+    updatedAt: "2026-09-01T00:00:00.000Z",
+    tasks: [{ id: "review-result", title: "Review result", status: "needs_review", dependsOn: [], resources: [] }],
+  };
+  await writeFile(`${sessionFile}.work-plan.json`, `${JSON.stringify(plan, null, 2)}\n`);
+  const server = await startScriptedServer(
+    root,
+    [beta],
+    { state: { sessionId: "review-ready", sessionFile, isStreaming: false } },
+    { workspaceIdleTimeoutMs: RETIREMENT_TIMEOUT_MS },
+  );
+  t.after(() => server.stop());
+
+  const client = connect(server.wsUrl());
+  t.after(() => client.close());
+  await client.waitFor("hello");
+  client.send({ type: "switch_workspace", root: beta });
+  const started = await client.waitFor((message) => message.type === "workspace_switched" && message.workspace.root === beta);
+  assert.equal(started.workspace.activity, "ready-for-review");
+
+  client.send({ type: "switch_workspace", root });
+  await client.waitFor((message) => message.type === "workspace_switched" && message.workspace.root === root);
+  await wait(RETIREMENT_TIMEOUT_MS * 3);
+
+  const observer = connect(server.wsUrl());
+  t.after(() => observer.close());
+  const hello = await observer.waitFor("hello");
+  assert.equal(hello.workspaces.find((workspace) => workspace.root === beta).activity, "ready-for-review");
+});
+
 test("closing a project releases it, moves whoever was watching, and leaves its history on disk", async (t) => {
   const beta = await secondProject();
   const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));

--- a/server/test/multiProjectWorkspaces.test.mjs
+++ b/server/test/multiProjectWorkspaces.test.mjs
@@ -26,6 +26,14 @@ import {
   wait,
 } from "./multiProjectHarness.mjs";
 
+const reviewPlan = (id) => ({
+  version: 1,
+  id,
+  title: `Review ${id}`,
+  updatedAt: "2026-09-01T00:00:00.000Z",
+  tasks: [{ id: `${id}-review`, title: `Private review task ${id}`, status: "needs_review", dependsOn: [], resources: [] }],
+});
+
 // openlore: scenario=ASingleProjectIsStillDescribed spec=api
 test("a single-project server still says which project it is serving", async (t) => {
   const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
@@ -128,6 +136,114 @@ test("a client hears about another project's activity, and none of its content",
   // everyone.
   assert.equal(Object.keys(activity).sort().join(","), "type,workspaces");
   await mover.waitFor((m) => m.type === "workspace_switched");
+});
+
+test("a background result moves from working to review-ready without exposing its content", async (t) => {
+  const beta = await secondProject();
+  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
+  const sessionFile = path.join(root, "background-review.jsonl");
+  const privatePlan = reviewPlan("private-background-result");
+  await writeFile(sessionFile, "");
+  const server = await startScriptedServer(root, [beta], {
+    state: { sessionId: "background-review", sessionFile, isStreaming: false },
+    commands_: {
+      prompt: {
+        writes: [{ path: `${sessionFile}.work-plan.json`, content: `${JSON.stringify(privatePlan, null, 2)}\n` }],
+        after: [
+          { type: "agent_start" },
+          {
+            type: "tool_execution_end",
+            toolCallId: "review-plan",
+            toolName: "work_plan",
+            result: {
+              content: [{ type: "text", text: "Private result content" }],
+              details: { type: "work_plan", sessionFile, plan: privatePlan, changed: true },
+            },
+            isError: false,
+          },
+          { type: "agent_settled" },
+        ],
+      },
+    },
+  });
+  t.after(() => server.stop());
+
+  const watcher = connect(server.wsUrl());
+  const worker = connect(server.wsUrl());
+  t.after(() => { watcher.close(); worker.close(); });
+  await watcher.waitFor("hello");
+  await worker.waitFor("hello");
+  worker.send({ type: "switch_workspace", root: beta });
+  await worker.waitFor((message) => message.type === "workspace_switched" && message.workspace.root === beta);
+  worker.send({ type: "prompt", text: "finish in the background" });
+
+  await watcher.waitFor(
+    (message) => message.type === "workspace_activity"
+      && message.workspaces.some((workspace) => workspace.root === beta && workspace.activity === "working"),
+  );
+  const ready = await watcher.waitFor(
+    (message) => message.type === "workspace_activity"
+      && message.workspaces.some((workspace) => workspace.root === beta && workspace.activity === "ready-for-review"),
+  );
+  const summary = ready.workspaces.find((workspace) => workspace.root === beta);
+  assert.equal(summary.needsAttention, true);
+  assert.deepEqual(Object.keys(summary).sort(), ["activity", "name", "needsAttention", "root"]);
+  assert.equal(
+    watcher.received.some((message) => JSON.stringify(message).includes("Private result content") || JSON.stringify(message).includes("Private review task")),
+    false,
+    "neither result nor Work Plan content crossed the workspace boundary",
+  );
+});
+
+test("several review-ready workspaces stay marked across selection without leaking plan content", async (t) => {
+  const beta = await secondProject();
+  const root = await realpath(await makeWorkspace({ "a.md": "alpha\n" }));
+  const rootSessionFile = path.join(root, "review-ready-root.jsonl");
+  const betaSessionFile = path.join(beta, "review-ready-beta.jsonl");
+  await writeFile(rootSessionFile, "");
+  await writeFile(betaSessionFile, "");
+  await writeFile(`${rootSessionFile}.work-plan.json`, `${JSON.stringify(reviewPlan("private-root"), null, 2)}\n`);
+  await writeFile(`${betaSessionFile}.work-plan.json`, `${JSON.stringify(reviewPlan("private-beta"), null, 2)}\n`);
+  const server = await startScriptedServer(root, [beta], {
+    stateByCwd: {
+      [root]: { sessionId: "review-ready-root", sessionFile: rootSessionFile, isStreaming: false },
+      [beta]: { sessionId: "review-ready-beta", sessionFile: betaSessionFile, isStreaming: false },
+    },
+  });
+  t.after(() => server.stop());
+  const watcher = connect(server.wsUrl());
+  const mover = connect(server.wsUrl());
+  t.after(() => { watcher.close(); mover.close(); });
+  const hello = await watcher.waitFor("hello");
+  await mover.waitFor("hello");
+  assert.equal(hello.workspace.activity, "ready-for-review");
+  assert.equal(hello.workPlan?.id, "private-root", "the root derives readiness from its own plan");
+
+  mover.send({ type: "switch_workspace", root: beta });
+  const onBeta = await mover.waitFor((message) => message.type === "workspace_switched" && message.workspace.root === beta);
+  assert.equal(onBeta.workspace.activity, "ready-for-review");
+  assert.equal(onBeta.workPlan?.id, "private-beta", "the second workspace derives readiness from its independent plan");
+
+  const bothReady = await watcher.waitFor(
+    (message) => message.type === "workspace_activity"
+      && [root, beta].every((workspaceRoot) => message.workspaces.some((workspace) => workspace.root === workspaceRoot && workspace.activity === "ready-for-review" && workspace.needsAttention)),
+  );
+  for (const summary of bothReady.workspaces) {
+    assert.deepEqual(Object.keys(summary).sort(), ["activity", "name", "needsAttention", "root"], "only generic summary fields cross workspaces");
+    assert.ok(!JSON.stringify(summary).includes("Private review task private-root"));
+    assert.ok(!JSON.stringify(summary).includes("Private review task private-beta"));
+  }
+
+  mover.send({ type: "switch_workspace", root });
+  await mover.waitFor((message) => message.type === "workspace_switched" && message.workspace.root === root);
+  mover.send({ type: "switch_workspace", root: beta });
+  const selectedAgain = await next(mover, (message) => message.type === "workspace_switched" && message.workspace.root === beta);
+  assert.equal(selectedAgain.workspace.activity, "ready-for-review", "selection never acknowledges review readiness");
+  assert.equal(
+    watcher.received.filter((message) => message.type === "workspace_activity").some((message) => /Private review task private-(root|beta)/.test(JSON.stringify(message))),
+    false,
+    "server-wide activity frames contain no plan content",
+  );
 });
 
 test("a connection names the project it binds to, and an unknown one falls back", async (t) => {

--- a/server/test/system-prompt.test.ts
+++ b/server/test/system-prompt.test.ts
@@ -31,6 +31,10 @@ describe("product system-prompt composition", () => {
     });
     assert.deepEqual(composed, [WORK_PLAN_SYSTEM_GUIDANCE, ...operator]);
     assert.equal(composed.filter((entry) => entry === WORK_PLAN_SYSTEM_GUIDANCE).length, 1);
+    assert.match(WORK_PLAN_SYSTEM_GUIDANCE, /needs_review/);
+    assert.match(WORK_PLAN_SYSTEM_GUIDANCE, /every other task to done or needs_review/);
+    assert.match(WORK_PLAN_SYSTEM_GUIDANCE, /acknowledge review.*tasks to done/);
+    assert.match(WORK_PLAN_SYSTEM_GUIDANCE, /meaningful work resumes/);
   });
 
   it("omits Work Plan guidance when an unsandboxed allowlist excludes the tool", () => {

--- a/server/test/work-plan-server.test.mjs
+++ b/server/test/work-plan-server.test.mjs
@@ -19,6 +19,113 @@ const plan = (status = "in_progress") => ({
   ],
 });
 
+const messageAfter = (client, predicate, seen) => client.waitFor(
+  (message) => predicate(message) && client.received.filter(predicate).length > seen,
+);
+
+test("workspace review readiness follows only persisted Work Plan transitions", async () => {
+  const root = await makeWorkspace();
+  const sessionFile = path.join(root, "review.jsonl");
+  const fakeConfig = path.join(root, "fake-rpc.json");
+  await writeFile(sessionFile, "");
+  const transition = (status) => ({
+    writes: [{ path: `${sessionFile}.work-plan.json`, content: `${JSON.stringify(plan(status), null, 2)}\n` }],
+    after: [
+      { type: "agent_start" },
+      {
+        type: "tool_execution_end",
+        toolCallId: `plan-${status}`,
+        toolName: "work_plan",
+        result: {
+          content: [{ type: "text", text: "Work Plan updated." }],
+          details: { type: "work_plan", sessionFile, plan: plan(status), changed: true },
+        },
+        isError: false,
+      },
+      { type: "agent_settled" },
+    ],
+  });
+  await writeFile(fakeConfig, JSON.stringify({
+    state: { sessionId: "review", sessionFile },
+    commands_: { prompt: [transition("needs_review"), transition("in_progress"), transition("needs_review"), transition("done")] },
+  }));
+
+  const server = await startServer(
+    root,
+    { sandbox: undefined, agentRuntime: { mode: "rpc", executable: process.execPath, args: [FAKE], startupTimeoutMs: 5_000 } },
+    { env: { FAKE_PI_RPC_CONFIG: fakeConfig } },
+  );
+  const client = connect(server.wsUrl());
+  try {
+    let workspaceRoot = root;
+    const after = async (label, predicate, seen) => {
+      try {
+        return await messageAfter(client, predicate, seen);
+      } catch (error) {
+        const activity = client.received
+          .filter((message) => message.type === "workspace_activity")
+          .map((message) => message.workspaces.find((workspace) => workspace.root === workspaceRoot)?.activity);
+        const statuses = client.received
+          .filter((message) => message.type === "work_plan_changed")
+          .map((message) => message.workPlan?.tasks[0]?.status);
+        throw new Error(`${label} timed out; activities=${activity.join(",")}; planStatuses=${statuses.join(",")}`, { cause: error });
+      }
+    };
+    const hello = await client.waitFor("hello");
+    workspaceRoot = hello.workspace.root;
+    assert.equal(hello.workspace.activity, "idle", "turn completion is not enough without a review-ready plan");
+
+    const ended = (message) => message.type === "agent_end";
+    const reviewPlanChanged = (message) => message.type === "work_plan_changed" && message.workPlan?.tasks[0]?.status === "needs_review";
+    const activePlanChanged = (message) => message.type === "work_plan_changed" && message.workPlan?.tasks[0]?.status === "in_progress";
+    const donePlanChanged = (message) => message.type === "work_plan_changed" && message.workPlan?.tasks[0]?.status === "done";
+    const readyActivity = (message) => message.type === "workspace_activity" && message.workspaces.some((workspace) => workspace.root === workspaceRoot && workspace.activity === "ready-for-review");
+    const workingActivity = (message) => message.type === "workspace_activity" && message.workspaces.some((workspace) => workspace.root === workspaceRoot && workspace.activity === "working");
+    const idleActivity = (message) => message.type === "workspace_activity" && message.workspaces.some((workspace) => workspace.root === workspaceRoot && workspace.activity === "idle");
+
+    let endCount = client.received.filter(ended).length;
+    let planCount = client.received.filter(reviewPlanChanged).length;
+    let activityCount = client.received.filter(readyActivity).length;
+    client.send({ type: "prompt", text: "prepare review" });
+    await after("first review plan", reviewPlanChanged, planCount);
+    await after("first agent end", ended, endCount);
+    const ready = await after("first ready activity", readyActivity, activityCount);
+    const readySummary = ready.workspaces.find((workspace) => workspace.root === workspaceRoot);
+    assert.equal(readySummary.needsAttention, true);
+    assert.deepEqual(Object.keys(readySummary).sort(), ["activity", "name", "needsAttention", "root"]);
+
+    endCount = client.received.filter(ended).length;
+    planCount = client.received.filter(activePlanChanged).length;
+    const workingCount = client.received.filter(workingActivity).length;
+    activityCount = client.received.filter(idleActivity).length;
+    client.send({ type: "prompt", text: "resume meaningful work" });
+    await after("resumed working activity", workingActivity, workingCount);
+    await after("resumed plan", activePlanChanged, planCount);
+    await after("resumed agent end", ended, endCount);
+    await after("resumed idle activity", idleActivity, activityCount);
+
+    endCount = client.received.filter(ended).length;
+    planCount = client.received.filter(reviewPlanChanged).length;
+    activityCount = client.received.filter(readyActivity).length;
+    client.send({ type: "prompt", text: "return for review" });
+    await after("second review plan", reviewPlanChanged, planCount);
+    await after("second agent end", ended, endCount);
+    await after("second ready activity", readyActivity, activityCount);
+
+    endCount = client.received.filter(ended).length;
+    planCount = client.received.filter(donePlanChanged).length;
+    activityCount = client.received.filter(idleActivity).length;
+    client.send({ type: "prompt", text: "acknowledge review" });
+    await after("acknowledged plan", donePlanChanged, planCount);
+    await after("acknowledged agent end", ended, endCount);
+    const acknowledged = await after("acknowledged idle activity", idleActivity, activityCount);
+    assert.equal(acknowledged.workspaces.find((workspace) => workspace.root === workspaceRoot).needsAttention, undefined);
+  } finally {
+    client.close();
+    await server.stop();
+  }
+});
+
 test("running server restores, forks, reconnects, and broadcasts authoritative Work Plans", async () => {
   const root = await makeWorkspace();
   const source = path.join(root, "source.jsonl");

--- a/server/test/work-plan.test.ts
+++ b/server/test/work-plan.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, it } from "node:test";
 import { Compile } from "typebox/compile";
-import { mutateWorkPlan, normalizeWorkPlanDraft, validateWorkPlan, WORK_PLAN_LIMITS, type WorkPlan } from "@pi-outpost/shared/work-plan";
+import { isWorkPlanReadyForReview, mutateWorkPlan, normalizeWorkPlanDraft, validateWorkPlan, WORK_PLAN_LIMITS, type WorkPlan } from "@pi-outpost/shared/work-plan";
 import { applyWorkPlanMutation, copyWorkPlan, deleteWorkPlan, loadWorkPlan, sameSessionFile, workPlanPath } from "../src/workPlanStore.ts";
 import { createWorkPlanToolDefinition } from "../src/workPlanTool.ts";
 
@@ -20,6 +20,32 @@ const base = (): WorkPlan => ({
 });
 
 describe("Work Plan contract", () => {
+  it("derives review readiness only from a fully reconciled authoritative plan", () => {
+    const withStatuses = (...statuses: WorkPlan["tasks"][number]["status"][]): WorkPlan => ({
+      ...base(),
+      tasks: statuses.map((status, index) => ({
+        id: `task-${index}`,
+        title: `Task ${index}`,
+        status,
+        dependsOn: [],
+        resources: [],
+      })),
+    });
+
+    assert.equal(isWorkPlanReadyForReview(null), false);
+    assert.equal(isWorkPlanReadyForReview(withStatuses()), false);
+    assert.equal(isWorkPlanReadyForReview(withStatuses("done")), false);
+    assert.equal(isWorkPlanReadyForReview(withStatuses("needs_review")), true);
+    assert.equal(isWorkPlanReadyForReview(withStatuses("done", "needs_review", "done")), true);
+    for (const unfinished of ["todo", "in_progress", "blocked"] as const) {
+      assert.equal(
+        isWorkPlanReadyForReview(withStatuses("done", "needs_review", unfinished)),
+        false,
+        `${unfinished} prevents review readiness`,
+      );
+    }
+  });
+
   it("normalizes a minimal creation draft into a canonical version-1 plan", () => {
     const generated = ["plan-generated", "task-one", "task-two"];
     const plan = normalizeWorkPlanDraft(

--- a/server/test/workspace-boundaries.test.ts
+++ b/server/test/workspace-boundaries.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { describe, test } from "node:test";
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { Workspace, shouldRetireWorkspace, type WorkspaceOptions } from "../src/workspace.ts";
+import { deriveWorkspaceActivity, workspaceActivityNeedsAttention } from "../src/workspaceActivity.ts";
 
 const limits = {
   pdfMaxBytes: 1_000_000,
@@ -100,16 +101,66 @@ describe("WorkspaceOwnsItsResources", () => {
 describe("RetirementDisabled", () => {
   test("a zero timeout cannot retire even a long-idle, unwatched workspace", () => {
     assert.equal(
-      shouldRetireWorkspace({ timeoutMs: 0, now: 100_000, lastUsedAt: 0, watched: false, busy: false }),
+      shouldRetireWorkspace({ timeoutMs: 0, now: 100_000, lastUsedAt: 0, watched: false, busy: false, readyForReview: false }),
       false,
     );
   });
 
   test("the same workspace retires once a positive timeout has elapsed", () => {
     assert.equal(
-      shouldRetireWorkspace({ timeoutMs: 30_000, now: 100_000, lastUsedAt: 0, watched: false, busy: false }),
+      shouldRetireWorkspace({ timeoutMs: 30_000, now: 100_000, lastUsedAt: 0, watched: false, busy: false, readyForReview: false }),
       true,
     );
+  });
+
+  test("review readiness protects an otherwise retireable workspace", () => {
+    assert.equal(
+      shouldRetireWorkspace({ timeoutMs: 30_000, now: 100_000, lastUsedAt: 0, watched: false, busy: false, readyForReview: true }),
+      false,
+    );
+  });
+
+  test("a waiting projection cannot hide review readiness from retirement", () => {
+    const activity = deriveWorkspaceActivity({
+      starting: false,
+      started: true,
+      waiting: true,
+      busy: false,
+      workPlanReadyForReview: true,
+    });
+    assert.equal(activity, "waiting", "waiting still wins in the selector");
+    assert.equal(
+      shouldRetireWorkspace({ timeoutMs: 30_000, now: 100_000, lastUsedAt: 0, watched: false, busy: false, readyForReview: true }),
+      false,
+      "retirement consumes the underlying plan fact rather than the projected activity",
+    );
+  });
+});
+
+describe("workspace activity projection", () => {
+  const state = {
+    starting: false,
+    started: true,
+    waiting: false,
+    busy: false,
+    workPlanReadyForReview: false,
+  };
+
+  test("applies lifecycle and attention precedence before review readiness", () => {
+    assert.equal(deriveWorkspaceActivity({ ...state, starting: true, started: false, waiting: true, busy: true, workPlanReadyForReview: true }), "starting");
+    assert.equal(deriveWorkspaceActivity({ ...state, started: false, waiting: true, busy: true, workPlanReadyForReview: true }), "stopped");
+    assert.equal(deriveWorkspaceActivity({ ...state, waiting: true, busy: true, workPlanReadyForReview: true }), "waiting");
+    assert.equal(deriveWorkspaceActivity({ ...state, busy: true, workPlanReadyForReview: true }), "working");
+    assert.equal(deriveWorkspaceActivity({ ...state, workPlanReadyForReview: true }), "ready-for-review");
+    assert.equal(deriveWorkspaceActivity(state), "idle");
+  });
+
+  test("only actionable workspace activities use generic attention", () => {
+    assert.equal(workspaceActivityNeedsAttention("waiting"), true);
+    assert.equal(workspaceActivityNeedsAttention("ready-for-review"), true);
+    for (const activity of ["stopped", "starting", "working", "idle"] as const) {
+      assert.equal(workspaceActivityNeedsAttention(activity), false);
+    }
   });
 });
 

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -358,7 +358,7 @@ export interface TreeNode {
 /**
  * What a project is doing, for the selector to show without subscribing to it.
  *
- * Deliberately five named states rather than a pair of booleans: "stopped" and
+ * Deliberately six named states rather than a pair of booleans: "stopped" and
  * "idle" differ in whether a session exists, "working" and "waiting" differ in
  * whether anyone must act, and a client that had to infer those from flags would
  * have to encode the same rules the server already applies.
@@ -373,7 +373,9 @@ export type WorkspaceActivity =
   /** A turn is in flight — including while nobody is looking at it. */
   | "working"
   /** A turn is blocked on a question only the user can answer. */
-  | "waiting";
+  | "waiting"
+  /** Inactive, with an authoritative Work Plan whose completed result awaits review. */
+  | "ready-for-review";
 
 /**
  * One open project, as the selector sees it. Carries no conversation: a client
@@ -388,7 +390,7 @@ export interface WorkspaceInfo {
   /** Directory basename, for the selector's row. The path disambiguates two alike. */
   name: string;
   activity: WorkspaceActivity;
-  /** Whether a turn there is blocked on the user, whatever the client is bound to. */
+  /** Whether this workspace needs user attention, either to answer or to review. */
   needsAttention?: boolean;
 }
 

--- a/shared/src/workPlan.ts
+++ b/shared/src/workPlan.ts
@@ -41,6 +41,19 @@ export interface WorkPlan {
   updatedAt: string;
 }
 
+/**
+ * Whether the authoritative plan says background work is complete and awaits a
+ * human review. Every task participates, including parents: an unreconciled
+ * container must not make the workspace look finished just because one child is
+ * ready.
+ */
+export function isWorkPlanReadyForReview(plan: WorkPlan | null): boolean {
+  return plan !== null
+    && plan.tasks.length > 0
+    && plan.tasks.some((task) => task.status === "needs_review")
+    && plan.tasks.every((task) => task.status === "done" || task.status === "needs_review");
+}
+
 export const WORK_PLAN_LIMITS = {
   // `action=get` returns the complete plan to the model after resume/compaction.
   // Keep that recovery state useful without letting it refill an entire context.

--- a/ui/src/components/ProjectMenu.test.tsx
+++ b/ui/src/components/ProjectMenu.test.tsx
@@ -39,6 +39,7 @@ describe("what the selector offers", () => {
         workspace(),
         workspace({ root: "/srv/beta", name: "beta", activity: "working" }),
         workspace({ root: "/srv/gamma", name: "gamma", activity: "stopped" }),
+        workspace({ root: "/srv/delta", name: "delta", activity: "ready-for-review", needsAttention: true }),
       ],
     });
 
@@ -49,6 +50,7 @@ describe("what the selector offers", () => {
       ["alpha", "/srv/alpha", "idle"],
       ["beta", "/srv/beta", "working"],
       ["gamma", "/srv/gamma", "stopped"],
+      ["delta", "/srv/delta", "ready for review"],
     ]) {
       expect(within(menu).getByText(name)).toBeInTheDocument();
       // The path is what separates two projects sharing a basename.
@@ -135,21 +137,26 @@ describe("what a pinned server offers", () => {
 });
 
 describe("attention, without interrupting anyone", () => {
-  it("counts the waiting projects on the button", () => {
+  it("counts actionable projects without interrupting focus", () => {
+    const focus = document.createElement("input");
+    document.body.append(focus);
+    focus.focus();
     setup({
       workspaces: [
         workspace(),
         workspace({ root: "/srv/beta", name: "beta", activity: "waiting", needsAttention: true }),
-        workspace({ root: "/srv/gamma", name: "gamma", activity: "waiting", needsAttention: true }),
+        workspace({ root: "/srv/gamma", name: "gamma", activity: "ready-for-review", needsAttention: true }),
       ],
     });
 
     const button = screen.getByRole("button", { expanded: false });
     expect(button).toHaveTextContent("2");
     // The badge is the only change to the current project's screen: no dialog,
-    // no focus move — there is nothing else here to render.
+    // no focus move.
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(document.activeElement).toBe(focus);
+    focus.remove();
   });
 
   it("names the waiting project in words once the menu is open", () => {
@@ -160,6 +167,25 @@ describe("attention, without interrupting anyone", () => {
     fireEvent.click(screen.getByRole("button", { expanded: false }));
     const row = within(screen.getByRole("menu")).getByText("beta").closest("div")!;
     expect(within(row).getByText("waiting for you")).toBeInTheDocument();
+  });
+
+  it("counts mixed attention and distinguishes every review-ready workspace", () => {
+    const active = workspace({ activity: "ready-for-review", needsAttention: true });
+    setup({
+      workspace: active,
+      workspaces: [
+        active,
+        workspace({ root: "/srv/beta", name: "beta", activity: "waiting", needsAttention: true }),
+        workspace({ root: "/srv/gamma", name: "gamma", activity: "ready-for-review", needsAttention: true }),
+      ],
+    });
+
+    const button = screen.getByRole("button", { expanded: false });
+    expect(button).toHaveTextContent("3");
+    expect(button).toHaveAttribute("title", "Project: alpha (ready for review)");
+    fireEvent.click(button);
+    expect(within(screen.getByRole("menu")).getAllByText("ready for review")).toHaveLength(2);
+    expect(within(screen.getByRole("menu")).getByText("waiting for you")).toBeInTheDocument();
   });
 });
 

--- a/ui/src/components/ProjectMenu.tsx
+++ b/ui/src/components/ProjectMenu.tsx
@@ -8,9 +8,9 @@
  *  - **No monograms.** The full name carries identity and the path disambiguates
  *    two projects with the same basename; an initial would cost the reader a
  *    decoding step for something the name already says.
- *  - **The state is a word, not only a colour.** The dot repeats it, and the five
+ *  - **The state is a word, not only a colour.** The dot repeats it, and the six
  *    marks differ in SHAPE — dashed ring, spinning arc, small dot, pulsing halo,
- *    glyph — so the column is legible in greyscale.
+ *    diamond, glyph — so the column is legible in greyscale.
  *
  * Absent entirely while a single project is open: nothing new appears in a header
  * that already carries seven controls until there is something to choose.
@@ -34,6 +34,7 @@ const LABELS: Record<WorkspaceActivity, string> = {
   idle: "idle",
   working: "working",
   waiting: "waiting for you",
+  "ready-for-review": "ready for review",
 };
 
 /** The state mark. Shape first, colour second — see the file header. */
@@ -56,6 +57,8 @@ function ActivityMark({ activity }: { activity: WorkspaceActivity }) {
       );
     case "waiting":
       return <span className="h-2 w-2 shrink-0 rounded-full bg-amber-500" />;
+    case "ready-for-review":
+      return <span className="h-2 w-2 shrink-0 rotate-45 rounded-[1px] border-2 border-violet-600 bg-violet-100 dark:border-violet-400 dark:bg-violet-950" />;
     default:
       return <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-zinc-400 dark:bg-zinc-600" />;
   }
@@ -67,6 +70,16 @@ function AttentionGlyph({ className }: { className: string }) {
     <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" aria-hidden="true">
       <path d="M12 6v7" />
       <path d="M12 18h.01" />
+    </svg>
+  );
+}
+
+/** A review sheet, distinct from the blocking-question exclamation. */
+function ReviewGlyph({ className }: { className: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M7 3h10v18H7z" />
+      <path d="m9.5 12 1.7 1.7 3.5-3.7" />
     </svg>
   );
 }
@@ -107,7 +120,7 @@ export function ProjectMenu(props: ProjectMenuProps) {
   if (!workspace) return null;
 
   const others = workspaces.filter((w) => w.root !== workspace.root);
-  const waiting = workspaces.filter((w) => w.needsAttention);
+  const attention = workspaces.filter((w) => w.needsAttention);
 
   return (
     <div ref={rootRef} className="relative">
@@ -118,17 +131,17 @@ export function ProjectMenu(props: ProjectMenuProps) {
         aria-haspopup="menu"
         title={`Project: ${workspace.name} (${LABELS[workspace.activity]})`}
         className={`flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs ${
-          waiting.length > 0
+          attention.length > 0
             ? "border-amber-500 bg-amber-50 text-zinc-700 dark:bg-amber-950/40 dark:text-zinc-200"
             : "border-zinc-400 bg-zinc-100 text-zinc-700 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-200"
         }`}
       >
         <ActivityMark activity={workspace.activity} />
         <span className="font-medium">{workspace.name}</span>
-        {waiting.length > 0 ? (
+        {attention.length > 0 ? (
           <span className="flex items-center gap-1 text-amber-600 dark:text-amber-500">
             <AttentionGlyph className="h-3 w-3" />
-            <span className="font-semibold">{waiting.length}</span>
+            <span className="font-semibold">{attention.length}</span>
           </span>
         ) : (
           // Muted dots: one per other open project, pulsing where an agent is
@@ -189,9 +202,9 @@ export function ProjectMenu(props: ProjectMenuProps) {
                 </button>
                 <span className="flex shrink-0 items-center gap-1.5">
                   {w.needsAttention ? (
-                    <span className="flex items-center gap-1 text-[11px] font-medium text-amber-600 dark:text-amber-500">
-                      <AttentionGlyph className="h-3 w-3" />
-                      {LABELS.waiting}
+                    <span className={`flex items-center gap-1 text-[11px] font-medium ${w.activity === "ready-for-review" ? "text-violet-700 dark:text-violet-400" : "text-amber-600 dark:text-amber-500"}`}>
+                      {w.activity === "ready-for-review" ? <ReviewGlyph className="h-3 w-3" /> : <AttentionGlyph className="h-3 w-3" />}
+                      {LABELS[w.activity]}
                     </span>
                   ) : (
                     <span className={`text-[11px] ${w.activity === "working" ? "text-blue-700 dark:text-blue-400" : "text-zinc-400 dark:text-zinc-500"}`}>

--- a/ui/src/useWorkspaceNotifications.test.ts
+++ b/ui/src/useWorkspaceNotifications.test.ts
@@ -42,7 +42,13 @@ describe("raising attention from a workspace nobody is watching", () => {
   it("stays silent while the document is in the foreground", () => {
     setVisibility("visible");
     renderHook(() =>
-      useWorkspaceNotifications([workspace({ root: "/srv/beta", name: "beta", activity: "waiting", needsAttention: true })], "/srv/alpha"),
+      useWorkspaceNotifications(
+        [
+          workspace({ root: "/srv/beta", name: "beta", activity: "waiting", needsAttention: true }),
+          workspace({ root: "/srv/gamma", name: "gamma", activity: "ready-for-review", needsAttention: true }),
+        ],
+        "/srv/alpha",
+      ),
     );
 
     // The selector's badge is the whole of it: interrupting someone who is
@@ -67,6 +73,30 @@ describe("raising attention from a workspace nobody is watching", () => {
     expect(raised.map((n) => n.options?.tag)).toEqual(["pi-outpost:/srv/beta", "pi-outpost:/srv/gamma"]);
   });
 
+  it("distinguishes ready workspaces without including plan content", () => {
+    renderHook(() =>
+      useWorkspaceNotifications(
+        [
+          workspace({ root: "/srv/beta", name: "beta", activity: "ready-for-review", needsAttention: true }),
+          workspace({ root: "/srv/gamma", name: "gamma", activity: "waiting", needsAttention: true }),
+        ],
+        "/srv/alpha",
+      ),
+    );
+
+    expect(raised).toEqual([
+      {
+        title: "beta is ready for review",
+        options: { body: "Background work is ready for review.", tag: "pi-outpost:/srv/beta" },
+      },
+      {
+        title: "gamma needs you",
+        options: { body: "The agent needs an answer to continue.", tag: "pi-outpost:/srv/gamma" },
+      },
+    ]);
+    expect(JSON.stringify(raised)).not.toMatch(/task|artifact|result/i);
+  });
+
   it("says nothing about the project the user is already looking at", () => {
     renderHook(() =>
       useWorkspaceNotifications([workspace({ activity: "waiting", needsAttention: true })], "/srv/alpha"),
@@ -89,6 +119,31 @@ describe("raising attention from a workspace nobody is watching", () => {
     rerender({ list: [workspace({ root: "/srv/beta", name: "beta", activity: "working" })] });
     rerender({ list: [...waiting] });
     expect(raised).toHaveLength(2);
+  });
+
+  it("does not clear review notification deduplication when the workspace is selected", () => {
+    const ready = [workspace({ root: "/srv/beta", name: "beta", activity: "ready-for-review", needsAttention: true })];
+    const { rerender } = renderHook(
+      ({ activeRoot }) => useWorkspaceNotifications(ready, activeRoot),
+      { initialProps: { activeRoot: "/srv/alpha" } },
+    );
+    expect(raised).toHaveLength(1);
+
+    rerender({ activeRoot: "/srv/beta" });
+    rerender({ activeRoot: "/srv/alpha" });
+    expect(raised).toHaveLength(1);
+
+    rerender({ activeRoot: "/srv/alpha" });
+    expect(raised).toHaveLength(1);
+  });
+
+  it("notifies again when the authoritative attention kind changes", () => {
+    const { rerender } = renderHook(({ list }) => useWorkspaceNotifications(list, "/srv/alpha"), {
+      initialProps: { list: [workspace({ root: "/srv/beta", name: "beta", activity: "waiting", needsAttention: true })] },
+    });
+    rerender({ list: [workspace({ root: "/srv/beta", name: "beta", activity: "ready-for-review", needsAttention: true })] });
+
+    expect(raised.map((notification) => notification.title)).toEqual(["beta needs you", "beta is ready for review"]);
   });
 
   it("never asks for permission on its own", () => {

--- a/ui/src/useWorkspaceNotifications.ts
+++ b/ui/src/useWorkspaceNotifications.ts
@@ -6,7 +6,7 @@
  *
  *  - document in the foreground: the selector's badge alone. Nothing moves,
  *    nothing opens, the focus stays where it is.
- *  - document unattended: the badge plus one notification PER waiting project,
+ *  - document unattended: the badge plus one notification PER attention episode,
  *    each naming its own — a notification that does not say where to click cannot
  *    be acted on, so a coalesced "2 projects need you" would be worse than none.
  *  - never: a modal over the project the user is currently looking at. A question
@@ -16,18 +16,19 @@ import { useEffect, useRef } from "react";
 import type { WorkspaceInfo } from "@pi-outpost/shared";
 
 export function useWorkspaceNotifications(workspaces: WorkspaceInfo[], activeRoot: string | null): void {
-  /** Roots already notified, so one blocked turn raises one notification. */
-  const notified = useRef<Set<string>>(new Set());
+  /** Last attention kind notified per root; selecting a root does not clear it. */
+  const notified = useRef<Map<string, WorkspaceInfo["activity"]>>(new Map());
 
   useEffect(() => {
     if (typeof Notification === "undefined") return;
 
-    const waiting = workspaces.filter((w) => w.needsAttention && w.root !== activeRoot);
+    const attention = workspaces.filter((workspace) => workspace.needsAttention);
+    const backgroundAttention = attention.filter((workspace) => workspace.root !== activeRoot);
 
-    // Cleared as soon as a project stops waiting, so the NEXT question there
-    // notifies again rather than being swallowed as a duplicate.
-    for (const root of [...notified.current]) {
-      if (!waiting.some((w) => w.root === root)) notified.current.delete(root);
+    // Cleared only by an authoritative activity update that ends attention. Merely
+    // selecting the project removes it from `backgroundAttention`, not from here.
+    for (const root of [...notified.current.keys()]) {
+      if (!attention.some((workspace) => workspace.root === root)) notified.current.delete(root);
     }
 
     // Asking is the user's call to make; never prompt for permission on our own.
@@ -36,12 +37,13 @@ export function useWorkspaceNotifications(workspaces: WorkspaceInfo[], activeRoo
     // is looking at the app is the level this design refuses.
     if (typeof document !== "undefined" && document.visibilityState === "visible") return;
 
-    for (const workspace of waiting) {
-      if (notified.current.has(workspace.root)) continue;
-      notified.current.add(workspace.root);
+    for (const workspace of backgroundAttention) {
+      if (notified.current.get(workspace.root) === workspace.activity) continue;
+      notified.current.set(workspace.root, workspace.activity);
       try {
-        new Notification(`${workspace.name} needs you`, {
-          body: "The agent needs an answer to continue.",
+        const readyForReview = workspace.activity === "ready-for-review";
+        new Notification(readyForReview ? `${workspace.name} is ready for review` : `${workspace.name} needs you`, {
+          body: readyForReview ? "Background work is ready for review." : "The agent needs an answer to continue.",
           // One notification per project, replaced rather than stacked if that
           // project asks again.
           tag: `pi-outpost:${workspace.root}`,


### PR DESCRIPTION
## Summary

- derive a distinct `ready-for-review` workspace activity from the synchronized, session-matched authoritative Work Plan
- surface simultaneous ready workspaces through generic attention metadata, the project selector, and content-free browser notifications without clearing readiness on selection
- preserve activity precedence and workspace isolation, and retain review-ready workspaces across idle retirement
- add server, UI, and running-app coverage plus an assertion-level OpenSpec scenario matrix

## Verification

- `npm run test --workspace server` — 1,679 passed; the subsequently added background `working` → `ready-for-review` isolation test also passes targeted
- `npm run test --workspace ui` — 1,403 passed
- `npm run typecheck`
- `npm run build`
- `npm run test:e2e` — 58 passed
- `npx openspec validate add-workspace-ready-for-review --strict`
- `npx openlore drift --base origin/main --json --fail-on error` — no error-severity drift

## Documentation impact

Updated:

- `README.md` — project activity states, attention/privacy behavior, retirement, and Work Plan-derived review readiness
- `docs/how-to.md` — multi-project ready-for-review flow, acknowledgement, notifications, and retention
- `docs/development.md` — real-app Playwright workflow for visible and multi-project behavior
- `server/test/README.md` — integration-suite ownership for Work Plan activity, isolation, and retirement
- `docs/design/multi-project-selector/README.md`, `States.dc.html`, and `canvas.json` — six-state selector inventory and the distinct review-ready visual language
- `openspec/changes/add-workspace-ready-for-review/verification.md` — complete main/delta scenario-to-test evidence

Validation performed:

- checked local Markdown links in all five affected Markdown documents
- parsed `docs/design/multi-project-selector/canvas.json`
- searched user/developer READMEs, guides, examples, and design sources for stale workspace-state, attention, notification, retirement, Work Plan, and test-workflow claims
- exercised the selector in the built app with Playwright and verified its DOM state and content isolation
