### PR TITLE
fix: settle the thinking level when the model changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,13 @@ setting exists precisely for the models the runtime is guessing about. A `set_th
 naming a level outside a declared set is refused rather than forwarded, whichever client
 sends it.
 
+Changing the model **settles** the level on the new model's scale: a session on `high`
+moving to a model that stops at `low` lands on `low`, and one moving to a model that
+accepts no thinking lands on `off` — never a step up, which would spend more effort than
+was asked for. The interface is told what it settled at, so it cannot go on showing a
+level the agent is not using. A model with a single accepted level says so in the control
+rather than offering a slider with nowhere to go.
+
 ### Theming
 
 Light and dark themes ship with the interface. Precedence: a local pick from the toggle

--- a/openspec/changes/settle-the-thinking-level-on-a-model-change/.openspec.yaml
+++ b/openspec/changes/settle-the-thinking-level-on-a-model-change/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-03

--- a/openspec/changes/settle-the-thinking-level-on-a-model-change/design.md
+++ b/openspec/changes/settle-the-thinking-level-on-a-model-change/design.md
@@ -1,0 +1,53 @@
+## Where the settling belongs
+
+The clamp could live in three places, and only one of them holds for every runtime.
+
+*In the client* — cheapest, and wrong: the client would then show a level the agent
+is not on. The next prompt would be answered at the old effort, or at whatever the
+provider decided, and the interface would be the only place the lie is invisible.
+
+*In the runtime adapters* — right for the embedded runtime, where the SDK already
+clamps and emits `thinking_level_changed`, and impossible for a declaration: a
+deployment's `thinkingLevels` entry is a fact the server holds and the child has
+never heard of. Two adapters would have to grow the same reconciliation, one of
+which cannot do it correctly.
+
+*In the server, on the model-change path* — where `acceptedThinkingLevels` already
+reconciles declaration against runtime. That function is the only place that knows
+the whole answer, so the settling sits beside it (`settleThinkingLevel`), and the
+broadcast is unconditional: the embedded runtime may have clamped on its own during
+`setModel`, and the client's held level is then already stale even though the server
+changed nothing.
+
+## Which level to fall back to
+
+Downward first: `high` on a model that tops out at `low` becomes `low`, not `off`.
+The user asked for as much thinking as they could get, and the nearest honest answer
+below is the one that keeps that intent. Stepping *up* to the nearest accepted level
+would spend more than was asked for — a real cost on a per-token deployment — so it
+happens only when nothing below is offered at all (`minimal` on a model whose scale
+starts at `high`).
+
+pi's own `clampThinkingLevel` searches upward first. The two agree wherever the
+runtime is the one narrowing the set — the levels below a requested one are always
+present in a model-derived scale, so both land on the same stop — and ours only ever
+decides the cases pi never sees: sets narrowed by a deployment's declaration.
+
+## Why the RPC mirror needs its own read
+
+`RpcRuntime` keeps `thinkingLevel` as a field because the dialect has no state push:
+the child answers `get_state` and emits records for a turn, and nothing in between.
+`set_thinking_level` is therefore the only thing that writes the field — until a
+model change, where the child clamps internally and reports nothing. One extra
+`get_state` after `set_model` closes it, on the path that already pays for a
+`get_available_thinking_levels` round trip.
+
+The fake child in `server/test/fixtures/fake-pi-rpc.mjs` gained the same clamp, so
+the test exercises the divergence rather than a fake that never diverges.
+
+## What the control says when there is nothing to choose
+
+A range input with one stop reads as a broken control: the thumb sits at the left
+and does not move, and nothing on screen says why. The popover states the fact
+instead — "this model accepts `off` only" — which is the same information the slider
+was failing to convey. Above one stop nothing changes.

--- a/openspec/changes/settle-the-thinking-level-on-a-model-change/proposal.md
+++ b/openspec/changes/settle-the-thinking-level-on-a-model-change/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+Reported from an office deployment: two models, one that reasons and one that does
+not, the default being the reasoning one on `high`. Selecting the other leaves the
+control reading `high`, and the slider cannot be moved.
+
+Three faults stack up to that.
+
+1. `set_model` broadcasts `model_changed` — the new model and its accepted levels —
+   and nothing else. The level itself is never re-stated, so the client keeps
+   showing the level the *previous* model was on.
+2. The RPC runtime's mirrored `thinkingLevel` is only written when *it* sets one.
+   The child clamps the session's level to the new model inside `set_model`
+   (`agent-session.js`: `_getThinkingLevelForModelSwitch` → `setThinkingLevel`) and
+   the RPC dialect emits no thinking-level record, so the mirror silently keeps the
+   old model's level and the snapshot reports a level the child is not on.
+3. Where the accepted set comes from a deployment's `thinkingLevels` declaration,
+   nothing clamps at all: the child has never been told about the declaration.
+
+`ModelBar` then finishes the job. A model that accepts one level (`["off"]`) gives a
+range with one stop — `max={levels.length - 1}` is `0` — which cannot be dragged
+anywhere, while the button still reads the stale `high`.
+
+## What Changes
+
+- On a model change the server **settles** the thinking level: where the level the
+  session carries is not one the new model accepts, it is moved to the nearest
+  accepted level *below* it (above only when nothing below is offered), through the
+  agent rather than only on the wire — and `thinking_changed` states what it settled
+  at, whoever did the clamping.
+- The RPC runtime re-reads the child's state after `set_model`, so the level it
+  reports is the level the child holds.
+- `ModelBar` states a one-level model in words instead of drawing an immovable
+  slider, and a current level the model does not accept is still named as itself
+  rather than quietly redrawn at another stop.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- None. -->
+
+### Modified Capabilities
+
+- `api`: a new requirement — the thinking level follows the model change, and the
+  clients are told the level it settled at.
+- `pi-rpc-runtime`: a new requirement — the reported thinking level is the child's,
+  after a model change the child clamped on its own.
+- `components`: a new requirement — a model with a single accepted level is stated,
+  not drawn as a range that cannot move.
+
+## Impact
+
+- **Server** — `server/src/index.ts` (`settleThinkingLevel`, called from `set_model`),
+  `server/src/rpcRuntime.ts` (re-read `get_state` after `set_model`).
+- **Shared** — `shared/src/protocol.ts` gains `clampThinkingLevel`.
+- **Client** — `ui/src/components/ModelBar.tsx` (`ThinkingControl`).
+- No wire-format change: `thinking_changed` already exists and already means this.
+- No change to `set_thinking` validation, to persistence, or to any model whose
+  accepted set covers the level in use.

--- a/openspec/changes/settle-the-thinking-level-on-a-model-change/scenario-coverage.md
+++ b/openspec/changes/settle-the-thinking-level-on-a-model-change/scenario-coverage.md
@@ -1,0 +1,42 @@
+# Scenario coverage
+
+Every `#### Scenario:` in the three delta files, enumerated with
+`rg '^#### Scenario:' openspec/changes/settle-the-thinking-level-on-a-model-change/`.
+All three requirements are ADDED, so every scenario below is new work — nothing is
+retained from an existing requirement.
+
+Test files:
+
+- `server/test/thinkingLevels.test.ts` (`clamp`) — the shared `clampThinkingLevel` fallback
+- `server/test/pi-rpc.test.ts` (`rpc`) — the RPC runtime over the real fake-pi-rpc child
+- `server/test/pi-rpc-server.test.mjs` (`wire`) — a real server, a real WebSocket, a real child
+- `ui/src/components/ModelBar.test.tsx` (`bar`) — the `ThinkingControl` component
+
+## api — SettleTheThinkingLevelOnAModelChange
+
+| Scenario | Status | Where | What would fail |
+|---|---|---|---|
+| ADeclaredNarrowingSettlesTheLevel | covered | `wire`: "a model change settles the thinking level on the new model's scale, and says so" — `server/test/pi-rpc-server.test.mjs` | The server is configured with `thinkingLevels` declaring `local/plain` as `["off"]`, the child starts on `high`. After `set_model`, the test waits for `thinking_changed` and asserts `off`, then reads the child's command log and asserts it received exactly one `set_thinking_level` with `off`. Dropping the `settleThinkingLevel` call makes the `thinking_changed` wait time out; broadcasting without moving the agent makes the command-log assertion fail. |
+| AnAcceptedLevelSurvivesTheChange | covered | `wire`: same test, second half — `server/test/pi-rpc-server.test.mjs` | Switching back to `local/thinker` (accepts `off`…`high`) with the level on `off`: the test asserts `thinking_changed` still carries `off` **and** that the command log holds exactly one `set_thinking_level` for the whole test. A settling that reset the level, or that re-set an already-accepted one, fails on the second assertion. |
+| TheFallbackStepsDownRatherThanUp | covered | `clamp`: "steps down rather than up: a model that tops out below the current level" and "steps down over a gap to the nearest level below" — `server/test/thinkingLevels.test.ts` | `clampThinkingLevel("high", ["off","low"])` must be `low`, and `clampThinkingLevel("high", ["off","low","medium","xhigh"])` must be `medium`, not `xhigh`. An upward-first search returns `xhigh` on the second and fails. The companion case ("steps up only when nothing below is on offer") pins the other direction so the rule is not simply "always go down". |
+
+## pi-rpc-runtime — TheReportedThinkingLevelFollowsTheChild
+
+| Scenario | Status | Where | What would fail |
+|---|---|---|---|
+| AClampedLevelIsReReadAfterAModelChange | covered | `rpc`: "re-reads the level the child clamped when the model changed" — `server/test/pi-rpc.test.ts` | The fake child now clamps inside `set_model` exactly as the real one does (`thinkingLevelsByModel` in `server/test/fixtures/fake-pi-rpc.mjs`) and emits nothing. The test asserts the snapshot reads `high` before and `off` after `setModel("fake","plain")`. Removing the `refreshThinkingLevel()` call leaves the mirror on `high` and the test fails — verified by reverting the two source files and running the suite: 4 failures, this among them. |
+
+## components — AModelWithOneLevelIsStatedNotDrawnAsARange
+
+| Scenario | Status | Where | What would fail |
+|---|---|---|---|
+| ASingleAcceptedLevelIsStated | covered | `bar`: "states the single level a model accepts instead of an immovable slider" — `ui/src/components/ModelBar.test.tsx` | With `thinkingLevels: ["off"]` the popover must contain no element labelled `Thinking level` and must name `off` in its sentence. The previous code rendered a range with `max="0"`; the `queryByLabelText(...)` assertion fails against it. |
+| ALevelOutsideTheAcceptedSetIsStillNamed | covered | `bar`: "renders at the first stop when the current level is not one the model accepts" — `ui/src/components/ModelBar.test.tsx` | Current level `high`, accepted set without it: the slider sits at index `0` **and** the button's text still contains `high`. A control that relabelled itself from the stop it landed on — showing `off` — fails the second assertion. |
+
+## Suites run
+
+- `node --import tsx/esm --test test/thinkingLevels.test.ts test/pi-rpc.test.ts` — 42 pass, 0 fail.
+- `node --import tsx/esm --test test/pi-rpc-server.test.mjs` — 6 pass, 0 fail.
+- `npx vitest run src/components/ModelBar.test.tsx` — 21 pass, 0 fail.
+- Negative check: with `server/src/index.ts` and `server/src/rpcRuntime.ts` reverted, the
+  RPC test and the wire test both fail (the wire test on a 60 s `thinking_changed` timeout).

