### PR TITLE
feat(work-plan): structured task evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,10 +671,27 @@ switching to the project does not clear it: tell the agent what you accept or wh
 Accepted review tasks move to `done`; meaningful resumed work moves the relevant task back to
 an active state, so the project stops being ready until it reaches the review boundary again.
 
+Tasks can also carry agent-owned verification or supporting evidence. Each generic record has
+an `id`, a free-form `type`, a `result` (`passed`, `failed`, `inconclusive` or
+`informational`), and at least a concise `summary` or a resource `reference`. The agent replaces
+one task's complete evidence collection with `set_evidence`, preserving older failures when it
+wants to append another result:
+
+```json
+{"action":"set_evidence","taskId":"build","evidence":[{"id":"tests","type":"test","result":"passed","summary":"Focused tests passed"},{"id":"probe","type":"external-check","result":"failed","summary":"External probe failed"}]}
+```
+
+Evidence and status are deliberately independent: evidence never completes or blocks a task,
+and marking a task `done` never fabricates evidence. Pi Outpost does not automatically turn tool
+activity into evidence or add an Outcome/Review UI; agents record evidence explicitly through
+the structured tool.
+
 Each plan is stored beside its session file. It is restored on reconnect and session resume,
 replaced when the active session changes, copied when a conversation is forked, and
 independent thereafter. Compaction summarizes conversational context only: it never alters
-the plan. Sessions created before Work Plans open without a panel.
+the plan or its evidence. Existing version-1 plans and task inputs without evidence remain valid
+and normalize to empty evidence collections. Sessions created before Work Plans open without a
+panel.
 
 ## Development
 

--- a/openspec/changes/work-plan-evidence-and-verification/.openspec.yaml
+++ b/openspec/changes/work-plan-evidence-and-verification/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-01

--- a/openspec/changes/work-plan-evidence-and-verification/design.md
+++ b/openspec/changes/work-plan-evidence-and-verification/design.md
@@ -1,0 +1,86 @@
+## Context
+
+See `proposal.md` for motivation, `specs/work-plan/spec.md` for the behavioral contract, and `specs/model/spec.md` for the authoritative protocol contract. The current Work Plan is a version-1 flat task graph in `shared/src/workPlan.ts`; the same shared value is validated into a session sidecar, copied on fork, restored on session selection, carried in initial/session snapshots, and broadcast in full after accepted mutations. The agent reaches it through one self-describing `work_plan` object schema whose action-specific requirements are enforced by the shared mutator.
+
+The OpenLore orientation identified the shared task validator/normalizer, `createWorkPlanToolDefinition`, the sidecar store, and the session/fork synchronization paths as the relevant surface. Its index was refreshing several Work Plan files, so the design also checked those source files and the current `work-plan` spec directly rather than relying on cached cross-module details.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Extend the canonical task value with bounded, provider-neutral evidence that can represent positive, negative, inconclusive, and informational results.
+- Keep one validation and normalization path for creation, replacement, mutation, restore, fork, and synchronization.
+- Give the agent an explicit atomic mutation for the complete evidence collection while retaining the current single-object tool-schema pattern and legible refusals.
+- Preserve version-1 compatibility and the 64 KiB recovery-context ceiling.
+- Prove behavior at shared-model, persistence, protocol synchronization, real provider, and running-app agent boundaries.
+
+**Non-Goals:**
+
+- Rendering an evidence or Outcome/Review interface, making evidence user-editable, or adding navigation beyond the existing generic resource resolver.
+- Running checks automatically, scraping tool results, linking evidence to transcript events, or changing a task status based on evidence.
+- An append-only audit log, evidence history, provider adapters, or an OpenLore integration.
+
+## Decisions
+
+### Evidence is embedded in each canonical task
+
+Add a `WorkPlanEvidence` value and an `evidence: WorkPlanEvidence[]` collection to `WorkPlanTask`. A record has:
+
+- `id`: non-empty bounded identity, unique within the owning task;
+- `type`: non-empty bounded free-form kind/source, rather than a provider enum;
+- `result`: `passed`, `failed`, `inconclusive`, or `informational`;
+- optional `summary`: bounded concise text;
+- optional `reference`: the existing `{ uri, label? }` generic resource shape.
+
+Validation requires at least one of `summary` or `reference`. The implementation should add explicit limits of 100 records per task, 100 characters for `type`, and 2,000 characters for `summary`; identifiers and references reuse existing Work Plan bounds. The complete serialized-plan limit remains the final authority.
+
+Embedding was chosen because evidence belongs to a task and all lifecycle paths already move the complete Work Plan. A separate evidence sidecar was rejected because it would introduce cross-file atomicity, fork coordination, and synchronization ordering for no independent lifecycle benefit. Provider-specific unions were rejected because every producer can map to the common type/result/summary/reference shape.
+
+### Preserve version 1 with read-time defaulting
+
+Keep `WorkPlan.version` at `1`. Every task parser and draft normalizer treats an omitted evidence property as `[]`, and canonical values returned from validation contain the array. New creation, normalized task-addition, and replacement schemas expose evidence as optional so calls and sidecars accepted before this change continue to validate. The next mutation naturally writes the canonical evidence-bearing form; no eager sidecar rewrite is needed.
+
+This is an additive compatible extension rather than a semantic replacement of the plan document, so a version-2 migration would add branching and rollback burden without protecting a changed invariant. Requiring evidence on serialized legacy tasks was rejected because it would make existing sessions unloadable.
+
+### One `set_evidence` action owns evidence mutation
+
+Extend `WORK_PLAN_ACTIONS` and `WorkPlanMutation` with `set_evidence`, requiring `taskId` and an `evidence` array. It replaces that task's complete collection, like `set_resources`; an empty array clears it. The mutator clones nested task state, validates every replacement record, preserves all other task fields, and commits only after `validateWorkPlan` accepts the complete next plan.
+
+One replacement action was chosen over provider-flavored actions and over separate add/update/remove operations. It keeps the already-large single tool schema small, gives deterministic correction/removal semantics, and makes atomicity obvious. Stable record IDs still let an agent read-modify-write a collection without confusing repeated checks. The system never filters failed records; removing or replacing them requires an explicit agent mutation.
+
+### Evidence and status have no coupling code path
+
+Evidence parsing and `set_evidence` update only the evidence collection. Existing status mutations continue to rebuild a task while carrying its evidence forward. No validator, store hook, tool-result listener, or prompt logic derives status from evidence or evidence from tool activity. Prompt guidance tells the agent to record verification deliberately and separately reconcile task status.
+
+Keeping independence structural, rather than relying only on prompt wording, prevents a passing check from silently completing work and prevents `done` from becoming a false assertion that verification occurred.
+
+### Reuse the existing full-plan lifecycle and synchronization contract
+
+The sidecar remains the only persisted artifact. Once evidence is part of the validated `WorkPlan`, existing load, atomic persist, copy-on-fork, compaction-independent `get`, initial/session snapshots, and `work_plan_changed` broadcasts carry it without a parallel channel. Protocol exports add the evidence/result types for downstream consumers, while UI components may ignore the new task field in this change.
+
+Lifecycle code should change only if tests reveal a path that reconstructs or narrows tasks. Focused tests must assert actual evidence values—including failed evidence—after restore, fork, reconnect, and multi-client synchronization, rather than only asserting task counts or statuses.
+
+### Keep the agent-facing schema finite and self-describing
+
+Add reusable TypeBox schemas for evidence result, reference, record, and collection. Expose the optional evidence collection in complete task shapes and creation tasks, plus the top-level `evidence` argument used by `set_evidence`. Continue using the single object schema with `additionalProperties: false`; runtime required-argument checks must name `taskId` or `evidence` when absent, and validation errors must retain paths into individual records.
+
+Update the tool description/guidelines with one literal valid `set_evidence` call and an explicit statement that evidence does not alter status. Do not add automatic producers. Because these descriptions influence agent behavior, verification includes a real running-app walkthrough in which an agent is asked to record both a successful and unsuccessful check, followed by reading the authoritative Work Plan. A second adversarial pass should rapidly issue evidence/status changes and switch or fork sessions while checking the DOM/session state for stale or cross-session evidence.
+
+## Risks / Trade-offs
+
+- [Replacement semantics can accidentally omit an older failure] → Describe `set_evidence` as complete replacement, return a legible refusal for malformed lists, and include prompt/test examples that preserve prior records when appending a new result.
+- [Evidence inflates the compact operational context returned after resume] → Bound records and fields while preserving the existing 64 KiB serialized-plan ceiling; test rejection at both collection and whole-plan limits.
+- [Legacy normalization can drop evidence during unrelated task mutation if nested copies are incomplete] → Centralize evidence parsing/cloning in the shared model and assert that status, move, dependency, resource, and task-update mutations preserve evidence.
+- [A failed result could be mistaken for task status] → Use the field name `result`, distinct enums, no coupling logic, explicit prompt language, and bidirectional independence tests.
+- [A generic type string is less analytically uniform than a fixed provider taxonomy] → Prefer forward compatibility and keep the four result semantics stable; future producers may establish conventions without changing the persisted schema.
+- [Older binaries ignore the additive field and may erase it on a subsequent write after rollback] → No data migration is required, but deployment rollback guidance should preserve sidecars or avoid mutating evidence-bearing sessions until the evidence-capable build is restored.
+
+## Migration Plan
+
+1. Add shared evidence types, bounds, validation/defaulting, deep-copy preservation, and `set_evidence` mutation while retaining version `1`.
+2. Extend the typed tool schema, required-argument diagnostics, prompt guidance, and shared protocol exports.
+3. Add focused compatibility, atomicity, independence, lifecycle, provider, and synchronization tests; then exercise the tool through the running application and its actual agent boundary.
+4. Update Work Plan user/developer documentation to describe evidence and its independence from completion.
+5. Deploy without rewriting sidecars. Existing plans gain empty evidence arrays when read and are persisted canonically on their next accepted mutation.
+
+Rollback requires no schema downgrade or database operation. Restore the prior build; preserve evidence-bearing sidecars if evidence must survive the rollback window, because an older build may ignore and later overwrite the additive fields.

--- a/openspec/changes/work-plan-evidence-and-verification/proposal.md
+++ b/openspec/changes/work-plan-evidence-and-verification/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Work Plans can describe what an agent intends to do and whether a task is complete, but they cannot retain the verification facts behind that status. Adding structured task evidence makes successful, failed, and inconclusive checks durable and inspectable without turning the plan into a verifier or deriving completion from activity.
+
+## What Changes
+
+- Add zero or more generic, structured evidence records to each Work Plan task, including stable identity, evidence kind/source, verification result, a concise summary, and an optional supporting reference.
+- Extend the agent-facing Work Plan operations and schema so agents can attach, replace, and remove task evidence atomically.
+- Keep evidence and task status independent: neither evidence mutations nor status mutations synthesize changes in the other.
+- Preserve evidence through normalization, persistence, restoration, full-plan replacement, session forks, compaction-independent reads, and authoritative Work Plan synchronization.
+- Retain failed and inconclusive evidence alongside successful evidence so unsuccessful verification remains visible.
+- Continue accepting existing version-1 Work Plans and creation inputs that omit evidence, defaulting missing task evidence to an empty collection.
+- Keep evidence provider-neutral so tests, commands, files, tool results, external checks, OpenLore, and future integrations can all produce the same model without provider-specific fields.
+- Do not add automatic verification, Outcome/Review UI, an OpenLore dependency, or inference of task completion from tool activity.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `work-plan`: Add structured, agent-owned task evidence; evidence mutation semantics; lifecycle preservation; independence from task status; and backward compatibility for plans without evidence.
+- `model`: Carry task evidence and its result through authoritative Work Plan snapshots and broadcasts without provider-specific protocol fields.
+
+## Impact
+
+- Shared Work Plan types, normalization, validation, limits, and mutation logic in `shared/src/workPlan.ts`, plus shared protocol exports.
+- The `work_plan` tool's typed schema, descriptions, examples, and execution behavior in `server/src/workPlanTool.ts` and system guidance where needed.
+- Existing sidecar persistence, session restoration/forking, compaction-independent reads, and full-snapshot synchronization must carry the expanded task model without introducing a separate evidence store.
+- Unit, tool-schema/provider, real RPC, persistence/fork, and server synchronization tests must cover evidence and status independence, failed evidence retention, lifecycle propagation, atomic refusal, and legacy inputs.
+- User-facing Work Plan documentation must describe evidence ownership and independence from completion; no new runtime dependency or UI surface is introduced.

