### PR TITLE
feat(cli): add a doctor command that says why the server did not start

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,7 @@ past message. Sessions are not auto-titled there either.
 pi-outpost [options]          start the server
 pi-outpost init [options]     write a starter configuration file
 pi-outpost config [options]   print the configuration that would be used, and where it came from
+pi-outpost doctor [options]   check whether this installation can start and serve, and say what stops it
 pi-outpost login --provider <name>
                               store an API key in <agentDir>/auth.json
 pi-outpost build-exe [options]
@@ -510,6 +511,41 @@ pi-outpost update [--check]   move to the newest published version, or just look
 
 There is deliberately **no `--token` flag**: a secret on the command line is readable by
 anyone who can list processes. Use `PI_OUTPOST_TOKEN` or the file's `server.token`.
+
+### `pi-outpost doctor`
+
+When the page will not load and it is not obvious why, run `doctor` in the directory
+you start the server from. It reports, in one pass and without stopping at the first
+problem:
+
+- **installation** — the version, and whether this is a global install, a checkout, an
+  `npx` run or a standalone executable
+- **configuration** — which file a start would read, or, when there is none, both paths
+  it looked in and the `init` that writes one
+- **settings** — the address to open, the agent's working directory, the runtime,
+  whether a token is set (never its value) and whether the terminal is on
+- **address** — whether the port is free, already serving another Pi Outpost, or taken
+  by something else
+- **web UI** — whether this installation actually has an interface to serve
+- **git**, and **node-pty** when the terminal is enabled
+
+It exits non-zero when something would stop the server from serving, so it can gate a
+script. Unlike `config`, it never needs a configuration file to run — that absence is
+one of the things it is there to report.
+
+**The most common cause of "the page does not connect", in a directory you have not
+used before**: there is no configuration file, so the server prints the paths it
+searched and exits before it ever binds the port. Installing Pi Outpost globally does
+not create one — the install and the configuration are separate acts:
+
+```
+pi-outpost init            # a configuration for this directory
+pi-outpost init --global   # one that every directory falls back to
+```
+
+The global file lives in `<user config dir>/config.json` — `$XDG_CONFIG_HOME/pi-outpost`
+or `~/.config/pi-outpost`, which on Windows means `C:\Users\<you>\.config\pi-outpost`
+and **not** `%APPDATA%`. `doctor` prints the resolved path, so there is nothing to guess.
 
 ## Integrated Terminal
 

--- a/openspec/changes/add-doctor-command/proposal.md
+++ b/openspec/changes/add-doctor-command/proposal.md
@@ -1,0 +1,51 @@
+# Change Proposal: `pi-outpost doctor`
+
+## Why
+
+A server that will not start and a page that will not load look identical from the
+browser, and nothing in the product tells them apart.
+
+The most common cause, reported from a Windows desktop: in a directory that has never
+been used before, there is no `pi-outpost.config.json`, and `findConfigFile` throws
+`NoConfigError`. The CLI prints the paths it searched and exits 1 **before it binds a
+port**, so a browser pointed at `localhost:3141` finds nothing to connect to. The
+operator concludes the server is broken; the server never ran. A global npm install
+does not write either configuration file — the install and the configuration are
+separate acts — and nothing said so.
+
+`pi-outpost config` is the command that would explain this, and it cannot: it loads the
+configuration before it prints anything, so in exactly the case worth diagnosing it
+fails with the same error the operator is trying to understand.
+
+Two further causes produce the same symptom and are equally silent:
+
+- **The port is held by something else.** Often an earlier Pi Outpost the operator
+  forgot, whose tab they may already have open.
+- **The installation has no interface to serve.** With neither an embedded bundle nor a
+  `web/dist` on disk, `index.ts` registers no route for the UI: the server starts,
+  listens, and answers 404 for every page.
+
+## What
+
+A `doctor` subcommand that runs **before** the configuration is loaded and reports, in
+one pass, without stopping at the first problem:
+
+1. **installation** — version, install shape (`detectChannel`), node, platform/arch.
+2. **configuration** — the file a start would read, marked in the search order; or, with
+   none, both candidate paths and the two forms of `init` that write one.
+3. **settings** — the address as a URL to open, the agent's working directory, the
+   runtime, whether a token is set (never its value), whether the terminal is on.
+4. **address** — free, held by another Pi Outpost (a warning: it is probably the one
+   they want), or held by something else (a failure: a start here cannot work).
+5. **web UI** — the embedded bundle, the `dist` that answered, or neither.
+6. **git**, and **node-pty** when the terminal is enabled — both warnings, since the
+   server runs without them.
+
+Exit code 1 when any check would stop the server from serving; 0 otherwise, so a script
+can gate on it.
+
+## What this change does not do
+
+It diagnoses; it does not repair. No file is written, no port is freed, no dependency is
+installed. Every finding names the command the operator would run, and stops there — a
+diagnostic that also acts is one that can act on a wrong diagnosis.

--- a/openspec/changes/add-doctor-command/scenario-coverage.md
+++ b/openspec/changes/add-doctor-command/scenario-coverage.md
@@ -1,0 +1,35 @@
+# Scenario coverage
+
+Scenarios enumerated with:
+
+```sh
+rg '^#### Scenario:' openspec/changes/add-doctor-command/specs/
+```
+
+Two kinds of citation appear below. Where a scenario is a claim about *what the report
+says*, the check's own unit test is cited: those functions are pure over an injected
+`Diagnosis`, so a test can produce a Windows path layout or an occupied port without
+arranging one. Where a scenario is a claim about *the command running at all* — the one
+property that lives in `index.ts`'s ordering and nowhere else — the citation is the CLI
+driven as a child process in a real directory.
+
+| Spec scenario | State | Test and contract assertion |
+|---|---|---|
+| `cli / DoctorAnswersWhereAStartRefuses` | covered | `server/test/config-cli.test.mjs` — “reports a directory with no configuration instead of refusing like every other command” runs the real CLI in an empty directory with its own `XDG_CONFIG_HOME`: asserts exit 1, that a report was produced at all (`[ok  ] installation`), that `[FAIL] configuration` names both candidate paths, that both forms of `init` are offered, and that the global-install sentence is present. Were `doctor` wired after `loadConfig`, the process would exit before printing any of it and every assertion would fail. `server/test/doctor.test.ts` — “a directory with no configuration anywhere fails, and names both files init would write” asserts the same content over the injected `NoConfigError`. |
+| `cli / DoctorNamesTheConfigurationAStartWouldRead` | covered | `server/test/doctor.test.ts` — “the chosen file is marked in the search order, so a shadowed candidate is visible” asserts exactly one `→` marker, on the chosen path, with the unread candidate still listed; “an explicitly named file says the search never ran, rather than listing it” asserts no marker is emitted for a search that did not happen. `server/test/config-cli.test.mjs` — “names the file a start would read, and the settings it would run with” asserts the marker against a real file on disk. “the candidates reported are the ones findConfigFile actually searches” writes each candidate in turn and asserts `findConfigFile` returns that exact path, so the reported list cannot drift from the performed search. |
+| `cli / DoctorEchoesAMissingNamedConfig` | covered | `server/test/config-cli.test.mjs` — “a --config that does not exist is reported as the path that was typed” asserts exit 1 and the exact path in the output. `server/test/doctor.test.ts` — “a named file that is missing fails with the resolver's own message” asserts the resolver's message is carried rather than reworded. |
+| `cli / DoctorReportsEveryProblemInOneRun` | covered | `server/test/doctor.test.ts` — “every check still runs after the configuration failed” breaks the configuration, the web UI and git at once and asserts all four checks are present with two failures. `server/test/config-cli.test.mjs` — the no-configuration case asserts `web UI` and `git` still appear after `[FAIL] configuration`. |
+| `cli / DoctorNamesWhatHoldsTheAddress` | covered | `server/test/doctor.test.ts` — “a free port is reported as bindable”, “another pi-outpost holding the port is a warning that points at it” (asserts `warn`, the URL, and `--port`), “a foreign service holding the port fails, because starting here cannot work” (asserts `fail` and `EADDRINUSE`). The probe itself is proved against real sockets: “a closed port is not listening”, “a server answering /health like this one is recognised”, “the startup stub's 503 still identifies this server”, “a foreign HTTP service is listening but is not this one”, and “a socket that accepts and never answers counts as taken, not as free” — the last one would otherwise report a busy port as free. |
+| `cli / DoctorReportsAnInstallationWithNoInterface` | covered | `server/test/doctor.test.ts` — “no interface anywhere fails, and says the server would answer 404 rather than refuse” asserts `fail`, the `404`, and that the searched directories are named; “a checkout is told to build, an installation is told to reinstall” asserts the two remedies differ by install channel; “a disk build is reported by the directory that answered” asserts the *second* candidate is the one reported when only it carries an `index.html`. |
+| `cli / DoctorNeverEchoesTheToken` | covered | `server/test/doctor.test.ts` — “a token is reported as set and never echoed” asserts `auth token: set` **and** that the literal value is absent from the whole rendered check. |
+| `cli / DoctorExitCodeMarksABlockedServer` | covered | `server/test/doctor.test.ts` — “a failure is a non-zero exit, so a script can trust the command” and “warnings alone exit zero, because nothing is stopping the server” assert both directions. The end-to-end exit 1 is asserted twice in `server/test/config-cli.test.mjs`. |
+
+## Not covered here, deliberately
+
+- **The `installation` line's own accuracy on each install shape.** `installationCheck` is
+  asserted over all five channels, but `detectChannel` deciding which one a given machine
+  is remains covered by `server/test/update.test.ts`, where it already was. This change
+  reuses that rule rather than restating it, so it adds no new claim to prove.
+- **A machine that genuinely lacks git or `node-pty`.** Both are injected in the unit
+  tests, and both produce warnings rather than failures. Arranging a host without git to
+  prove a warning would test the host, not the report.