--- a/openspec/changes/settle-the-thinking-level-on-a-model-change/scenario-coverage.md
+++ b/openspec/changes/settle-the-thinking-level-on-a-model-change/scenario-coverage.md
@@ -26,6 +26,12 @@ Test files:
 |---|---|---|---|
 | AClampedLevelIsReReadAfterAModelChange | covered | `rpc`: "re-reads the level the child clamped when the model changed" — `server/test/pi-rpc.test.ts` | The fake child now clamps inside `set_model` exactly as the real one does (`thinkingLevelsByModel` in `server/test/fixtures/fake-pi-rpc.mjs`) and emits nothing. The test asserts the snapshot reads `high` before and `off` after `setModel("fake","plain")`. Removing the `refreshThinkingLevel()` call leaves the mirror on `high` and the test fails — verified by reverting the two source files and running the suite: 4 failures, this among them. |
 
+## pi-rpc-runtime — AModelKeepsItsReportedCapabilitiesAcrossASelection
+
+| Scenario | Status | Where | What would fail |
+|---|---|---|---|
+| ASilentSetModelAnswerKeepsTheCatalogsCapability | covered | `rpc`: "keeps what the catalog says a model reasons when set_model does not repeat it" — `server/test/pi-rpc.test.ts` | The child is scripted to answer `set_model` with `null`. The test asserts both the returned model and the snapshot report `reasoning: true`. Without the catalog fallback, `toModel(null)` yields nothing, the runtime falls back to `{provider, id}`, and the server reads `reasoning ?? false` — which is how the bench lost the whole 🧠 control on a model change. |
+
 ## components — AModelWithOneLevelIsStatedNotDrawnAsARange
 
 | Scenario | Status | Where | What would fail |

--- a/openspec/changes/settle-the-thinking-level-on-a-model-change/specs/api/spec.md
+++ b/openspec/changes/settle-the-thinking-level-on-a-model-change/specs/api/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: SettleTheThinkingLevelOnAModelChange
+
+When the current model changes, the server SHALL settle the session's thinking level on
+the set the new model accepts, and SHALL tell the workspace's clients the level it
+settled at.
+
+Where the level the session carries is not in the accepted set, the server SHALL move
+the agent to the nearest accepted level below it, and to the nearest above only when no
+accepted level lies below. The move SHALL go through the agent, not only onto the wire:
+a client showing a level the agent is not on would report an effort the next turn does
+not use.
+
+The level SHALL be stated whether or not the server itself moved it. A runtime that
+clamps during its own model change reports nothing to the clients that hold the old
+level, and a deployment that declares a model's accepted levels narrows a set the
+runtime has never been told about.
+
+#### Scenario: ADeclaredNarrowingSettlesTheLevel
+- **GIVEN** a configuration declaring that a model accepts only `off`, and a session on `high`
+- **WHEN** the client changes to that model
+- **THEN** the agent is set to `off` and the client is told the level is `off`
+
+#### Scenario: AnAcceptedLevelSurvivesTheChange
+- **GIVEN** a session whose level is on the new model's accepted set
+- **WHEN** the model is changed
+- **THEN** the level is left untouched and the client is still told what it is
+
+#### Scenario: TheFallbackStepsDownRatherThanUp
+- **GIVEN** a session on `high` and a model whose accepted set stops at `low`
+- **WHEN** the level is settled on that model
+- **THEN** it becomes `low` rather than `off`, and rather than a level above `high`