--- a/openspec/changes/work-plan-evidence-and-verification/scenario-coverage.md
+++ b/openspec/changes/work-plan-evidence-and-verification/scenario-coverage.md
@@ -1,0 +1,102 @@
+# Scenario-to-test matrix
+
+Scenarios were enumerated with `rg '^#### Scenario:' openspec/specs/{work-plan,model}/spec.md openspec/changes/work-plan-evidence-and-verification/specs/{work-plan,model}/spec.md`. “Covered” means the cited assertions exercise the observable boundary, not merely the test title. The running-app checks used the real web application and provider boundary, then compared the DOM, tool-result transcript, and persisted sidecars.
+
+## Applicable main Work Plan scenarios
+
+| Scenario | Coverage | Assertion evidence |
+| --- | --- | --- |
+| Progressive decomposition | covered | `server/test/work-plan.test.ts` — “progressively decomposes a task without changing its identity” asserts the stable parent identity and inserted child relationship. |
+| Blocked work is explained | covered | `ui/src/components/WorkPlanPanel.test.tsx` — “shows hierarchy, distinct states, focus, and aggregate progress” inspects the blocked state and reason. |
+| Atomic task update | covered | `server/test/work-plan.test.ts` — “rejects invalid hierarchy and dependency cycles without changing the input” and “returns authoritative details and refuses a partial invalid mutation” compare the pre/post state. |
+| Activity does not complete work | covered | `server/test/work-plan-server.test.mjs` — “running server restores, forks, reconnects, and broadcasts authoritative Work Plans” performs an unrelated read and asserts status remains unchanged. |
+| Reconcile before completion | covered | Prompt composition is asserted by `server/test/work-plan.test.ts` — “ships valid evidence guidance with explicit replacement and status independence”. In the running app, the actual provider recorded passed and failed evidence while the task was still `todo`, changed status in a separate call, then issued `get`; DOM, expanded tool result, transcript, and sidecar agreed. |
+| Resume interrupted work | covered | `server/test/work-plan-server.test.mjs` — initial and reconnect snapshots compare the restored authoritative plan. |
+| Compaction preserves the plan | covered | `server/test/work-plan-server.test.mjs` rewrites the transcript, then compares the separate sidecar and reconnect snapshot. |
+| Agent reads the plan after compaction | covered | `server/test/work-plan-server.test.mjs` requires a post-compaction `get` and asserts the returned authoritative evidence-bearing plan. |
+| Readable overview | covered | `ui/src/components/WorkPlanPanel.test.tsx` — “shows hierarchy, distinct states, focus, and aggregate progress” asserts the user-visible summary boundary. |
+| Preview a collapsed plan | covered | `ui/src/components/WorkPlanPanel.test.tsx` — “previews task lines from the collapsed progress control before opening details”; `e2e/work-plan.spec.ts` exercises the collapsed control. |
+| Navigate a resource | covered | `ui/src/components/WorkPlanPanel.test.tsx` — resource navigation and safety tests; `e2e/work-plan.spec.ts` opens a real workspace resource. |
+| Creation schema declares its complete input | covered | `server/test/work-plan.test.ts` — “publishes a bounded action-specific schema with no unconstrained payload” recursively checks the serialized creation schema. |
+| Mutation branches require their own arguments | covered | The same schema test asserts each branch’s action-specific `required` array. |
+| A refusal names the field it refuses | covered | `server/test/work-plan.test.ts` — “refuses an action whose own argument is missing, by name” and “answers a refused property by naming it”. |
+| Clearing optional values is discoverable | covered | `server/test/work-plan.test.ts` — “clears optional task text through JSON null” and the serialized schema assertions. |
+| The tool carries a worked example | covered | `server/test/work-plan.test.ts` — “ships a worked example the model can copy” and “ships valid evidence guidance…” validate literal calls against the contract. |
+| Create a minimal plan | covered | `server/test/work-plan.test.ts` — “normalizes a minimal creation draft into a canonical version-1 plan” checks exact defaults. |
+| Create direct subtasks | covered | `server/test/work-plan.test.ts` — “preserves explicit fields and flattens tasks plus one subtask level” checks parent wiring. |
+| A plan is created with its dependencies | covered | `server/test/work-plan.test.ts` — “creates a plan that already carries its dependencies” checks canonical IDs. |
+| A dependency may name a task declared later | covered | `server/test/work-plan.test.ts` — “resolves a dependency on a task declared further down”. |
+| An unresolvable dependency is refused by name | covered | `server/test/work-plan.test.ts` — “names the dependency it cannot resolve” checks the diagnostic and atomic refusal. |
+| The agent names its own tasks | covered | `server/test/work-plan.test.ts` — “honours a task id the agent supplies and generates the rest”. |
+| Duplicate supplied identity is rejected atomically | covered | `server/test/work-plan.test.ts` — “rejects a duplicate supplied id without persisting anything”. |
+| Creation limits are discoverable and atomic | covered | `server/test/work-plan.test.ts` — bounded schema plus depth, count, generated-ID, serialized-size, and no-sidecar assertions. |
+| Explicit task fields survive normalization | covered | `server/test/work-plan.test.ts` — “preserves explicit fields…” compares status, text, resources, and hierarchy. |
+| Persistence mechanics stay out of the creation input | covered | `server/test/work-plan.test.ts` — “rejects persistence fields in the ergonomic draft” and serialized schema inspection. |
+| Creation returns usable task identities | covered | `server/test/work-plan.test.ts` — “creates once from a compact hierarchy and returns the bounded authoritative plan”. |
+| Creation does not overwrite an existing plan | covered | The same tool test attempts a second create and compares the stored plan unchanged. |
+| Invalid nested creation is atomic | covered | `server/test/work-plan.test.ts` — “does not create a sidecar when any nested creation task is invalid”. |
+| Existing task addition remains accepted | covered | `server/test/work-plan.test.ts` — legacy compatibility test; real RPC and embedded-provider tests execute `add_task`. |
+| Duplicate task identity is rejected atomically | covered | `server/test/work-plan.test.ts` — “rejects a duplicate add_task identity without changing the plan”. |
+| Existing full replacement remains accepted | covered | `server/test/work-plan.test.ts` — “keeps normalized version-1 replacement compatible”. |
+| Typed update preserves unspecified fields | covered | `server/test/work-plan.test.ts` — “keeps every unspecified field in a typed partial update”. |
+| An operation that names a task refuses to run without one | covered | `server/test/work-plan.test.ts` — “refuses an action whose own argument is missing, by name”. |
+| A payload-carrying operation refuses to run empty | covered | The same test covers empty add, replace, dependency, resource, and evidence payloads. |
+| An update that changes nothing is refused | covered | `server/test/work-plan.test.ts` tool-validation assertions reject a task-only update. |
+| Changed fields are accepted beside the task identifier | covered | `server/test/work-plan.test.ts` — “accepts changed fields beside the task identifier”. |
+| An explicit changes object still wins | covered | The same test asserts the nested `changes` values take precedence. |
+| Identity cannot be changed through either shape | covered | `server/test/work-plan.test.ts` — “refuses task identity supplied at either level of an update”. |
+
+## Delta evidence scenarios
+
+| Scenario | Coverage | Assertion evidence |
+| --- | --- | --- |
+| Attach successful verification | covered | `server/test/work-plan.test.ts` — “preserves generic successful, unsuccessful, and supporting evidence” compares the passed record exactly. |
+| Retain unsuccessful verification | covered | The same test compares failed and inconclusive records; mutation/persistence tests retain them through later operations. |
+| Reference supporting information | covered | The same test accepts a reference-only generic URI/label and the schema test validates that shape. |
+| Reject an uninformative evidence record atomically | covered | `server/test/work-plan.test.ts` — “rejects invalid or duplicate evidence atomically” compares the input plan after refusal. |
+| Reject duplicate evidence identity atomically | covered | The same test rejects duplicate per-task IDs without mutation. |
+| Passing evidence does not complete a task | covered | `server/test/work-plan.test.ts` — “replaces and clears evidence without inferring task status”. |
+| Failed evidence does not block a task automatically | covered | The same test records failed evidence on a done task and asserts status remains done. |
+| Completion does not fabricate evidence | covered | The same test updates status independently and asserts `evidence: []`; unrelated-mutation preservation covers existing evidence. |
+| Status edits preserve recorded failures | covered | `server/test/work-plan.test.ts` — “preserves evidence through every unrelated task mutation” deep-compares failed evidence. |
+| Create a task with evidence | covered | `server/test/work-plan.test.ts` — successful/unsuccessful/supporting evidence normalization; RPC/provider integration persists exact records. |
+| Create a task without evidence | covered | `server/test/work-plan.test.ts` — minimal creation and legacy compatibility assert canonical `evidence: []`. |
+| Restore a legacy version-1 plan | covered | `server/test/work-plan.test.ts` — “loads a legacy version-1 sidecar with empty canonical evidence”. |
+| Evidence limits are discoverable and atomic | covered | `server/test/work-plan.test.ts` — “enforces evidence collection and field limits before the whole-plan limit” plus finite schema checks. |
+| Replace a task's evidence | covered | `server/test/work-plan.test.ts` — “replaces and clears evidence without inferring task status” asserts complete replacement. |
+| Remove all task evidence | covered | The same test passes `[]` and asserts the collection is empty while status is unchanged. |
+| Missing evidence arguments are refused by name | covered | `server/test/work-plan.test.ts` — “refuses missing or invalid evidence replacements…” asserts `taskId`/`evidence` diagnostics. |
+| Invalid replacement does not discard prior evidence | covered | The same test and the persisted-server test compare exact prior evidence and raw sidecar after refusal. |
+| Progressive decomposition | covered | `server/test/work-plan.test.ts` — decomposition identity test plus “preserves evidence through every unrelated task mutation”. |
+| Blocked work is explained | covered | UI blocked-reason assertion remains unchanged; evidence mutation test separately proves failed evidence does not infer blocked status. |
+| Tasks may have no evidence | covered | Minimal and legacy normalization tests assert an empty canonical collection. |
+| Atomic task update | covered | Shared and persisted-server invalid replacement tests compare plan, sidecar, and broadcast state unchanged. |
+| Activity does not complete work | covered | Running-server unrelated-read assertion keeps task status unchanged while exact evidence is retained. |
+| Reconcile before completion | covered | Guidance tests require explicit passed/failed/inconclusive recording. The running-app agent issued `set_evidence` with exact passed and failed records, then a separate `update_task`, then `get`; the intermediate transcript proves evidence did not infer status. |
+| Activity does not fabricate evidence | covered | `server/test/work-plan-server.test.mjs` performs unrelated activity and asserts no evidence or status mutation is broadcast or persisted. |
+| Resume interrupted work | covered | Persistence and reconnect assertions compare exact successful, failed, and inconclusive records. |
+| Fork preserves independent evidence | covered | `server/test/work-plan.test.ts` mutates source and fork both ways after copying; running-server test checks source isolation. |
+| Existing task addition remains accepted | covered | Legacy compatibility and real provider-boundary sequences execute evidence-free `add_task`. |
+| Duplicate task identity is rejected atomically | covered | Duplicate add test compares evidence-bearing input unchanged. |
+| Existing full replacement remains accepted | covered | Legacy version-1 replacement normalizes missing evidence; evidence-bearing normalized plans round-trip exactly. |
+| Typed update preserves unspecified fields | covered | Partial-update and unrelated-mutation tests deep-compare nested evidence. |
+| Evidence synchronizes as authoritative task state | covered | Server initial restore, compaction, reconnect, replacement, and multi-client assertions compare exact evidence. In the running app, two rapid mutation sequences produced distinct plan/task IDs; rapid switches exposed only the selected session’s ID, a fork copied exact evidence, reload restored it, all three sidecars matched their expected source, and browser error/warning logs were empty. |
+
+## Delta model protocol scenarios
+
+The delta contains the complete modified `Work Plan protocol state` requirement, so these rows also account for its applicable main-spec scenarios.
+
+| Scenario | Coverage | Assertion evidence |
+| --- | --- | --- |
+| Snapshot supplies Work Plan | covered | `server/test/work-plan-server.test.mjs` — “running server restores, forks, reconnects, and broadcasts authoritative Work Plans” compares exact passed and failed records in initial, replacement, fork, and reconnect snapshots. |
+| Change reaches all clients | covered | The same running-server test waits for both connected clients’ `work_plan_changed` frames and deep-compares the exact authoritative evidence-bearing plan. |
+
+## Final verification record
+
+- Focused Work Plan contract/tool/persistence tests: 45 passed.
+- Focused running-server, real Pi RPC, and embedded-provider integrations: 3 passed.
+- Full server suite: 1,761 passed.
+- Root workspace typecheck: passed.
+- Strict OpenSpec validation: passed.
+- Running-app Playwright happy and adversarial passes: DOM, transcript/tool results, sidecars, session switch, fork, and reconnect agreed; browser warning/error log was empty.
+- Required code review after corrections: **APPROVED**, with 0 CRITICAL, HIGH, MEDIUM, or LOW findings remaining.

--- a/openspec/changes/work-plan-evidence-and-verification/specs/model/spec.md
+++ b/openspec/changes/work-plan-evidence-and-verification/specs/model/spec.md
@@ -1,0 +1,14 @@
+## MODIFIED Requirements
+
+### Requirement: Work Plan protocol state
+The typed server protocol SHALL carry the current session Work Plan in authoritative state snapshots and SHALL broadcast accepted Work Plan changes to connected clients. The serialized form SHALL include stable task IDs, hierarchy, status, dependencies, generic resources, status reason, and each task's generic evidence records including their result; it SHALL not expose UI-specific markup, provider-specific evidence fields, or domain-specific resource types.
+
+#### Scenario: Snapshot supplies Work Plan
+- **WHEN** a client connects to a session whose Work Plan contains successful and unsuccessful task evidence
+- **THEN** its initial authoritative state includes the exact plan, evidence records, and results
+
+#### Scenario: Change reaches all clients
+- **GIVEN** two clients display the same session
+- **WHEN** the agent accepts a Work Plan evidence change
+- **THEN** both clients receive the same updated authoritative plan including the exact evidence records and results
+