--- a/openspec/changes/add-doctor-command/specs/cli/spec.md
+++ b/openspec/changes/add-doctor-command/specs/cli/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: DoctorCommand
+
+`pi-outpost doctor` SHALL report whether this installation can start and serve, and name
+what stops it. It SHALL run without a configuration file, SHALL evaluate every check
+even after one has failed, and SHALL exit non-zero when any finding would stop the
+server from serving.
+
+#### Scenario: DoctorAnswersWhereAStartRefuses
+- **GIVEN** a directory with no `pi-outpost.config.json`, and no user-level `config.json`
+- **WHEN** the operator runs `pi-outpost doctor`
+- **THEN** a full report is printed, naming both paths that were searched
+- **AND** it says the server refuses to start before it binds a port
+- **AND** it offers both `pi-outpost init` and `pi-outpost init --global`, stating that a
+  global install writes neither file
+- **AND** the command exits 1
+
+#### Scenario: DoctorNamesTheConfigurationAStartWouldRead
+- **GIVEN** a configuration file that a start would resolve
+- **WHEN** the operator runs `pi-outpost doctor`
+- **THEN** the file is reported, marked among the candidates in the order they are searched
+- **AND** a file named explicitly by a flag or environment variable is reported as such,
+  without a search that did not happen being described
+
+#### Scenario: DoctorEchoesAMissingNamedConfig
+- **GIVEN** `--config` naming a file that does not exist
+- **WHEN** the operator runs `pi-outpost doctor`
+- **THEN** the report carries that exact path and the command exits 1
+
+#### Scenario: DoctorReportsEveryProblemInOneRun
+- **GIVEN** an installation with more than one thing wrong
+- **WHEN** the operator runs `pi-outpost doctor`
+- **THEN** every check still runs after a failing one, and all findings appear in one report
+
+#### Scenario: DoctorNamesWhatHoldsTheAddress
+- **GIVEN** the configured host and port
+- **WHEN** the address is probed
+- **THEN** a free port is reported as bindable
+- **AND** a port answering `/health` as this server does is a warning naming the URL
+- **AND** a port held by anything else is a failure that names `--port`
+
+#### Scenario: DoctorReportsAnInstallationWithNoInterface
+- **GIVEN** neither an embedded web bundle nor a `dist` carrying an `index.html`
+- **WHEN** the operator runs `pi-outpost doctor`
+- **THEN** it reports that the server would start and answer 404 for every page
+- **AND** the remedy differs for a source checkout and for an installed copy
+
+#### Scenario: DoctorNeverEchoesTheToken
+- **GIVEN** a configuration carrying `server.token`
+- **WHEN** the settings are reported
+- **THEN** the token is reported as set and its value never appears
+
+#### Scenario: DoctorExitCodeMarksABlockedServer
+- **GIVEN** findings that include warnings but no failures
+- **THEN** the command exits 0
+- **GIVEN** any finding that would stop the server from serving
+- **THEN** the command exits 1

--- a/openspec/changes/add-doctor-command/tasks.md
+++ b/openspec/changes/add-doctor-command/tasks.md
@@ -1,0 +1,26 @@
+# Implementation Tasks: `pi-outpost doctor`
+
+## Tasks
+
+- [x] Share the configuration search with the diagnostic
+  - [x] Export `implicitConfigCandidates` from `config.ts` and make `findConfigFile` use it
+- [x] `server/src/doctor.ts`
+  - [x] `Diagnosis` record: every input supplied rather than looked up, so checks stay pure
+  - [x] `installationCheck` reusing `detectChannel` / `currentEvidence` from `update.ts`
+  - [x] `configurationCheck` calling the real `findConfigFile`, never a second copy of the rule
+  - [x] `settingsCheck` reporting the address as a URL, and the token as set/none only
+  - [x] `addressCheck` over a `/health` probe: free, this server, or a foreign one
+  - [x] `webUiCheck` over the same candidates `index.ts` tries, in its order
+  - [x] `gitCheck` and `terminalCheck` as warnings — the server runs without either
+  - [x] `renderReport` / `exitCodeFor`
+- [x] Wire it in
+  - [x] `doctor` in `parseCli`'s command list and in `--help`
+  - [x] Run it in `index.ts` *before* `loadConfig`, holding the console where it is owned
+  - [x] `probePty` exported from `terminalManager.ts`, so the probe is the terminal's own load
+- [x] Tests
+  - [x] `server/test/doctor.test.ts` — every check, both branches of each
+  - [x] Real sockets for the probe: closed, `/health`, the 503 stub, a foreign service, and one that accepts and never answers
+  - [x] `server/test/config-cli.test.mjs` — the real CLI in a directory with no configuration
+  - [x] `server/test/cli.test.ts` — the subcommand and the flags it accepts
+- [x] Documentation
+  - [x] README: the command list, a `pi-outpost doctor` section, and where the global config lives on Windows

--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -51,6 +51,7 @@ Usage
   pi-outpost [options]           start the server
   pi-outpost init [options]      write a starter configuration file
   pi-outpost config [options]    print the configuration that would be used, and where it came from
+  pi-outpost doctor [options]    check whether this installation can start and serve, and say what stops it
   pi-outpost login --provider <name>
                                  store an API key for a provider in <agentDir>/auth.json
   pi-outpost build-exe [options] build a standalone executable from this installation