--- a/openspec/changes/settle-the-thinking-level-on-a-model-change/specs/components/spec.md
+++ b/openspec/changes/settle-the-thinking-level-on-a-model-change/specs/components/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: AModelWithOneLevelIsStatedNotDrawnAsARange
+
+Where the accepted set supplied to `ModelBar` holds a single level, the thinking control
+SHALL state that level rather than render a range with one stop. A range whose thumb
+cannot move reads as a broken control, not as a fact about the model.
+
+The control SHALL name the level the session holds as itself, even when it is not one of
+the stops on offer, rather than redrawing it as the stop it happens to sit at. Settling
+that mismatch belongs to the server; until it does, the interface SHALL not claim it has
+already happened.
+
+#### Scenario: ASingleAcceptedLevelIsStated
+- **GIVEN** `ModelBar` is supplied with an accepted set holding only `off`
+- **WHEN** the thinking control is opened
+- **THEN** it states that the model accepts `off` only, and offers no range control
+
+#### Scenario: ALevelOutsideTheAcceptedSetIsStillNamed
+- **GIVEN** `ModelBar` is supplied with `high` as the current level and an accepted set without it
+- **WHEN** the thinking control is opened
+- **THEN** the control still reads `high`

--- a/openspec/changes/settle-the-thinking-level-on-a-model-change/specs/pi-rpc-runtime/spec.md
+++ b/openspec/changes/settle-the-thinking-level-on-a-model-change/specs/pi-rpc-runtime/spec.md
@@ -13,3 +13,18 @@ invisible until it is asked for: the runtime SHALL re-read the child's state aft
 - **GIVEN** a child on `high` and a model change to one that accepts only `off`
 - **WHEN** the runtime changes the model
 - **THEN** its snapshot reports `off`, the level the child clamped to
+
+### Requirement: AModelKeepsItsReportedCapabilitiesAcrossASelection
+
+The RPC runtime SHALL report a model's `reasoning` capability after a selection even where
+the child's `set_model` answer does not repeat it, taking it from the catalog it already
+holds.
+
+Whether a model reasons decides whether a thinking control exists at all. It is a property
+of the model, not of the answer to one command, and a dialect that answers `set_model`
+with nothing SHALL NOT cost a reasoning model its control.
+
+#### Scenario: ASilentSetModelAnswerKeepsTheCatalogsCapability
+- **GIVEN** a catalog listing a model as reasoning, and a child answering `set_model` with no model
+- **WHEN** the runtime changes to that model
+- **THEN** it still reports the model as reasoning

--- a/openspec/changes/settle-the-thinking-level-on-a-model-change/specs/pi-rpc-runtime/spec.md
+++ b/openspec/changes/settle-the-thinking-level-on-a-model-change/specs/pi-rpc-runtime/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: TheReportedThinkingLevelFollowsTheChild
+
+The RPC runtime SHALL report the thinking level the child actually holds, including
+after a model change the child clamped on its own.
+
+The dialect pushes no thinking-level record, so a level the runtime did not set is
+invisible until it is asked for: the runtime SHALL re-read the child's state after a
+`set_model`, alongside the accepted levels it already refreshes there.
+
+#### Scenario: AClampedLevelIsReReadAfterAModelChange
+- **GIVEN** a child on `high` and a model change to one that accepts only `off`
+- **WHEN** the runtime changes the model
+- **THEN** its snapshot reports `off`, the level the child clamped to

--- a/openspec/changes/settle-the-thinking-level-on-a-model-change/tasks.md
+++ b/openspec/changes/settle-the-thinking-level-on-a-model-change/tasks.md
@@ -3,10 +3,11 @@
 - [x] 1.1 Add `clampThinkingLevel(level, levels)` to `shared/src/protocol.ts`, beside `normalizeThinkingLevels`. Done — steps down first, up only when nothing below is offered, `off` as the floor. `server/test/thinkingLevels.test.ts` covers the accepted level, the two step-down cases, the gap, the step-up, and the empty set.
 - [x] 1.2 Add `settleThinkingLevel(workspace)` to `server/src/index.ts` beside `acceptedThinkingLevels`, and call it after the `model_changed` broadcast in `set_model`. Done — it moves the agent's level through `setThinkingLevel` only when the accepted set excludes it, and broadcasts `thinking_changed` either way.
 
-## 2. The RPC runtime reports the child's level
+## 2. The RPC runtime reports the child's level and the model's capabilities
 
 - [x] 2.1 Re-read `get_state` after `set_model` in `server/src/rpcRuntime.ts`. Done — `refreshThinkingLevel()`, called after `refreshThinkingLevels()`.
-- [x] 2.2 Teach the fake child to clamp on a model change, as the real one does. Done — `thinkingLevelsByModel` in `server/test/fixtures/fake-pi-rpc.mjs` drives both `get_available_thinking_levels` and the silent clamp inside `set_model`. `server/test/pi-rpc.test.ts` "re-reads the level the child clamped when the model changed".
+- [x] 2.2 Keep `reasoning` across a selection: where the `set_model` answer omits it, take it from the catalog `rpcRuntime` already holds. Done — `server/test/pi-rpc.test.ts` "keeps what the catalog says a model reasons when set_model does not repeat it". Found by the running-app pass, where the control disappeared entirely on a model change.
+- [x] 2.3 Teach the fake child to clamp on a model change, as the real one does. Done — `thinkingLevelsByModel` in `server/test/fixtures/fake-pi-rpc.mjs` drives both `get_available_thinking_levels` and the silent clamp inside `set_model`. `server/test/pi-rpc.test.ts` "re-reads the level the child clamped when the model changed".
 
 ## 3. The control stops drawing a range that cannot move
 
@@ -23,4 +24,4 @@
 
 ## 6. Prove it in the running app
 
-- [ ] 6.1 Drive the model switch in the running widget (`npm run bench`) with a declared off-only model, and read back the control after the switch.
+- [x] 6.1 Drive the model switch in the running widget (`npm run bench`), with the bench's thinking server extended to hold a second model declared `["off"]` and a session starting on `high`. Done — see `verification.md`. The pass found two things no suite could: the fake child never answered `set_model` with a model, so the whole 🧠 control vanished on a switch (a real dialect gap, now closed by the catalog fallback in `rpcRuntime.setModel`), and the child's own clamp is now visible in the interface rather than hidden behind a stale label.

