### PR TITLE
chore(ci): check spec scenarios and refuse assertion-free tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,21 @@ jobs:
       # or a second React bundled in. Both are invisible until someone installs it.
       - run: npm run check:embed
 
+      # A change can declare scenarios nobody ever wrote a test for and stay green
+      # everywhere: the suite passes, the coverage percentage holds, and the only
+      # thing that would have caught it is a person reading the delta specs beside
+      # the tests. This checks the mechanical half — every scenario is accounted
+      # for in the change's scenario-coverage.md, and every file it cites exists.
+      # Scoped to the changes this branch touches, so an older change without a
+      # matrix does not fail unrelated work.
+      - run: npm run test:scripts
+        if: matrix.os == 'ubuntu-latest'
+      - name: Spec scenarios are accounted for
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          git fetch --no-tags --depth=1 origin ${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}
+          node scripts/check-scenario-coverage.mjs --base FETCH_HEAD
+
   # The two ways this project is consumed, in a real browser: the app the server
   # serves, and the widget a host page mounts. Shadow DOM, cross-origin wiring and
   # an actually-applied stylesheet are all invisible to jsdom, which is where the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,17 @@ scenario is `partial` or `uncovered`. If a correct test exposes a product bug,
 keep the assertion strong: fix the implementation when in scope, otherwise
 report the blocker instead of weakening the test.
 
+Write the matrix to `openspec/changes/<change>/scenario-coverage.md`, and run
+`npm run check:scenarios` before opening the PR — CI runs it over the changes the
+branch touches. It verifies the mechanical half: a matrix exists, every declared
+scenario appears in it as `covered`, and every file the evidence cites is really
+in the repository. It cannot tell whether a cited assertion is worth anything;
+that is the reading job above, and passing this check is not evidence of coverage.
+
+`npm run lint` refuses a test with no assertion at all (`vitest/expect-expect`),
+which is the cheapest form of the same mistake: a test whose name claims a
+contract and whose body never checks it.
+
 ## UI and UX changes: test them in the running app
 
 Any change that touches the interface **or the way it is used** — a component, a

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "check:css": "node scripts/check-web-css.mjs",
     "check:embed": "node scripts/check-embed-package.mjs",
     "check:cli": "node scripts/check-cli-package.mjs",
+    "check:scenarios": "node scripts/check-scenario-coverage.mjs",
+    "test:scripts": "node --test scripts/*.test.mjs",
     "test:linux": "node scripts/test-linux.mjs",
     "build:e2e-host": "vite build --config e2e/vite.config.ts",
     "test:e2e": "npm run build:e2e-host && playwright test --config e2e/playwright.config.ts",