--- a/openspec/changes/work-plan-evidence-and-verification/specs/work-plan/spec.md
+++ b/openspec/changes/work-plan-evidence-and-verification/specs/work-plan/spec.md
@@ -1,0 +1,170 @@
+## ADDED Requirements
+
+### Requirement: Generic structured task evidence
+Every Work Plan task SHALL contain an evidence collection with zero or more agent-owned records. Each evidence record SHALL have an identifier that is unique within its task, a non-empty free-form `type` identifying the kind or source of evidence, and one `result` from `passed`, `failed`, `inconclusive`, or `informational`. Each record SHALL also contain at least one of a concise non-empty `summary` or a generic resource `reference`; a reference SHALL use the same provider-neutral URI and optional label shape as other Work Plan resources. The model SHALL NOT contain provider-specific fields.
+
+#### Scenario: Attach successful verification
+- **WHEN** the agent supplies evidence for a task with result `passed`
+- **THEN** the accepted Work Plan contains that structured evidence record on the named task
+
+#### Scenario: Retain unsuccessful verification
+- **WHEN** the agent supplies evidence with result `failed` or `inconclusive`
+- **THEN** the accepted Work Plan retains that record rather than filtering, converting, or discarding it
+
+#### Scenario: Reference supporting information
+- **WHEN** an evidence record supplies a generic resource reference instead of a summary
+- **THEN** the record is accepted when the reference contains a valid URI
+
+#### Scenario: Reject an uninformative evidence record atomically
+- **WHEN** an evidence record contains neither a non-empty summary nor a valid reference
+- **THEN** the operation is rejected and no partial Work Plan mutation becomes visible or persisted
+
+#### Scenario: Reject duplicate evidence identity atomically
+- **WHEN** one task's evidence collection contains the same evidence identifier more than once
+- **THEN** the operation is rejected and the Work Plan remains unchanged
+
+### Requirement: Evidence and task status are independent
+Evidence SHALL remain separate from task status. Adding, replacing, or removing evidence SHALL NOT change the task's status or status reason. Changing a task's status or status reason SHALL NOT add, remove, or fabricate evidence. Tool activity, evidence contents, and evidence results SHALL NOT be interpreted as task completion.
+
+#### Scenario: Passing evidence does not complete a task
+- **GIVEN** a task is `in_progress`
+- **WHEN** the agent attaches evidence whose result is `passed`
+- **THEN** the task remains `in_progress` with its existing status reason
+
+#### Scenario: Failed evidence does not block a task automatically
+- **GIVEN** a task has any status
+- **WHEN** the agent attaches evidence whose result is `failed`
+- **THEN** the task keeps that status until the agent explicitly changes it
+
+#### Scenario: Completion does not fabricate evidence
+- **GIVEN** a task has no evidence
+- **WHEN** the agent explicitly marks the task `done`
+- **THEN** its evidence collection remains empty
+
+#### Scenario: Status edits preserve recorded failures
+- **GIVEN** a task has failed or inconclusive evidence
+- **WHEN** the agent changes the task's status or status reason
+- **THEN** the existing evidence remains unchanged
+
+### Requirement: Evidence-aware creation and compatibility
+The ergonomic creation shape, normalized task addition shape, and full-plan replacement shape SHALL declare and validate task evidence wherever they accept complete task state. Creation inputs MAY omit evidence; normalization SHALL then produce an empty evidence collection. Existing version-1 Work Plans and normalized task inputs that omit evidence SHALL remain valid and SHALL normalize missing evidence to an empty collection without requiring a version migration. Evidence collections and their fields SHALL be bounded, and the existing 500-task and 64 KiB complete-plan limits SHALL remain authoritative.
+
+#### Scenario: Create a task with evidence
+- **WHEN** a creation task supplies valid evidence records
+- **THEN** normalization preserves those records on the created task
+
+#### Scenario: Create a task without evidence
+- **WHEN** a creation task omits evidence
+- **THEN** normalization creates the task with an empty evidence collection
+
+#### Scenario: Restore a legacy version-1 plan
+- **GIVEN** a valid version-1 Work Plan persisted before evidence existed
+- **WHEN** the system loads or replaces that plan
+- **THEN** the plan remains valid and every task that omitted evidence is normalized to an empty evidence collection
+
+#### Scenario: Evidence limits are discoverable and atomic
+- **WHEN** the agent inspects or submits an evidence-bearing task input
+- **THEN** the schema declares the evidence collection and field bounds
+- **AND** input exceeding a declared or complete-plan limit is rejected without changing persisted state
+
+### Requirement: Atomic evidence management
+The structured Work Plan interface SHALL expose a `set_evidence` operation that atomically replaces the complete evidence collection of one named task, including with an empty collection to remove all evidence. The operation SHALL require both the task identifier and evidence collection, SHALL validate every record before committing, and SHALL return and synchronize the complete authoritative Work Plan through the existing contract. The tool description and prompt guidance SHALL explain the evidence shape, accepted results, replacement semantics, and independence from task status.
+
+#### Scenario: Replace a task's evidence
+- **GIVEN** a task has existing evidence
+- **WHEN** the agent submits `set_evidence` with a valid replacement collection
+- **THEN** the task contains exactly the submitted records and its other fields remain unchanged
+
+#### Scenario: Remove all task evidence
+- **GIVEN** a task has existing evidence
+- **WHEN** the agent submits `set_evidence` with an empty collection
+- **THEN** the evidence collection becomes empty and the task status remains unchanged
+
+#### Scenario: Missing evidence arguments are refused by name
+- **WHEN** `set_evidence` omits the task identifier or evidence collection
+- **THEN** the operation is rejected, the diagnosis names the missing argument, and the persisted Work Plan is unchanged
+
+#### Scenario: Invalid replacement does not discard prior evidence
+- **GIVEN** a task has existing evidence
+- **WHEN** any record in a replacement evidence collection is invalid
+- **THEN** the complete operation is rejected and the prior evidence remains unchanged
+
+## MODIFIED Requirements
+
+### Requirement: Agent-owned hierarchical Work Plan
+The system SHALL represent an optional Work Plan for a session as a title and a hierarchy of tasks. Every task SHALL have a stable identifier, a human-readable title, one of `todo`, `in_progress`, `done`, `blocked`, or `needs_review`, an evidence collection, and optional description, parent, dependencies, generic resource references, and status reason. The hierarchy SHALL allow arbitrary depth; task identity SHALL survive renaming and moving. Evidence SHALL be agent-owned task state and SHALL use the generic structured evidence contract.
+
+#### Scenario: Progressive decomposition
+- **WHEN** the agent adds children to an existing task
+- **THEN** the plan shows the parent and its newly decomposed children without changing the parent's identity
+
+#### Scenario: Blocked work is explained
+- **WHEN** the agent marks a task `blocked` with a reason
+- **THEN** the plan distinguishes it from `needs_review` and shows the reason during inspection
+
+#### Scenario: Tasks may have no evidence
+- **WHEN** a task has not been given supporting or verification evidence
+- **THEN** the task remains valid with an empty evidence collection regardless of status
+
+### Requirement: Structured agent management
+The system SHALL expose structured operations for the agent to create a plan, add, edit, move, remove, and reopen tasks, set status and status reason, add or remove dependencies and resource references, set task evidence, and replace the plan. Each accepted operation SHALL be atomic. The system SHALL describe the Work Plan to the agent as explicit working state for systematic decomposition, execution tracking, and verification, not merely progress reporting. For non-trivial work, it SHALL guide the agent to maintain and reconcile that state before declaring completion; trivial interactions SHALL NOT require a plan. The system SHALL NOT infer task state, completion, or evidence from tool calls, messages, Structured Exchange artifacts, or other activity.
+
+#### Scenario: Atomic task update
+- **WHEN** an agent operation is invalid
+- **THEN** no partial Work Plan mutation becomes visible or persisted
+
+#### Scenario: Activity does not complete work
+- **WHEN** the agent performs tools while a task remains `in_progress`
+- **THEN** the task remains `in_progress` until the agent explicitly changes it
+
+#### Scenario: Reconcile before completion
+- **GIVEN** the agent used a Work Plan for non-trivial work
+- **WHEN** the agent is preparing to declare that work complete
+- **THEN** its Work Plan guidance requires the agent to reconcile the plan with execution and verification outcomes first
+
+#### Scenario: Activity does not fabricate evidence
+- **WHEN** the agent runs a test, command, tool, or external check without recording evidence
+- **THEN** the Work Plan evidence remains unchanged
+
+### Requirement: Session-scoped persistence and restoration
+The system SHALL persist the Work Plan with its owning session and restore it when that session is reopened. A restored plan SHALL preserve task hierarchy, identities, statuses, dependencies, resources, reasons, and evidence, and SHALL be available to the resumed agent as compact operational context. A session fork SHALL copy the source Work Plan evidence into an independent target-side Work Plan, and subsequent evidence mutations on either branch SHALL NOT alter the other.
+
+#### Scenario: Resume interrupted work
+- **GIVEN** a saved session with a task in progress and remaining tasks
+- **WHEN** the session is reopened
+- **THEN** the same Work Plan, including all task evidence, is shown and supplied to the agent
+
+#### Scenario: Fork preserves independent evidence
+- **GIVEN** a saved session whose Work Plan contains successful and unsuccessful evidence
+- **WHEN** the session is forked
+- **THEN** the fork begins with the same evidence
+- **AND** subsequent evidence mutations in the fork do not change the source session's Work Plan
+
+### Requirement: Compatible fine-grained mutations
+After creation, the Work Plan interface SHALL retain its existing operations to read and clear the plan; add, update, move, and remove tasks; set dependencies, resources, and evidence; and replace the complete normalized plan. Each operation SHALL expose its complete typed input without changing its accepted mutation semantics. Full replacement SHALL continue accepting the version-1 persisted Work Plan representation, including valid plans created before evidence fields existed.
+
+#### Scenario: Existing task addition remains accepted
+- **GIVEN** a fully specified task input accepted before this change
+- **WHEN** the agent submits it through the task-addition operation
+- **THEN** the system accepts it without requiring an evidence field
+- **AND** the normalized task has an empty evidence collection
+
+#### Scenario: Duplicate task identity is rejected atomically
+- **GIVEN** an existing plan contains a task identifier
+- **WHEN** the agent submits a fully specified task with the same identifier through the task-addition operation
+- **THEN** the operation is rejected without changing the plan
+
+#### Scenario: Existing full replacement remains accepted
+- **GIVEN** a valid normalized version-1 Work Plan accepted before this change
+- **WHEN** the agent submits it through the full replacement operation
+- **THEN** the system accepts it without requiring evidence or migration to another version
+- **AND** its normalized representation remains version `1` with empty evidence for tasks that omitted it
+
+#### Scenario: Typed update preserves unspecified fields
+- **GIVEN** an existing task with evidence
+- **WHEN** the agent updates one schema-declared mutable field other than evidence
+- **THEN** every unspecified task field, including evidence, keeps its current value
+
+#### Scenario: Evidence synchronizes as authoritative task state
+- **WHEN** an evidence mutation is accepted
+- **THEN** reconnect, restoration, compaction-independent reads, and connected-client synchronization expose the complete updated evidence collection through the existing Work Plan snapshots

--- a/openspec/changes/work-plan-evidence-and-verification/tasks.md
+++ b/openspec/changes/work-plan-evidence-and-verification/tasks.md
@@ -1,0 +1,32 @@
+## 1. Shared Evidence Model
+
+- [x] 1.1 Add failing shared-model tests for valid passed, failed, inconclusive, informational, summary-only, and reference-only evidence; invalid result/type/content; duplicate IDs; collection/field limits; and the existing 64 KiB ceiling, and verify the focused `server/test/work-plan.test.ts` run fails for the intended missing behavior.
+- [x] 1.2 Add `WorkPlanEvidenceResult`/`WorkPlanEvidence` types, constants, bounds, validation, per-task ID uniqueness, and optional-input-to-empty-array normalization in `shared/src/workPlan.ts`, and verify the focused model tests from 1.1 pass while normalized plans remain version `1`.
+- [x] 1.3 Add compatibility tests for legacy version-1 sidecars, `create`, `add_task`, and `replace` inputs that omit evidence, then verify each is accepted and returns canonical tasks with `evidence: []`.
+- [x] 1.4 Add failing mutation tests for `set_evidence` replacement/clearing, missing arguments, invalid atomic replacement, failed-result retention, and bidirectional evidence/status independence, then implement the mutation with complete nested-state preservation and verify all shared Work Plan mutation tests pass.
+- [x] 1.5 Add preservation tests for unrelated status, reason, move, dependency, resource, and task-update operations, and verify every operation leaves pre-existing successful and unsuccessful evidence byte-for-byte equivalent.
+
+## 2. Agent Tool and Protocol Contract
+
+- [x] 2.1 Extend shared protocol exports with the evidence/result types and verify `npm run typecheck` accepts all server and downstream Work Plan consumers without adding evidence UI behavior.
+- [x] 2.2 Add failing schema tests proving complete-task and creation shapes expose bounded optional evidence, `set_evidence` exposes its typed collection, result values use one enum node, reference-only records validate, uninformative records fail, and no unconstrained/provider-specific schema reaches a provider.
+- [x] 2.3 Extend `server/src/workPlanTool.ts` with reusable evidence schemas, the `set_evidence` action arguments, per-action required-field diagnostics, and complete authoritative synchronization details, then verify the focused tool-schema/refusal tests from 2.2 pass.
+- [x] 2.4 Update Work Plan tool descriptions, worked guidance, and system guidance to explain complete-replacement semantics, preserving prior failures when appending, and status independence; verify prompt tests assert a literal valid evidence call and explicitly forbid automatic completion/evidence inference.
+- [x] 2.5 Extend the real Pi RPC and embedded-provider fixtures to inspect and execute the evidence-capable schema, including recording both passed and failed evidence, and verify the focused RPC/provider integration tests persist the exact authoritative records.
+
+## 3. Persistence, Fork, and Synchronization
+
+- [x] 3.1 Extend sidecar tests to persist, reload, and delete evidence-bearing plans and to load a legacy plan without evidence; verify successful, failed, and inconclusive records survive round trips while legacy tasks normalize to empty collections.
+- [x] 3.2 Extend fork tests with mixed evidence and mutate the fork after copying; verify the fork initially matches the source and later evidence replacement on either session cannot affect the other.
+- [x] 3.3 Extend server synchronization tests for initial restore, post-compaction `get`, reconnect, session replacement, and multi-client `work_plan_changed` delivery; verify assertions inspect exact evidence contents and results rather than only task status/counts.
+- [x] 3.4 Exercise invalid `set_evidence` through the persisted server boundary and verify the prior sidecar and every connected client's authoritative Work Plan remain unchanged.
+
+## 4. Documentation and Verification
+
+- [x] 4.1 Update the Work Plans section of `README.md` with the generic evidence shape, accepted results, `set_evidence` replacement semantics, persistence/fork behavior, legacy compatibility, and status independence; verify examples match the actual tool schema and document no automatic verifier or new UI.
+- [x] 4.2 Enumerate every applicable main and delta `#### Scenario:` with `rg '^#### Scenario:' openspec/`, create a scenario-to-test matrix for this change, and verify every scenario is classified `covered` with the exact test file/name and assertions at the boundary described by the scenario.
+- [x] 4.3 Run the focused Work Plan unit, tool, persistence, provider, and server tests first, then `npm run test --workspace server` and `npm run typecheck`; verify all commands pass without weakening evidence, failure-retention, atomicity, or independence assertions.
+- [x] 4.4 Run strict OpenSpec validation for `work-plan-evidence-and-verification` and verify the proposal capability, complete modified requirement blocks, scenario formatting, design decisions, and checkbox task syntax all pass.
+- [x] 4.5 Start the real application and use Playwright to ask the actual agent to create a task, record both successful and unsuccessful evidence, change status separately, and read the plan back; verify the DOM, session transcript/tool result, and persisted sidecar agree and no status was inferred.
+- [x] 4.6 Perform an adversarial Playwright pass with rapid evidence/status mutations plus session switch/fork/reconnect transitions; after each burst read the DOM and persisted/session state and verify there is no stale, lost, cross-session, or fabricated evidence and no stuck UI state.
+- [x] 4.7 Inspect the final diff for documentation impact, run `git diff HEAD`, invoke the required code-reviewer with the task context and full diff, address all CRITICAL/HIGH findings, and verify the final review verdict plus any remaining MEDIUM/LOW findings is recorded before completion.

