### PR TITLE
chore(release): v0.20.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-outpost",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "type": "module",
   "description": "A web interface for the pi coding agent: a browser chat UI you run with npx — no clone, no build.",
   "license": "MIT",

--- a/embed/package.json
+++ b/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-outpost/embed",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "type": "module",
   "description": "Mount pi-outpost as a Shadow-DOM-isolated widget inside another web app.",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "cli": {
       "name": "pi-outpost",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "^0.84.4",
@@ -42,7 +42,7 @@
     },
     "embed": {
       "name": "@pi-outpost/embed",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "MIT",
       "devDependencies": {
         "@microsoft/api-extractor": "^7.58.9",


### PR DESCRIPTION
A minor, not a patch: two features have landed since 0.19.0, and neither is a fix.

- A workspace answers what it currently holds. The Outcome view is composed server-side from state Pi Outpost already owns — the session's Work Plan tasks, their recorded evidence, and git working-tree status across every repository — with nothing upgraded to success and no model asked to summarise it (#150)
- An interactive terminal in the browser. A real PTY multiplexed over the existing authenticated WebSocket, with multiple tabs, renaming, and a cwd it detects live so one click repoints the agent, the file tree and git at that subdirectory (#147)

#150 merged after `v0.19.0` was tagged, so it ships here rather than there.

## What the terminal means for an installation

It is off unless it is asked for: `--terminal`, `PI_OUTPOST_TERMINAL=1`, or `terminal.enabled` in the configuration file, and a sandboxed server refuses it on its own. A host configuration can lock it, and no wire path exists to switch a locked terminal on from the client.

`node-pty` arrives as an `optionalDependency` of both `pi-outpost` and the server workspace, and is loaded lazily. Where it fails to build or install — the standalone executable and the esbuild bundle among them — the server answers `terminal_error` and everything else works as before. That is the shape the release pipeline needs: `npm ci` in `release.yml` must not die on a native addon.

Also on this tag, without user-visible behaviour: five merged OpenSpec changes folded into the main specs and archived.

## The bump itself

Only `cli` and `embed` carry a version — the other workspaces are private and versionless — so this is the whole bump, plus the same two numbers in `package-lock.json`.

The lockfile change is deliberately limited to those two version fields. `npm version 0.20.0 --workspace cli --workspace embed` under the npm available here (10.9.7) rewrote 136 lines of it, adding `"peer": true` markers across the tree; that is a different npm's opinion of the dependency graph, not part of this release. The four version lines were edited directly instead, which is the same shape as `10f16f1` for 0.19.0.

Once this merges, `v0.20.0` goes on the merge commit in `main` — the tag is what `.github/workflows/release.yml` publishes from, so it must point at a commit that is on `main`, as `v0.19.0` did.

## Documentation impact

None. `rg "0\.19\.0"` outside `package-lock.json` matches nothing in the tree, so no document states the version being bumped. The terminal's own documentation — `terminal.enabled`, `terminal.shell`, `terminal.shellArgs`, the `--terminal` / `--no-terminal` flags and the "Integrated Terminal" section of `README.md` — arrived with #147 and is accurate as merged.

## Out of scope, worth noting

`openspec/changes/` still holds `add-integrated-terminal`, now merged. As with 0.18.0 and 0.19.0, archiving is a separate chore; this PR keeps to the version bump.

Issue #154 records the one review item deliberately left open on #147: on Windows, the bare `bash.exe` candidate resolves through the `PATH` to the WSL launcher, which passes the `GNU bash` check and gets selected where Git Bash is absent. It does not block this release — the terminal is opt-in and the fallback only matters on a Windows host without Git Bash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrjdHGzf2L5feLfpA5Efb1

---
_Generated by [Claude Code](https://claude.ai/code/session_01HrjdHGzf2L5feLfpA5Efb1)_