--- a/scripts/check-scenario-coverage.mjs
+++ b/scripts/check-scenario-coverage.mjs
@@ -1,0 +1,348 @@
+#!/usr/bin/env node
+/**
+ * Every scenario an OpenSpec change declares must be accounted for in that change's
+ * `scenario-coverage.md`, and every citation in it must point at a file that exists.
+ *
+ * The house rule is that a feature is not done until each `#### Scenario:` is matched
+ * to a test whose assertions would fail if the contract broke. A green suite cannot
+ * show that, and neither can a coverage percentage: a change can carry three scenarios
+ * nobody ever wrote a test for while every badge stays green. This is the mechanical
+ * half of the rule — it proves the matrix exists, covers every scenario, and cites
+ * real files. Whether the cited assertions are worth anything is still a reading job.
+ *
+ * Usage:
+ *   node scripts/check-scenario-coverage.mjs                 # changes touched since origin/main
+ *   node scripts/check-scenario-coverage.mjs --base <ref>    # ...since another ref
+ *   node scripts/check-scenario-coverage.mjs --all           # every started change
+ *   node scripts/check-scenario-coverage.mjs --change <name> # one change, by directory name
+ *   node scripts/check-scenario-coverage.mjs --allow-incomplete   # `partial`/`uncovered` rows do not fail
+ */
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// The repository this speaks about. Overridable so the checker can be run against a
+// fixture tree in its own tests.
+const ROOT = process.env.PI_OUTPOST_SCENARIO_ROOT
+  ? path.resolve(process.env.PI_OUTPOST_SCENARIO_ROOT)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const CHANGES_DIR = path.join(ROOT, "openspec", "changes");
+const MATRIX_NAME = "scenario-coverage.md";
+
+const args = process.argv.slice(2);
+const flag = (name) => args.includes(name);
+const value = (name) => {
+  const index = args.indexOf(name);
+  return index === -1 ? undefined : args[index + 1];
+};
+
+const allowIncomplete = flag("--allow-incomplete");
+const base = value("--base") ?? "origin/main";
+
+/** A change directory that exists and is not the archive. */
+function activeChanges() {
+  if (!fs.existsSync(CHANGES_DIR)) return [];
+  return fs
+    .readdirSync(CHANGES_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name !== "archive")
+    .map((entry) => entry.name)
+    .sort();
+}
+
+/** Delta spec files of one change, at any capability depth. */
+function deltaSpecs(change) {
+  const specsRoot = path.join(CHANGES_DIR, change, "specs");
+  if (!fs.existsSync(specsRoot)) return [];
+  const found = [];
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith(".md")) found.push(full);
+    }
+  };
+  walk(specsRoot);
+  return found.sort();
+}
+
+/**
+ * A change nobody has started yet has nothing to prove: its tasks are all open, so
+ * demanding a matrix would only teach people to write one before the code exists.
+ */
+function isStarted(change) {
+  const tasks = path.join(CHANGES_DIR, change, "tasks.md");
+  if (!fs.existsSync(tasks)) return true;
+  return /^\s*-\s*\[x\]/im.test(fs.readFileSync(tasks, "utf8"));
+}
+
+/** Changes with files modified against the base ref — what this branch is actually proposing. */
+function changesTouchedSince(ref) {
+  let output;
+  try {
+    output = execFileSync("git", ["diff", "--name-only", `${ref}...HEAD`], { cwd: ROOT, encoding: "utf8" });
+  } catch {
+    try {
+      output = execFileSync("git", ["diff", "--name-only", ref], { cwd: ROOT, encoding: "utf8" });
+    } catch {
+      return undefined; // no such ref (a shallow CI clone, a fresh repo) — the caller falls back
+    }
+  }
+  const names = new Set();
+  for (const line of output.split("\n")) {
+    const match = line.match(/^openspec\/changes\/([^/]+)\//);
+    if (match && match[1] !== "archive") names.add(match[1]);
+  }
+  return [...names].sort();
+}
+
+/** Comparable form of a scenario title: quotes, dashes and spacing vary between documents. */
+function normalize(text) {
+  return text
+    .replace(/[‘’]/g, "'")
+    .replace(/[“”]/g, '"')
+    .replace(/[–—]/g, "-")
+    .replace(/\s+/g, " ")
+    .replace(/[.:;,]+$/, "")
+    .trim()
+    .toLowerCase();
+}
+
+/**
+ * A matrix may name a row `capability / ScenarioName`, in backticks, to disambiguate
+ * two capabilities that share a scenario title. Both forms are read: the qualified
+ * one binds to exactly one capability, the bare one only when the title is unique
+ * within the change.
+ */
+function rowKeys(text) {
+  const bare = text.replace(/`/g, "").trim();
+  const slash = bare.lastIndexOf("/");
+  if (slash === -1) return { qualified: undefined, title: normalize(bare) };
+  return {
+    qualified: `${normalize(bare.slice(0, slash))}/${normalize(bare.slice(slash + 1))}`,
+    title: normalize(bare.slice(slash + 1)),
+  };
+}
+
+function scenariosOf(file) {
+  const found = [];
+  const lines = fs.readFileSync(file, "utf8").split("\n");
+  for (const line of lines) {
+    const match = line.match(/^####\s+Scenario:\s*(.+?)\s*$/);
+    if (match) found.push(match[1]);
+  }
+  return found;
+}
+
+/** Rows of the `| Scenario | Coverage | Assertion evidence |` table, however many tables there are. */
+function matrixRows(file) {
+  const rows = [];
+  for (const line of fs.readFileSync(file, "utf8").split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("|")) continue;
+    const cells = trimmed.replace(/^\|/, "").replace(/\|$/, "").split("|").map((cell) => cell.trim());
+    if (cells.length < 3) continue;
+    if (/^-{2,}$/.test(cells[0].replace(/[\s:]/g, ""))) continue; // separator
+    if (normalize(cells[0]) === "scenario") continue; // header
+    rows.push({ scenario: cells[0], coverage: cells[1], evidence: cells.slice(2).join(" | ") });
+  }
+  return rows;
+}
+
+/**
+ * Tracked files, by full path and by basename. A matrix cites `server/test/x.test.mjs`
+ * in one row and plain `x.test.mjs` in the next; both are fine, and both stop being
+ * fine the moment the file is renamed, which is the rot worth catching.
+ */
+const tracked = (() => {
+  const paths = new Set();
+  const basenames = new Set();
+  try {
+    // Tracked, plus what is merely present: a change under review routinely cites a
+    // test file that is new and not yet committed.
+    for (const argv of [["ls-files"], ["ls-files", "--others", "--exclude-standard"]]) {
+      const output = execFileSync("git", argv, { cwd: ROOT, encoding: "utf8", maxBuffer: 32 * 1024 * 1024 });
+      for (const line of output.split("\n")) {
+        const file = line.trim();
+        if (!file) continue;
+        paths.add(file);
+        basenames.add(path.basename(file));
+      }
+    }
+  } catch {
+    // Not a git checkout: fall back to on-disk lookups only.
+  }
+  return { paths, basenames };
+})();
+
+function fileExists(cited) {
+  const candidates = [cited];
+  // Spec citations are routinely written relative to the openspec root.
+  if (cited.startsWith("specs/") || cited.startsWith("changes/")) candidates.push(path.join("openspec", cited));
+  for (const candidate of candidates) {
+    if (fs.existsSync(path.join(ROOT, candidate))) return true;
+    if (tracked.paths.has(candidate)) return true;
+  }
+  if (!cited.includes("/")) return tracked.basenames.has(cited);
+  return false;
+}
+
+/** Paths cited in an evidence cell, in backticks, that look like files. */
+function citedFiles(evidence) {
+  const cited = [];
+  // No newlines inside the span: a fenced block would otherwise swallow the table
+  // below it and the matrix would look as if it cited nothing.
+  for (const match of evidence.matchAll(/`([^`\n]+)`/g)) {
+    const candidate = match[1].trim();
+    if (/^[\w./@-]+\.(ts|tsx|mjs|cjs|js|jsx|md|json)$/.test(candidate)) cited.push(candidate);
+  }
+  return cited;
+}
+
+function checkChange(change) {
+  const problems = [];
+  const specs = deltaSpecs(change);
+  if (specs.length === 0) return { change, skipped: "no delta specs", problems };
+  if (!isStarted(change)) return { change, skipped: "not started", problems };
+
+  const specsRoot = path.join(CHANGES_DIR, change, "specs");
+  const declared = [];
+  for (const spec of specs) {
+    // `specs/<capability-path>/spec.md` — the capability is what disambiguates two
+    // deltas that happen to name a scenario the same way.
+    const capability = normalize(path.dirname(path.relative(specsRoot, spec)));
+    for (const scenario of scenariosOf(spec)) {
+      declared.push({ scenario, capability, spec: path.relative(ROOT, spec) });
+    }
+  }
+  if (declared.length === 0) return { change, skipped: "no scenarios declared", problems };
+
+  const matrixPath = path.join(CHANGES_DIR, change, MATRIX_NAME);
+  if (!fs.existsSync(matrixPath)) {
+    problems.push(
+      `no ${MATRIX_NAME}: ${declared.length} scenario(s) are declared and none is matched to a test`,
+    );
+    return { change, declared: declared.length, problems };
+  }
+
+  const rows = matrixRows(matrixPath).map((row) => ({ ...row, keys: rowKeys(row.scenario) }));
+
+  // A bare title can only address one scenario. When two capabilities declare the
+  // same title, one row would otherwise mark both covered on the strength of a
+  // single test — so those rows have to name their capability.
+  const titleCount = new Map();
+  for (const { scenario } of declared) {
+    const key = normalize(scenario);
+    titleCount.set(key, (titleCount.get(key) ?? 0) + 1);
+  }
+
+  const claimedBy = new Map();
+  for (const { scenario, capability, spec } of declared) {
+    const title = normalize(scenario);
+    const qualified = `${capability}/${title}`;
+    let row = rows.find((candidate) => candidate.keys.qualified === qualified && !claimedBy.has(candidate));
+    if (!row) {
+      const bare = rows.filter((candidate) => candidate.keys.qualified === undefined && candidate.keys.title === title);
+      // A matrix may repeat a title across its sections — main spec scenarios beside
+      // the delta's, say — and that is fine: each declared scenario takes a row of
+      // its own. What is not fine is two capabilities sharing a title with fewer
+      // rows than scenarios, where one test would silently cover both.
+      if (titleCount.get(title) > 1 && bare.length < titleCount.get(title)) {
+        problems.push(
+          `"${scenario}" is declared by more than one capability (${spec} among them) and ${MATRIX_NAME} does not name each one — write \`<capability> / ${scenario}\` per capability`,
+        );
+        continue;
+      }
+      row = bare.find((candidate) => !claimedBy.has(candidate));
+    }
+    if (!row) {
+      problems.push(`"${scenario}" (${spec}) is missing from ${MATRIX_NAME}`);
+      continue;
+    }
+    const already = claimedBy.get(row);
+    if (already) {
+      problems.push(`one row ("${row.scenario}") is standing in for both "${already}" and "${scenario}" — give each its own row`);
+      continue;
+    }
+    claimedBy.set(row, scenario);
+
+    const coverage = normalize(row.coverage);
+    if (coverage !== "covered" && !allowIncomplete) {
+      problems.push(`"${scenario}" is recorded as \`${row.coverage || "(empty)"}\`, not \`covered\``);
+      continue;
+    }
+    if (row.evidence.trim() === "") {
+      problems.push(`"${scenario}" is marked covered with an empty evidence cell`);
+    }
+  }
+
+  // Citations rot: a test file gets renamed and the matrix keeps pointing at the old
+  // name, which reads as proof and is not. Every path the matrix names must exist —
+  // wherever in the table it appears, since a row may lean on the one above it.
+  const matrixText = fs.readFileSync(matrixPath, "utf8");
+  const cited = citedFiles(matrixText);
+  if (cited.length === 0) {
+    // Prose alone reads as proof and is not: a matrix has to point at the tests it
+    // is claiming, somewhere, or there is nothing here a reviewer can go and check.
+    problems.push(`${MATRIX_NAME} cites no test file at all — name the files its evidence rests on`);
+  }
+  const seen = new Set();
+  for (const file of cited) {
+    if (seen.has(file)) continue;
+    seen.add(file);
+    if (!fileExists(file)) {
+      problems.push(`cites \`${file}\`, which is nowhere in the repository`);
+    }
+  }
+
+  return { change, declared: declared.length, rows: rows.length, problems };
+}
+
+const only = value("--change");
+let targets;
+if (only) {
+  targets = [only];
+} else if (flag("--all")) {
+  targets = activeChanges();
+} else {
+  const touched = changesTouchedSince(base);
+  if (touched === undefined) {
+    console.log(`[scenario-coverage] "${base}" is unknown here — checking every started change instead`);
+    targets = activeChanges();
+  } else {
+    targets = touched;
+  }
+}
+
+if (targets.length === 0) {
+  console.log("[scenario-coverage] no change to check");
+  process.exit(0);
+}
+
+let failed = false;
+for (const change of targets) {
+  if (!fs.existsSync(path.join(CHANGES_DIR, change))) {
+    console.error(`[scenario-coverage] ✗ ${change}: no such change`);
+    failed = true;
+    continue;
+  }
+  const result = checkChange(change);
+  if (result.skipped) {
+    console.log(`[scenario-coverage] – ${change}: skipped (${result.skipped})`);
+    continue;
+  }
+  if (result.problems.length === 0) {
+    console.log(`[scenario-coverage] ✓ ${change}: ${result.declared} scenario(s), all covered with existing citations`);
+    continue;
+  }
+  failed = true;
+  console.error(`[scenario-coverage] ✗ ${change}:`);
+  for (const problem of result.problems) console.error(`    ${problem}`);
+}
+
+if (failed) {
+  console.error("");
+  console.error("A scenario is covered when a test's assertions would fail if its contract broke.");
+  console.error(`Record each one in openspec/changes/<change>/${MATRIX_NAME}, citing the test file and test name.`);
+  process.exit(1);
+}

--- a/scripts/check-scenario-coverage.test.mjs
+++ b/scripts/check-scenario-coverage.test.mjs
@@ -1,0 +1,162 @@
+/**
+ * The gate is only worth having if it fails on the things it claims to catch. Each
+ * test builds a small change on disk and runs the real script against it.
+ */
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, describe, test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "check-scenario-coverage.mjs");
+const roots = [];
+
+/** A throwaway repository with one change in it. */
+function fixture({ specs, matrix, tasks = "- [x] done" }) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "scenario-gate-"));
+  roots.push(root);
+  const change = path.join(root, "openspec", "changes", "a-change");
+  for (const [capability, body] of Object.entries(specs)) {
+    const dir = path.join(change, "specs", capability);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "spec.md"), body);
+  }
+  fs.writeFileSync(path.join(change, "tasks.md"), `${tasks}\n`);
+  if (matrix !== undefined) fs.writeFileSync(path.join(change, "scenario-coverage.md"), matrix);
+  return root;
+}
+
+/** The script's verdict: `{ code, output }`, both streams together. */
+function run(root, args = ["--all"]) {
+  try {
+    const output = execFileSync(process.execPath, [SCRIPT, ...args], {
+      env: { ...process.env, PI_OUTPOST_SCENARIO_ROOT: root },
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { code: 0, output };
+  } catch (error) {
+    return { code: error.status ?? 1, output: `${error.stdout ?? ""}${error.stderr ?? ""}` };
+  }
+}
+
+const oneScenario = "## ADDED Requirements\n\n### Requirement: A\nThe system SHALL do a thing.\n\n#### Scenario: It does the thing\n- **WHEN** asked\n- **THEN** it does\n";
+
+after(() => {
+  for (const root of roots) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("check-scenario-coverage", () => {
+  test("accepts a change whose every scenario is covered with a real citation", () => {
+    const root = fixture({
+      specs: { alpha: oneScenario },
+      matrix: "| Scenario | Coverage | Evidence |\n|---|---|---|\n| It does the thing | covered | `scripts/check-scenario-coverage.mjs` — the checker itself, cited because it exists |\n",
+    });
+    fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
+    fs.writeFileSync(path.join(root, "scripts", "check-scenario-coverage.mjs"), "// fixture\n");
+    const { code } = run(root);
+    assert.equal(code, 0);
+  });
+
+  test("refuses a change with no matrix at all", () => {
+    const { code, output } = run(fixture({ specs: { alpha: oneScenario } }));
+    assert.equal(code, 1);
+    assert.match(output, /no scenario-coverage\.md/);
+  });
+
+  test("refuses a scenario the matrix never mentions", () => {
+    const { code, output } = run(
+      fixture({
+        specs: { alpha: `${oneScenario}\n#### Scenario: It also does another thing\n- **WHEN** asked twice\n- **THEN** it does\n` },
+        matrix: "| Scenario | Coverage | Evidence |\n|---|---|---|\n| It does the thing | covered | `package.json` — a file that exists |\n",
+      }),
+    );
+    assert.equal(code, 1);
+    assert.match(output, /"It also does another thing".*is missing/s);
+  });
+
+  test("refuses a row that is not `covered`", () => {
+    const { code, output } = run(
+      fixture({
+        specs: { alpha: oneScenario },
+        matrix: "| Scenario | Coverage | Evidence |\n|---|---|---|\n| It does the thing | partial | `package.json` — half a test |\n",
+      }),
+    );
+    assert.equal(code, 1);
+    assert.match(output, /recorded as `partial`/);
+  });
+
+  test("accepts a `partial` row when incompleteness is allowed", () => {
+    const root = fixture({
+      specs: { alpha: oneScenario },
+      matrix: "| Scenario | Coverage | Evidence |\n|---|---|---|\n| It does the thing | partial | `package.json` — half a test |\n",
+    });
+    fs.writeFileSync(path.join(root, "package.json"), "{}\n");
+    assert.equal(run(root, ["--all", "--allow-incomplete"]).code, 0);
+  });
+
+  test("refuses a citation naming a file that is nowhere in the tree", () => {
+    const { code, output } = run(
+      fixture({
+        specs: { alpha: oneScenario },
+        matrix: "| Scenario | Coverage | Evidence |\n|---|---|---|\n| It does the thing | covered | `server/test/renamed-away.test.mjs` — gone |\n",
+      }),
+    );
+    assert.equal(code, 1);
+    assert.match(output, /renamed-away\.test\.mjs.*nowhere in the repository/);
+  });
+
+  test("refuses a matrix that cites nothing at all", () => {
+    const { code, output } = run(
+      fixture({
+        specs: { alpha: oneScenario },
+        matrix: "| Scenario | Coverage | Evidence |\n|---|---|---|\n| It does the thing | covered | it is tested, trust me |\n",
+      }),
+    );
+    assert.equal(code, 1);
+    assert.match(output, /cites no test file at all/);
+  });
+
+  test("refuses one unqualified row standing in for two capabilities", () => {
+    const root = fixture({
+      specs: { alpha: oneScenario, beta: oneScenario },
+      matrix: "| Scenario | Coverage | Evidence |\n|---|---|---|\n| It does the thing | covered | `package.json` — one test for two capabilities |\n",
+    });
+    fs.writeFileSync(path.join(root, "package.json"), "{}\n");
+    const { code, output } = run(root);
+    assert.equal(code, 1);
+    assert.match(output, /declared by more than one capability/);
+  });
+
+  test("accepts the same two capabilities once each row names its own", () => {
+    const root = fixture({
+      specs: { alpha: oneScenario, beta: oneScenario },
+      matrix:
+        "| Scenario | Coverage | Evidence |\n|---|---|---|\n" +
+        "| `alpha / It does the thing` | covered | `package.json` — alpha's test |\n" +
+        "| `beta / It does the thing` | covered | `package.json` — beta's test |\n",
+    });
+    fs.writeFileSync(path.join(root, "package.json"), "{}\n");
+    assert.equal(run(root).code, 0);
+  });
+
+  test("reads citations under a fenced block rather than swallowing the table", () => {
+    const root = fixture({
+      specs: { alpha: oneScenario },
+      matrix:
+        "Enumerated with:\n\n```sh\nrg '^#### Scenario:' openspec/\n```\n\n" +
+        "| Scenario | Coverage | Evidence |\n|---|---|---|\n| It does the thing | covered | `server/test/renamed-away.test.mjs` — gone |\n",
+    });
+    const { code, output } = run(root);
+    assert.equal(code, 1);
+    assert.match(output, /renamed-away\.test\.mjs.*nowhere in the repository/);
+  });
+
+  test("skips a change nobody has started", () => {
+    const { code, output } = run(fixture({ specs: { alpha: oneScenario }, tasks: "- [ ] not yet" }));
+    assert.equal(code, 0);
+    assert.match(output, /skipped \(not started\)/);
+  });
+});

--- a/ui/.oxlintrc.json
+++ b/ui/.oxlintrc.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../node_modules/oxlint/configuration_schema.json",
+  "plugins": ["vitest"],
+  "rules": {
+    "vitest/expect-expect": ["error", { "assertFunctionNames": ["expect", "assert*"] }],
+    "vitest/no-standalone-expect": "error",
+    "vitest/no-identical-title": "error",
+    "vitest/require-mock-type-parameters": "off"
+  },
+  "ignorePatterns": ["dist", "coverage"]
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,6 +9,7 @@
     "./util/*": "./src/util/*"
   },
   "scripts": {
+    "lint": "oxlint",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage --coverage.provider=v8 --coverage.reporter=text --coverage.reporter=lcov --coverage.thresholds.lines=91 --coverage.thresholds.branches=85 --coverage.thresholds.functions=93"
@@ -33,6 +34,7 @@
     "@testing-library/react": "^16.3.2",
     "@vitest/coverage-v8": "^4.1.10",
     "jsdom": "^30.0.0",
+    "oxlint": "^1.71.0",
     "vitest": "^4.1.10"
   }
 }


### PR DESCRIPTION
## Why

A change can declare scenarios nobody ever wrote a test for and stay green everywhere: the suite passes, the coverage percentage holds, and the only thing standing between the two is a person reading the delta specs beside the tests. The house rule already says to do that reading; nothing enforces the part a machine can do.

Reviewing PR #147 made the gap concrete — its `specs/config/spec.md` declares three scenarios (default disabled, flag/env override, `sandboxLocks.terminal` prevents tampering) and no test mentions the lock, while `tasks.md` was fully ticked and CI was green.

## What it checks

`scripts/check-scenario-coverage.mjs`, wired into the `check` job and available as `npm run check:scenarios`:

- every `#### Scenario:` in a change's delta specs appears in that change's `scenario-coverage.md`;
- each row is `covered` (`--allow-incomplete` relaxes this for work in progress);
- the evidence cell is not empty, and every file the matrix cites is really in the repository.

It matches the matrix formats already in the repo: `capability / Name` row titles, rows that lean on the file named in the row above, spec paths written relative to `openspec/`, and bare basenames resolved anywhere in the tree — so it catches a **renamed test**, not a citation style. Changes nobody has started are skipped, and CI scopes the run to the changes the branch touches, so an older change without a matrix cannot fail unrelated work.

Run against every started change today, it passes on four and reports one real gap: `add-workspace-ready-for-review` declares 27 scenarios with no matrix at all. That one is left as-is here — it is a separate piece of work, and the branch-scoped CI run does not block anything until someone touches that change.

## The lint half

`ui` gains oxlint (same version and shape as `web`) with `vitest/expect-expect` as an error: a test containing no assertion at all is the cheapest form of the same mistake — a name that claims a contract, a body that checks nothing. `assert*` helpers count as assertions, so the graph-layout suites that assert through `assertAllInside()` stay green; the repo passes as-is. `npm run lint` picks the workspace up automatically.

## What it deliberately does not do

It cannot tell whether a cited assertion is worth anything. Passing this check is not evidence of coverage — reading the assertions is still the rule, and `CLAUDE.md` now says so next to the command.

## Documentation impact

`CLAUDE.md` — the spec-scenario section gains the two commands and an explicit note that the mechanical check does not replace reading the assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JpDnwLWKe5zYdPdhzhvKde