--- a/openspec/specs/model/spec.md
+++ b/openspec/specs/model/spec.md
@@ -378,16 +378,16 @@ The client/server protocol SHALL carry requests and responses for browsing serve
 - **THEN** the server returns the directory entries and acknowledges only a successfully persisted settings update
 
 ### Requirement: Work Plan protocol state
-The typed server protocol SHALL carry the current session Work Plan in authoritative state snapshots and SHALL broadcast accepted Work Plan changes to connected clients. The serialized form SHALL include stable task IDs, hierarchy, status, dependencies, generic resources, and status reason; it SHALL not expose UI-specific markup or domain-specific resource types.
+The typed server protocol SHALL carry the current session Work Plan in authoritative state snapshots and SHALL broadcast accepted Work Plan changes to connected clients. The serialized form SHALL include stable task IDs, hierarchy, status, dependencies, generic resources, status reason, and each task's generic evidence records including their result; it SHALL not expose UI-specific markup, provider-specific evidence fields, or domain-specific resource types.
 
 #### Scenario: Snapshot supplies Work Plan
-- **WHEN** a client connects to a session with a Work Plan
-- **THEN** its initial authoritative state includes that plan
+- **WHEN** a client connects to a session whose Work Plan contains successful and unsuccessful task evidence
+- **THEN** its initial authoritative state includes the exact plan, evidence records, and results
 
 #### Scenario: Change reaches all clients
 - **GIVEN** two clients display the same session
-- **WHEN** the agent changes the Work Plan
-- **THEN** both clients receive the same updated authoritative plan
+- **WHEN** the agent accepts a Work Plan evidence change
+- **THEN** both clients receive the same updated authoritative plan including the exact evidence records and results
 
 ## Technical Notes
 

--- a/openspec/specs/work-plan/spec.md
+++ b/openspec/specs/work-plan/spec.md
@@ -7,7 +7,7 @@ Provides an agent-owned, human-readable account of the current work that survive
 ## Requirements
 
 ### Requirement: Agent-owned hierarchical Work Plan
-The system SHALL represent an optional Work Plan for a session as a title and a hierarchy of tasks. Every task SHALL have a stable identifier, a human-readable title, one of `todo`, `in_progress`, `done`, `blocked`, or `needs_review`, and optional description, parent, dependencies, generic resource references, and status reason. The hierarchy SHALL allow arbitrary depth; task identity SHALL survive renaming and moving.
+The system SHALL represent an optional Work Plan for a session as a title and a hierarchy of tasks. Every task SHALL have a stable identifier, a human-readable title, one of `todo`, `in_progress`, `done`, `blocked`, or `needs_review`, an evidence collection, and optional description, parent, dependencies, generic resource references, and status reason. The hierarchy SHALL allow arbitrary depth; task identity SHALL survive renaming and moving. Evidence SHALL be agent-owned task state and SHALL use the generic structured evidence contract.
 
 #### Scenario: Progressive decomposition
 - **WHEN** the agent adds children to an existing task
@@ -17,8 +17,12 @@ The system SHALL represent an optional Work Plan for a session as a title and a 
 - **WHEN** the agent marks a task `blocked` with a reason
 - **THEN** the plan distinguishes it from `needs_review` and shows the reason during inspection
 
+#### Scenario: Tasks may have no evidence
+- **WHEN** a task has not been given supporting or verification evidence
+- **THEN** the task remains valid with an empty evidence collection regardless of status
+
 ### Requirement: Structured agent management
-The system SHALL expose structured operations for the agent to create a plan, add, edit, move, remove, and reopen tasks, set status and status reason, add or remove dependencies and resource references, and replace the plan. Each accepted operation SHALL be atomic. The system SHALL describe the Work Plan to the agent as explicit working state for systematic decomposition, execution tracking, and verification, not merely progress reporting. For non-trivial work, it SHALL guide the agent to maintain and reconcile that state before declaring completion; trivial interactions SHALL NOT require a plan. The system SHALL NOT infer task state or completion from tool calls, messages, or Structured Exchange artifacts.
+The system SHALL expose structured operations for the agent to create a plan, add, edit, move, remove, and reopen tasks, set status and status reason, add or remove dependencies and resource references, set task evidence, and replace the plan. Each accepted operation SHALL be atomic. The system SHALL describe the Work Plan to the agent as explicit working state for systematic decomposition, execution tracking, and verification, not merely progress reporting. For non-trivial work, it SHALL guide the agent to maintain and reconcile that state before declaring completion; trivial interactions SHALL NOT require a plan. The system SHALL NOT infer task state, completion, or evidence from tool calls, messages, Structured Exchange artifacts, or other activity.
 
 #### Scenario: Atomic task update
 - **WHEN** an agent operation is invalid
@@ -33,13 +37,23 @@ The system SHALL expose structured operations for the agent to create a plan, ad
 - **WHEN** the agent is preparing to declare that work complete
 - **THEN** its Work Plan guidance requires the agent to reconcile the plan with execution and verification outcomes first
 
+#### Scenario: Activity does not fabricate evidence
+- **WHEN** the agent runs a test, command, tool, or external check without recording evidence
+- **THEN** the Work Plan evidence remains unchanged
+
 ### Requirement: Session-scoped persistence and restoration
-The system SHALL persist the Work Plan with its owning session and restore it when that session is reopened. A restored plan SHALL preserve task hierarchy, identities, statuses, dependencies, resources, and reasons, and SHALL be available to the resumed agent as compact operational context.
+The system SHALL persist the Work Plan with its owning session and restore it when that session is reopened. A restored plan SHALL preserve task hierarchy, identities, statuses, dependencies, resources, reasons, and evidence, and SHALL be available to the resumed agent as compact operational context. A session fork SHALL copy the source Work Plan evidence into an independent target-side Work Plan, and subsequent evidence mutations on either branch SHALL NOT alter the other.
 
 #### Scenario: Resume interrupted work
 - **GIVEN** a saved session with a task in progress and remaining tasks
 - **WHEN** the session is reopened
-- **THEN** the same Work Plan is shown and supplied to the agent
+- **THEN** the same Work Plan, including all task evidence, is shown and supplied to the agent
+
+#### Scenario: Fork preserves independent evidence
+- **GIVEN** a saved session whose Work Plan contains successful and unsuccessful evidence
+- **WHEN** the session is forked
+- **THEN** the fork begins with the same evidence
+- **AND** subsequent evidence mutations in the fork do not change the source session's Work Plan
 
 ### Requirement: Compaction-independent working state
 Work Plan persistence SHALL be independent from Pi conversation compaction. Compaction of conversational context SHALL NOT remove, summarize, alter, or invalidate the persisted Work Plan. Following compaction, the current Work Plan state SHALL remain directly accessible to the agent through the structured Work Plan interface without reconstructing it from the compacted conversation summary.
@@ -157,13 +171,103 @@ The Work Plan interface SHALL provide a creation operation that accepts a human-
 - **WHEN** any task in a nested creation input is invalid or would exceed a Work Plan limit
 - **THEN** no part of the new plan becomes visible or persisted
 
+### Requirement: Generic structured task evidence
+Every Work Plan task SHALL contain an evidence collection with zero or more agent-owned records. Each evidence record SHALL have an identifier that is unique within its task, a non-empty free-form `type` identifying the kind or source of evidence, and one `result` from `passed`, `failed`, `inconclusive`, or `informational`. Each record SHALL also contain at least one of a concise non-empty `summary` or a generic resource `reference`; a reference SHALL use the same provider-neutral URI and optional label shape as other Work Plan resources. The model SHALL NOT contain provider-specific fields.
+
+#### Scenario: Attach successful verification
+- **WHEN** the agent supplies evidence for a task with result `passed`
+- **THEN** the accepted Work Plan contains that structured evidence record on the named task
+
+#### Scenario: Retain unsuccessful verification
+- **WHEN** the agent supplies evidence with result `failed` or `inconclusive`
+- **THEN** the accepted Work Plan retains that record rather than filtering, converting, or discarding it
+
+#### Scenario: Reference supporting information
+- **WHEN** an evidence record supplies a generic resource reference instead of a summary
+- **THEN** the record is accepted when the reference contains a valid URI
+
+#### Scenario: Reject an uninformative evidence record atomically
+- **WHEN** an evidence record contains neither a non-empty summary nor a valid reference
+- **THEN** the operation is rejected and no partial Work Plan mutation becomes visible or persisted
+
+#### Scenario: Reject duplicate evidence identity atomically
+- **WHEN** one task's evidence collection contains the same evidence identifier more than once
+- **THEN** the operation is rejected and the Work Plan remains unchanged
+
+### Requirement: Evidence and task status are independent
+Evidence SHALL remain separate from task status. Adding, replacing, or removing evidence SHALL NOT change the task's status or status reason. Changing a task's status or status reason SHALL NOT add, remove, or fabricate evidence. Tool activity, evidence contents, and evidence results SHALL NOT be interpreted as task completion.
+
+#### Scenario: Passing evidence does not complete a task
+- **GIVEN** a task is `in_progress`
+- **WHEN** the agent attaches evidence whose result is `passed`
+- **THEN** the task remains `in_progress` with its existing status reason
+
+#### Scenario: Failed evidence does not block a task automatically
+- **GIVEN** a task has any status
+- **WHEN** the agent attaches evidence whose result is `failed`
+- **THEN** the task keeps that status until the agent explicitly changes it
+
+#### Scenario: Completion does not fabricate evidence
+- **GIVEN** a task has no evidence
+- **WHEN** the agent explicitly marks the task `done`
+- **THEN** its evidence collection remains empty
+
+#### Scenario: Status edits preserve recorded failures
+- **GIVEN** a task has failed or inconclusive evidence
+- **WHEN** the agent changes the task's status or status reason
+- **THEN** the existing evidence remains unchanged
+
+### Requirement: Evidence-aware creation and compatibility
+The ergonomic creation shape, normalized task addition shape, and full-plan replacement shape SHALL declare and validate task evidence wherever they accept complete task state. Creation inputs MAY omit evidence; normalization SHALL then produce an empty evidence collection. Existing version-1 Work Plans and normalized task inputs that omit evidence SHALL remain valid and SHALL normalize missing evidence to an empty collection without requiring a version migration. Evidence collections and their fields SHALL be bounded, and the existing 500-task and 64 KiB complete-plan limits SHALL remain authoritative.
+
+#### Scenario: Create a task with evidence
+- **WHEN** a creation task supplies valid evidence records
+- **THEN** normalization preserves those records on the created task
+
+#### Scenario: Create a task without evidence
+- **WHEN** a creation task omits evidence
+- **THEN** normalization creates the task with an empty evidence collection
+
+#### Scenario: Restore a legacy version-1 plan
+- **GIVEN** a valid version-1 Work Plan persisted before evidence existed
+- **WHEN** the system loads or replaces that plan
+- **THEN** the plan remains valid and every task that omitted evidence is normalized to an empty evidence collection
+
+#### Scenario: Evidence limits are discoverable and atomic
+- **WHEN** the agent inspects or submits an evidence-bearing task input
+- **THEN** the schema declares the evidence collection and field bounds
+- **AND** input exceeding a declared or complete-plan limit is rejected without changing persisted state
+
+### Requirement: Atomic evidence management
+The structured Work Plan interface SHALL expose a `set_evidence` operation that atomically replaces the complete evidence collection of one named task, including with an empty collection to remove all evidence. The operation SHALL require both the task identifier and evidence collection, SHALL validate every record before committing, and SHALL return and synchronize the complete authoritative Work Plan through the existing contract. The tool description and prompt guidance SHALL explain the evidence shape, accepted results, replacement semantics, and independence from task status.
+
+#### Scenario: Replace a task's evidence
+- **GIVEN** a task has existing evidence
+- **WHEN** the agent submits `set_evidence` with a valid replacement collection
+- **THEN** the task contains exactly the submitted records and its other fields remain unchanged
+
+#### Scenario: Remove all task evidence
+- **GIVEN** a task has existing evidence
+- **WHEN** the agent submits `set_evidence` with an empty collection
+- **THEN** the evidence collection becomes empty and the task status remains unchanged
+
+#### Scenario: Missing evidence arguments are refused by name
+- **WHEN** `set_evidence` omits the task identifier or evidence collection
+- **THEN** the operation is rejected, the diagnosis names the missing argument, and the persisted Work Plan is unchanged
+
+#### Scenario: Invalid replacement does not discard prior evidence
+- **GIVEN** a task has existing evidence
+- **WHEN** any record in a replacement evidence collection is invalid
+- **THEN** the complete operation is rejected and the prior evidence remains unchanged
+
 ### Requirement: Compatible fine-grained mutations
-After creation, the Work Plan interface SHALL retain its existing operations to read and clear the plan; add, update, move, and remove tasks; set dependencies and resources; and replace the complete normalized plan. Each operation SHALL expose its complete typed input without changing its accepted mutation semantics. Full replacement SHALL continue accepting the existing version-1 persisted Work Plan representation.
+After creation, the Work Plan interface SHALL retain its existing operations to read and clear the plan; add, update, move, and remove tasks; set dependencies, resources, and evidence; and replace the complete normalized plan. Each operation SHALL expose its complete typed input without changing its accepted mutation semantics. Full replacement SHALL continue accepting the version-1 persisted Work Plan representation, including valid plans created before evidence fields existed.
 
 #### Scenario: Existing task addition remains accepted
 - **GIVEN** a fully specified task input accepted before this change
 - **WHEN** the agent submits it through the task-addition operation
-- **THEN** the system accepts it without requiring the ergonomic creation shape
+- **THEN** the system accepts it without requiring an evidence field
+- **AND** the normalized task has an empty evidence collection
 
 #### Scenario: Duplicate task identity is rejected atomically
 - **GIVEN** an existing plan contains a task identifier
@@ -173,13 +277,17 @@ After creation, the Work Plan interface SHALL retain its existing operations to 
 #### Scenario: Existing full replacement remains accepted
 - **GIVEN** a valid normalized version-1 Work Plan accepted before this change
 - **WHEN** the agent submits it through the full replacement operation
-- **THEN** the system accepts it without requiring migration to the ergonomic creation shape
-- **AND** its persisted representation remains version `1`
+- **THEN** the system accepts it without requiring evidence or migration to another version
+- **AND** its normalized representation remains version `1` with empty evidence for tasks that omitted it
 
 #### Scenario: Typed update preserves unspecified fields