--- a/openspec/changes/settle-the-thinking-level-on-a-model-change/tasks.md
+++ b/openspec/changes/settle-the-thinking-level-on-a-model-change/tasks.md
@@ -1,0 +1,26 @@
+## 1. Settle the level on the model-change path
+
+- [x] 1.1 Add `clampThinkingLevel(level, levels)` to `shared/src/protocol.ts`, beside `normalizeThinkingLevels`. Done — steps down first, up only when nothing below is offered, `off` as the floor. `server/test/thinkingLevels.test.ts` covers the accepted level, the two step-down cases, the gap, the step-up, and the empty set.
+- [x] 1.2 Add `settleThinkingLevel(workspace)` to `server/src/index.ts` beside `acceptedThinkingLevels`, and call it after the `model_changed` broadcast in `set_model`. Done — it moves the agent's level through `setThinkingLevel` only when the accepted set excludes it, and broadcasts `thinking_changed` either way.
+
+## 2. The RPC runtime reports the child's level
+
+- [x] 2.1 Re-read `get_state` after `set_model` in `server/src/rpcRuntime.ts`. Done — `refreshThinkingLevel()`, called after `refreshThinkingLevels()`.
+- [x] 2.2 Teach the fake child to clamp on a model change, as the real one does. Done — `thinkingLevelsByModel` in `server/test/fixtures/fake-pi-rpc.mjs` drives both `get_available_thinking_levels` and the silent clamp inside `set_model`. `server/test/pi-rpc.test.ts` "re-reads the level the child clamped when the model changed".
+
+## 3. The control stops drawing a range that cannot move
+
+- [x] 3.1 `ui/src/components/ModelBar.tsx`: a single accepted level is stated in words; the current level is named as itself when it is not one of the stops. Done — `ModelBar.test.tsx` "states the single level a model accepts instead of an immovable slider" and the extended "renders at the first stop when the current level is not one the model accepts".
+
+## 4. Prove it on the wire
+
+- [x] 4.1 `server/test/pi-rpc-server.test.mjs` "a model change settles the thinking level on the new model's scale, and says so" — a declared `["off"]` model, a session on `high`, over a real server and WebSocket: `thinking_changed` carries `off`, the child received exactly one `set_thinking_level` (`off`), and switching back to the wide-scale model leaves the level alone.
+
+## 5. Coverage and validation
+
+- [x] 5.1 `scenario-coverage.md` — every scenario of the three delta files matched to an assertion.
+- [x] 5.2 Typecheck, focused suites and `openspec validate --strict`.
+
+## 6. Prove it in the running app
+
+- [ ] 6.1 Drive the model switch in the running widget (`npm run bench`) with a declared off-only model, and read back the control after the switch.

--- a/openspec/changes/settle-the-thinking-level-on-a-model-change/verification.md
+++ b/openspec/changes/settle-the-thinking-level-on-a-model-change/verification.md
@@ -2,9 +2,10 @@
 
 `npm run bench`, the widget at `http://127.0.0.1:4321/?server=http://127.0.0.1:4327`
 (host page on its own origin, RPC child behind the server). The bench's thinking server
-now carries two models: `local/qwen3.8-27b`, whose child reports `low, medium, high,
-xhigh`, and `local/plain-mini`, declared `["off"]` in server configuration — the office
-case, where the child has never heard of the narrowing. The session starts on `high`.
+now carries two models: `local/qwen3.8-27b`, whose child reports `off, low, medium, high,
+xhigh` (a real reasoning model keeps `off`, and it has no `minimal`), and
+`local/plain-mini`, declared `["off"]` in server configuration — the office case, where
+the child has never heard of the narrowing. The session starts on `high`.
 
 Everything below was read back from the widget's shadow DOM, not from a screenshot.
 
@@ -16,21 +17,31 @@ Everything below was read back from the widget's shadow DOM, not from a screensh
 | control opened | range `max=4`, `value=3`, end labels `off` … `xhigh` |
 | switched to `local/plain-mini` with the control open | button `🧠off`, **no** range element, popover reads "this model accepts `off` only" |
 | reloaded the page | the snapshot comes back `plain-mini` / `off`, control still stating the single level |
-| back to `local/qwen3.8-27b` | button `🧠low`, range `max=4` `value=1` — label and stop agree |
+| dragged to the top stop | button `🧠xhigh`, range `value=4` |
+| switched to `local/plain-mini` | button `🧠off`, no range |
+| back to `local/qwen3.8-27b` | button `🧠off`, range `max=4` `value=0` — label and stop agree |
 
 Before the change, the third row is the bug as reported: the button kept reading `high`
 and the range had `max=0`, a thumb that could not be moved.
 
-The last row is the child's own clamp made visible. Its accepted set does not include
-`off`, so on the way back it moves `off` to `low` and says nothing; the runtime now
-re-reads the state, and the interface shows `low` instead of claiming `off`.
+The last rows are the level *not* coming back. A detour through a model that accepts no
+thinking destroys the level, and nothing restores it: on a `set_model` the child takes the
+level saved for the target model, else the persisted global default, else the current one
+(`agent-session.js` `_getThinkingLevelForModelSwitch`), and pi-outpost persists neither.
+That was already true before this change — what changes is that the interface now says
+`off` instead of still reading `xhigh`.
+
+An earlier bench configuration gave the wide model a set without `off`, which made the
+return read `low`: the child, finding nothing below, stepped *up*. That was the fake
+diverging from a real model's set, not a behaviour of the product, and the bench no longer
+does it.
 
 ## The destructive pass
 
 | What was done | What happened |
 |---|---|
 | six model switches dispatched in one tick, ending on the narrow model | settles on `plain-mini` / `off`; no interleaved state, no level from the other model |
-| seven switches ending on the wide model | settles on `qwen3.8-27b` / `low`, range `value=1` — consistent with the label |
+| seven switches ending on the wide model | settles on `qwen3.8-27b` with the range value matching the label — no state from the other model |
 | dragged to the top stop, then switched model in the same tick | `xhigh` first, then `off` once the switch landed; nothing stuck mid-way |
 | nine rapid toggles of the 🧠 button | popover open, still stating the single accepted level |
 | the same model re-picked three times | unchanged, no flicker in the level |

--- a/openspec/changes/settle-the-thinking-level-on-a-model-change/verification.md
+++ b/openspec/changes/settle-the-thinking-level-on-a-model-change/verification.md
@@ -1,0 +1,46 @@
+# Running-app verification
+
+`npm run bench`, the widget at `http://127.0.0.1:4321/?server=http://127.0.0.1:4327`
+(host page on its own origin, RPC child behind the server). The bench's thinking server
+now carries two models: `local/qwen3.8-27b`, whose child reports `low, medium, high,
+xhigh`, and `local/plain-mini`, declared `["off"]` in server configuration — the office
+case, where the child has never heard of the narrowing. The session starts on `high`.
+
+Everything below was read back from the widget's shadow DOM, not from a screenshot.
+
+## The walkthrough
+
+| Step | Read back |
+|---|---|
+| initial state | model `local/qwen3.8-27b`, button `🧠high` |
+| control opened | range `max=4`, `value=3`, end labels `off` … `xhigh` |
+| switched to `local/plain-mini` with the control open | button `🧠off`, **no** range element, popover reads "this model accepts `off` only" |
+| reloaded the page | the snapshot comes back `plain-mini` / `off`, control still stating the single level |
+| back to `local/qwen3.8-27b` | button `🧠low`, range `max=4` `value=1` — label and stop agree |
+
+Before the change, the third row is the bug as reported: the button kept reading `high`
+and the range had `max=0`, a thumb that could not be moved.
+
+The last row is the child's own clamp made visible. Its accepted set does not include
+`off`, so on the way back it moves `off` to `low` and says nothing; the runtime now
+re-reads the state, and the interface shows `low` instead of claiming `off`.
+
+## The destructive pass
+
+| What was done | What happened |
+|---|---|
+| six model switches dispatched in one tick, ending on the narrow model | settles on `plain-mini` / `off`; no interleaved state, no level from the other model |
+| seven switches ending on the wide model | settles on `qwen3.8-27b` / `low`, range `value=1` — consistent with the label |
+| dragged to the top stop, then switched model in the same tick | `xhigh` first, then `off` once the switch landed; nothing stuck mid-way |
+| nine rapid toggles of the 🧠 button | popover open, still stating the single accepted level |
+| the same model re-picked three times | unchanged, no flicker in the level |
+| `pkill fake-pi-rpc` under the running app, then a model switch | "Agent runtime failed: the Pi RPC process ended (signal SIGTERM)" and, on the switch, "Agent runtime unavailable" — the select stays on the model that is actually current and the level is not invented |
+
+## What the pass found that the suites did not
+
+The fake child answered `set_model` with no data, where the real RPC dialect answers with
+the model. `toModel(undefined)` then fell back to `{provider, id}`, the server read
+`reasoning ?? false`, and **the whole thinking control disappeared** on a model change —
+in the bench, and in any deployment whose child answers the same way. Fixed in
+`rpcRuntime.setModel` by falling back to the catalog, which already knows whether a model
+reasons; the fake now answers as the real one does.

