### PR TITLE
chore(release): v0.19.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-outpost",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "type": "module",
   "description": "A web interface for the pi coding agent: a browser chat UI you run with npx — no clone, no build.",
   "license": "MIT",

--- a/embed/package.json
+++ b/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-outpost/embed",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "type": "module",
   "description": "Mount pi-outpost as a Shadow-DOM-isolated widget inside another web app.",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "cli": {
       "name": "pi-outpost",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "^0.84.4",
@@ -42,7 +42,7 @@
     },
     "embed": {
       "name": "@pi-outpost/embed",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "license": "MIT",
       "devDependencies": {
         "@microsoft/api-extractor": "^7.58.9",


### PR DESCRIPTION
A minor, not a patch: two features have landed since 0.18.0, and neither is a fix.

- A workspace can be marked ready for review, so a directory of projects shows which ones are waiting on a person rather than on the agent (#141)
- Work Plan tasks carry structured, provider-neutral evidence, replaced atomically per task by a new `set_evidence` action; version-1 plans stay valid and normalise to an empty collection (#146)

Also on this tag, without user-visible behaviour: CI now refuses a change whose declared OpenSpec scenarios are missing from its coverage matrix, and a test that asserts nothing (#148).

Only `cli` and `embed` carry a version — the other workspaces are private and versionless — so this is the whole bump, plus the same two numbers in `package-lock.json`.

The lockfile change is deliberately limited to those two version fields. `npm install --package-lock-only` under the npm available here (10.9.7) rewrote 125 lines, adding `"peer": true` markers across the esbuild platform packages; that is a different npm's opinion of the tree, not part of this release.

Once this merges, `v0.19.0` goes on the merge commit in `main` — the tag is what `.github/workflows/release.yml` publishes from, so it must point at a commit that is on `main`, as `v0.18.0` did.

## Documentation impact

None. No document states a version number: `rg` for `0.18.0` outside the lockfile matches only `katex@^0.18.4` in `web/package.json` and prerelease fixtures in `server/test/releaseChannel.test.mjs`.

## Out of scope, worth noting

`openspec/changes/` still holds `add-workspace-ready-for-review` and `work-plan-evidence-and-verification`, both merged. For 0.18.0 the archiving was a separate PR (#144) ahead of the release; this PR keeps to the version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hoh7z4mz7wwQiyUfDcMBVo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hoh7z4mz7wwQiyUfDcMBVo)_