-- **GIVEN** an existing task
-- **WHEN** the agent updates one schema-declared mutable field
-- **THEN** every unspecified task field keeps its current value
+- **GIVEN** an existing task with evidence
+- **WHEN** the agent updates one schema-declared mutable field other than evidence
+- **THEN** every unspecified task field, including evidence, keeps its current value
+
+#### Scenario: Evidence synchronizes as authoritative task state
+- **WHEN** an evidence mutation is accepted
+- **THEN** reconnect, restoration, compaction-independent reads, and connected-client synchronization expose the complete updated evidence collection through the existing Work Plan snapshots
 
 ### Requirement: Missing operation arguments are refused by name
 Because the schema declares every operation-specific argument as optional, the server SHALL check each operation's own requirements and SHALL refuse a call that omits one, naming the action and the missing argument. An operation that names a task SHALL refuse a call carrying no task identifier rather than resolving no task and reporting success. An update SHALL refuse a call that changes nothing.

--- a/server/src/systemPrompt.ts
+++ b/server/src/systemPrompt.ts
@@ -10,6 +10,8 @@ export const WEB_UI_CONTEXT = [
 
 export const WORK_PLAN_SYSTEM_GUIDANCE = [
   "Use work_plan as explicit working state for non-trivial multi-step work: create and maintain it as understanding or execution changes.",
+  "Record verification evidence deliberately, including failed or inconclusive checks; tool activity does not record evidence automatically.",
+  "Evidence and task status are independent: reconcile both explicitly, because evidence does not complete a task and completion does not fabricate evidence.",
   "Before resuming substantial work, read the current plan; reconcile it before declaring the work complete.",
   "When completed work needs human review, leave at least one task as needs_review and reconcile every other task to done or needs_review; acknowledge review by moving the applicable tasks to done, and move them back to an active state when meaningful work resumes.",
   "Skip a Work Plan for trivial interactions.",

--- a/server/src/workPlanTool.ts
+++ b/server/src/workPlanTool.ts
@@ -1,6 +1,12 @@
 import { Type, type TSchema } from "typebox";
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
-import { WORK_PLAN_ACTIONS, WORK_PLAN_CREATE_MAX_DEPTH, WORK_PLAN_LIMITS, WORK_PLAN_STATUSES } from "@pi-outpost/shared/work-plan";
+import {
+  WORK_PLAN_ACTIONS,
+  WORK_PLAN_CREATE_MAX_DEPTH,
+  WORK_PLAN_EVIDENCE_RESULTS,
+  WORK_PLAN_LIMITS,
+  WORK_PLAN_STATUSES,
+} from "@pi-outpost/shared/work-plan";
 import { applyWorkPlanMutation } from "./workPlanStore.ts";
 
 const objectOptions = { additionalProperties: false } as const;
@@ -39,6 +45,19 @@ const resourceSchema = Type.Object({
 }, objectOptions);
 const resourcesSchema = Type.Array(resourceSchema, { maxItems: WORK_PLAN_LIMITS.resourcesPerTask });
 const dependenciesSchema = Type.Array(identifierSchema, { maxItems: WORK_PLAN_LIMITS.tasks, uniqueItems: true });
+const evidenceResultSchema = stringEnum(WORK_PLAN_EVIDENCE_RESULTS);
+const evidenceSchema = Type.Object({
+  id: identifierSchema,
+  type: boundedText(WORK_PLAN_LIMITS.evidenceType, "Free-form evidence kind or source, such as test, command, file, or external-check."),
+  result: evidenceResultSchema,
+  summary: Type.Optional(boundedText(WORK_PLAN_LIMITS.evidenceSummary)),
+  reference: Type.Optional(resourceSchema),
+}, {
+  ...objectOptions,
+  anyOf: [{ required: ["summary"] }, { required: ["reference"] }],
+  description: "One evidence record. Supply at least a summary or reference.",
+});
+const evidenceCollectionSchema = Type.Array(evidenceSchema, { maxItems: WORK_PLAN_LIMITS.evidencePerTask });
 
 const normalizedTaskSchema = Type.Object({
   id: identifierSchema,
@@ -48,6 +67,7 @@ const normalizedTaskSchema = Type.Object({
   parentId: Type.Optional(identifierSchema),
   dependsOn: Type.Optional(dependenciesSchema),
   resources: Type.Optional(resourcesSchema),
+  evidence: Type.Optional(evidenceCollectionSchema),
   statusReason: Type.Optional(reasonSchema),
 }, objectOptions);
 
@@ -69,6 +89,7 @@ const creationTaskSchema = (depth: number): TSchema => Type.Object({
   status: Type.Optional(statusSchema),
   statusReason: Type.Optional(reasonSchema),
   resources: Type.Optional(resourcesSchema),
+  evidence: Type.Optional(evidenceCollectionSchema),
   dependsOn: Type.Optional(Type.Array(identifierSchema, {
     maxItems: WORK_PLAN_LIMITS.tasks,
     uniqueItems: true,
@@ -116,7 +137,7 @@ export const workPlanParameters = Type.Object({
   })),
   plan: Type.Optional(Type.Object({ ...normalizedPlanSchema.properties }, { ...objectOptions, description: "A complete normalized plan (replace)." })),
   task: Type.Optional(Type.Object({ ...normalizedTaskSchema.properties }, { ...objectOptions, description: "One complete task, id and status included (add_task)." })),
-  taskId: Type.Optional(Type.String({ ...identifierSchema, description: "Which task to act on (update_task, move_task, remove_task, set_dependencies, set_resources)." })),
+  taskId: Type.Optional(Type.String({ ...identifierSchema, description: "Which task to act on (update_task, move_task, remove_task, set_dependencies, set_resources, set_evidence)." })),
   changes: Type.Optional(Type.Object({ ...taskChangesSchema.properties }, { ...objectOptions, description: "Fields to change (update_task). The same fields may be given here beside taskId instead." })),
   status: Type.Optional(stringEnum(WORK_PLAN_STATUSES, "New status (update_task, when no changes object is given).")),
   description: Type.Optional(Type.Union([descriptionSchema, Type.Null()], { description: "New description, or null to clear it (update_task, when no changes object is given)." })),
@@ -124,13 +145,17 @@ export const workPlanParameters = Type.Object({
   parentId: Type.Optional(Type.Union([identifierSchema, Type.Null()], { description: "New parent, or null for top level (move_task)." })),
   dependsOn: Type.Optional(Type.Array(identifierSchema, { maxItems: WORK_PLAN_LIMITS.tasks, uniqueItems: true, description: "Complete dependency set for taskId (set_dependencies)." })),
   resources: Type.Optional(Type.Array(resourceSchema, { maxItems: WORK_PLAN_LIMITS.resourcesPerTask, description: "Complete resource set for taskId (set_resources)." })),
+  evidence: Type.Optional(Type.Array(evidenceSchema, {
+    maxItems: WORK_PLAN_LIMITS.evidencePerTask,
+    description: "Complete evidence set for taskId (set_evidence). Replaces the prior collection; [] clears it and never changes task status.",
+  })),
 }, objectOptions);
 
 export function createWorkPlanToolDefinition(): ToolDefinition {
   return {
     name: "work_plan",
     label: "Work Plan",
-    description: "Read or atomically update the persistent Work Plan for this session. Use create for a compact two-level task hierarchy (500 tasks total, 64 KiB normalized plan) whose tasks need only a title, replace for a complete normalized version-1 document, and the task operations for precise later mutations.",
+    description: "Read or atomically update the persistent Work Plan for this session. Use create for a compact two-level task hierarchy (500 tasks total, 64 KiB normalized plan) whose tasks need only a title, set_evidence to replace one task's complete generic verification/support record collection, replace for a complete normalized version-1 document, and the other task operations for precise later mutations.",
     promptSnippet: "Create, inspect, and update the session's persistent Work Plan",
     // A worked call, because the schema alone left models repairing by guess. The
     // titles are deliberately meaningless: an example that reads like real work
@@ -140,6 +165,8 @@ export function createWorkPlanToolDefinition(): ToolDefinition {
       'Create the whole plan in one call, dependencies included: {"action":"create","title":"<plan title>","tasks":[{"id":"a","title":"<first task>"},{"id":"b","title":"<second task>","dependsOn":["a"],"subtasks":[{"title":"<a step of the second task>"}]}]}',
       "Give a task an explicit short id whenever something references it; ids are generated for the rest.",
       'Update one task with {"action":"update_task","taskId":"b","status":"in_progress"}. Statuses are todo, in_progress, done, blocked, needs_review.',
+      'Record verification explicitly with {"action":"set_evidence","taskId":"b","evidence":[{"id":"tests","type":"test","result":"passed","summary":"Focused tests passed"},{"id":"probe","type":"external-check","result":"failed","summary":"The external probe failed"}]}. Results are passed, failed, inconclusive, informational.',
+      "set_evidence replaces the complete evidence collection: include prior failures when appending a result, or use [] to clear it. Evidence never changes task status, and status changes never create evidence.",
       // Pointing a small model at `replace` for this was a trap: that action wants
       // a complete normalized document, down to a plan id and an updatedAt it
       // would have to invent. `clear` then `create` reaches the same state through

--- a/server/test/fixtures/work-plan-rpc-provider.mjs
+++ b/server/test/fixtures/work-plan-rpc-provider.mjs
@@ -36,18 +36,26 @@ function assertWorkPlanSchema(context) {
   };
   walk(tool.parameters, "$parameters");
   if (empty.length > 0) throw new Error(`unconstrained work_plan schemas reached provider: ${empty.join(", ")}`);
-  // One object whose `action` enumerates the operations — not a union of ten
+  // One object whose `action` enumerates the operations — not a union of
   // branches, whose failures pi reports all at once.
   if (tool.parameters.anyOf) throw new Error("work_plan provider schema is a union again");
   const actions = tool.parameters.properties?.action?.enum;
-  for (const action of ["get", "clear", "create", "replace", "add_task", "update_task", "move_task", "remove_task", "set_dependencies", "set_resources"]) {
+  for (const action of ["get", "clear", "create", "replace", "add_task", "update_task", "move_task", "remove_task", "set_dependencies", "set_resources", "set_evidence"]) {
     if (!actions?.includes(action)) throw new Error(`work_plan provider schema does not offer ${action}`);
+  }
+  const evidence = tool.parameters.properties?.evidence;
+  if (evidence?.type !== "array" || evidence.maxItems !== 100) throw new Error("work_plan provider schema does not bound evidence");
+  const record = evidence.items;
+  if (record?.additionalProperties !== false) throw new Error("work_plan evidence accepts provider-specific fields");
+  const results = record?.properties?.result?.enum;
+  for (const result of ["passed", "failed", "inconclusive", "informational"]) {
+    if (!results?.includes(result)) throw new Error(`work_plan evidence does not offer result ${result}`);
   }
 }
 
 function assertWorkPlanGuidance(context) {
   const prompt = String(context.systemPrompt ?? "");
-  for (const phrase of ["explicit working state", "Before resuming substantial work", "Skip a Work Plan for trivial interactions"]) {
+  for (const phrase of ["explicit working state", "Record verification evidence deliberately", "Evidence and task status are independent", "Before resuming substantial work", "Skip a Work Plan for trivial interactions"]) {
     if (!prompt.includes(phrase)) throw new Error(`work_plan system guidance did not reach provider: ${phrase}`);
   }
 }
@@ -58,7 +66,7 @@ function streamWorkPlan(model, context) {
   const stream = createAssistantMessageEventStream();
   queueMicrotask(() => {
     const results = context.messages.filter((item) => item.role === "toolResult" && item.toolName === "work_plan");
-    if (results.length >= 4) {
+    if (results.length >= 5) {
       const output = message(model, [{ type: "text", text: "Plan updated." }], "stop");
       stream.push({ type: "start", partial: output });
       stream.push({ type: "text_start", contentIndex: 0, partial: output });
@@ -76,6 +84,14 @@ function streamWorkPlan(model, context) {
         {
           action: "add_task",
           task: { id: "release-note", title: "Write release note", status: "todo", dependsOn: [], resources: [] },
+        },
+        {
+          action: "set_evidence",
+          taskId: createdPlan?.tasks?.[0]?.id,
+          evidence: [
+            { id: "focused-tests", type: "test", result: "passed", summary: "Focused tests passed" },
+            { id: "external-probe", type: "external-check", result: "failed", summary: "External probe failed" },
+          ],
         },
         {
           action: "update_task",

--- a/server/test/work-plan-server.test.mjs
+++ b/server/test/work-plan-server.test.mjs
@@ -9,13 +9,21 @@ const FAKE = fileURLToPath(new URL("./fixtures/fake-pi-rpc.mjs", import.meta.url
 const REAL_PI = fileURLToPath(new URL("../../node_modules/@earendil-works/pi-coding-agent/dist/cli.js", import.meta.url));
 const WORK_PLAN_PROVIDER = fileURLToPath(new URL("./fixtures/work-plan-rpc-provider.mjs", import.meta.url));
 
-const plan = (status = "in_progress") => ({
+const evidence = () => [
+  { id: "focused-tests", type: "test", result: "passed", summary: "Focused tests passed" },
+  { id: "external-probe", type: "external-check", result: "failed", summary: "External probe failed" },
+];
+const replacementEvidence = () => [
+  { id: "release-check", type: "command", result: "inconclusive", summary: "Release check timed out" },
+];
+
+const plan = (status = "in_progress", taskEvidence = evidence()) => ({
   version: 1,
   id: "release",
   title: "Prepare release",
   updatedAt: "2026-08-23T00:00:00.000Z",
   tasks: [
-    { id: "build", title: "Build", status, dependsOn: [], resources: [] },
+    { id: "build", title: "Build", status, dependsOn: [], resources: [], evidence: taskEvidence },
   ],
 });
 
@@ -165,6 +173,18 @@ test("running server restores, forks, reconnects, and broadcasts authoritative W
         },
         prompt: [
           {
+            after: [{
+              type: "tool_execution_end",
+              toolCallId: "plan-get",
+              toolName: "work_plan",
+              result: {
+                content: [{ type: "text", text: `Work Plan \"Prepare release\": 1 tasks (0 done).\n${JSON.stringify(plan())}` }],
+                details: { type: "work_plan", sessionFile: target, plan: plan(), changed: false },
+              },
+              isError: false,
+            }],
+          },
+          {
             after: [
               { type: "agent_start" },
               { type: "tool_execution_start", toolCallId: "read-1", toolName: "read", args: { path: "README.md" } },
@@ -173,14 +193,40 @@ test("running server restores, forks, reconnects, and broadcasts authoritative W
             ],
           },
           {
-            writes: [{ path: `${target}.work-plan.json`, content: `${JSON.stringify(plan("done"), null, 2)}\n` }],
+            after: [{
+              type: "tool_execution_end",
+              toolCallId: "plan-invalid",
+              toolName: "work_plan",
+              result: {
+                content: [{ type: "text", text: "Work Plan update refused: evidence[0] requires summary or reference" }],
+                details: undefined,
+                isError: true,
+              },
+              isError: true,
+            }],
+          },
+          {
+            writes: [{ path: `${target}.work-plan.json`, content: `${JSON.stringify(plan("in_progress", replacementEvidence()), null, 2)}\n` }],
+            after: [{
+              type: "tool_execution_end",
+              toolCallId: "plan-evidence",
+              toolName: "work_plan",
+              result: {
+                content: [{ type: "text", text: "Work Plan evidence replaced." }],
+                details: { type: "work_plan", sessionFile: target, plan: plan("in_progress", replacementEvidence()), changed: true },
+              },
+              isError: false,
+            }],
+          },
+          {
+            writes: [{ path: `${target}.work-plan.json`, content: `${JSON.stringify(plan("done", replacementEvidence()), null, 2)}\n` }],
             after: [{
               type: "tool_execution_end",
               toolCallId: "plan-1",
               toolName: "work_plan",
               result: {
                 content: [{ type: "text", text: "Work Plan updated." }],
-                details: { type: "work_plan", sessionFile: target, plan: plan("done"), changed: true },
+                details: { type: "work_plan", sessionFile: target, plan: plan("done", replacementEvidence()), changed: true },
               },
               isError: false,
             }],
@@ -203,6 +249,7 @@ test("running server restores, forks, reconnects, and broadcasts authoritative W
   let third;
   let postCompaction;
   let afterUnrelatedTool;
+  let invalidObserver;
   let concurrentFork;
   try {
     const hello = await first.waitFor("hello");
@@ -246,6 +293,10 @@ test("running server restores, forks, reconnects, and broadcasts authoritative W
     assert.equal(reconnected.sessionId, "fork");
     assert.deepEqual(reconnected.workPlan, plan(), "a reconnect receives the copied authoritative plan");
 
+    first.send({ type: "prompt", text: "Read the Work Plan after compaction" });
+    await first.waitFor((message) => message.type === "tool_end" && message.toolCallId === "plan-get");
+    assert.deepEqual(JSON.parse(await readFile(`${target}.work-plan.json`, "utf8")), plan(), "post-compaction get leaves complete evidence unchanged");
+
     first.send({ type: "prompt", text: "Inspect without changing the plan" });
     await first.waitFor((message) => message.type === "tool_end" && message.toolCallId === "read-1");
     afterUnrelatedTool = connect(server.wsUrl());
@@ -257,16 +308,43 @@ test("running server restores, forks, reconnects, and broadcasts authoritative W
     afterUnrelatedTool.close();
     afterUnrelatedTool = undefined;
 
+    const firstChanges = first.received.filter((message) => message.type === "work_plan_changed").length;
+    const secondChanges = second.received.filter((message) => message.type === "work_plan_changed").length;
+    first.send({ type: "prompt", text: "Record invalid evidence" });
+    await first.waitFor((message) => message.type === "tool_end" && message.toolCallId === "plan-invalid");
+    assert.equal(first.received.filter((message) => message.type === "work_plan_changed").length, firstChanges);
+    assert.equal(second.received.filter((message) => message.type === "work_plan_changed").length, secondChanges);
+    assert.deepEqual(JSON.parse(await readFile(`${target}.work-plan.json`, "utf8")), plan(), "invalid evidence leaves the sidecar unchanged");
+    invalidObserver = connect(server.wsUrl());
+    assert.deepEqual((await invalidObserver.waitFor("hello")).workPlan, plan(), "new clients still receive the prior authoritative evidence");
+    invalidObserver.close();
+    invalidObserver = undefined;
+
+    first.send({ type: "prompt", text: "Replace the task evidence" });
+    const evidenceChanged = (message) => message.type === "work_plan_changed"
+      && message.workPlan?.tasks[0]?.evidence?.[0]?.id === "release-check";
+    assert.deepEqual((await first.waitFor(evidenceChanged)).workPlan, plan("in_progress", replacementEvidence()));
+    assert.deepEqual(
+      (await second.waitFor(evidenceChanged)).workPlan,
+      plan("in_progress", replacementEvidence()),
+      "set_evidence immediately reaches every connected client",
+    );
+    assert.deepEqual(
+      JSON.parse(await readFile(`${target}.work-plan.json`, "utf8")),
+      plan("in_progress", replacementEvidence()),
+      "the evidence broadcast matches persisted authoritative state",
+    );
+
     first.send({ type: "prompt", text: "Finish the plan" });
     const finished = (message) => message.type === "work_plan_changed" && message.workPlan?.tasks[0]?.status === "done";
-    assert.deepEqual((await first.waitFor(finished)).workPlan, plan("done"));
-    assert.deepEqual((await second.waitFor(finished)).workPlan, plan("done"), "all clients receive one authoritative update");
+    assert.deepEqual((await first.waitFor(finished)).workPlan, plan("done", replacementEvidence()));
+    assert.deepEqual((await second.waitFor(finished)).workPlan, plan("done", replacementEvidence()), "all clients receive one authoritative update");
 
     // There is deliberately no client-side mutation message in the protocol.
     // An unsolicited server-shaped frame is ignored and cannot replace state.
     first.send({ type: "work_plan_changed", workPlan: plan("blocked") });
     third = connect(server.wsUrl());
-    assert.deepEqual((await third.waitFor("hello")).workPlan, plan("done"));
+    assert.deepEqual((await third.waitFor("hello")).workPlan, plan("done", replacementEvidence()));
     assert.deepEqual(JSON.parse(await readFile(`${source}.work-plan.json`, "utf8")), plan(), "fork changes stay isolated");
   } finally {
     first.close();
@@ -274,6 +352,7 @@ test("running server restores, forks, reconnects, and broadcasts authoritative W
     third?.close();
     postCompaction?.close();
     afterUnrelatedTool?.close();
+    invalidObserver?.close();
     concurrentFork?.close();
     await server.stop();
   }
@@ -305,12 +384,14 @@ test("a real Pi RPC child executes work_plan and synchronizes its persisted resu
       (message) => message.type === "work_plan_changed"
         && message.workPlan?.title === "RPC release"
         && message.workPlan?.tasks.length === 2
-        && message.workPlan.tasks[0].status === "done",
+        && message.workPlan.tasks[0].status === "done"
+        && message.workPlan.tasks[0].evidence?.length === 2,
       30_000,
     );
     assert.equal(changed.workPlan.tasks[0].status, "done");
+    assert.deepEqual(changed.workPlan.tasks[0].evidence, evidence());
     assert.equal(changed.workPlan.tasks[1].id, "release-note");
-    await client.waitFor("agent_end", 30_000); // emitted only after the provider receives the fourth (`get`) result
+    await client.waitFor("agent_end", 30_000); // emitted only after the provider receives the fifth (`get`) result
     const sidecars = (await readdir(root, { recursive: true }))
       .filter((entry) => entry.endsWith(".work-plan.json"));
     assert.equal(sidecars.length, 1, "the real child persisted exactly one Work Plan sidecar");
@@ -338,10 +419,12 @@ test("the embedded SDK provider receives the same fully typed work_plan schema",
       (message) => message.type === "work_plan_changed"
         && message.workPlan?.title === "RPC release"
         && message.workPlan?.tasks.length === 2
-        && message.workPlan.tasks[0].status === "done",
+        && message.workPlan.tasks[0].status === "done"
+        && message.workPlan.tasks[0].evidence?.length === 2,
       30_000,
     );
     assert.equal(changed.workPlan.tasks[0].status, "done");
+    assert.deepEqual(changed.workPlan.tasks[0].evidence, evidence());
     assert.equal(changed.workPlan.tasks[1].id, "release-note");
     await client.waitFor("agent_end", 30_000);
   } finally {

--- a/server/test/work-plan.test.ts
+++ b/server/test/work-plan.test.ts
@@ -6,6 +6,7 @@ import { describe, it } from "node:test";
 import { Compile } from "typebox/compile";
 import { isWorkPlanReadyForReview, mutateWorkPlan, normalizeWorkPlanDraft, validateWorkPlan, WORK_PLAN_LIMITS, type WorkPlan } from "@pi-outpost/shared/work-plan";
 import { applyWorkPlanMutation, copyWorkPlan, deleteWorkPlan, loadWorkPlan, sameSessionFile, workPlanPath } from "../src/workPlanStore.ts";
+import { WORK_PLAN_SYSTEM_GUIDANCE } from "../src/systemPrompt.ts";
 import { createWorkPlanToolDefinition } from "../src/workPlanTool.ts";
 
 const base = (): WorkPlan => ({
@@ -14,10 +15,20 @@ const base = (): WorkPlan => ({
   title: "Deliver the change",
   updatedAt: "2026-08-23T00:00:00.000Z",
   tasks: [
-    { id: "analyse", title: "Analyse", status: "done", dependsOn: [], resources: [] },
-    { id: "build", title: "Build", status: "in_progress", dependsOn: ["analyse"], resources: [{ uri: "workspace:src/index.ts" }] },
+    { id: "analyse", title: "Analyse", status: "done", dependsOn: [], resources: [], evidence: [] },
+    { id: "build", title: "Build", status: "in_progress", dependsOn: ["analyse"], resources: [{ uri: "workspace:src/index.ts" }], evidence: [] },
   ],
 });
+
+const legacyBase = (): Record<string, unknown> => ({
+  ...base(),
+  tasks: base().tasks.map(({ evidence: _evidence, ...task }) => task),
+});
+
+const verificationEvidence = () => [
+  { id: "tests", type: "test", result: "failed" as const, summary: "One regression remains" },
+  { id: "report", type: "file", result: "informational" as const, reference: { uri: "workspace:reports/check.json" } },
+];
 
 describe("Work Plan contract", () => {
   it("derives review readiness only from a fully reconciled authoritative plan", () => {
@@ -58,8 +69,8 @@ describe("Work Plan contract", () => {
       title: "Ship safely",
       updatedAt: "2026-08-23T12:00:00.000Z",
       tasks: [
-        { id: "task-one", title: "Build", status: "todo", dependsOn: [], resources: [] },
-        { id: "task-two", title: "Verify", status: "todo", dependsOn: [], resources: [] },
+        { id: "task-one", title: "Build", status: "todo", dependsOn: [], resources: [], evidence: [] },
+        { id: "task-two", title: "Verify", status: "todo", dependsOn: [], resources: [], evidence: [] },
       ],
     });
   });
@@ -93,6 +104,7 @@ describe("Work Plan contract", () => {
       statusReason: "Waiting for review",
       dependsOn: [],
       resources: [{ uri: "workspace:src/index.ts", label: "Entry point" }],
+      evidence: [],
     });
   });
 
@@ -174,6 +186,71 @@ describe("Work Plan contract", () => {
     );
   });
 
+  it("preserves generic successful, unsuccessful, and supporting evidence", () => {
+    const plan = validateWorkPlan({
+      ...base(),
+      tasks: [{
+        ...base().tasks[0],
+        evidence: [
+          { id: "unit", type: "test", result: "passed", summary: "Unit tests passed" },
+          { id: "lint", type: "command", result: "failed", summary: "Lint found an error" },
+          { id: "probe", type: "external-check", result: "inconclusive", summary: "Service timed out" },
+          { id: "report", type: "file", result: "informational", reference: { uri: "workspace:reports/check.json", label: "Check report" } },
+        ],
+      }],
+    });
+
+    assert.deepEqual(plan.tasks[0].evidence, [
+      { id: "unit", type: "test", result: "passed", summary: "Unit tests passed" },
+      { id: "lint", type: "command", result: "failed", summary: "Lint found an error" },
+      { id: "probe", type: "external-check", result: "inconclusive", summary: "Service timed out" },
+      { id: "report", type: "file", result: "informational", reference: { uri: "workspace:reports/check.json", label: "Check report" } },
+    ]);
+  });
+
+  it("rejects invalid or duplicate evidence atomically", () => {
+    const planWith = (evidence: unknown[]) => ({
+      ...base(),
+      tasks: [{ ...base().tasks[0], evidence }],
+    });
+
+    for (const [evidence, message] of [
+      [[{ id: "bad", type: "test", result: "unknown", summary: "No" }], /evidence\[0\]\.result must be one of/],
+      [[{ id: "bad", type: " ", result: "passed", summary: "No" }], /evidence\[0\]\.type must be a non-empty string/],
+      [[{ id: "bad", type: "test", result: "passed" }], /evidence\[0\] requires summary or reference/],
+      [[
+        { id: "same", type: "test", result: "failed", summary: "First" },
+        { id: "same", type: "test", result: "passed", summary: "Second" },
+      ], /duplicate evidence id: same/],
+    ] as const) {
+      assert.throws(() => validateWorkPlan(planWith(evidence as unknown[])), message);
+    }
+  });
+
+  it("enforces evidence collection and field limits before the whole-plan limit", () => {
+    const planWith = (evidence: unknown[]) => ({
+      ...base(),
+      tasks: [{ ...base().tasks[0], evidence }],
+    });
+    assert.throws(
+      () => validateWorkPlan(planWith(Array.from({ length: 101 }, (_, index) => ({
+        id: `e-${index}`,
+        type: "test",
+        result: "passed",
+        summary: "ok",
+      })) )),
+      /at most 100 evidence records/,
+    );
+    assert.throws(
+      () => validateWorkPlan(planWith([{ id: "type", type: "x".repeat(101), result: "passed", summary: "ok" }])),
+      /evidence\[0\]\.type is longer than 100 characters/,
+    );
+    assert.throws(
+      () => validateWorkPlan(planWith([{ id: "summary", type: "test", result: "passed", summary: "x".repeat(2_001) }])),
+      /evidence\[0\]\.summary is longer than 2000 characters/,
+    );
+  });
+
   it("accepts changed fields beside the task identifier", () => {
     const plan = normalizeWorkPlanDraft({ title: "P", tasks: [{ id: "a", title: "First" }] });
     const updated = mutateWorkPlan(plan, { action: "update_task", taskId: "a", status: "in_progress" } as never);
@@ -194,6 +271,111 @@ describe("Work Plan contract", () => {
     );
   });
 
+  it("keeps legacy creation, task addition, and replacement compatible", () => {
+    const legacy = validateWorkPlan(legacyBase());
+    assert.deepEqual(legacy.tasks.map((task) => task.evidence), [[], []]);
+
+    const created = normalizeWorkPlanDraft({ title: "Legacy create", tasks: [{ id: "old", title: "No evidence" }] });
+    assert.deepEqual(created.tasks[0].evidence, []);
+
+    const added = mutateWorkPlan(created, {
+      action: "add_task",
+      task: { id: "also-old", title: "Still no evidence", status: "todo", dependsOn: [], resources: [] },
+    });
+    assert.deepEqual(added?.tasks[1].evidence, []);
+
+    const replaced = mutateWorkPlan(null, { action: "replace", plan: legacyBase() });
+    assert.equal(replaced?.version, 1);
+    assert.deepEqual(replaced?.tasks.map((task) => task.evidence), [[], []]);
+  });
+
+  it("replaces and clears evidence without inferring task status", () => {
+    const original = base();
+    const recorded = mutateWorkPlan(original, {
+      action: "set_evidence",
+      taskId: "build",
+      evidence: verificationEvidence(),
+    });
+    assert.equal(recorded?.tasks[1].status, "in_progress", "failed evidence does not block the task");
+    assert.deepEqual(recorded?.tasks[1].evidence, verificationEvidence());
+    assert.deepEqual(original, base(), "the input plan remains immutable");
+
+    const passed = mutateWorkPlan(recorded, {
+      action: "set_evidence",
+      taskId: "build",
+      evidence: [{ id: "tests", type: "test", result: "passed", summary: "All tests passed" }],
+    });
+    assert.equal(passed?.tasks[1].status, "in_progress", "passing evidence does not complete the task");
+
+    const cleared = mutateWorkPlan(recorded, { action: "set_evidence", taskId: "build", evidence: [] });
+    assert.deepEqual(cleared?.tasks[1].evidence, []);
+    assert.equal(cleared?.tasks[1].status, "in_progress");
+
+    const completed = mutateWorkPlan(base(), {
+      action: "update_task",
+      taskId: "build",
+      changes: { status: "done" },
+    });
+    assert.deepEqual(completed?.tasks[1].evidence, [], "completion does not fabricate evidence");
+  });
+
+  it("refuses missing or invalid evidence replacements without altering prior evidence", () => {
+    const plan = mutateWorkPlan(base(), {
+      action: "set_evidence",
+      taskId: "build",
+      evidence: verificationEvidence(),
+    })!;
+    assert.throws(
+      () => mutateWorkPlan(plan, { action: "set_evidence", evidence: [] } as never),
+      /action=set_evidence requires taskId/,
+    );
+    assert.throws(
+      () => mutateWorkPlan(plan, { action: "set_evidence", taskId: "build" } as never),
+      /action=set_evidence requires evidence/,
+    );
+    assert.throws(
+      () => mutateWorkPlan(plan, {
+        action: "update_task",
+        taskId: "build",
+        changes: { evidence: [] },
+      } as never),
+      /evidence cannot be changed through update_task; use action=set_evidence/,
+    );
+    assert.throws(
+      () => mutateWorkPlan(plan, {
+        action: "set_evidence",
+        taskId: "build",
+        evidence: [
+          ...verificationEvidence(),
+          { id: "invalid", type: "test", result: "failed" },
+        ],
+      }),
+      /evidence\[2\] requires summary or reference/,
+    );
+    assert.deepEqual(plan.tasks[1].evidence, verificationEvidence());
+  });
+
+  it("preserves evidence through every unrelated task mutation", () => {
+    const plan = mutateWorkPlan(base(), {
+      action: "set_evidence",
+      taskId: "build",
+      evidence: verificationEvidence(),
+    })!;
+    const expected = JSON.stringify(plan.tasks[1].evidence);
+    const mutations = [
+      { action: "update_task", taskId: "build", changes: { title: "Build carefully", status: "blocked", statusReason: "Waiting" } },
+      { action: "move_task", taskId: "build", parentId: "analyse" },
+      { action: "set_dependencies", taskId: "build", dependsOn: [] },
+      { action: "set_resources", taskId: "build", resources: [{ uri: "workspace:src/other.ts" }] },
+      { action: "add_task", task: { id: "verify", title: "Verify", status: "todo", dependsOn: [], resources: [] } },
+      { action: "remove_task", taskId: "analyse" },
+    ] as const;
+    for (const mutation of mutations) {
+      const next = mutateWorkPlan(plan, mutation as never);
+      assert.equal(JSON.stringify(next?.tasks.find((task) => task.id === "build")?.evidence), expected, JSON.stringify(mutation));
+    }
+  });
+
   it("refuses an action whose own argument is missing, by name", () => {
     // The published schema makes every per-action argument optional, so that a
     // wrong property is answered by naming it rather than by ten branch
@@ -206,6 +388,7 @@ describe("Work Plan contract", () => {
       [{ action: "move_task", parentId: "a" }, /action=move_task requires taskId/],
       [{ action: "set_dependencies", dependsOn: ["a"] }, /action=set_dependencies requires taskId/],
       [{ action: "set_resources", resources: [] }, /action=set_resources requires taskId/],
+      [{ action: "set_evidence", evidence: [] }, /action=set_evidence requires taskId/],
       [{ action: "update_task", status: "done" }, /action=update_task requires taskId/],
       [{ action: "add_task" }, /action=add_task requires task/],
       [{ action: "update_task", taskId: "a" }, /requires at least one changed field/],
@@ -381,18 +564,55 @@ describe("Work Plan persistence", () => {
     }
   });
 
+  it("loads a legacy version-1 sidecar with empty canonical evidence", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "pi-outpost-work-plan-legacy-"));
+    try {
+      const sessionFile = path.join(root, "legacy.jsonl");
+      await fs.writeFile(workPlanPath(sessionFile), `${JSON.stringify(legacyBase(), null, 2)}\n`);
+      const restored = await loadWorkPlan(sessionFile);
+      assert.equal(restored?.version, 1);
+      assert.deepEqual(restored?.tasks.map((task) => task.evidence), [[], []]);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("loads absence, persists atomically, copies forks, and deletes with the session", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "pi-outpost-work-plan-"));
     try {
       const source = path.join(root, "source.jsonl");
       const fork = path.join(root, "fork.jsonl");
+      const sourcePlan = mutateWorkPlan(base(), {
+        action: "set_evidence",
+        taskId: "build",
+        evidence: verificationEvidence(),
+      })!;
       assert.equal(await loadWorkPlan(source), null);
-      await applyWorkPlanMutation(source, { action: "replace", plan: base() });
-      assert.deepEqual(await loadWorkPlan(source), base());
+      await applyWorkPlanMutation(source, { action: "replace", plan: sourcePlan });
+      assert.deepEqual((await loadWorkPlan(source))?.tasks[1].evidence, verificationEvidence());
       await copyWorkPlan(source, fork);
-      await applyWorkPlanMutation(fork, { action: "update_task", taskId: "build", changes: { status: "done" } });
-      assert.equal((await loadWorkPlan(source))?.tasks[1].status, "in_progress");
-      assert.equal((await loadWorkPlan(fork))?.tasks[1].status, "done");
+      const forkEvidence = [{ id: "probe", type: "external-check", result: "inconclusive" as const, summary: "Timed out" }];
+      await applyWorkPlanMutation(fork, { action: "set_evidence", taskId: "build", evidence: forkEvidence });
+      assert.deepEqual((await loadWorkPlan(source))?.tasks[1].evidence, verificationEvidence(), "fork evidence stays isolated from source");
+      assert.deepEqual((await loadWorkPlan(fork))?.tasks[1].evidence, forkEvidence);
+
+      const sourceEvidence = [{ id: "tests", type: "test", result: "passed" as const, summary: "All pass" }];
+      await applyWorkPlanMutation(source, { action: "set_evidence", taskId: "build", evidence: sourceEvidence });
+      assert.deepEqual((await loadWorkPlan(source))?.tasks[1].evidence, sourceEvidence);
+      assert.deepEqual((await loadWorkPlan(fork))?.tasks[1].evidence, forkEvidence, "source evidence stays isolated from fork");
+
+      const beforeRefusal = await fs.readFile(workPlanPath(source), "utf8");
+      await assert.rejects(
+        applyWorkPlanMutation(source, {
+          action: "set_evidence",
+          taskId: "build",
+          evidence: [...sourceEvidence, { id: "invalid", type: "test", result: "failed" }],
+        }),
+        /evidence\[1\] requires summary or reference/,
+      );
+      assert.equal(await fs.readFile(workPlanPath(source), "utf8"), beforeRefusal, "invalid evidence does not rewrite the sidecar");
+      assert.deepEqual((await loadWorkPlan(source))?.tasks[1].evidence, sourceEvidence);
+
       await deleteWorkPlan(source);
       assert.equal(await loadWorkPlan(source), null);
       assert.equal(await fs.stat(workPlanPath(source)).catch(() => null), null);
@@ -450,7 +670,7 @@ describe("work_plan tool", () => {
     const properties = schema.properties as Record<string, Record<string, unknown>>;
     assert.deepEqual(
       properties.action.enum,
-      ["get", "create", "replace", "add_task", "update_task", "move_task", "remove_task", "set_dependencies", "set_resources", "clear"],
+      ["get", "create", "replace", "add_task", "update_task", "move_task", "remove_task", "set_dependencies", "set_resources", "set_evidence", "clear"],
       "every action is one enum node, so an unknown action fails once",
     );
     // Each operation-specific argument says which actions use it, since the
@@ -458,7 +678,7 @@ describe("work_plan tool", () => {
     for (const [field, action] of [
       ["title", /create/], ["tasks", /create/], ["plan", /replace/], ["task", /add_task/],
       ["taskId", /update_task/], ["changes", /update_task/], ["parentId", /move_task/],
-      ["dependsOn", /set_dependencies/], ["resources", /set_resources/],
+      ["dependsOn", /set_dependencies/], ["resources", /set_resources/], ["evidence", /set_evidence/],
     ] as const) {
       assert.match(String(properties[field].description), action, `${field} names the action that uses it`);
     }
@@ -471,6 +691,8 @@ describe("work_plan tool", () => {
       assert.deepEqual(draft.required, ["title"]);
       const taskProperties = draft.properties as Record<string, Record<string, unknown>>;
       assert.deepEqual(taskProperties.status.enum, ["todo", "in_progress", "done", "blocked", "needs_review"]);
+      assert.equal(taskProperties.evidence.type, "array");
+      assert.equal(taskProperties.evidence.maxItems, WORK_PLAN_LIMITS.evidencePerTask);
       // A plan that has dependencies says so where it is written, in one call.
       assert.equal(taskProperties.dependsOn.type, "array");
       assert.match(String(taskProperties.dependsOn.description), /same call/);
@@ -485,6 +707,34 @@ describe("work_plan tool", () => {
         `${field} declares JSON null clearing`,
       );
     }
+  });
+
+  it("publishes finite evidence schemas for creation, replacement, addition, and mutation", () => {
+    const schema = createWorkPlanToolDefinition().parameters as unknown as Record<string, unknown>;
+    const properties = schema.properties as Record<string, Record<string, unknown>>;
+    const creationEvidence = ((properties.tasks.items as Record<string, unknown>).properties as Record<string, Record<string, unknown>>).evidence;
+    const completeEvidence = (((properties.task.properties as Record<string, Record<string, unknown>>).evidence));
+    for (const evidence of [creationEvidence, completeEvidence, properties.evidence]) {
+      assert.equal(evidence.type, "array");
+      assert.equal(evidence.maxItems, WORK_PLAN_LIMITS.evidencePerTask);
+      const record = evidence.items as Record<string, unknown>;
+      assert.equal(record.additionalProperties, false);
+      assert.deepEqual(record.required, ["id", "type", "result"]);
+      const recordProperties = record.properties as Record<string, Record<string, unknown>>;
+      assert.deepEqual(recordProperties.result.enum, ["passed", "failed", "inconclusive", "informational"]);
+      assert.equal(recordProperties.result.anyOf, undefined, "results use one enum node");
+      assert.equal(recordProperties.type.maxLength, WORK_PLAN_LIMITS.evidenceType);
+      assert.equal(recordProperties.summary.maxLength, WORK_PLAN_LIMITS.evidenceSummary);
+      assert.equal((recordProperties.reference as Record<string, unknown>).additionalProperties, false);
+    }
+
+    const validator = Compile(createWorkPlanToolDefinition().parameters as never);
+    const summaryOnly = { id: "tests", type: "test", result: "passed", summary: "All pass" };
+    const referenceOnly = { id: "report", type: "file", result: "informational", reference: { uri: "workspace:report.json" } };
+    assert.equal(validator.Check({ action: "create", title: "Evidence", tasks: [{ title: "Verify", evidence: [summaryOnly, referenceOnly] }] }), true);
+    assert.equal(validator.Check({ action: "set_evidence", taskId: "verify", evidence: [summaryOnly, referenceOnly] }), true);
+    assert.equal(validator.Check({ action: "set_evidence", taskId: "verify", evidence: [{ id: "empty", type: "test", result: "passed" }] }), false);
+    assert.equal(validator.Check({ action: "set_evidence", taskId: "verify", evidence: [{ ...summaryOnly, provider: "openlore" }] }), false);
   });
 
   it("anchors every pattern, so a provider can generate a parser for the schema", () => {
@@ -570,6 +820,27 @@ describe("work_plan tool", () => {
     const plan = normalizeWorkPlanDraft({ title: call.title, tasks: call.tasks });
     assert.equal(plan.tasks.filter((task) => task.dependsOn.length > 0).length, 1, "the example shows a dependency");
     assert.equal(plan.tasks.filter((task) => task.parentId !== undefined).length, 1, "the example shows a subtask");
+  });
+
+  it("ships valid evidence guidance with explicit replacement and status independence", () => {
+    const tool = createWorkPlanToolDefinition();
+    const example = (tool.promptGuidelines ?? []).find((line) => line.includes('"action":"set_evidence"'));
+    assert.ok(example, "the guidelines carry a literal evidence call");
+    const call = JSON.parse(example.slice(example.indexOf("{"), example.lastIndexOf("}") + 1));
+    const validator = Compile(tool.parameters as never);
+    assert.equal(validator.Check(call), true, "the evidence example passes the published schema");
+    assert.deepEqual(call.evidence.map((record: { result: string }) => record.result), ["passed", "failed"]);
+
+    const guidance = (tool.promptGuidelines ?? []).join(" ");
+    assert.match(guidance, /replaces the complete evidence collection/i);
+    assert.match(guidance, /include prior failures/i);
+    assert.match(guidance, /Evidence never changes task status/i);
+    assert.match(guidance, /status changes never create evidence/i);
+
+    assert.match(WORK_PLAN_SYSTEM_GUIDANCE, /failed or inconclusive checks/i);
+    assert.match(WORK_PLAN_SYSTEM_GUIDANCE, /does not record evidence automatically/i);
+    assert.match(WORK_PLAN_SYSTEM_GUIDANCE, /Evidence and task status are independent/i);
+    assert.match(WORK_PLAN_SYSTEM_GUIDANCE, /completion does not fabricate evidence/i);
   });
 
   it("keeps behavioral selection guidance out of the mechanical tool contract", () => {

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -186,7 +186,14 @@ export interface ContextUsage {
   percent: number | null;
 }
 
-export type { WorkPlan, WorkPlanResource, WorkPlanStatus, WorkPlanTask } from "./workPlan.ts";
+export type {
+  WorkPlan,
+  WorkPlanEvidence,
+  WorkPlanEvidenceResult,
+  WorkPlanResource,
+  WorkPlanStatus,
+  WorkPlanTask,
+} from "./workPlan.ts";
 import type { WorkPlan } from "./workPlan.ts";
 
 /**

--- a/shared/src/workPlan.ts
+++ b/shared/src/workPlan.ts
@@ -1,6 +1,9 @@
 export const WORK_PLAN_STATUSES = ["todo", "in_progress", "done", "blocked", "needs_review"] as const;
 export type WorkPlanStatus = (typeof WORK_PLAN_STATUSES)[number];
 
+export const WORK_PLAN_EVIDENCE_RESULTS = ["passed", "failed", "inconclusive", "informational"] as const;
+export type WorkPlanEvidenceResult = (typeof WORK_PLAN_EVIDENCE_RESULTS)[number];
+
 /** Every operation the tool accepts; the tool schema publishes this list verbatim. */
 export const WORK_PLAN_ACTIONS = [
   "get",
@@ -12,6 +15,7 @@ export const WORK_PLAN_ACTIONS = [
   "remove_task",
   "set_dependencies",
   "set_resources",
+  "set_evidence",
   "clear",
 ] as const;
 export type WorkPlanAction = (typeof WORK_PLAN_ACTIONS)[number];
@@ -22,6 +26,15 @@ export interface WorkPlanResource {
   label?: string;
 }
 
+export interface WorkPlanEvidence {
+  id: string;
+  /** Free-form evidence kind or source, such as test, command, file, or external-check. */
+  type: string;
+  result: WorkPlanEvidenceResult;
+  summary?: string;
+  reference?: WorkPlanResource;
+}
+
 export interface WorkPlanTask {
   id: string;
   title: string;
@@ -30,6 +43,7 @@ export interface WorkPlanTask {
   parentId?: string;
   dependsOn: string[];
   resources: WorkPlanResource[];
+  evidence: WorkPlanEvidence[];
   statusReason?: string;
 }
 
@@ -63,6 +77,9 @@ export const WORK_PLAN_LIMITS = {
   description: 4_000,
   reason: 2_000,
   resourcesPerTask: 50,
+  evidencePerTask: 100,
+  evidenceType: 100,
+  evidenceSummary: 2_000,
   uri: 2_000,
 } as const;
 
@@ -77,6 +94,7 @@ export interface WorkPlanDraftTask {
   status?: WorkPlanStatus;
   statusReason?: string;
   resources?: WorkPlanResource[];
+  evidence?: WorkPlanEvidence[];
   /** Ids of other tasks in the same draft; resolved once the whole tree is read. */
   dependsOn?: string[];
   subtasks?: WorkPlanDraftTask[];
@@ -103,7 +121,8 @@ export type WorkPlanMutation =
   | { action: "move_task"; taskId: string; parentId?: string | null }
   | { action: "remove_task"; taskId: string }
   | { action: "set_dependencies"; taskId: string; dependsOn: unknown }
-  | { action: "set_resources"; taskId: string; resources: unknown };
+  | { action: "set_resources"; taskId: string; resources: unknown }
+  | { action: "set_evidence"; taskId: string; evidence: unknown };
 
 function object(value: unknown): Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error("must be an object");
@@ -151,6 +170,49 @@ function resources(value: unknown): WorkPlanResource[] {
   return result;
 }
 
+function evidenceRecords(value: unknown): WorkPlanEvidence[] {
+  if (!Array.isArray(value)) throw new Error("evidence must be an array");
+  if (value.length > WORK_PLAN_LIMITS.evidencePerTask) {
+    throw new Error(`a task may contain at most ${WORK_PLAN_LIMITS.evidencePerTask} evidence records`);
+  }
+  const result = value.map((item, index) => {
+    const field = `evidence[${index}]`;
+    const raw = object(item);
+    onlyFields(raw, ["id", "type", "result", "summary", "reference"], field);
+    if (typeof raw.result !== "string" || !WORK_PLAN_EVIDENCE_RESULTS.includes(raw.result as WorkPlanEvidenceResult)) {
+      throw new Error(`${field}.result must be one of ${WORK_PLAN_EVIDENCE_RESULTS.join(", ")}`);
+    }
+    const summary = raw.summary === undefined
+      ? undefined
+      : text(raw.summary, `${field}.summary`, WORK_PLAN_LIMITS.evidenceSummary);
+    let reference: WorkPlanResource | undefined;
+    if (raw.reference !== undefined) {
+      const referenceRaw = object(raw.reference);
+      onlyFields(referenceRaw, ["uri", "label"], `${field}.reference`);
+      reference = {
+        uri: text(referenceRaw.uri, `${field}.reference.uri`, WORK_PLAN_LIMITS.uri),
+        ...(referenceRaw.label === undefined
+          ? {}
+          : { label: text(referenceRaw.label, `${field}.reference.label`, WORK_PLAN_LIMITS.title) }),
+      };
+    }
+    if (summary === undefined && reference === undefined) throw new Error(`${field} requires summary or reference`);
+    return {
+      id: text(raw.id, `${field}.id`, WORK_PLAN_LIMITS.title),
+      type: text(raw.type, `${field}.type`, WORK_PLAN_LIMITS.evidenceType),
+      result: raw.result as WorkPlanEvidenceResult,
+      ...(summary === undefined ? {} : { summary }),
+      ...(reference === undefined ? {} : { reference }),
+    };
+  });
+  const seen = new Set<string>();
+  for (const record of result) {
+    if (seen.has(record.id)) throw new Error(`duplicate evidence id: ${record.id}`);
+    seen.add(record.id);
+  }
+  return result;
+}
+
 function task(value: unknown): WorkPlanTask {
   const raw = object(value);
   const status = raw.status;
@@ -167,6 +229,7 @@ function task(value: unknown): WorkPlanTask {
       : { parentId: text(raw.parentId, "task.parentId", WORK_PLAN_LIMITS.title) }),
     dependsOn: raw.dependsOn === undefined ? [] : ids(raw.dependsOn, "task.dependsOn"),
     resources: raw.resources === undefined ? [] : resources(raw.resources),
+    evidence: raw.evidence === undefined ? [] : evidenceRecords(raw.evidence),
     ...(raw.statusReason === undefined ? {} : { statusReason: optionalText(raw.statusReason, "task.statusReason", WORK_PLAN_LIMITS.reason) }),
   };
 }
@@ -274,7 +337,7 @@ export function normalizeWorkPlanDraft(
     }
     for (const [index, item] of items.entries()) {
       const draft = object(item);
-      onlyFields(draft, ["id", "title", "description", "status", "statusReason", "resources", "dependsOn", "subtasks"], `tasks[${index}]`);
+      onlyFields(draft, ["id", "title", "description", "status", "statusReason", "resources", "evidence", "dependsOn", "subtasks"], `tasks[${index}]`);
       const status = draft.status ?? "todo";
       if (typeof status !== "string" || !WORK_PLAN_STATUSES.includes(status as WorkPlanStatus)) {
         throw new Error(`status must be one of ${WORK_PLAN_STATUSES.join(", ")}`);
@@ -292,6 +355,7 @@ export function normalizeWorkPlanDraft(
         // reading order, so a task may depend on one declared further down.
         dependsOn: draft.dependsOn === undefined ? [] : ids(draft.dependsOn, `tasks[${index}].dependsOn`),
         resources: draft.resources === undefined ? [] : resources(draft.resources),
+        evidence: draft.evidence === undefined ? [] : evidenceRecords(draft.evidence),
         ...(draft.statusReason === undefined
           ? {}
           : { statusReason: text(draft.statusReason, "task.statusReason", WORK_PLAN_LIMITS.reason) }),
@@ -352,6 +416,7 @@ const REQUIRED_ARGUMENTS: Partial<Record<WorkPlanAction, readonly string[]>> = {
   remove_task: ["taskId"],
   set_dependencies: ["taskId", "dependsOn"],
   set_resources: ["taskId", "resources"],
+  set_evidence: ["taskId", "evidence"],
 };
 
 function assertRequiredArguments(mutation: Record<string, unknown>): void {
@@ -372,7 +437,15 @@ export function mutateWorkPlan(current: WorkPlan | null, mutation: WorkPlanMutat
   }
   if (mutation.action === "replace") return validateWorkPlan(mutation.plan);
   if (current === null) throw new Error("create a plan with action=create or action=replace before mutating tasks");
-  let tasks = current.tasks.map((item) => ({ ...item, dependsOn: [...item.dependsOn], resources: item.resources.map((resource) => ({ ...resource })) }));
+  let tasks = current.tasks.map((item) => ({
+    ...item,
+    dependsOn: [...item.dependsOn],
+    resources: item.resources.map((resource) => ({ ...resource })),
+    evidence: item.evidence.map((record) => ({
+      ...record,
+      ...(record.reference === undefined ? {} : { reference: { ...record.reference } }),
+    })),
+  }));
   const index = "taskId" in mutation ? tasks.findIndex((item) => item.id === mutation.taskId) : -1;
   if ("taskId" in mutation && index < 0) throw new Error(`unknown task: ${mutation.taskId}`);
   switch (mutation.action) {
@@ -382,6 +455,9 @@ export function mutateWorkPlan(current: WorkPlan | null, mutation: WorkPlanMutat
     case "update_task": {
       const changes = object(mutation.changes ?? loosenedChanges(mutation));
       if (changes.id !== undefined) throw new Error("task identity cannot be changed");
+      if (Object.hasOwn(changes, "evidence")) {
+        throw new Error("task evidence cannot be changed through update_task; use action=set_evidence");
+      }
       if (Object.keys(changes).length === 0) {
         throw new Error("action=update_task requires at least one changed field, in changes or beside taskId");
       }
@@ -411,6 +487,9 @@ export function mutateWorkPlan(current: WorkPlan | null, mutation: WorkPlanMutat
       break;
     case "set_resources":
       tasks[index] = { ...tasks[index], resources: resources(mutation.resources) };
+      break;
+    case "set_evidence":
+      tasks[index] = { ...tasks[index], evidence: evidenceRecords(mutation.evidence) };
       break;
   }
   return validateWorkPlan({ ...current, tasks, updatedAt: new Date().toISOString() });


### PR DESCRIPTION
## Why

Work Plans could say a task was `done`, but not what proved it. Verification facts lived only in the transcript and vanished with compaction. This adds durable, inspectable evidence per task — successful, failed, and inconclusive alike — without turning the plan into a verifier or inferring completion from activity.

## What changed

- **Evidence model** (`shared/src/workPlan.ts`): every task carries an evidence collection. Each record has a task-unique `id`, a non-empty free-form `type`, a `result` of `passed` / `failed` / `inconclusive` / `informational`, and at least one of a non-empty `summary` or a generic resource `reference` (same provider-neutral URI + optional label shape as other Work Plan resources). No provider-specific fields.
- **`set_evidence` action** (`server/src/workPlanTool.ts`): atomically replaces one named task's complete evidence collection, including with an empty collection to clear it. Every record is validated before commit; an invalid replacement leaves prior evidence untouched. Missing `taskId` or `evidence` is refused by name.
- **Independence from status**: evidence mutations never change status or status reason; status edits never add, drop, or fabricate evidence. Passing evidence does not complete a task; failing evidence does not block one.
- **Backward compatibility**: version-1 plans and task inputs that omit evidence stay valid and normalize to an empty collection. No version bump, no migration.
- **Lifecycle**: evidence rides the existing Work Plan snapshots through persistence, restoration, fork (independent thereafter), compaction-independent reads, and multi-client synchronization (`shared/src/protocol.ts`).
- **Prompt guidance** (`server/src/systemPrompt.ts`): explains the evidence shape, accepted results, replacement semantics, and independence from status.

Not in scope: automatic verification, an Outcome/Review UI, an OpenLore dependency, or deriving evidence from tool activity.

## Specs

OpenSpec change `work-plan-evidence-and-verification` (21/21 tasks), with delta specs synced into the main `work-plan` and `model` specs. `openspec validate --specs`: 40 passed, 0 failed. Scenario-to-test matrix in the change's `scenario-coverage.md`.

## Verification

- `npm run typecheck` — clean.
- Test coverage extended in `server/test/work-plan.test.ts`, `server/test/work-plan-server.test.mjs`, and the RPC provider fixture: evidence/status independence, failed-evidence retention, atomic refusal, legacy inputs, fork independence, and client synchronization.

## Documentation impact

`README.md` — the Work Plan section now documents evidence records, the `set_evidence` call (with a worked JSON example), the independence rule, and that legacy plans without evidence remain valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JpDnwLWKe5zYdPdhzhvKde