@@ -161,7 +162,7 @@ Agent runtime
 export class CliError extends Error {}
 
 export interface ParsedCli {
-  command: "serve" | "init" | "config" | "login" | "build-exe" | "update" | "help" | "version";
+  command: "serve" | "init" | "config" | "doctor" | "login" | "build-exe" | "update" | "help" | "version";
   flags: CliOptions;
   init: { global: boolean; force: boolean };
   login: { provider?: string };
@@ -171,8 +172,8 @@ export interface ParsedCli {
   open?: boolean;
 }
 
-type Command = "init" | "config" | "login" | "build-exe" | "update";
-const COMMANDS: readonly string[] = ["init", "config", "login", "build-exe", "update"] satisfies Command[];
+type Command = "init" | "config" | "doctor" | "login" | "build-exe" | "update";
+const COMMANDS: readonly string[] = ["init", "config", "doctor", "login", "build-exe", "update"] satisfies Command[];
 
 function integerFlag(value: string | undefined, name: string): number | undefined {
   if (value === undefined) return undefined;

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -549,6 +549,17 @@ export function userConfigDir(env: NodeJS.ProcessEnv = process.env): string {
   return path.join(base, "pi-outpost");
 }
 
+/**
+ * The two places a configuration is looked for when nothing names one, in order.
+ *
+ * Exported because `doctor` reports this list to an operator whose server refused to
+ * start, and a second copy of it there would eventually describe a search this code
+ * no longer performs — which is the one thing a diagnostic may never do.
+ */
+export function implicitConfigCandidates(launchDir: string, env: NodeJS.ProcessEnv = process.env): string[] {
+  return [path.join(launchDir, "pi-outpost.config.json"), path.join(userConfigDir(env), "config.json")];
+}
+
 /** Profile names are file names, not paths — `../../../etc/evil` must not resolve. */
 const PROFILE_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 
@@ -594,10 +605,7 @@ export function findConfigFile(
   }
   if (env.PI_OUTPOST_PROFILE) return profilePath(env.PI_OUTPOST_PROFILE, env);
 
-  const implicit = [
-    path.join(launchDir, "pi-outpost.config.json"),
-    path.join(userConfigDir(env), "config.json"),
-  ];
+  const implicit = implicitConfigCandidates(launchDir, env);
   const found = implicit.find((candidate) => fs.existsSync(candidate));
   if (!found) throw new NoConfigError(implicit);
   return found;

--- a/server/src/doctor.ts
+++ b/server/src/doctor.ts
@@ -1,0 +1,449 @@
+/**
+ * `pi-outpost doctor` — why the server did not start, or why the page found nothing.
+ *
+ * Every other command here assumes a working installation and reports the one thing
+ * it was asked to do. This one assumes nothing, and that is its whole point: the
+ * failure it exists for is a server that refused to start, so a diagnostic that needs
+ * the server's own preconditions would refuse alongside it.
+ *
+ * `pi-outpost config` was the closest thing before, and it has exactly that flaw. It
+ * loads the configuration before it prints anything (index.ts runs `loadConfig` above
+ * the `config` branch), so in a directory with no configuration file — the case worth
+ * diagnosing — it fails with the very error the operator is trying to understand.
+ *
+ * Two rules shape what follows:
+ *
+ * 1. **Nothing here stops at the first problem.** An operator with three things wrong
+ *    should learn all three from one run, not one per run.
+ * 2. **Nothing here re-implements a rule it reports on.** The configuration search
+ *    calls `findConfigFile`, the install shape calls `detectChannel`, the web assets
+ *    are looked for where `index.ts` looks. A diagnostic that describes behaviour by
+ *    restating it is a diagnostic that will one day describe behaviour the product no
+ *    longer has, confidently and in detail.
+ */
+import fsSync from "node:fs";
+import path from "node:path";
+import { type AppConfig, implicitConfigCandidates, NoConfigError } from "./config.ts";
+import { browsableUrl } from "./openBrowser.ts";
+import { type InstallChannel } from "./update.ts";
+
+/**
+ * How much a finding matters.
+ *
+ * `fail` is reserved for what actually stops a server from serving; `warn` is a
+ * capability that will be missing when it is reached. The distinction decides the
+ * exit code, so it decides whether a script can trust this command.
+ */
+export type CheckStatus = "ok" | "warn" | "fail";
+
+export interface Check {
+  /** Short label, printed in a fixed-width column. */
+  name: string;
+  status: CheckStatus;
+  /** What was found. One entry per line. */
+  detail: string[];
+  /** What to do about it. Omitted when there is nothing to do. */
+  remedy?: string[];
+}
+
+/** What is listening at an address, as far as a client can tell from outside. */
+export interface AddressProbe {
+  /** Something accepted a connection. */
+  listening: boolean;
+  /** It answered `/health` the way this server does. Undefined when nothing listened. */
+  answersHealth?: boolean;
+}
+
+export type ProbeAddress = (host: string, port: number) => Promise<AddressProbe>;
+
+/**
+ * Everything the report is composed from, supplied rather than looked up.
+ *
+ * The gathering lives in `runDoctor`; the checks below are pure functions of this
+ * record. That is what lets a test assert the sentence an operator reads on a machine
+ * it does not have — a Windows path layout, an occupied port, a missing `node-pty` —
+ * without arranging the world to produce it.
+ */
+export interface Diagnosis {
+  version: string;
+  nodeVersion: string;
+  platform: NodeJS.Platform;
+  arch: string;
+  channel: InstallChannel;
+  launchDir: string;
+  env: NodeJS.ProcessEnv;
+  /** Resolves the configuration exactly as a real start would. Throws what that throws. */
+  findConfig: () => string;
+  /** Loads it exactly as a real start would. Throws what that throws. */
+  loadConfig: () => AppConfig;
+  probeAddress: ProbeAddress;
+  /** Count of assets compiled into this binary; 0 when the UI is served from disk. */
+  embeddedWebAssets: number;
+  /** Disk locations for the UI, in the order `index.ts` tries them. */
+  webDistCandidates: string[];
+  /** Whether a candidate holds an `index.html` — the same test `index.ts` makes. */
+  hasIndexHtml: (candidate: string) => boolean;
+  /** The git this server would use, or the reason there is none. */
+  git: () => Promise<{ executable: string } | { error: string }>;
+  /** Whether the optional PTY binding can actually be loaded here. */
+  loadPty: () => Promise<{ ok: true } | { ok: false; error: string }>;
+}
+
+/** One attempt at reading the configuration: the result, or whatever refused it. */
+export type LoadOutcome = { config: AppConfig } | { error: unknown };
+
+const ok = (name: string, ...detail: string[]): Check => ({ name, status: "ok", detail });
+
+/**
+ * The installation, named as the operator would have to name it to fix anything.
+ *
+ * Never a failure on its own — an unknown channel runs perfectly well. It is here
+ * because every remedy below is different for a global install, a checkout and a
+ * downloaded executable, and because "I have it installed globally" is a belief this
+ * line can confirm or correct in one glance.
+ */
+export function installationCheck(d: Diagnosis): Check {
+  const shape: Record<InstallChannel, string> = {
+    global: "installed globally (npm -g)",
+    checkout: "a source checkout",
+    ephemeral: "a one-off run (npx), fetched for this invocation",
+    executable: "a standalone executable",
+    unknown: "an installation this command could not classify",
+  };
+  return ok(
+    "installation",
+    `pi-outpost ${d.version} — ${shape[d.channel]}`,
+    `node ${d.nodeVersion} on ${d.platform}/${d.arch}`,
+  );
+}
+
+/**
+ * Which configuration file a start would read, or why it would refuse to start.
+ *
+ * The check that exists for the reported symptom. A server with no configuration file
+ * anywhere does not start degraded — it prints the paths it looked in and exits 1,
+ * before it ever binds a port, so a browser pointed at it finds nothing to connect to.
+ * The operator sees a page that will not load and reasonably concludes the server is
+ * broken, when the server never ran.
+ *
+ * `pi-outpost init` is offered in both forms deliberately. A global *install* does not
+ * create a global *configuration*, and nothing before this said so: the two are
+ * separate acts and only the second one makes a bare `pi-outpost` work in a directory
+ * it has never seen.
+ */
+export function configurationCheck(d: Diagnosis): Check {
+  const candidates = implicitConfigCandidates(d.launchDir, d.env);
+  try {
+    const chosen = d.findConfig();
+    const searched = candidates.map((candidate) => `${candidate === chosen ? "→" : " "} ${candidate}`);
+    // An explicit --config, --profile or PI_OUTPOST_CONFIG answers before the search
+    // ever runs, so the implicit list would be describing a search that did not
+    // happen. Say which one decided instead.
+    if (!candidates.includes(chosen)) {
+      return ok("configuration", `will read ${chosen}`, "(named explicitly, so the usual search was not performed)");
+    }
+    return ok("configuration", `will read ${chosen}`, "searched, in order:", ...searched);
+  } catch (error) {
+    if (error instanceof NoConfigError) {
+      return {
+        name: "configuration",
+        status: "fail",
+        detail: [
+          "no configuration file — the server refuses to start, before it binds a port.",
+          "Looked in, in order:",
+          ...candidates.map((candidate) => `  ${candidate}`),
+        ],
+        remedy: [
+          "pi-outpost init            writes one here, for this directory only",
+          "pi-outpost init --global   writes one every directory falls back to",
+          "",
+          "Installing pi-outpost globally does not write either file: the install and",
+          "the configuration are separate acts, and only this one makes a bare",
+          "`pi-outpost` work in a directory it has never seen.",
+        ],
+      };
+    }
+    // A named file that is not there, or a profile that does not exist. The message
+    // already carries the path, and it is the real one: this called the same
+    // function a start calls.
+    return {
+      name: "configuration",
+      status: "fail",
+      detail: [error instanceof Error ? error.message : String(error)],
+      remedy: ["The path above was named explicitly — correct it, or drop the flag to search the usual places."],
+    };
+  }
+}
+
+/**
+ * The settings a start would run with, and the two that decide whether a browser can
+ * reach it at all.
+ *
+ * Only reached when a configuration file was found: with none there is nothing to
+ * report, and `configurationCheck` has already said so.
+ */
+export function settingsCheck(loaded: LoadOutcome): Check | undefined {
+  if ("error" in loaded) {
+    const error = loaded.error;
+    if (error instanceof NoConfigError) return undefined;
+    return {
+      name: "settings",
+      status: "fail",
+      detail: [
+        "the configuration file was found but could not be used:",
+        `  ${error instanceof Error ? error.message : String(error)}`,
+      ],
+      remedy: ["Fix the setting named above; the server stops on this before it starts."],
+    };
+  }
+  const config = loaded.config;
+  const url = browsableUrl({ address: config.host, port: config.port });
+  return ok(
+    "settings",
+    `listens on ${config.host}:${config.port} — open ${url}`,
+    `agent works in ${config.cwd}`,
+    `agent runtime: ${config.agentRuntime.mode}${
+      config.agentRuntime.mode === "rpc" ? ` (${config.agentRuntime.executable ?? "no executable set"})` : ""
+    }`,
+    `auth token: ${config.token === undefined ? "none (loopback only)" : "set"}`,
+    `terminal: ${config.terminal.enabled ? "enabled" : "disabled"}`,
+  );
+}
+
+/**
+ * Whether the address is free, and what holds it when it is not.
+ *
+ * `EADDRINUSE` already has a good message at startup, but it arrives *as* the failure
+ * and says nothing about what is there. The common case on a desktop is an earlier
+ * pi-outpost still running — often the one whose page the operator has open — and
+ * that is worth distinguishing from a foreign service, because the remedy differs:
+ * one is "you already have it running, use that tab", the other is "choose a port".
+ */
+export async function addressCheck(d: Diagnosis, host: string, port: number): Promise<Check> {
+  const probe = await d.probeAddress(host, port);
+  const url = browsableUrl({ address: host, port });
+  if (!probe.listening) return ok("address", `${host}:${port} is free — the server can bind it`);
+  if (probe.answersHealth === true) {
+    return {
+      name: "address",
+      status: "warn",
+      detail: [`${host}:${port} is already serving a pi-outpost — ${url}`],
+      remedy: [
+        "That is very likely the one you already started. Use it, stop it before",
+        'starting another, or run this one elsewhere with "--port <n>".',
+      ],
+    };
+  }
+  return {
+    name: "address",
+    status: "fail",
+    detail: [`${host}:${port} is taken by something that is not a pi-outpost`],
+    remedy: ['Starting here fails with EADDRINUSE — "--port <n>" starts this one somewhere else.'],
+  };
+}
+
+/**
+ * Whether this installation can serve the page at all.
+ *
+ * The failure this catches is quiet and looks exactly like the symptom that brings
+ * people here: with neither an embedded bundle nor a `dist` on disk, `index.ts`
+ * registers no route for the UI, the server starts and listens perfectly, and the
+ * browser gets a 404 for `/`. "The web page does not connect to the server" is what
+ * that looks like from the outside, and nothing in the log says otherwise.
+ */
+export function webUiCheck(d: Diagnosis): Check {
+  if (d.embeddedWebAssets > 0) {
+    return ok("web UI", `served from this binary (${d.embeddedWebAssets} assets embedded)`);
+  }
+  const found = d.webDistCandidates.find((candidate) => d.hasIndexHtml(candidate));
+  if (found !== undefined) return ok("web UI", `served from ${found}`);
+  return {
+    name: "web UI",
+    status: "fail",
+    detail: [
+      "no interface to serve — the server would start and answer 404 for every page.",
+      "Looked for an index.html in:",
+      ...d.webDistCandidates.map((candidate) => `  ${candidate}`),
+    ],
+    remedy:
+      d.channel === "checkout"
+        ? ["npm run build --workspace web"]
+        : ["This installation is incomplete — reinstall it, or run `pi-outpost update`."],
+  };
+}
+
+/**
+ * git, which the product degrades without rather than refusing to start.
+ *
+ * A warning, never a failure: the server runs, and the git surface says why it is
+ * missing. It is reported because "the repository panel is empty" is otherwise a
+ * mystery on a machine where git is installed but absent from the PATH a desktop
+ * launcher hands its children — which is most of them.
+ */
+export async function gitCheck(d: Diagnosis): Promise<Check> {
+  const result = await d.git();
+  if ("executable" in result) return ok("git", result.executable);
+  return {
+    name: "git",
+    status: "warn",
+    detail: [result.error],
+    remedy: ['Install git, or name it with "gitPath" in the configuration file.'],
+  };
+}
+
+/**
+ * The optional PTY binding, asked only when the terminal is switched on.
+ *
+ * `node-pty` is an optional dependency and its absence is a supported state: the
+ * server answers `terminal_error` and everything else works. That is invisible from
+ * the outside though — the terminal button is there and does nothing that looks like
+ * an explanation — so it is worth one line here whenever the feature is on.
+ */
+export async function terminalCheck(d: Diagnosis, enabled: boolean): Promise<Check | undefined> {
+  if (!enabled) return undefined;
+  const pty = await d.loadPty();
+  if (pty.ok) return ok("terminal", "enabled, and node-pty loads here");
+  return {
+    name: "terminal",
+    status: "warn",
+    detail: ["enabled, but node-pty could not be loaded:", `  ${pty.error}`, "Opening a terminal will answer terminal_error."],
+    remedy: [
+      "node-pty is an optional native dependency: it needs a C++ toolchain at install",
+      "time, and the standalone executable does not carry one at all.",
+    ],
+  };
+}
+
+/**
+ * The whole report, in the order an operator needs it.
+ *
+ * Configuration comes before everything that depends on it, and every check after it
+ * still runs when it failed — a machine with no configuration file can still be told
+ * its port is occupied and its UI is missing, and being told all three at once is the
+ * difference between one run and three.
+ */
+export async function diagnose(d: Diagnosis): Promise<Check[]> {
+  // Loaded once and shared. Three checks want the configuration, and `loadConfig`
+  // announces what it loaded on the way out — three loads would print that banner
+  // three times, above a report that says the same thing more carefully.
+  const loaded: LoadOutcome = (() => {
+    try {
+      return { config: d.loadConfig() };
+    } catch (error) {
+      return { error };
+    }
+  })();
+
+  const checks: Check[] = [installationCheck(d), configurationCheck(d)];
+
+  const settings = settingsCheck(loaded);
+  if (settings !== undefined) checks.push(settings);
+
+  // The address and the terminal are questions about a specific configuration. With
+  // none loadable there is no host, no port and no terminal setting to ask about, and
+  // inventing the defaults here would report on a server that will never run.
+  const config = "config" in loaded ? loaded.config : undefined;
+  if (config !== undefined) checks.push(await addressCheck(d, config.host, config.port));
+
+  checks.push(webUiCheck(d));
+  checks.push(await gitCheck(d));
+
+  const terminal = await terminalCheck(d, config?.terminal.enabled === true);
+  if (terminal !== undefined) checks.push(terminal);
+
+  return checks;
+}
+
+/** `fail` anywhere means the server would not serve; a script may rely on this. */
+export function exitCodeFor(checks: readonly Check[]): number {
+  return checks.some((check) => check.status === "fail") ? 1 : 0;
+}
+
+const MARK: Record<CheckStatus, string> = { ok: "ok  ", warn: "warn", fail: "FAIL" };
+
+/**
+ * The report as text.
+ *
+ * A fixed-width status column and a hanging indent, rather than a table: the paths
+ * here are long, absolute and Windows-shaped, and a table that wraps them is harder
+ * to read than a list that does not try.
+ */
+export function renderReport(checks: readonly Check[]): string {
+  const lines: string[] = [];
+  for (const check of checks) {
+    const [first, ...rest] = check.detail;
+    const indent = " ".repeat(22);
+    lines.push(`[${MARK[check.status]}] ${check.name.padEnd(14)} ${first ?? ""}`.trimEnd());
+    // trimEnd on every line: a remedy uses "" as a paragraph break, and a line of
+    // twenty-two spaces is trailing whitespace in whatever the operator pastes it into.
+    for (const line of rest) lines.push(`${indent}${line}`.trimEnd());
+    for (const line of check.remedy ?? []) lines.push(`${indent}${line}`.trimEnd());
+    if ((check.remedy?.length ?? 0) > 0) lines.push("");
+  }
+  const failed = checks.filter((check) => check.status === "fail").length;
+  const warned = checks.filter((check) => check.status === "warn").length;
+  lines.push(
+    failed > 0
+      ? `${failed} problem${failed === 1 ? "" : "s"} would stop this server from serving.`
+      : warned > 0
+        ? "Nothing would stop the server; the warnings above are capabilities you will find missing."
+        : "Nothing to report — this installation can start and serve.",
+  );
+  return lines.join("\n");
+}
+
+/** Real probe: ask `/health` and let the answer, or the refusal, decide. */
+export const probeAddress: ProbeAddress = async (host, port) => {
+  const http = await import("node:http");
+  const url = new URL("health", browsableUrl({ address: host, port }));
+  return await new Promise<AddressProbe>((resolve) => {
+    const request = http.get(url, { timeout: 2_000 }, (response) => {
+      const chunks: Buffer[] = [];
+      response.on("data", (chunk: Buffer) => chunks.push(chunk));
+      response.on("end", () => {
+        // 200 and 503 both come from this server — 503 is the startup stub, which is
+        // still a pi-outpost holding the port. Anything else answered, but not this.
+        const body = Buffer.concat(chunks).toString("utf8");
+        const looksLikeUs = (() => {
+          try {
+            return typeof (JSON.parse(body) as { ok?: unknown }).ok === "boolean";
+          } catch {
+            return false;
+          }
+        })();
+        resolve({ listening: true, answersHealth: looksLikeUs });
+      });
+    });
+    request.on("timeout", () => {
+      request.destroy();
+      // Something accepted the connection and then said nothing: it is listening, and
+      // it is not answering the way this server does.
+      resolve({ listening: true, answersHealth: false });
+    });
+    request.on("error", (error: NodeJS.ErrnoException) => {
+      resolve(error.code === "ECONNREFUSED" ? { listening: false } : { listening: true, answersHealth: false });
+    });
+  });
+};
+
+/**
+ * The same test `index.ts` makes of a candidate: it must carry a real `index.html`.
+ *
+ * Named apart from that file's own async `hasIndexHtml` rather than shadowing it —
+ * one answers during startup where everything is already a promise, this one answers
+ * a report being composed line by line.
+ */
+export function carriesIndexHtml(candidate: string): boolean {
+  return fsSync.statSync(path.join(candidate, "index.html"), { throwIfNoEntry: false })?.isFile() === true;
+}
+
+/** The candidates `index.ts` tries for the UI on disk, in its order. */
+export function webDistCandidatesFor(serverDir: string, env: NodeJS.ProcessEnv = process.env): string[] {
+  return env.PI_OUTPOST_WEB_DIST
+    ? [path.resolve(env.PI_OUTPOST_WEB_DIST)]
+    : [
+        path.resolve(serverDir, "./web/dist"),
+        path.resolve(serverDir, "./web"),
+        path.resolve(serverDir, "../../web/dist"),
+      ];
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -62,19 +62,35 @@ import { pathToFileURL } from "node:url";
 import { CliError, helpText, parseCli, readSecret, runInit } from "./cli.ts";
 import { bindFailureMessage, holdConsoleIfOwned } from "./startupFailure.ts";
 import { BuildExeError, buildExecutable } from "./buildExe.ts";
-import { TerminalManager } from "./terminalManager.ts";
+import { probePty, TerminalManager } from "./terminalManager.ts";
 import { browsableUrl, openBrowser, shouldOpenBrowser } from "./openBrowser.ts";
-import { runStartupUpdateNotice, runUpdateCommand, updateCheckEnabled, whyCheckingDisabled } from "./update.ts";
+import {
+  currentEvidence,
+  detectChannel,
+  runStartupUpdateNotice,
+  runUpdateCommand,
+  updateCheckEnabled,
+  whyCheckingDisabled,
+} from "./update.ts";
 import {
   allExtensionPaths,
   allSkillPaths,
   ConfigWriteError,
   declaredThinkingLevels,
   type EditableSettings,
+  findConfigFile,
   loadConfig,
   NoConfigError,
   persistEditableSettings,
 } from "./config.ts";
+import {
+  carriesIndexHtml,
+  diagnose,
+  exitCodeFor,
+  probeAddress,
+  renderReport,
+  webDistCandidatesFor,
+} from "./doctor.ts";
 import { listServerDirectories, ServerDirectoryError } from "./serverDirectories.ts";
 import {
   CredentialError,
@@ -263,6 +279,53 @@ if (cli.command === "update") {
       ...(settings.registry !== undefined ? { registry: settings.registry } : {}),
     }),
   );
+}
+
+// Before the configuration is loaded, and that is the entire point: the failure this
+// command exists to explain is a configuration that cannot be found or cannot be
+// read, and a diagnostic that loads one first would die of the disease it diagnoses.
+// `config` sits below for exactly the opposite reason — it reports a configuration,
+// so it must have one.
+if (cli.command === "doctor") {
+  const checks = await diagnose({
+    version: VERSION,
+    nodeVersion: process.version,
+    platform: process.platform,
+    arch: process.arch,
+    channel: detectChannel(currentEvidence(VERSION)),
+    launchDir: LAUNCH_DIR,
+    env: process.env,
+    findConfig: () => findConfigFile(LAUNCH_DIR, cli.flags),
+    // Quiet: the report below says what was loaded and from where, in more detail
+    // than the banner, and a banner above it would only disagree in formatting.
+    loadConfig: () => loadConfig(LAUNCH_DIR, cli.flags, process.env, { quiet: true }),
+    probeAddress,
+    embeddedWebAssets: EMBEDDED_WEB ? Object.keys(EMBEDDED_WEB).length : 0,
+    webDistCandidates: webDistCandidatesFor(import.meta.dirname),
+    hasIndexHtml: carriesIndexHtml,
+    git: async () => {
+      // The configured path when there is a configuration to read it from, so a
+      // wrong `gitPath` is reported as the wrong path rather than as "no git".
+      const configured = (() => {
+        try {
+          return loadConfig(LAUNCH_DIR, cli.flags, process.env, { quiet: true }).gitPath;
+        } catch {
+          return undefined;
+        }
+      })();
+      try {
+        return { executable: await resolveGitExecutable(configured) };
+      } catch (error) {
+        return { error: error instanceof Error ? error.message : String(error) };
+      }
+    },
+    loadPty: probePty,
+  });
+  console.log(renderReport(checks));
+  // A double-clicked executable owns its console: the report would close with the
+  // process, which is the failure mode this command was written against.
+  await holdConsoleIfOwned();
+  process.exit(exitCodeFor(checks));
 }
 
 const config = await (async () => {

--- a/server/src/terminalManager.ts
+++ b/server/src/terminalManager.ts
@@ -50,6 +50,22 @@ function ensureSpawnHelperExecutable(): void {
   }
 }
 
+/**
+ * Whether the optional PTY binding can be loaded in this installation.
+ *
+ * `doctor` asks this rather than importing `node-pty` itself, so what it reports is
+ * the same load the terminal actually performs — helper permissions included. A
+ * separate `import()` there would succeed in cases this one fails.
+ */
+export async function probePty(): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    await getPty();
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
 async function getPty(): Promise<typeof pty> {
   if (ptyModule) return ptyModule;
   if (ptyLoadError) throw ptyLoadError;

--- a/server/test/cli.test.ts
+++ b/server/test/cli.test.ts
@@ -72,6 +72,20 @@ describe("parseCli", () => {
     assert.equal(result.command, "config");
   });
 
+  test("doctor subcommand", () => {
+    const result = parseCli(["doctor"]);
+    assert.equal(result.command, "doctor");
+  });
+
+  test("doctor takes the flags that decide which configuration it would report on", () => {
+    // Without these it would diagnose the default search while the operator's real
+    // start reads something else entirely — a report about a server they never run.
+    const result = parseCli(["doctor", "--config", "/etc/pi.json", "--port", "8080"]);
+    assert.equal(result.command, "doctor");
+    assert.equal(result.flags.config, "/etc/pi.json");
+    assert.equal(result.flags.port, 8080);
+  });
+
   test("login subcommand", () => {
     const result = parseCli(["login", "--provider", "anthropic"]);
     assert.equal(result.command, "login");

--- a/server/test/config-cli.test.mjs
+++ b/server/test/config-cli.test.mjs
@@ -317,3 +317,68 @@ describe("configuration: discovery, precedence, profiles", () => {
     assert.match(again.out, /already exists/);
   });
 });
+
+/**
+ * `doctor` against the real CLI, in directories where a start would fail.
+ *
+ * The point of the command is that it answers where every other one refuses: it runs
+ * before the configuration is loaded, so a directory with no configuration file gets a
+ * report rather than the one-line refusal. That is a property of the wiring in
+ * index.ts and cannot be observed by importing anything — only by running it.
+ */
+describe("doctor", () => {
+  let dir;
+  let xdg;
+
+  before(async () => {
+    dir = await realpath(await mkdtemp(path.join(tmpdir(), "pi-outpost-doctor-")));
+    xdg = path.join(dir, "xdg");
+    await mkdir(path.join(xdg, "pi-outpost"), { recursive: true });
+  });
+
+  after(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("reports a directory with no configuration instead of refusing like every other command", async () => {
+    const empty = path.join(dir, "new-folder");
+    await mkdir(empty, { recursive: true });
+    const { code, out } = await cli(["doctor"], { cwd: empty, env: { XDG_CONFIG_HOME: xdg } });
+
+    assert.equal(code, 1, "something would stop this server, so the exit code says so");
+    // A report, not the bare "no configuration file found" a start prints.
+    assert.match(out, /\[ok {2}\] installation/, "the report was produced at all");
+    assert.match(out, /\[FAIL\] configuration/);
+    assert.match(out, /new-folder[\/\\]pi-outpost\.config\.json/);
+    assert.match(out, /xdg[\/\\]pi-outpost[\/\\]config\.json/);
+    assert.match(out, /pi-outpost init --global/);
+    // The one belief that sends people looking in the wrong place.
+    assert.match(out, /Installing pi-outpost globally does not write either file/);
+    // And it kept going: a failed configuration must not swallow the later checks.
+    assert.match(out, /\] web UI/);
+    assert.match(out, /\] git/);
+  });
+
+  test("names the file a start would read, and the settings it would run with", async () => {
+    const configured = path.join(dir, "configured");
+    await mkdir(configured, { recursive: true });
+    const local = path.join(configured, "pi-outpost.config.json");
+    await writeFile(local, configWithPort(4009));
+
+    const { out } = await cli(["doctor"], { cwd: configured, env: { XDG_CONFIG_HOME: xdg } });
+    assert.match(out, /\[ok {2}\] configuration/);
+    assert.match(out, new RegExp(`→ ${local.replace(/[\\.]/g, "\\$&")}`), "the winner is marked in the search order");
+    assert.match(out, /listens on 127\.0\.0\.1:4009 — open http:\/\/127\.0\.0\.1:4009\//);
+    // Which of the three answers the port gives depends on the machine; that it was
+    // asked about *this* address, and not the default one, is the contract here.
+    assert.match(out, /\] address\s+127\.0\.0\.1:4009 /);
+  });
+
+  test("a --config that does not exist is reported as the path that was typed", async () => {
+    const missing = path.join(dir, "nope.json");
+    const { code, out } = await cli(["doctor", "--config", missing], { cwd: dir, env: { XDG_CONFIG_HOME: xdg } });
+    assert.equal(code, 1);
+    assert.match(out, /\[FAIL\] configuration/);
+    assert.ok(out.includes(missing), "the path the operator typed is in the report");
+  });
+});

--- a/server/test/doctor.test.ts
+++ b/server/test/doctor.test.ts
@@ -1,0 +1,510 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import net from "node:net";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { after, describe, test } from "node:test";
+import {
+  addressCheck,
+  type Check,
+  configurationCheck,
+  type Diagnosis,
+  diagnose,
+  exitCodeFor,
+  gitCheck,
+  installationCheck,
+  probeAddress,
+  renderReport,
+  settingsCheck,
+  terminalCheck,
+  webDistCandidatesFor,
+  webUiCheck,
+} from "../src/doctor.ts";
+import { findConfigFile, implicitConfigCandidates, NoConfigError, userConfigDir } from "../src/config.ts";
+
+const temps: string[] = [];
+const tempDir = () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "doctor-"));
+  temps.push(dir);
+  return dir;
+};
+after(() => {
+  for (const dir of temps) rmSync(dir, { recursive: true, force: true });
+});
+
+/** A diagnosis where everything is fine, so each test can break exactly one thing. */
+function healthy(overrides: Partial<Diagnosis> = {}): Diagnosis {
+  return {
+    version: "1.2.3",
+    nodeVersion: "v22.0.0",
+    platform: "win32",
+    arch: "x64",
+    channel: "global",
+    launchDir: "C:\\work\\new-folder",
+    env: { USERPROFILE: "C:\\Users\\lf" },
+    findConfig: () => "C:\\work\\new-folder\\pi-outpost.config.json",
+    loadConfig: () => {
+      throw new NoConfigError([]);
+    },
+    probeAddress: async () => ({ listening: false }),
+    embeddedWebAssets: 42,
+    webDistCandidates: ["C:\\app\\web\\dist"],
+    hasIndexHtml: () => false,
+    git: async () => ({ executable: "C:\\Program Files\\Git\\cmd\\git.exe" }),
+    loadPty: async () => ({ ok: true }),
+    ...overrides,
+  };
+}
+
+const text = (check: Check) => [...check.detail, ...(check.remedy ?? [])].join("\n");
+
+// ---------------------------------------------------------------------------
+// configuration — the check the command exists for
+// ---------------------------------------------------------------------------
+describe("configurationCheck", () => {
+  test("a directory with no configuration anywhere fails, and names both files init would write", () => {
+    const candidates = implicitConfigCandidates("C:\\work\\new-folder", { USERPROFILE: "C:\\Users\\lf" });
+    const check = configurationCheck(
+      healthy({
+        findConfig: () => {
+          throw new NoConfigError(candidates);
+        },
+      }),
+    );
+
+    assert.equal(check.status, "fail", "no configuration file stops the server, so it is not a warning");
+    const said = text(check);
+    // The paths matter more than the prose: they are what the operator goes and looks at.
+    for (const candidate of candidates) assert.ok(said.includes(candidate), `report names ${candidate}`);
+    assert.match(said, /before it binds a port/, "says the server never reached the port");
+    assert.match(said, /pi-outpost init\b/);
+    assert.match(said, /pi-outpost init --global/);
+    // The belief that sent the operator looking in the wrong place.
+    assert.match(said, /Installing pi-outpost globally does not write either file/);
+  });
+
+  test("the chosen file is marked in the search order, so a shadowed candidate is visible", () => {
+    const chosen = path.join("C:\\work\\new-folder", "pi-outpost.config.json");
+    const check = configurationCheck(healthy({ findConfig: () => chosen }));
+    assert.equal(check.status, "ok");
+    const marked = check.detail.filter((line) => line.startsWith("→"));
+    assert.equal(marked.length, 1, "exactly one candidate is marked as the winner");
+    assert.ok(marked[0].includes(chosen));
+    // The global candidate is still listed, unmarked: that it was not read is the point.
+    assert.ok(text(check).includes(path.join(userConfigDir({ USERPROFILE: "C:\\Users\\lf" }), "config.json")));
+  });
+
+  test("an explicitly named file says the search never ran, rather than listing it", () => {
+    const check = configurationCheck(healthy({ findConfig: () => "D:\\elsewhere\\custom.json" }));
+    assert.equal(check.status, "ok");
+    assert.match(text(check), /named explicitly, so the usual search was not performed/);
+    assert.equal(
+      check.detail.some((line) => line.startsWith("→")),
+      false,
+      "a search that did not happen has no winner to mark",
+    );
+  });
+
+  test("a named file that is missing fails with the resolver's own message", () => {
+    const check = configurationCheck(
+      healthy({
+        findConfig: () => {
+          throw new Error("[config] config file not found: D:\\typo.json");
+        },
+      }),
+    );
+    assert.equal(check.status, "fail");
+    assert.match(text(check), /D:\\typo\.json/, "the path the operator typed is in the report");
+    assert.match(text(check), /named explicitly/);
+  });
+
+  test("the candidates reported are the ones findConfigFile actually searches", () => {
+    // A diagnostic that describes a search the product does not perform is worse than
+    // no diagnostic. Proven by making the first candidate real and asserting the
+    // resolver picks that exact path.
+    const dir = tempDir();
+    const env = { XDG_CONFIG_HOME: path.join(dir, "xdg") };
+    const [local, global] = implicitConfigCandidates(dir, env);
+
+    assert.equal(local, path.join(dir, "pi-outpost.config.json"));
+    assert.equal(global, path.join(dir, "xdg", "pi-outpost", "config.json"));
+
+    writeFileSync(local, "{}");
+    assert.equal(findConfigFile(dir, {}, env), local, "the first candidate is what a start reads");
+
+    rmSync(local);
+    mkdirSync(path.dirname(global), { recursive: true });
+    writeFileSync(global, "{}");
+    assert.equal(findConfigFile(dir, {}, env), global, "the second candidate is the fallback a start uses");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// settings
+// ---------------------------------------------------------------------------
+describe("settingsCheck", () => {
+  const config = (over: Record<string, unknown> = {}) =>
+    ({
+      configFile: "/etc/pi.json",
+      host: "127.0.0.1",
+      port: 3141,
+      cwd: "/work",
+      agentRuntime: { mode: "embedded", args: [] },
+      terminal: { enabled: false },
+      ...over,
+    }) as never;
+
+  test("reports the address as a URL the operator can open", () => {
+    const check = settingsCheck({ config: config() });
+    assert.ok(check);
+    assert.equal(check.status, "ok");
+    assert.match(text(check), /listens on 127\.0\.0\.1:3141 — open http:\/\/127\.0\.0\.1:3141\//);
+    assert.match(text(check), /auth token: none \(loopback only\)/);
+    assert.match(text(check), /terminal: disabled/);
+  });
+
+  test("a token is reported as set and never echoed", () => {
+    const check = settingsCheck({ config: config({ token: "s3cret-value" }) });
+    assert.ok(check);
+    assert.match(text(check), /auth token: set/);
+    assert.equal(text(check).includes("s3cret-value"), false, "the token itself never reaches the report");
+  });
+
+  test("an rpc runtime names the executable it would spawn", () => {
+    const check = settingsCheck({ config: config({ agentRuntime: { mode: "rpc", executable: "pi", args: [] } }) });
+    assert.ok(check);
+    assert.match(text(check), /agent runtime: rpc \(pi\)/);
+  });
+
+  test("a configuration that exists but cannot be used fails, carrying the reason", () => {
+    const check = settingsCheck({ error: new Error('[config] "port" must be a port number') });
+    assert.ok(check);
+    assert.equal(check.status, "fail");
+    assert.match(text(check), /"port" must be a port number/);
+  });
+
+  test("no configuration at all produces no settings line, because the check above said it", () => {
+    assert.equal(settingsCheck({ error: new NoConfigError([]) }), undefined);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// address
+// ---------------------------------------------------------------------------
+describe("addressCheck", () => {
+  test("a free port is reported as bindable", async () => {
+    const check = await addressCheck(healthy(), "127.0.0.1", 3141);
+    assert.equal(check.status, "ok");
+    assert.match(text(check), /is free/);
+  });
+
+  test("another pi-outpost holding the port is a warning that points at it", async () => {
+    const d = healthy({ probeAddress: async () => ({ listening: true, answersHealth: true }) });
+    const check = await addressCheck(d, "127.0.0.1", 3141);
+    // Not a failure: the operator very likely wants the server that is already there.
+    assert.equal(check.status, "warn");
+    assert.match(text(check), /already serving a pi-outpost — http:\/\/127\.0\.0\.1:3141\//);
+    assert.match(text(check), /--port <n>/);
+  });
+
+  test("a foreign service holding the port fails, because starting here cannot work", async () => {
+    const d = healthy({ probeAddress: async () => ({ listening: true, answersHealth: false }) });
+    const check = await addressCheck(d, "127.0.0.1", 3141);
+    assert.equal(check.status, "fail");
+    assert.match(text(check), /not a pi-outpost/);
+    assert.match(text(check), /EADDRINUSE/);
+  });
+
+  test("an IPv6 address keeps its brackets in the URL", async () => {
+    const d = healthy({ probeAddress: async () => ({ listening: true, answersHealth: true }) });
+    const check = await addressCheck(d, "::1", 3141);
+    assert.match(text(check), /http:\/\/\[::1\]:3141\//, "an unbracketed ::1:3141 names no port at all");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// the real probe, against real sockets
+// ---------------------------------------------------------------------------
+describe("probeAddress", () => {
+  /** A port nothing is on: opened, its number read, then closed. */
+  async function freePort(): Promise<number> {
+    const server = net.createServer();
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const port = (server.address() as net.AddressInfo).port;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    return port;
+  }
+
+  test("a closed port is not listening", async () => {
+    const probe = await probeAddress("127.0.0.1", await freePort());
+    assert.deepEqual(probe, { listening: false }, "a refused connection is the free-port answer");
+  });
+
+  test("a server answering /health like this one is recognised", async () => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const port = (server.address() as net.AddressInfo).port;
+    try {
+      assert.deepEqual(await probeAddress("127.0.0.1", port), { listening: true, answersHealth: true });
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  test("the startup stub's 503 still identifies this server, because it is still holding the port", async () => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(503, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: false }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const port = (server.address() as net.AddressInfo).port;
+    try {
+      assert.deepEqual(await probeAddress("127.0.0.1", port), { listening: true, answersHealth: true });
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  test("a foreign HTTP service is listening but is not this one", async () => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(404, { "content-type": "text/html" });
+      res.end("<h1>nginx</h1>");
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const port = (server.address() as net.AddressInfo).port;
+    try {
+      assert.deepEqual(await probeAddress("127.0.0.1", port), { listening: true, answersHealth: false });
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  test("a socket that accepts and never answers counts as taken, not as free", async () => {
+    // The case that would otherwise hang the command: a listener that reads the
+    // request and says nothing. It must resolve on its own timeout as occupied —
+    // reporting "free" here would send the operator to a bind that fails.
+    const accepted: net.Socket[] = [];
+    const server = net.createServer((socket) => accepted.push(socket));
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const port = (server.address() as net.AddressInfo).port;
+    try {
+      const probe = await probeAddress("127.0.0.1", port);
+      assert.deepEqual(probe, { listening: true, answersHealth: false });
+    } finally {
+      // `close` waits for open connections, and this server's whole point is a
+      // connection that never ends — so the sockets go first, or the test hangs.
+      for (const socket of accepted) socket.destroy();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// web UI, git, terminal
+// ---------------------------------------------------------------------------
+describe("webUiCheck", () => {
+  test("an embedded bundle is reported with its size", () => {
+    const check = webUiCheck(healthy({ embeddedWebAssets: 42 }));
+    assert.equal(check.status, "ok");
+    assert.match(text(check), /42 assets embedded/);
+  });
+
+  test("a disk build is reported by the directory that answered", () => {
+    const check = webUiCheck(
+      healthy({
+        embeddedWebAssets: 0,
+        webDistCandidates: ["/a/web/dist", "/b/web/dist"],
+        hasIndexHtml: (candidate) => candidate === "/b/web/dist",
+      }),
+    );
+    assert.equal(check.status, "ok");
+    assert.match(text(check), /served from \/b\/web\/dist/);
+  });
+
+  test("no interface anywhere fails, and says the server would answer 404 rather than refuse", () => {
+    // The quiet one: the server starts, listens, and serves nothing. From the browser
+    // that is indistinguishable from a server that never started.
+    const check = webUiCheck(healthy({ embeddedWebAssets: 0, webDistCandidates: ["/a/web/dist"] }));
+    assert.equal(check.status, "fail");
+    assert.match(text(check), /404/);
+    assert.ok(text(check).includes("/a/web/dist"), "the places it looked are named");
+  });
+
+  test("a checkout is told to build, an installation is told to reinstall", () => {
+    const missing = { embeddedWebAssets: 0, webDistCandidates: ["/a"] };
+    assert.match(text(webUiCheck(healthy({ ...missing, channel: "checkout" }))), /npm run build --workspace web/);
+    assert.match(text(webUiCheck(healthy({ ...missing, channel: "global" }))), /reinstall it/);
+  });
+
+  test("PI_OUTPOST_WEB_DIST replaces the candidate list rather than extending it", () => {
+    assert.deepEqual(webDistCandidatesFor("/app/dist", { PI_OUTPOST_WEB_DIST: "/custom/ui" }), [
+      path.resolve("/custom/ui"),
+    ]);
+    assert.equal(webDistCandidatesFor("/app/dist", {}).length, 3);
+  });
+});
+
+describe("gitCheck", () => {
+  test("a resolved git is reported by path", async () => {
+    const check = await gitCheck(healthy());
+    assert.equal(check.status, "ok");
+    assert.match(text(check), /git\.exe/);
+  });
+
+  test("no git is a warning, not a failure, because the server still starts", async () => {
+    const check = await gitCheck(healthy({ git: async () => ({ error: "git is not installed" }) }));
+    assert.equal(check.status, "warn");
+    assert.match(text(check), /gitPath/);
+  });
+});
+
+describe("terminalCheck", () => {
+  test("a disabled terminal produces no line at all", async () => {
+    assert.equal(await terminalCheck(healthy(), false), undefined);
+  });
+
+  test("an enabled terminal with a loadable binding is reported ok", async () => {
+    const check = await terminalCheck(healthy(), true);
+    assert.ok(check);
+    assert.equal(check.status, "ok");
+  });
+
+  test("an enabled terminal whose binding will not load warns with the loader's reason", async () => {
+    const check = await terminalCheck(
+      healthy({ loadPty: async () => ({ ok: false, error: "Cannot find module 'node-pty'" }) }),
+      true,
+    );
+    assert.ok(check);
+    assert.equal(check.status, "warn", "the rest of the product works, so this cannot be a failure");
+    assert.match(text(check), /Cannot find module 'node-pty'/);
+    assert.match(text(check), /terminal_error/, "says what the user will actually see");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// the report as a whole
+// ---------------------------------------------------------------------------
+describe("diagnose", () => {
+  test("every check still runs after the configuration failed", async () => {
+    // One run, all the problems. The alternative — stopping at the first — is three
+    // runs for three faults, which is exactly the experience this command replaces.
+    const checks = await diagnose(
+      healthy({
+        findConfig: () => {
+          throw new NoConfigError(["/a/pi-outpost.config.json"]);
+        },
+        embeddedWebAssets: 0,
+        webDistCandidates: ["/a/web/dist"],
+        git: async () => ({ error: "git is not installed" }),
+      }),
+    );
+    const names = checks.map((check) => check.name);
+    assert.deepEqual(names, ["installation", "configuration", "web UI", "git"]);
+    assert.equal(checks.filter((check) => check.status === "fail").length, 2);
+  });
+
+  test("with a usable configuration the address and terminal are asked about too", async () => {
+    const config = {
+      configFile: "/etc/pi.json",
+      host: "127.0.0.1",
+      port: 3141,
+      cwd: "/work",
+      agentRuntime: { mode: "embedded", args: [] },
+      terminal: { enabled: true },
+    } as never;
+    const checks = await diagnose(healthy({ loadConfig: () => config }));
+    assert.deepEqual(checks.map((check) => check.name), [
+      "installation",
+      "configuration",
+      "settings",
+      "address",
+      "web UI",
+      "git",
+      "terminal",
+    ]);
+  });
+
+  test("the configuration is read once, however many checks want it", async () => {
+    let loads = 0;
+    const config = {
+      configFile: "/etc/pi.json",
+      host: "127.0.0.1",
+      port: 3141,
+      cwd: "/work",
+      agentRuntime: { mode: "embedded", args: [] },
+      terminal: { enabled: true },
+    } as never;
+    await diagnose(
+      healthy({
+        loadConfig: () => {
+          loads += 1;
+          return config;
+        },
+      }),
+    );
+    // loadConfig announces what it loaded; three loads would print that banner three
+    // times, above a report that says the same thing better.
+    assert.equal(loads, 1);
+  });
+});
+
+describe("exitCodeFor", () => {
+  const check = (status: Check["status"]): Check => ({ name: "x", status, detail: [] });
+
+  test("a failure is a non-zero exit, so a script can trust the command", () => {
+    assert.equal(exitCodeFor([check("ok"), check("fail")]), 1);
+  });
+
+  test("warnings alone exit zero, because nothing is stopping the server", () => {
+    assert.equal(exitCodeFor([check("ok"), check("warn")]), 0);
+  });
+});
+
+describe("renderReport", () => {
+  test("no line carries trailing whitespace", () => {
+    const report = renderReport([
+      { name: "configuration", status: "fail", detail: ["gone"], remedy: ["do this", "", "and this"] },
+    ]);
+    for (const line of report.split("\n")) {
+      assert.equal(line, line.trimEnd(), `line has trailing whitespace: ${JSON.stringify(line)}`);
+    }
+  });
+
+  test("the closing sentence distinguishes the three outcomes", () => {
+    const one = (status: Check["status"]): Check => ({ name: "x", status, detail: ["d"] });
+    assert.match(renderReport([one("ok")]), /Nothing to report/);
+    assert.match(renderReport([one("warn")]), /Nothing would stop the server/);
+    assert.match(renderReport([one("fail")]), /1 problem would stop this server/);
+    assert.match(renderReport([one("fail"), one("fail")]), /2 problems would stop this server/);
+  });
+
+  test("continuation lines are indented under the status column, not against the margin", () => {
+    const report = renderReport([{ name: "configuration", status: "fail", detail: ["first", "second"] }]);
+    const [, second] = report.split("\n");
+    assert.match(second, /^ {22}second$/, "a wrapped path must not read as a new finding");
+  });
+});
+
+describe("installationCheck", () => {
+  test("names the install shape, because every remedy differs by it", () => {
+    for (const [channel, expected] of [
+      ["global", /installed globally/],
+      ["checkout", /source checkout/],
+      ["ephemeral", /one-off run \(npx\)/],
+      ["executable", /standalone executable/],
+      ["unknown", /could not classify/],
+    ] as const) {
+      const check = installationCheck(healthy({ channel }));
+      assert.equal(check.status, "ok", "how it was installed never stops it from running");
+      assert.match(text(check), expected);
+    }
+  });
+
+  test("carries the versions a bug report needs", () => {
+    assert.match(text(installationCheck(healthy())), /pi-outpost 1\.2\.3 —.*\n.*node v22\.0\.0 on win32\/x64/);
+  });
+});


### PR DESCRIPTION
A server that will not start and a page that will not load are the same thing from the browser, and nothing in the product told them apart.

## The report that prompted this

On a Windows desktop, in a directory never used before, the page would not connect. The cause is not subtle once you can see it — but nothing showed it:

`findConfigFile` looks in exactly two implicit places (`server/src/config.ts`), and with neither present throws `NoConfigError`. `server/src/index.ts` catches it, prints the paths it searched, and exits 1 **before it binds a port**. The browser then has nothing to connect to at all. The operator concludes the server is broken; the server never ran.

Underneath that sits a belief nothing in the product corrected: **a global npm install writes neither configuration file**. The install and the configuration are separate acts, and only `pi-outpost init` (or `init --global`) makes a bare `pi-outpost` work in a directory it has never seen.

`pi-outpost config` is the command that would have explained this, and it cannot — it loads the configuration before it prints anything, so in exactly the case worth diagnosing it fails with the same error the operator is trying to understand. **`doctor` runs before `loadConfig`, and that ordering is the whole feature.**

## What it reports

One pass, never stopping at the first problem:

| Check | What it answers |
|---|---|
| `installation` | version and install shape (global / checkout / npx / executable) — every remedy below differs by it |
| `configuration` | the file a start would read, marked among the candidates in search order; or both paths and the two forms of `init` |
| `settings` | the address as a URL to open, cwd, runtime, whether a token is set (never its value), whether the terminal is on |
| `address` | free; another Pi Outpost (a warning — probably the one they want); or a foreign service (a failure) |
| `web UI` | whether this installation has an interface to serve at all |
| `git`, `node-pty` | warnings, since the server runs without either |

Exit 1 when a finding would stop the server from serving, 0 otherwise, so a script can gate on it.

The `web UI` check is worth naming separately, because it is the other silent producer of this exact symptom: with neither an embedded bundle nor a `dist` on disk, `index.ts` registers no route for the interface. The server starts, listens, and answers 404 for every page — indistinguishable from the outside from a server that never ran.

Real output, in the reported situation:

```
[ok  ] installation   pi-outpost 0.20.0 — installed globally (npm -g)
                      node v22.22.2 on win32/x64
[FAIL] configuration  no configuration file — the server refuses to start, before it binds a port.
                      Looked in, in order:
                        C:\work\new-folder\pi-outpost.config.json
                        C:\Users\lf\.config\pi-outpost\config.json
                      pi-outpost init            writes one here, for this directory only
                      pi-outpost init --global   writes one every directory falls back to

                      Installing pi-outpost globally does not write either file: the install and
                      the configuration are separate acts, and only this one makes a bare
                      `pi-outpost` work in a directory it has never seen.
```

## Nothing here restates a rule it reports on

A diagnostic that describes behaviour by reimplementing it eventually describes behaviour the product no longer has — confidently, and in detail. So:

- the configuration search calls the real `findConfigFile`, through a candidate list (`implicitConfigCandidates`) now shared with it rather than copied;
- the install shape calls `detectChannel` / `currentEvidence` from `update.ts`;
- the PTY probe is `terminalManager`'s own `getPty`, exported as `probePty`, so what is reported is the load the terminal actually performs;
- the web assets are looked for where `index.ts` looks, in its order.

The one refactor to production code is `implicitConfigCandidates` — three lines, no behaviour change, and a test asserts the reported list *is* the searched one by writing each candidate in turn and checking `findConfigFile` returns that exact path.

## Testing

The checks are pure functions over an injected `Diagnosis`, so a Windows path layout, an occupied port and a missing `node-pty` are all assertable without arranging any of them.

- `server/test/doctor.test.ts` — 39 tests, every check and both branches of each.
- **The probe runs against real sockets**: a closed port, a `/health` answer, the 503 startup stub, a foreign HTTP service, and one that accepts and never answers — that last one would otherwise report a busy port as free. (Writing it found a hang in the test itself: `server.close()` waits for open connections, and that server's whole point is a connection that never ends.)
- `server/test/config-cli.test.mjs` — the ordering property lives in `index.ts` and nowhere else, so it is proved by driving the real CLI in a directory with no configuration: exit 1, a full report, and `web UI` and `git` still reported after `[FAIL] configuration`.
- `server/test/cli.test.ts` — the subcommand and the flags it must accept.

Verified locally: `npm run typecheck` (all workspaces) and `npm run lint` clean; 212/212 pass across `doctor`, `cli`, `config-cli`, `config` and `terminalManager`; `npm run check:scenarios` ✓ 8 scenarios, all covered.

Three suites fail in my container — `config-persist`, `credentials`, `git-executable` — and fail **identically on a clean `main` with this branch stashed**: they are artifacts of running as root (an unwritable-file test cannot throw) and of an API key present in the environment ("no key anywhere" is false). Not introduced here.

`openspec validate --specs --strict` could not be run: the `openspec` CLI is not a dependency of the repo and is unavailable in this environment. The mechanical gate `check:scenarios` did run and passes.

## Documentation impact

- `README.md` — `doctor` added to the command list, a `### pi-outpost doctor` section covering what it reports and the exit code, and an explicit note that the global configuration lives in the user config directory: `$XDG_CONFIG_HOME/pi-outpost` or `~/.config/pi-outpost`, which on Windows means `C:\Users\YOURNAME\.config\pi-outpost` and **not** `%APPDATA%`. That path is correct and deliberate (XDG); it is simply not where a Windows user looks by hand, and `doctor` prints the resolved one so there is nothing to guess.
- `openspec/changes/add-doctor-command/` — proposal, tasks, a `cli` delta with 8 scenarios (named in the PascalCase style the `cli` spec uses), and the coverage matrix.

## Out of scope

It diagnoses; it does not repair. No file is written, no port is freed, no dependency installed — every finding names the command the operator would run and stops there. A diagnostic that also acts is one that can act on a wrong diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrjdHGzf2L5feLfpA5Efb1