### PR TITLE
chore(release): v0.18.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-outpost",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "type": "module",
   "description": "A web interface for the pi coding agent: a browser chat UI you run with npx — no clone, no build.",
   "license": "MIT",

--- a/embed/package.json
+++ b/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-outpost/embed",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "type": "module",
   "description": "Mount pi-outpost as a Shadow-DOM-isolated widget inside another web app.",
   "license": "MIT",
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.58.9",
     "@pi-outpost/shared": "*",
+    "@pi-outpost/ui": "*",
     "@tailwindcss/vite": "^4.3.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
@@ -74,7 +75,6 @@
     "tailwindcss": "^4.3.2",
     "typescript": "~6.0.2",
     "vite": "^8.1.1",
-    "vite-plugin-dts": "^5.0.3",
-    "@pi-outpost/ui": "*"
+    "vite-plugin-dts": "^5.0.3"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "cli": {
       "name": "pi-outpost",
-      "version": "0.17.1",
+      "version": "0.18.0",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "^0.84.4",
@@ -42,7 +42,7 @@
     },
     "embed": {
       "name": "@pi-outpost/embed",
-      "version": "0.17.1",
+      "version": "0.18.0",
       "license": "MIT",
       "devDependencies": {
         "@microsoft/api-extractor": "^7.58.9",


### PR DESCRIPTION
Bumps `@pi-outpost/cli` and `@pi-outpost/embed` to **0.18.0**.

A minor rather than a patch: three features have landed since 0.17.1, and a patch number would misdescribe them.

## What is in it

**Per-repository git (#140).** A workspace resolves a repository per path instead of holding one. A directory of independently versioned projects — nothing at the root, one repository per child — used to get no git surface at all; it now gets badges across every repository, per-file diffs and history, and a branch chip that follows what you touch in the tree. Includes the follow-ups found by driving it: a commit log that could render under another project's name, and a menu that sat on "loading…" when the selection moved beneath it.

**Git is found, and its absence is explained (#142).** Resolved from `gitPath`, then `PATH`, then the platform's standard install locations — because git is routinely installed and absent from the `PATH` a server process inherits, which used to remove the whole git surface silently. When it is unavailable, Settings now says which of three things is true: the executable could not be run, the workspace holds no repository, or git refused it — carrying git's own message, which for "detected dubious ownership" names both the directory and the remedy. A repository the disk claims but git will not read no longer counts as available.

**Declared thinking levels (#143).** `thinkingLevels` lets a deployment state what its model accepts, for a model the runtime cannot describe. Provider-wide or per model, authoritative over the runtime's guess, and `set_thinking` refuses a level outside a declared set.

Also: `AGENTS.md`/`CLAUDE.md` now require a destructive pass in the running app, not only the happy path — both UI defects above were found that way, with green suites over them.

## Verification

```
server      1751 pass / 0 fail
ui          1427 pass / 0 fail
typecheck   green · lint green
check:cli   ok — the tarball carries 2 build inputs
check:embed 6 entry points present and published, mount() exported, React external
openspec    43 of 44 valid
```

One server run out of three showed a single intermittent failure whose name did not survive the output; two subsequent full runs were clean, and CI on all three PRs was green. The known intermittent in this suite is `file-lifecycle` under load, tracked separately.

The remaining openspec failure is `integrate-openlore-per-workspace`, an in-progress change untouched by this release: its `MODIFIED "IsolateWorkspacesFromEachOther"` block predates the `RepositoriesArePerWorkspace` scenario #140 added, and archiving it as-is would drop that scenario. Worth fixing before that change is archived.

## Not done here

Tagging. `v0.18.0` pushed as a tag is what triggers the publish workflow — that is the outward-facing, irreversible half, and it is yours to make. After this merges:

```
git tag v0.18.0 && git push origin v0.18.0
```

## Documentation impact

None beyond the version numbers. The user-facing documentation for all three features shipped with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JpDnwLWKe5zYdPdhzhvKde
