### PR TITLE
chore(deps): sync the lockfile with the package manifests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,9 @@
       },
       "engines": {
         "node": ">=24"
+      },
+      "optionalDependencies": {
+        "node-pty": "^1.1.0"
       }
     },
     "embed": {
@@ -8287,7 +8290,8 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -8333,6 +8337,7 @@
       "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "node-addon-api": "^7.1.0"
       }
@@ -10769,7 +10774,6 @@
         "@fastify/websocket": "^11.0.2",
         "@pi-outpost/shared": "*",
         "fastify": "^5.3.0",
-        "node-pty": "^1.1.0",
         "pdfjs-dist": "6.2.108",
         "typebox": "1.3.18"
       },
@@ -10782,6 +10786,9 @@
       },
       "engines": {
         "node": ">=24"
+      },
+      "optionalDependencies": {
+        "node-pty": "^1.1.0"
       }
     },
     "server/node_modules/typescript": {
@@ -10826,6 +10833,7 @@
         "@testing-library/react": "^16.3.2",
         "@vitest/coverage-v8": "^4.1.10",
         "jsdom": "^30.0.0",
+        "oxlint": "^1.71.0",
         "vitest": "^4.1.10"
       },
       "peerDependencies": {


### PR DESCRIPTION
`npm install --package-lock-only` on a clean checkout of `main` rewrites the lockfile — which means the lockfile no longer describes what the manifests declare.

The terminal work (#147) moved `node-pty` to `optionalDependencies` in `cli` and `server`, and added `oxlint` to `ui`'s dev dependencies. Neither reached the lockfile.

That drift is the entire diff: `node-pty` and its `node-addon-api` marked optional, the two `optionalDependencies` blocks recorded, `oxlint` listed under `ui`. **No version moves and no package resolved differently.**

Worth its own commit rather than being left to accumulate: the next commit that touches a dependency picks it up, and that is usually a release — where it reads as an install-behaviour change nobody chose. It was noticed while cutting `v0.20.1`, and deliberately kept out of that tag.

## Verification

`npm ci --dry-run` resolves the tree against this lockfile without error.

## Documentation impact

None: no documented command, flag, dependency or workflow changes — the manifests already said this, only the lockfile did not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PryLsHtHcqbkjAqsxVH8rQ