### PR TITLE
ci(release): install dependencies before replacing npm, and run on Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,17 +98,28 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       
-      # On commence en Node 22 pour les tests et le lint
+      # Node 24 for the tests and the lint — the same version CI runs, so a suite
+      # that passed on a pull request is the suite this job runs.
       - uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
           registry-url: https://registry.npmjs.org
 
-      # Trusted publishing (OIDC) needs npm >= 11.5.1; Node 22 ships npm 10.
-      - run: npm install -g npm@latest
-
+      # Dependencies first, with the npm this Node ships.
+      #
+      # The upgrade below used to run before this line, and it cost a release.
+      # npm 12 blocks a dependency's install scripts by default (allowScripts), and
+      # `node-pty` publishes prebuilds for darwin and win32 only — on Linux it has to
+      # compile at install time. Blocked, it installs with no binary at all, and the
+      # four TerminalManager tests that spawn a real PTY fail with "Cannot find module
+      # './prebuilds/linux-x64//pty.node'". The same command passes in CI, which never
+      # replaces its npm, so nothing before the tag ever showed it.
       - run: npm ci
+
+      # Trusted publishing (OIDC) needs npm >= 11.5.1. It is wanted for `npm publish`
+      # and for nothing else, so it goes after the install rather than before it.
+      - run: npm install -g npm@latest
 
       # A tag claims a version; at least one package must actually be at it, and none
       # may disagree with it.


### PR DESCRIPTION
The `v0.20.0` tag failed. This is the fix, and the failure is worth stating precisely because the obvious reading of it is wrong.

## What failed

The three `executables` jobs were green on all platforms. `publish` died at `npm test --workspace server`, 4 failures out of 1842, all four in `TerminalManager` — the cases that spawn a real PTY:

```
Failed to load native module: pty.node, checked: build/Release, build/Debug, prebuilds/linux-x64
Error: Cannot find module './prebuilds/linux-x64//pty.node'
```

Nothing reached npm: the publish step never ran, `attach` was skipped, and both packages are still 404 at `0.20.0` with `latest` on `0.19.0`. The matrix gating the publish did exactly what it was built to do.

## Why, and why CI could not have caught it

`npm install -g npm@latest` ran **before** `npm ci`, so the dependencies were installed by npm 12 — which blocks a package's install scripts by default:

```
npm warn install-scripts 1 package had install scripts blocked because they are not covered by allowScripts:
npm warn install-scripts   node-pty@1.1.0 (install: node scripts/prebuild.js || node-gyp rebuild; postinstall: node scripts/post-install.js)
```

`node-pty` publishes prebuilds for `darwin-arm64`, `darwin-x64`, `win32-arm64` and `win32-x64` — **there is no `linux-x64` prebuild**. On Linux the install script *is* the binary: blocked, the package installs and carries nothing that can load, which is exactly what the error above says it went looking for.

Reproduced directly rather than inferred — one manifest, two npms:

| npm | result |
|---|---|
| 10.9.7 | `node_modules/node-pty/build/Release/pty.node` present, loads on Node 22 |
| 12.0.2 | no binary, and the `install-scripts` warning above |

CI never replaces its npm, so it compiled `node-pty` and the same suite passed on the same commit `8b177ea` — green on ubuntu **and** windows. No pull request could have shown this; only a tag runs the job that swaps npm out.

## The change

- **`npm ci` now runs before the npm upgrade.** The upgrade is wanted for `npm publish` (trusted publishing over OIDC needs npm >= 11.5.1) and for nothing else, so it belongs after the install, not before it.
- **Node 22 → 24 in the `publish` job**, as asked. This is *not* the fix — Node 22 builds `node-pty` perfectly well when its own npm does the installing, which is how it works on my machine. It is consistency: 24 is what CI runs, so the suite this job executes is the suite that passed on the pull request.

## What this does not change

The `Publish` step runs after `Setup Node 26 for SEA build`, so it uses Node 26's own npm; a global npm installed under the earlier Node is not on its PATH. That was already true before this change, and it is why OIDC publishing has been working. The upgrade step may well be vestigial — worth checking separately, not while unblocking a release.

## Re-releasing

The workflow only runs from a tag, and a re-run of the failed run would use the workflow file **as of the tagged commit** — the broken one. So once this merges, `v0.20.0` has to be moved to a commit that carries the fix (delete the tag, re-tag, push). That is safe here precisely because nothing was published.

## Known, and deliberately not fixed here

The four tests hard-require `node-pty`; they do not skip when the optional binding is absent. That contradicts the feature's own design — the server answers `terminal_error` and keeps working, and `add-integrated-terminal`'s coverage matrix records a working PTY as a deliberate gap for the wire tests. Guarding them would have turned this release failure into a silent skip, which is why it is not in this PR: the red suite was a true signal, and it caught something that reaches users.

Which is the last thing worth saying: **anyone installing `pi-outpost` with npm 12 gets no terminal**, silently, for the same reason. The server degrades as designed and `pi-outpost doctor` now reports it (`enabled, but node-pty could not be loaded`). A README note and a remedy line naming `npm install-scripts approve node-pty` would close that loop — happy to open an issue or a follow-up PR.

## Documentation impact

None. The change is a workflow step order and a runtime version; no documented flag, command, configuration key or behaviour changes. `openspec/` is untouched — no scenario describes the release job's internal ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrjdHGzf2L5feLfpA5Efb1

---
_Generated by [Claude Code](https://claude.ai/code/session_01HrjdHGzf2L5feLfpA5Efb1)_