### PR TITLE
chore(release): v0.20.1

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-outpost",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "type": "module",
   "description": "A web interface for the pi coding agent: a browser chat UI you run with npx — no clone, no build.",
   "license": "MIT",

--- a/embed/package.json
+++ b/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-outpost/embed",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "type": "module",
   "description": "Mount pi-outpost as a Shadow-DOM-isolated widget inside another web app.",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "cli": {
       "name": "pi-outpost",
-      "version": "0.20.0",
+      "version": "0.20.1",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "^0.84.4",
@@ -42,7 +42,7 @@
     },
     "embed": {
       "name": "@pi-outpost/embed",
-      "version": "0.20.0",
+      "version": "0.20.1",
       "license": "MIT",
       "devDependencies": {
         "@microsoft/api-extractor": "^7.58.9",


### PR DESCRIPTION
A patch release: one fix has landed since `v0.20.0`, and it is the whole tag.

- **Changing the model settles the thinking level** on the new model's scale, and the interface is told what it settled at. A session on `high` moving to a model that accepts no thinking no longer keeps reading `high` above a range with one stop it cannot move. The fallback steps down in effort, never up. (#158)
- Also in it: a model keeps its `reasoning` flag across a selection, so a child answering `set_model` without repeating it no longer takes the thinking control away entirely.

Only `cli` and `embed` carry a version; the lockfile records the same two numbers. Nothing else in the diff.

Tag `v0.20.1` once this is merged — the tag is what publishes.

## Documentation impact

None: the README's "Thinking levels" section was updated in #158, in the same release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PryLsHtHcqbkjAqsxVH8rQ