--- a/scripts/embed-bench.mts
+++ b/scripts/embed-bench.mts
@@ -246,14 +246,35 @@ const progress = await startServer(
 );
 
 // A server whose model accepts only a subset of the thinking levels — no `high` —
-// so the model-aware thinking slider can be watched by hand.
+// so the model-aware thinking slider can be watched by hand. Its second model is the
+// office case: a deployment declaring that it accepts no thinking at all, reached from
+// a session sitting on a level that model has never heard of.
 const thinkingRoot = await makeWorkspace({ "readme.md": "# thinking\n" });
 const thinkingConfig = path.join(thinkingRoot, "fake-rpc.json");
 await writeFile(
   thinkingConfig,
   JSON.stringify({
-    state: { sessionId: "thinking-1", model: { provider: "local", id: "qwen3.8-27b", name: "Qwen3.8 27B", reasoning: true } },
-    commands_: { get_available_thinking_levels: { data: { levels: ["low", "medium", "xhigh"] } } },
+    state: {
+      sessionId: "thinking-1",
+      thinkingLevel: "high",
+      model: { provider: "local", id: "qwen3.8-27b", name: "Qwen3.8 27B", reasoning: true },
+    },
+    commands_: {
+      get_available_models: {
+        data: {
+          models: [
+            { provider: "local", id: "qwen3.8-27b", name: "Qwen3.8 27B", reasoning: true },
+            { provider: "local", id: "plain-mini", name: "Plain Mini", reasoning: true },
+          ],
+        },
+      },
+    },
+    // What the child answers for each model, and what it silently clamps to on a
+    // model change — the real one does both.
+    thinkingLevelsByModel: {
+      "local/qwen3.8-27b": ["low", "medium", "high", "xhigh"],
+      "local/plain-mini": ["off", "low", "medium", "high", "xhigh"],
+    },
   }),
 );
 const thinking = await startServer(
@@ -261,6 +282,9 @@ const thinking = await startServer(
   {
     server: { allowedOrigins: [host.url], port: HOST_PORT + 6 },
     branding: { title: "bench thinking" },
+    // The declaration the child knows nothing about: nobody but the server can clamp
+    // a session's level onto this model.
+    thinkingLevels: [{ provider: "local", id: "plain-mini", levels: ["off"] }],
     agentRuntime: {
       mode: "rpc",
       executable: process.execPath,
@@ -315,7 +339,7 @@ console.log(
 );
 console.log(`  seeded transcript           ${link(diagrams.base)}   (diagrams + table)`);
 console.log(`  tool progress bar           ${link(progress.base)}   (send any prompt, watch the tool card)`);
-console.log(`  model-aware thinking slider ${link(thinking.base)}   (open the 🧠 control: off..xhigh, no high)`);
+console.log(`  model-aware thinking slider ${link(thinking.base)}   (🧠: low..xhigh, no off; switch to Plain Mini — declared off-only — and watch it settle)`);
 console.log("\n  embed workspace controls — the same widget under each policy\n");
 console.log(`  settings (the default)      ${link(plain.base)}   no header control; the root lives in Settings`);
 console.log(`  root                        ${link(rootMode.base)}   one root, moved from the header`);

--- a/scripts/embed-bench.mts
+++ b/scripts/embed-bench.mts
@@ -272,7 +272,10 @@ await writeFile(
     // What the child answers for each model, and what it silently clamps to on a
     // model change — the real one does both.
     thinkingLevelsByModel: {
-      "local/qwen3.8-27b": ["low", "medium", "high", "xhigh"],
+      // `off` included, as a real reasoning model's set is: thinking can be turned off
+      // whatever the effort tiers are. Without it the child would step a returning `off`
+      // *up* to `low`, which is a fake's artefact and not what a deployment sees.
+      "local/qwen3.8-27b": ["off", "low", "medium", "high", "xhigh"],
       "local/plain-mini": ["off", "low", "medium", "high", "xhigh"],
     },
   }),

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -34,6 +34,7 @@ import {
   type WorkspaceInfo,
   type SessionSummary,
   THINKING_LEVELS,
+  clampThinkingLevel,
   type ThinkingLevel,
   type TreeNode,
   type WireImage,
@@ -1175,6 +1176,28 @@ function modelName(workspace: Workspace): string {
 function acceptedThinkingLevels(workspace: Workspace): ThinkingLevel[] | undefined {
   const state = workspace.agent.snapshot();
   return declaredThinkingLevels(config.thinkingLevels, state.model) ?? state.thinkingLevels;
+}
+
+/**
+ * Settle the thinking level on the model that is now current, and say what it
+ * settled at.
+ *
+ * A model change moves the scale under the level the session is carrying: the new
+ * model may not accept it. The runtime clamps only what it knows — never a
+ * deployment's declaration, which it has never been told about, and over RPC not
+ * observably at all, since that dialect pushes no thinking-level record. Left
+ * alone, a client keeps showing `high` for a model that takes only `off`, on a
+ * slider with one stop it cannot move.
+ */
+async function settleThinkingLevel(workspace: Workspace): Promise<void> {
+  const levels = acceptedThinkingLevels(workspace);
+  const current = workspace.agent.snapshot().thinkingLevel;
+  if (levels && !levels.includes(current)) {
+    await workspace.agent.setThinkingLevel(clampThinkingLevel(current, levels));
+  }
+  // Broadcast either way: the runtime may have clamped on its own during the model
+  // change, and the level the client holds is then already wrong.
+  broadcast(workspace, { type: "thinking_changed", level: workspace.agent.snapshot().thinkingLevel });
 }
 
 function contextUsage(workspace: Workspace): ContextUsage | undefined {
@@ -3189,7 +3212,7 @@ function handleClientMessage(socket: WebSocket, raw: string): void {
       const { provider, id } = message;
       workspace.agent
         .setModel(provider, id)
-        .then((model) => {
+        .then(async (model) => {
           const levels = acceptedThinkingLevels(workspace);
           broadcast(workspace, {
             type: "model_changed",
@@ -3197,6 +3220,7 @@ function handleClientMessage(socket: WebSocket, raw: string): void {
             reasoning: model.reasoning ?? false,
             ...(levels ? { thinkingLevels: levels } : {}),
           });
+          await settleThinkingLevel(workspace);
         })
         .catch((error) => {
           if (!refuseUnsupported(socket, error)) {

--- a/server/src/rpcRuntime.ts
+++ b/server/src/rpcRuntime.ts
@@ -643,7 +643,15 @@ class RpcRuntime implements AgentRuntime {
 
   async setModel(provider: string, id: string): Promise<RuntimeModel> {
     const data = await this.command("set_model", { provider, modelId: id });
-    const model = toModel(data) ?? { provider, id };
+    // A dialect that answers `set_model` with nothing, or with a model missing
+    // `reasoning`, must not cost the model its thinking control: the catalog already
+    // says whether it reasons, and the answer does not change with the selection.
+    const answered = toModel(data);
+    const known = this.availableModels.find((choice) => choice.provider === provider && choice.id === id);
+    const model = {
+      ...(answered ?? { provider, id, ...(known?.name ? { name: known.name } : {}) }),
+      ...(answered?.reasoning === undefined && known ? { reasoning: known.reasoning } : {}),
+    };
     this.model = model;
     // A different model accepts a different set of thinking levels.
     await this.refreshThinkingLevels();

--- a/server/src/rpcRuntime.ts
+++ b/server/src/rpcRuntime.ts
@@ -213,6 +213,12 @@ class RpcRuntime implements AgentRuntime {
    * offers the full set. Depends on the model, so it is refreshed on every
    * catalog refresh and after a `set_model`.
    */
+  /** The level the child actually holds — it clamps on a model change, silently. */
+  private async refreshThinkingLevel(): Promise<void> {
+    const state = (await this.process.command("get_state")) as Record<string, unknown> | undefined;
+    if (typeof state?.thinkingLevel === "string") this.thinkingLevel = state.thinkingLevel as ThinkingLevel;
+  }
+
   private async refreshThinkingLevels(): Promise<void> {
     try {
       const answer = (await this.process.command("get_available_thinking_levels")) as { levels?: unknown } | undefined;
@@ -641,6 +647,11 @@ class RpcRuntime implements AgentRuntime {
     this.model = model;
     // A different model accepts a different set of thinking levels.
     await this.refreshThinkingLevels();
+    // ...and the child clamps the session's level to the new model inside `set_model`
+    // without any record to say so — RPC pushes no thinking-level event. Re-read the
+    // state, or this mirror keeps reporting the previous model's level for a model
+    // that never accepted it.
+    await this.refreshThinkingLevel();
     return model;
   }
 

--- a/server/test/fixtures/fake-pi-rpc.mjs
+++ b/server/test/fixtures/fake-pi-rpc.mjs
@@ -123,6 +123,9 @@ const DATA = {
   get_session_stats: () => config.stats ?? { contextUsage: { tokens: 10, contextWindow: 1000, percent: 1 } },
   get_available_models: () => ({ models: config.models ?? [state.model] }),
   get_commands: () => ({ commands: config.commands ?? [] }),
+  // rpc-mode answers `set_model` with the model itself, `reasoning` included — the
+  // server reads that field to decide whether a thinking control exists at all.
+  set_model: () => ({ ...state.model }),
   get_available_thinking_levels: () => {
     const levels = acceptedThinkingLevels(state.model);
     return levels ? { levels } : undefined;

--- a/server/test/fixtures/fake-pi-rpc.mjs
+++ b/server/test/fixtures/fake-pi-rpc.mjs
@@ -92,6 +92,29 @@ function applyReplacement(replacement) {
   if (replacement.leafId !== undefined) leafId = replacement.leafId;
 }
 
+const THINKING_ORDER = ["off", "minimal", "low", "medium", "high", "xhigh"];
+
+/** What this child accepts for a model, where the test declares it per model. */
+function acceptedThinkingLevels(model) {
+  return config.thinkingLevelsByModel?.[`${model?.provider}/${model?.id}`];
+}
+
+/**
+ * What the real child does inside `set_model`: the session's level is clamped to
+ * the new model's scale — nearest level below, else the nearest above — and no
+ * record is emitted to say so.
+ */
+function clampToModel() {
+  const levels = acceptedThinkingLevels(state.model);
+  if (!levels || levels.includes(state.thinkingLevel)) return;
+  const index = THINKING_ORDER.indexOf(state.thinkingLevel);
+  state.thinkingLevel =
+    THINKING_ORDER.slice(0, Math.max(0, index)).reverse().find((level) => levels.includes(level)) ??
+    THINKING_ORDER.slice(index + 1).find((level) => levels.includes(level)) ??
+    levels[0] ??
+    "off";
+}
+
 const DATA = {
   get_state: () => ({ ...state }),
   get_messages: () => ({ messages }),
@@ -100,6 +123,10 @@ const DATA = {
   get_session_stats: () => config.stats ?? { contextUsage: { tokens: 10, contextWindow: 1000, percent: 1 } },
   get_available_models: () => ({ models: config.models ?? [state.model] }),
   get_commands: () => ({ commands: config.commands ?? [] }),
+  get_available_thinking_levels: () => {
+    const levels = acceptedThinkingLevels(state.model);
+    return levels ? { levels } : undefined;
+  },
 };
 
 // --- reading ---------------------------------------------------------------
@@ -169,7 +196,10 @@ function handle(command) {
 
 function finishSuccessfulCommand(command, type, script, responseId) {
   // Commands that change what the state queries return
-  if (type === "set_model") state.model = { provider: command.provider, id: command.modelId, name: command.modelId, reasoning: true };
+  if (type === "set_model") {
+    state.model = { provider: command.provider, id: command.modelId, name: command.modelId, reasoning: true };
+    clampToModel();
+  }
   if (type === "set_thinking_level") state.thinkingLevel = command.level;
   if (type === "set_session_name") state.sessionName = command.name;
   if (type === "prompt" || type === "steer") state.isStreaming = true;

--- a/server/test/pi-rpc-server.test.mjs
+++ b/server/test/pi-rpc-server.test.mjs
@@ -246,6 +246,83 @@ test("a declared set answers for the model, whatever the runtime reports", async
   }
 });
 
+test("a model change settles the thinking level on the new model's scale, and says so", async () => {
+  // The office report: default model on `high`, switch to the model that takes no
+  // thinking, and the control keeps showing `high` on a slider with one stop. The
+  // declared set is the case the child cannot clamp for us — it has never been told
+  // about the declaration.
+  const root = await makeWorkspace();
+  const fakeConfig = path.join(root, "fake-rpc.json");
+  await writeFile(
+    fakeConfig,
+    JSON.stringify({
+      commandLog: path.join(root, "commands.jsonl"),
+      state: {
+        sessionId: "settle-1",
+        thinkingLevel: "high",
+        model: { provider: "local", id: "thinker", name: "Thinker", reasoning: true },
+      },
+      commands_: {
+        get_available_models: {
+          data: {
+            models: [
+              { provider: "local", id: "thinker", name: "Thinker", reasoning: true },
+              { provider: "local", id: "plain", name: "Plain", reasoning: true },
+            ],
+          },
+        },
+      },
+    }),
+  );
+
+  const server = await startServer(
+    root,
+    {
+      sandbox: undefined,
+      agentRuntime: { mode: "rpc", executable: process.execPath, args: [FAKE], startupTimeoutMs: 5_000 },
+      thinkingLevels: [
+        { provider: "local", id: "thinker", levels: ["off", "low", "medium", "high"] },
+        { provider: "local", id: "plain", levels: ["off"] },
+      ],
+    },
+    { env: { FAKE_PI_RPC_CONFIG: fakeConfig } },
+  );
+  const client = connect(server.wsUrl());
+  try {
+    const hello = await client.waitFor("hello");
+    assert.equal(hello.thinkingLevel, "high");
+
+    client.send({ type: "set_model", provider: "local", id: "plain" });
+    const changed = await client.waitFor("model_changed");
+    assert.deepEqual(changed.thinkingLevels, ["off"]);
+
+    const settled = await client.waitFor("thinking_changed");
+    assert.equal(settled.level, "off", "the client is told the level the new model actually holds");
+
+    // Back to the wide-scale model: `off` is on its scale, so the level stays put —
+    // settling is not a reset, and the client is told the level either way.
+    client.send({ type: "set_model", provider: "local", id: "thinker" });
+    await client.waitFor("model_changed");
+    const back = await client.waitFor("thinking_changed");
+    assert.equal(back.level, "off", "an accepted level survives the model change untouched");
+
+    // Not merely a client-side redraw: the agent was moved too, and only when it had to be.
+    const commands = (await readFile(path.join(root, "commands.jsonl"), "utf8").catch(() => ""))
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line))
+      .filter((command) => command.type === "set_thinking_level");
+    assert.deepEqual(
+      commands.map((command) => command.level),
+      ["off"],
+      "the child was told to drop to off, once",
+    );
+  } finally {
+    client.close();
+    await server.stop();
+  }
+});
+
 test("the snapshot carries the model's accepted thinking levels, and they follow a model change", async () => {
   const root = await makeWorkspace();
   const fakeConfig = path.join(root, "fake-rpc.json");

--- a/server/test/pi-rpc.test.ts
+++ b/server/test/pi-rpc.test.ts
@@ -279,6 +279,23 @@ describe("RpcRuntimeStarts", () => {
     assert.deepEqual(runtime.snapshot().thinkingLevels, ["off", "low", "medium", "xhigh"]);
   });
 
+  test("keeps what the catalog says a model reasons when set_model does not repeat it", async () => {
+    // The server reads `reasoning` off this answer to decide whether a thinking
+    // control exists at all. A dialect that answers `set_model` with nothing would
+    // otherwise take the control away from a model that reasons perfectly well.
+    const { runtime } = await startFake({
+      models: [
+        { provider: "fake", id: "one", name: "One", reasoning: true },
+        { provider: "fake", id: "two", name: "Two", reasoning: true },
+      ],
+      commands_: { set_model: { data: null } },
+    });
+
+    const model = await runtime.setModel("fake", "two");
+    assert.equal(model.reasoning, true);
+    assert.equal(runtime.snapshot().model?.reasoning, true);
+  });
+
   test("re-reads the level the child clamped when the model changed", async () => {
     // The child clamps inside `set_model` and emits nothing: RPC has no
     // thinking-level record. A mirror that only updates on `set_thinking_level`

--- a/server/test/pi-rpc.test.ts
+++ b/server/test/pi-rpc.test.ts
@@ -279,6 +279,28 @@ describe("RpcRuntimeStarts", () => {
     assert.deepEqual(runtime.snapshot().thinkingLevels, ["off", "low", "medium", "xhigh"]);
   });
 
+  test("re-reads the level the child clamped when the model changed", async () => {
+    // The child clamps inside `set_model` and emits nothing: RPC has no
+    // thinking-level record. A mirror that only updates on `set_thinking_level`
+    // keeps reporting the previous model's level for a model that never took it.
+    const { runtime } = await startFake({
+      state: {
+        thinkingLevel: "high",
+        model: { provider: "fake", id: "thinker", name: "Thinker", reasoning: true },
+      },
+      models: [
+        { provider: "fake", id: "thinker", name: "Thinker", reasoning: true },
+        { provider: "fake", id: "plain", name: "Plain", reasoning: false },
+      ],
+      thinkingLevelsByModel: { "fake/thinker": ["off", "low", "medium", "high"], "fake/plain": ["off"] },
+    });
+    assert.equal(runtime.snapshot().thinkingLevel, "high");
+
+    await runtime.setModel("fake", "plain");
+    assert.equal(runtime.snapshot().thinkingLevel, "off");
+    assert.deepEqual(runtime.snapshot().thinkingLevels, ["off"]);
+  });
+
   test("omits the accepted levels when the child has no command for them", async () => {
     const { runtime } = await startFake({
       failures: { get_available_thinking_levels: "Unknown command: get_available_thinking_levels" },

--- a/server/test/thinkingLevels.test.ts
+++ b/server/test/thinkingLevels.test.ts
@@ -5,7 +5,7 @@
  */
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
-import { normalizeThinkingLevels } from "@pi-outpost/shared";
+import { clampThinkingLevel, normalizeThinkingLevels } from "@pi-outpost/shared";
 
 describe("normalizeThinkingLevels", () => {
   test("drops names this build does not know and keeps canonical order", () => {
@@ -37,5 +37,29 @@ describe("normalizeThinkingLevels", () => {
     assert.equal(normalizeThinkingLevels(null), undefined);
     assert.equal(normalizeThinkingLevels("high"), undefined);
     assert.equal(normalizeThinkingLevels(42), undefined);
+  });
+});
+
+describe("clampThinkingLevel", () => {
+  test("keeps a level the model accepts", () => {
+    assert.equal(clampThinkingLevel("medium", ["off", "low", "medium", "xhigh"]), "medium");
+  });
+
+  test("steps down rather than up: a model that tops out below the current level", () => {
+    // The office case: a session on `high` moving to a model that takes nothing.
+    assert.equal(clampThinkingLevel("high", ["off"]), "off");
+    assert.equal(clampThinkingLevel("high", ["off", "low"]), "low");
+  });
+
+  test("steps down over a gap to the nearest level below", () => {
+    assert.equal(clampThinkingLevel("high", ["off", "low", "medium", "xhigh"]), "medium");
+  });
+
+  test("steps up only when nothing below is on offer", () => {
+    assert.equal(clampThinkingLevel("minimal", ["high", "xhigh"]), "high");
+  });
+
+  test("an empty set is off", () => {
+    assert.equal(clampThinkingLevel("high", []), "off");
   });
 });

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -143,6 +143,27 @@ export function normalizeThinkingLevels(levels: unknown): ThinkingLevel[] | unde
   return THINKING_LEVELS.filter((l) => l === "off" || known.has(l));
 }
 
+/**
+ * The level to keep when a model does not accept the current one — after a model
+ * change, where the level the session carries may not be on the new model's scale.
+ *
+ * It steps *down* in effort first: a session on `high` moving to a model that tops
+ * out at `low` should think as hard as that model can, and a silent step up would
+ * bill the user for effort nobody asked for. Only when nothing below is on offer
+ * does it step up, and `off` is always the floor.
+ */
+export function clampThinkingLevel(level: ThinkingLevel, levels: readonly ThinkingLevel[]): ThinkingLevel {
+  if (levels.includes(level)) return level;
+  const index = THINKING_LEVELS.indexOf(level);
+  for (let i = index - 1; i >= 0; i--) {
+    if (levels.includes(THINKING_LEVELS[i])) return THINKING_LEVELS[i];
+  }
+  for (let i = index + 1; i < THINKING_LEVELS.length; i++) {
+    if (levels.includes(THINKING_LEVELS[i])) return THINKING_LEVELS[i];
+  }
+  return levels[0] ?? "off";
+}
+
 /** Slash command available in the composer (extension command, prompt template or skill). */
 export interface CommandInfo {
   /** Invocation name without the leading slash (e.g. "commit", "skill:review"). */

--- a/ui/src/components/ModelBar.test.tsx
+++ b/ui/src/components/ModelBar.test.tsx
@@ -162,6 +162,18 @@ describe("ModelBar controls", () => {
     renderFull({ thinkingLevel: "high", thinkingLevels: ["off", "low", "medium", "xhigh"] });
     fireEvent.click(screen.getByTitle("thinking level"));
     expect((screen.getByLabelText("Thinking level") as HTMLInputElement).value).toBe("0");
+    // ...while still naming the level the session actually holds: the server settles
+    // that on a model change, and until it does the control must not claim otherwise.
+    expect(screen.getByTitle("thinking level").textContent).toContain("high");
+  });
+
+  it("states the single level a model accepts instead of an immovable slider", () => {
+    // A one-stop range cannot be dragged anywhere, which reads as a broken control
+    // rather than as a fact about the model.
+    renderFull({ thinkingLevel: "off", thinkingLevels: ["off"] });
+    fireEvent.click(screen.getByTitle("thinking level"));
+    expect(screen.queryByLabelText("Thinking level")).toBeNull();
+    expect(screen.getByText(/accepts/).textContent).toContain("off");
   });
 
   it("falls back to the full set when no accepted-levels list is supplied", () => {

--- a/ui/src/components/ModelBar.tsx
+++ b/ui/src/components/ModelBar.tsx
@@ -147,6 +147,12 @@ function ContextRing({ usage }: { usage: ContextUsage | null }) {
  * accepted set has a gap (`low, medium, xhigh`, no `high`) is presented as three
  * ordered stops, not a range with a dead position. Absent a list, it offers the
  * full set, which is what it did before it was model-aware.
+ *
+ * A model that accepts one level only gets a sentence instead of a slider: a range
+ * whose single stop cannot move reads as a broken control, not as a statement about
+ * the model. And a current level the model does not accept is shown as itself,
+ * never quietly redrawn at another stop — the server settles that, and until it
+ * does the interface should not pretend it already has.
  */
 function ThinkingControl({
   thinkingLevel,
@@ -158,7 +164,8 @@ function ThinkingControl({
   const ref = useRef<HTMLDivElement>(null);
   const active = thinkingLevel !== "off";
   const levels = thinkingLevels && thinkingLevels.length > 0 ? thinkingLevels : THINKING_LEVELS;
-  const index = Math.max(0, levels.indexOf(thinkingLevel as ThinkingLevel));
+  const stop = levels.indexOf(thinkingLevel as ThinkingLevel);
+  const adjustable = levels.length > 1;
 
   useEffect(() => {
     if (!open) return;
@@ -200,21 +207,29 @@ function ThinkingControl({
             <span className="text-zinc-500 dark:text-zinc-400">thinking</span>
             <span className="font-mono text-zinc-700 dark:text-zinc-200">{thinkingLevel}</span>
           </div>
-          <input
-            type="range"
-            min={0}
-            max={levels.length - 1}
-            step={1}
-            value={index}
-            onChange={(e) => onSetThinking(levels[Number(e.target.value)])}
-            aria-label="Thinking level"
-            aria-valuetext={thinkingLevel}
-            className="w-full accent-amber-500"
-          />
-          <div className="mt-0.5 flex justify-between font-mono text-[9px] text-zinc-400 dark:text-zinc-600">
-            <span>{levels[0]}</span>
-            <span>{levels[levels.length - 1]}</span>
-          </div>
+          {adjustable ? (
+            <>
+              <input
+                type="range"
+                min={0}
+                max={levels.length - 1}
+                step={1}
+                value={stop === -1 ? 0 : stop}
+                onChange={(e) => onSetThinking(levels[Number(e.target.value)])}
+                aria-label="Thinking level"
+                aria-valuetext={thinkingLevel}
+                className="w-full accent-amber-500"
+              />
+              <div className="mt-0.5 flex justify-between font-mono text-[9px] text-zinc-400 dark:text-zinc-600">
+                <span>{levels[0]}</span>
+                <span>{levels[levels.length - 1]}</span>
+              </div>
+            </>
+          ) : (
+            <p className="text-[11px] text-zinc-500 dark:text-zinc-400">
+              this model accepts <span className="font-mono">{levels[0]}</span> only
+            </p>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## The report

Two models at an office deployment: one that reasons, one that does not, the default being the reasoning one on `high`. Selecting the other leaves the control reading `high`, and the slider cannot be moved.

## What was wrong

Three faults stack up to that, and each is enough on its own.

1. `set_model` broadcast `model_changed` — the new model and its accepted levels — and never the level itself. The client kept showing the level the *previous* model was on.
2. `RpcRuntime`'s mirrored `thinkingLevel` was only written when it set one. The child clamps the session's level inside `set_model` (`agent-session.js`: `_getThinkingLevelForModelSwitch` → `setThinkingLevel`) and the RPC dialect pushes no thinking-level record, so the mirror kept reporting a level the child was not on.
3. Where the accepted set comes from a `thinkingLevels` declaration, nothing clamped at all — the child has never been told about the declaration. This is the office case.

`ModelBar` finished the job: a model accepting one level (`["off"]`) gave a range with `max={levels.length - 1}` = `0`, a thumb that cannot move, under a button still reading `high`.

## What changes

- The server **settles** the level on the model-change path, beside the function that already reconciles declaration against runtime, and states what it settled at whoever did the clamping. The fallback steps **down** in effort — `high` on a model that stops at `low` becomes `low`, not `off` — and up only when nothing below is offered.
- `RpcRuntime` re-reads the child's state after `set_model`.
- The control states a one-level model in words instead of drawing a range with nowhere to go, and names the level the session holds as itself rather than redrawing it at another stop.

## Found while driving the running app

The fake RPC child answered `set_model` with no data, where the real dialect answers with the model. `toModel` fell back to `{provider, id}`, the server read `reasoning ?? false`, and **the whole 🧠 control disappeared** on a model change — true for any child answering the same way, not only the fake. `setModel` now takes `reasoning` from the catalog it already holds; the fake answers as the real one does.

## Verification

- `server/test/thinkingLevels.test.ts` — the shared `clampThinkingLevel` fallback, both directions.
- `server/test/pi-rpc.test.ts` — the clamped level re-read after a model change; the catalog capability kept across a silent `set_model` answer.
- `server/test/pi-rpc-server.test.mjs` — a real server, WebSocket and child: a declared `["off"]` model settles a session from `high`, the child receives exactly one `set_thinking_level`, and switching back leaves an accepted level alone.
- `ui/src/components/ModelBar.test.tsx` — the stated single level; a level outside the set still named.
- Negative check: with the two source files reverted, the RPC test and the wire test both fail.
- Running app (`openspec/changes/settle-the-thinking-level-on-a-model-change/verification.md`): the walkthrough plus a destructive pass — bursts of switches in one tick, a drag then a switch in the same tick, rapid toggles, a reload, and `pkill fake-pi-rpc` under the running app. The bench's thinking server gained a second model, declared off-only, so the report can be reproduced by hand.

## Documentation impact

`README.md` — the "Thinking levels" section now says what a model change does to the level, and what a single-level model shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PryLsHtHcqbkjAqsxVH8rQ