### PR TITLE
docs: measure what a session costs before it says anything, next to pi and opencode

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ once — each with its own sandbox, history and agent — and a sandbox you deci
 - [Start in 5 minutes](#start-in-5-minutes)
 - [How do I…](#how-do-i)
 - [What you get](#what-you-get)
+- [Next to pi and opencode](#next-to-pi-and-opencode)
 - [Model credentials](#model-credentials)
 - [Projects](#projects)
 - [Settings from the browser](#settings-from-the-browser)
@@ -211,6 +212,23 @@ one needs, the command that proves it works, and the caution that goes with it.
   prefill
 - Two agent runtimes behind the same interface: the bundled pi SDK, or a supervised
   `pi --mode rpc` child process
+
+## Next to pi and opencode
+
+pi is the agent underneath this: the second column below is the first plus what a web
+interface adds. opencode is a terminal agent of the same family, listed for scale.
+
+| | pi | Pi Outpost | opencode |
+|---|---|---|---|
+| Interface | terminal | browser, installable, embeddable | terminal |
+| Several projects at once | — | yes, each with its own agent and sandbox | — |
+| Files, git, PDF and Office in the interface | — | yes | — |
+| Baseline context (system prompt + tool definitions) | **~2.4k tokens** | **~11k tokens** | not measured |
+
+That baseline is what every turn carries before you have typed anything, and most of the
+difference is one tool: `work_plan` alone is ~4k tokens. The full table, the per-tool
+breakdown and the probe that produced them are in
+[`docs/comparison.md`](docs/comparison.md).
 
 ## Model credentials
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ once — each with its own sandbox, history and agent — and a sandbox you deci
 - [Start in 5 minutes](#start-in-5-minutes)
 - [How do I…](#how-do-i)
 - [What you get](#what-you-get)
-- [Next to pi and opencode](#next-to-pi-and-opencode)
 - [Model credentials](#model-credentials)
 - [Projects](#projects)
 - [Settings from the browser](#settings-from-the-browser)
@@ -212,24 +211,6 @@ one needs, the command that proves it works, and the caution that goes with it.
   prefill
 - Two agent runtimes behind the same interface: the bundled pi SDK, or a supervised
   `pi --mode rpc` child process
-
-## Next to pi and opencode
-
-pi is the agent underneath this: the second column below is the first plus what a web
-interface adds. opencode is a terminal agent of the same family, listed for scale.
-
-| | pi | Pi Outpost | opencode |
-|---|---|---|---|
-| Interface | terminal | browser, installable, embeddable | terminal |
-| Several projects at once | — | yes, each with its own agent and sandbox | — |
-| Files, git, PDF and Office in the interface | — | yes | — |
-| Baseline context (system prompt + tool definitions) | **~2.4k tokens** | **~11k tokens** | **~7.6k tokens** |
-
-That baseline is what every turn carries before you have typed anything, and most of the
-difference is one tool: `work_plan` alone is ~4k tokens — where opencode's comparable
-`todowrite` is ~0.7k. The full table, the per-tool
-breakdown and the probe that produced them are in
-[`docs/comparison.md`](docs/comparison.md).
 
 ## Model credentials
 

--- a/README.md
+++ b/README.md
@@ -223,10 +223,11 @@ interface adds. opencode is a terminal agent of the same family, listed for scal
 | Interface | terminal | browser, installable, embeddable | terminal |
 | Several projects at once | — | yes, each with its own agent and sandbox | — |
 | Files, git, PDF and Office in the interface | — | yes | — |
-| Baseline context (system prompt + tool definitions) | **~2.4k tokens** | **~11k tokens** | not measured |
+| Baseline context (system prompt + tool definitions) | **~2.4k tokens** | **~11k tokens** | **~7.6k tokens** |
 
 That baseline is what every turn carries before you have typed anything, and most of the
-difference is one tool: `work_plan` alone is ~4k tokens. The full table, the per-tool
+difference is one tool: `work_plan` alone is ~4k tokens — where opencode's comparable
+`todowrite` is ~0.7k. The full table, the per-tool
 breakdown and the probe that produced them are in
 [`docs/comparison.md`](docs/comparison.md).
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,5 +1,11 @@
 # Pi Outpost next to pi and opencode
 
+> **Working notes, not a published claim.** The figures are provisional and this page is
+> not linked from the README. It is kept because it is worth maintaining — re-run the
+> probe when a tool or a prompt changes — and it becomes publishable when the numbers have
+> been checked on more than one machine and one run.
+
+
 Measured on **2026-09-03**, against **pi-outpost 0.20.1** and the **pi SDK 0.84.4** it
 bundles. All three columns are measured — opencode **1.18.27**, installed and run for this
 page. The features are read from documentation and behaviour; the context figures come

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -6,8 +6,8 @@
 > been checked on more than one machine and one run.
 
 
-Measured on **2026-09-03**, against **pi-outpost 0.20.1** plus the tool-publication work
-that followed it (#162, #164, #166), and the **pi SDK 0.84.4** it bundles. All three columns are measured — opencode **1.18.27**, installed and run for this
+Measured on **2026-09-03**, against **pi-outpost 0.20.1** plus the tool work that followed
+it (#162, #164, #166, #167), and the **pi SDK 0.84.4** it bundles. All three columns are measured — opencode **1.18.27**, installed and run for this
 page. The features are read from documentation and behaviour; the context figures come
 from the probes described below and can be re-run.
 
@@ -49,9 +49,9 @@ every conversation, and the first thing to look at when a context window feels s
 | | system prompt | tools | baseline |
 |---|---|---|---|
 | pi, default toolset | ~0.7k tokens | 8 tools, ~1.7k | **~2.4k tokens** |
-| **Pi Outpost, at rest** | ~1.5k tokens | 11 tools, ~3.9k | **~5.4k tokens** |
+| **Pi Outpost, at rest** | ~1.5k tokens | 11 tools, ~3.8k | **~5.2k tokens** |
 | opencode 1.18.27, default agent | ~2.4k tokens | 10 tools, ~5.2k | **~7.6k tokens** |
-| Pi Outpost, everything published | ~2.0k tokens | 16 tools, ~7.3k | ~9.3k tokens |
+| Pi Outpost, everything published | ~2.0k tokens | 16 tools, ~7.0k | ~9.0k tokens |
 
 **At rest** is what almost every turn of almost every conversation carries. Five tools are
 withheld until something asks for them: `work_plan_extended` until the session has a plan,
@@ -59,7 +59,8 @@ and the four document extractors until a document of their kind is named. A sess
 plans and reads documents ends up at the last row; one that refactors TypeScript stays at
 the second.
 
-It was **~10.7k** before that work — the row this page carried when it was first written.
+It was **~10.7k** before that work — the row this page carried when it was first written,
+and the reason the work happened.
 
 opencode's ten tools, largest first: `bash` 5 319 chars (~1.3k), `task` 3 856 (~1.0k),
 `todowrite` 2 686 (~0.7k), `edit` 1 958, `read` 1 734, `webfetch` 1 293, `grep` 1 183,
@@ -68,18 +69,19 @@ descriptions are written at length — and every one of them is sent on every re
 is what puts its floor above a Pi Outpost session at rest.
 
 The comparison worth drawing is `todowrite` against `work_plan`: the same job — an
-agent-owned list of what it is doing — at **2 686 characters against 4 969**. It was
+agent-owned list of what it is doing — at **2 686 characters against 4 331**. It was
 16 160 when this page was first written, which is what prompted the work: 73 copies of one
-regex, a second way to spell `update_task`, and the collection shapes for four operations
-that cannot be called before a plan exists. What is left does more than `todowrite` —
-dependencies, evidence, review states — and is now within twice its size.
+regex, a second way to spell `update_task`, the collection shapes for four operations that
+cannot be called before a plan exists, and 92 length bounds restating what the normaliser
+already enforced. What is left does more than `todowrite` — dependencies, evidence, review
+states — and is now within 1.6× of its size.
 
 Per tool, largest first, in the state each is actually sent in:
 
 | Tool | chars | ~tokens | Sent |
 |---|---|---|---|
-| `work_plan_extended` | 5 360 | ~1.3k | once the session has a plan |
-| `work_plan` | 4 969 | ~1.2k | always |
+| `work_plan_extended` | 4 602 | ~1.2k | once the session has a plan |
+| `work_plan` | 4 331 | ~1.1k | always |
 | `bash` (opencode) | 5 319 | ~1.3k | always |
 | `xlsx_extract` | 2 345 | ~0.6k | once a spreadsheet is named |
 | `write_structure_figure` | 2 195 | ~0.5k | always |
@@ -126,8 +128,8 @@ enough to tell a 4k tool from a 0.2k one, which is the decision this page is for
   deployment that loads skills pays for them on top, and that cost belongs to the
   deployment rather than to the software.
 - **What a conversation goes on to publish.** The resting figure is the floor, not the
-  average: a session that opens a work plan adds ~1.3k tokens for the rest of it, and one
-  that reads a spreadsheet adds ~0.6k until five turns pass without another.
+  average: a session that opens a work plan adds ~1.2k tokens for the rest of it, and one
+  that reads a spreadsheet adds ~0.6k until five turns pass without another call.
 - **The sandbox.** It replaces the built-in tools with path-scoped equivalents of much
   the same size, so the figure moves little.
 - **Two methods, one comparison.** pi and pi-outpost are read from their own sessions

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,0 +1,102 @@
+# Pi Outpost next to pi and opencode
+
+Measured on **2026-09-03**, against **pi-outpost 0.20.1** and the **pi SDK 0.84.4** it
+bundles. Figures for pi and pi-outpost come from the probe described below and are
+reproducible; the opencode column is compiled from its public documentation and is
+**not measured here** — see [What is not measured](#what-is-not-measured).
+
+The point of this page is not a scoreboard. Two of the three are terminal agents and one
+is a web interface; they are picked for different reasons. What is worth comparing is
+what you get without assembling it yourself, and what it costs you in context before you
+have said anything.
+
+## What is included
+
+| | pi | Pi Outpost | opencode |
+|---|---|---|---|
+| Interface | terminal TUI | browser, installable as an app | terminal TUI |
+| Runs where the files are | local | local or a server you reach over the network | local |
+| Several projects at once | one session, one directory | yes — each with its own agent, sandbox, history | one session per instance |
+| Sandbox / permissions | tool allowlist | read root, writable root, write and bash switches, per project, editable from the interface | permission rules per tool and pattern |
+| File browser and editor | — | tree, syntax-highlighted viewer, editor confined to the writable zone | — |
+| Git | through bash | change badges, per-file diffs, log, per-file history graph, multi-repository workspaces | through bash |
+| PDF and Office | — | `pdf_extract`, `docx_extract`, `xlsx_extract`, `pptx_extract`, no shell and no external binary | — |
+| Structured results | — | a tool can hand back a graph, a sequence or a table and the interface draws it | — |
+| Work plans | — | agent-owned plan with dependencies, evidence and review states | to-do list tool |
+| Embeddable in another app | — | `@pi-outpost/embed`, Shadow-DOM isolated | — |
+| Standalone executable | — | one per platform, no Node needed | single binary |
+| Local or gateway models | any OpenAI-compatible endpoint | the same, declarable from the browser | many providers, catalogue-driven |
+| Sharing a session | — | anyone who can reach the server sees the same conversation | shareable session links |
+| LSP diagnostics | — | — | yes |
+| Editor integration | — | — | IDE extensions |
+
+pi is the agent underneath Pi Outpost, so the second column is the first plus what the
+web interface adds. Nothing in it is a criticism of the terminal: a TUI is the right
+shape for a machine you are sitting at, and the interface exists for the machines you
+are not.
+
+## What a session costs before you say anything
+
+The system prompt and the tool definitions are sent on every turn. They are the floor of
+every conversation, and the first thing to look at when a context window feels small.
+
+| | system prompt | tools | baseline |
+|---|---|---|---|
+| pi, default toolset | ~0.7k tokens | 8 tools, ~1.7k | **~2.4k tokens** |
+| Pi Outpost, default configuration | ~1.9k tokens | 15 tools, ~8.8k | **~10.7k tokens** |
+| opencode | not measured | not measured | not measured |
+
+Per tool, largest first — this is where the difference actually is:
+
+| Tool | chars | ~tokens | |
+|---|---|---|---|
+| `work_plan` | 16 160 | ~4.0k | Pi Outpost |
+| `xlsx_extract` | 2 345 | ~0.6k | Pi Outpost |
+| `write_structure_figure` | 2 195 | ~0.5k | Pi Outpost |
+| `docx_extract` | 2 027 | ~0.5k | Pi Outpost |
+| `pdf_extract` | 1 944 | ~0.5k | Pi Outpost |
+| `pptx_extract` | 1 933 | ~0.5k | Pi Outpost |
+| `edit` | 1 773 | ~0.4k | pi |
+| `present_structure` | 1 535 | ~0.4k | Pi Outpost |
+| `grep` | 1 107 | ~0.3k | pi |
+| `read` | 824 | ~0.2k | pi |
+| `powershell` | 734 | ~0.2k | pi |
+| `bash` | 716 | ~0.2k | pi |
+| `find` | 684 | ~0.2k | pi |
+| `write` | 573 | ~0.1k | pi |
+| `ls` | 538 | ~0.1k | pi |
+
+**`work_plan` is 37% of the whole baseline** — on its own it is larger than everything pi
+sends by default, and it is the reason the system prompt grows too: a tool's prompt
+guidelines are appended to it. The four document extractors together cost about as much
+as pi's entire toolset. Everything else is noise by comparison.
+
+That is the shape of any optimisation worth doing: one tool's description, not the
+distribution of fifteen.
+
+## How the figures were produced
+
+```bash
+npx tsx server/scripts/probe-context-baseline.mts
+```
+
+It builds two real `AgentSession`s — pi's defaults, and pi-outpost's toolset on top —
+then reads `session.systemPrompt` and `session.getAllTools()`, counting the JSON of each
+tool's name, description, prompt guidelines and parameter schema. Reading the sources
+instead would miss where a tool's guidelines actually land, which is in the prompt.
+
+Tokens are **characters ÷ 4**. That is an order of magnitude, not a bill: the real count
+depends on the tokenizer, and a JSON schema tokenizes worse than prose. It is accurate
+enough to tell a 4k tool from a 0.2k one, which is the decision this page is for.
+
+### What is not measured
+
+- **Skills, extensions and project context files.** Discovery is off in the probe. A
+  deployment that loads skills pays for them on top, and that cost belongs to the
+  deployment rather than to the software.
+- **The sandbox.** It replaces the built-in tools with path-scoped equivalents of much
+  the same size, so the figure moves little.
+- **opencode.** It is not installed on the machine these numbers come from, and an
+  invented figure for someone else's software would be worth less than an empty cell.
+  Its default toolset is comparable in count and its prompt is of the same family, so the
+  honest way to fill that row is to run the equivalent probe against it.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -50,14 +50,17 @@ every conversation, and the first thing to look at when a context window feels s
 |---|---|---|---|
 | pi, default toolset | ~0.7k tokens | 8 tools, ~1.7k | **~2.4k tokens** |
 | **Pi Outpost, at rest** | ~1.5k tokens | 11 tools, ~3.8k | **~5.2k tokens** |
+| **Pi Outpost, a Work Plan open** | ~1.7k tokens | 12 tools, ~4.9k | **~6.6k tokens** |
 | opencode 1.18.27, default agent | ~2.4k tokens | 10 tools, ~5.2k | **~7.6k tokens** |
-| Pi Outpost, everything published | ~2.0k tokens | 16 tools, ~7.0k | ~9.0k tokens |
 
-**At rest** is what almost every turn of almost every conversation carries. Five tools are
-withheld until something asks for them: `work_plan_extended` until the session has a plan,
-and the four document extractors until a document of their kind is named. A session that
-plans and reads documents ends up at the last row; one that refactors TypeScript stays at
-the second.
+Those are the two states a conversation sits in. **At rest** is most turns of most
+conversations: no `work_plan_extended`, no document extractor. **A Work Plan open** is what
+real work settles into, since a plan is opened once and kept for the session — it is the
+figure to compare against opencode's, which carries every tool it has on every request.
+
+A document extractor adds ~0.5k on top while it lasts, and it does not last: five turns
+after its last call it is forgotten. There is deliberately no "everything published" row —
+holding all four at once is a moment, not a state.
 
 It was **~10.7k** before that work — the row this page carried when it was first written,
 and the reason the work happened.
@@ -80,14 +83,14 @@ Per tool, largest first, in the state each is actually sent in:
 
 | Tool | chars | ~tokens | Sent |
 |---|---|---|---|
-| `work_plan_extended` | 4 602 | ~1.2k | once the session has a plan |
+| `work_plan_extended` | 4 602 | ~1.2k | once the session has a plan, then kept |
 | `work_plan` | 4 331 | ~1.1k | always |
 | `bash` (opencode) | 5 319 | ~1.3k | always |
-| `xlsx_extract` | 2 345 | ~0.6k | once a spreadsheet is named |
+| `xlsx_extract` | 2 345 | ~0.6k | while a spreadsheet is in play |
 | `write_structure_figure` | 2 195 | ~0.5k | always |
-| `docx_extract` | 2 027 | ~0.5k | once a Word file is named |
-| `pdf_extract` | 1 944 | ~0.5k | once a PDF is named |
-| `pptx_extract` | 1 933 | ~0.5k | once a deck is named |
+| `docx_extract` | 2 027 | ~0.5k | while a Word file is in play |
+| `pdf_extract` | 1 944 | ~0.5k | while a PDF is in play |
+| `pptx_extract` | 1 933 | ~0.5k | while a deck is in play |
 | `edit` | 1 773 | ~0.4k | always |
 | `present_structure` | 1 535 | ~0.4k | always |
 | `grep` | 1 107 | ~0.3k | always |
@@ -110,7 +113,7 @@ npx tsx server/scripts/probe-context-baseline.mts
 ```
 
 It builds three real `AgentSession`s — pi's defaults, what pi-outpost publishes at rest,
-and everything it can publish — then reads `session.systemPrompt` and
+and what it publishes with a Work Plan open — then reads `session.systemPrompt` and
 `session.getAllTools()`, counting the JSON of each tool's name, description, prompt
 guidelines and parameter schema. The resting figure withholds the on-demand tools through
 `setActiveToolsByName`, the way the server does, rather than subtracting them afterwards:
@@ -127,9 +130,8 @@ enough to tell a 4k tool from a 0.2k one, which is the decision this page is for
 - **Skills, extensions and project context files.** Discovery is off in the probe. A
   deployment that loads skills pays for them on top, and that cost belongs to the
   deployment rather than to the software.
-- **What a conversation goes on to publish.** The resting figure is the floor, not the
-  average: a session that opens a work plan adds ~1.2k tokens for the rest of it, and one
-  that reads a spreadsheet adds ~0.6k until five turns pass without another call.
+- **The transient tools.** A document extractor adds ~0.5k while the document is being
+  worked on and goes five turns after its last call, so neither row above includes one.
 - **The sandbox.** It replaces the built-in tools with path-scoped equivalents of much
   the same size, so the figure moves little.
 - **Two methods, one comparison.** pi and pi-outpost are read from their own sessions

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,9 +1,9 @@
 # Pi Outpost next to pi and opencode
 
 Measured on **2026-09-03**, against **pi-outpost 0.20.1** and the **pi SDK 0.84.4** it
-bundles. Figures for pi and pi-outpost come from the probe described below and are
-reproducible; the opencode column is compiled from its public documentation and is
-**not measured here** — see [What is not measured](#what-is-not-measured).
+bundles. All three columns are measured — opencode **1.18.27**, installed and run for this
+page. The features are read from documentation and behaviour; the context figures come
+from the probes described below and can be re-run.
 
 The point of this page is not a scoreboard. Two of the three are terminal agents and one
 is a web interface; they are picked for different reasons. What is worth comparing is
@@ -43,14 +43,24 @@ every conversation, and the first thing to look at when a context window feels s
 | | system prompt | tools | baseline |
 |---|---|---|---|
 | pi, default toolset | ~0.7k tokens | 8 tools, ~1.7k | **~2.4k tokens** |
+| opencode 1.18.27, default agent | ~2.4k tokens | 10 tools, ~5.2k | **~7.6k tokens** |
 | Pi Outpost, default configuration | ~1.9k tokens | 15 tools, ~8.8k | **~10.7k tokens** |
-| opencode | not measured | not measured | not measured |
+
+opencode's ten tools, largest first: `bash` 5 319 chars (~1.3k), `task` 3 856 (~1.0k),
+`todowrite` 2 686 (~0.7k), `edit` 1 958, `read` 1 734, `webfetch` 1 293, `grep` 1 183,
+`glob` 1 114, `write` 1 026, `skill` 676. Its prompt carries more than pi's and its tool
+descriptions are written at length; the totals land between the two others.
+
+The comparison worth drawing is `todowrite` against `work_plan`: the same job — an
+agent-owned list of what it is doing — at **2 686 characters against 16 160**. Work
+plans do more (dependencies, evidence, review states), but not six times more.
 
 Per tool, largest first — this is where the difference actually is:
 
 | Tool | chars | ~tokens | |
 |---|---|---|---|
 | `work_plan` | 16 160 | ~4.0k | Pi Outpost |
+| `bash` (opencode) | 5 319 | ~1.3k | opencode |
 | `xlsx_extract` | 2 345 | ~0.6k | Pi Outpost |
 | `write_structure_figure` | 2 195 | ~0.5k | Pi Outpost |
 | `docx_extract` | 2 027 | ~0.5k | Pi Outpost |
@@ -96,7 +106,11 @@ enough to tell a 4k tool from a 0.2k one, which is the decision this page is for
   deployment rather than to the software.
 - **The sandbox.** It replaces the built-in tools with path-scoped equivalents of much
   the same size, so the figure moves little.
-- **opencode.** It is not installed on the machine these numbers come from, and an
-  invented figure for someone else's software would be worth less than an empty cell.
-  Its default toolset is comparable in count and its prompt is of the same family, so the
-  honest way to fill that row is to run the equivalent probe against it.
+- **Two methods, one comparison.** pi and pi-outpost are read from their own sessions
+  (`session.systemPrompt` and `session.getAllTools()`); opencode is read from the wire —
+  it was pointed at a local OpenAI-compatible endpoint that logged the request, and the
+  figures are the `system` messages and the `tools` array it actually sent. The wire is
+  the stricter of the two, so if anything opencode's number is the more generous.
+- **opencode's environment.** Run with `--pure` and a clean `HOME`, so no plugins, no
+  project `AGENTS.md`, and none of the skills it would otherwise discover — including,
+  on this machine, the ones under `~/.claude/skills`.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -6,8 +6,8 @@
 > been checked on more than one machine and one run.
 
 
-Measured on **2026-09-03**, against **pi-outpost 0.20.1** and the **pi SDK 0.84.4** it
-bundles. All three columns are measured — opencode **1.18.27**, installed and run for this
+Measured on **2026-09-03**, against **pi-outpost 0.20.1** plus the tool-publication work
+that followed it (#162, #164, #166), and the **pi SDK 0.84.4** it bundles. All three columns are measured — opencode **1.18.27**, installed and run for this
 page. The features are read from documentation and behaviour; the context figures come
 from the probes described below and can be re-run.
 
@@ -28,7 +28,7 @@ have said anything.
 | Git | through bash | change badges, per-file diffs, log, per-file history graph, multi-repository workspaces | through bash |
 | PDF and Office | — | `pdf_extract`, `docx_extract`, `xlsx_extract`, `pptx_extract`, no shell and no external binary | — |
 | Structured results | — | a tool can hand back a graph, a sequence or a table and the interface draws it | — |
-| Work plans | — | agent-owned plan with dependencies, evidence and review states | to-do list tool |
+| Work plans | — | agent-owned plan with dependencies, evidence and review states, published in two halves | to-do list tool |
 | Embeddable in another app | — | `@pi-outpost/embed`, Shadow-DOM isolated | — |
 | Standalone executable | — | one per platform, no Node needed | single binary |
 | Local or gateway models | any OpenAI-compatible endpoint | the same, declarable from the browser | many providers, catalogue-driven |
@@ -49,46 +49,57 @@ every conversation, and the first thing to look at when a context window feels s
 | | system prompt | tools | baseline |
 |---|---|---|---|
 | pi, default toolset | ~0.7k tokens | 8 tools, ~1.7k | **~2.4k tokens** |
+| **Pi Outpost, at rest** | ~1.5k tokens | 11 tools, ~3.9k | **~5.4k tokens** |
 | opencode 1.18.27, default agent | ~2.4k tokens | 10 tools, ~5.2k | **~7.6k tokens** |
-| Pi Outpost, default configuration | ~1.9k tokens | 15 tools, ~8.8k | **~10.7k tokens** |
+| Pi Outpost, everything published | ~2.0k tokens | 16 tools, ~7.3k | ~9.3k tokens |
+
+**At rest** is what almost every turn of almost every conversation carries. Five tools are
+withheld until something asks for them: `work_plan_extended` until the session has a plan,
+and the four document extractors until a document of their kind is named. A session that
+plans and reads documents ends up at the last row; one that refactors TypeScript stays at
+the second.
+
+It was **~10.7k** before that work — the row this page carried when it was first written.
 
 opencode's ten tools, largest first: `bash` 5 319 chars (~1.3k), `task` 3 856 (~1.0k),
 `todowrite` 2 686 (~0.7k), `edit` 1 958, `read` 1 734, `webfetch` 1 293, `grep` 1 183,
 `glob` 1 114, `write` 1 026, `skill` 676. Its prompt carries more than pi's and its tool
-descriptions are written at length; the totals land between the two others.
+descriptions are written at length — and every one of them is sent on every request, which
+is what puts its floor above a Pi Outpost session at rest.
 
 The comparison worth drawing is `todowrite` against `work_plan`: the same job — an
-agent-owned list of what it is doing — at **2 686 characters against 16 160**. Work
-plans do more (dependencies, evidence, review states), but not six times more.
+agent-owned list of what it is doing — at **2 686 characters against 4 969**. It was
+16 160 when this page was first written, which is what prompted the work: 73 copies of one
+regex, a second way to spell `update_task`, and the collection shapes for four operations
+that cannot be called before a plan exists. What is left does more than `todowrite` —
+dependencies, evidence, review states — and is now within twice its size.
 
-Per tool, largest first — this is where the difference actually is:
+Per tool, largest first, in the state each is actually sent in:
 
-| Tool | chars | ~tokens | |
+| Tool | chars | ~tokens | Sent |
 |---|---|---|---|
-| `work_plan` | 16 160 | ~4.0k | Pi Outpost |
-| `bash` (opencode) | 5 319 | ~1.3k | opencode |
-| `xlsx_extract` | 2 345 | ~0.6k | Pi Outpost |
-| `write_structure_figure` | 2 195 | ~0.5k | Pi Outpost |
-| `docx_extract` | 2 027 | ~0.5k | Pi Outpost |
-| `pdf_extract` | 1 944 | ~0.5k | Pi Outpost |
-| `pptx_extract` | 1 933 | ~0.5k | Pi Outpost |
-| `edit` | 1 773 | ~0.4k | pi |
-| `present_structure` | 1 535 | ~0.4k | Pi Outpost |
-| `grep` | 1 107 | ~0.3k | pi |
-| `read` | 824 | ~0.2k | pi |
-| `powershell` | 734 | ~0.2k | pi |
-| `bash` | 716 | ~0.2k | pi |
-| `find` | 684 | ~0.2k | pi |
-| `write` | 573 | ~0.1k | pi |
-| `ls` | 538 | ~0.1k | pi |
+| `work_plan_extended` | 5 360 | ~1.3k | once the session has a plan |
+| `work_plan` | 4 969 | ~1.2k | always |
+| `bash` (opencode) | 5 319 | ~1.3k | always |
+| `xlsx_extract` | 2 345 | ~0.6k | once a spreadsheet is named |
+| `write_structure_figure` | 2 195 | ~0.5k | always |
+| `docx_extract` | 2 027 | ~0.5k | once a Word file is named |
+| `pdf_extract` | 1 944 | ~0.5k | once a PDF is named |
+| `pptx_extract` | 1 933 | ~0.5k | once a deck is named |
+| `edit` | 1 773 | ~0.4k | always |
+| `present_structure` | 1 535 | ~0.4k | always |
+| `grep` | 1 107 | ~0.3k | always |
+| `read` | 824 | ~0.2k | always |
+| `powershell` | 734 | ~0.2k | always |
+| `bash` | 716 | ~0.2k | always |
+| `find` | 684 | ~0.2k | always |
+| `write` | 573 | ~0.1k | always |
+| `ls` | 538 | ~0.1k | always |
 
-**`work_plan` is 37% of the whole baseline** — on its own it is larger than everything pi
-sends by default, and it is the reason the system prompt grows too: a tool's prompt
-guidelines are appended to it. The four document extractors together cost about as much
-as pi's entire toolset. Everything else is noise by comparison.
-
-That is the shape of any optimisation worth doing: one tool's description, not the
-distribution of fifteen.
+`work_plan` is still the largest thing sent to every conversation, and the four extractors
+together are still about the size of pi's entire toolset — but none of the five is sent to a
+session that has no use for it. The shape of any further optimisation is the same as the
+last one: one tool's definition, not the distribution of sixteen.
 
 ## How the figures were produced
 
@@ -96,9 +107,13 @@ distribution of fifteen.
 npx tsx server/scripts/probe-context-baseline.mts
 ```
 
-It builds two real `AgentSession`s — pi's defaults, and pi-outpost's toolset on top —
-then reads `session.systemPrompt` and `session.getAllTools()`, counting the JSON of each
-tool's name, description, prompt guidelines and parameter schema. Reading the sources
+It builds three real `AgentSession`s — pi's defaults, what pi-outpost publishes at rest,
+and everything it can publish — then reads `session.systemPrompt` and
+`session.getAllTools()`, counting the JSON of each tool's name, description, prompt
+guidelines and parameter schema. The resting figure withholds the on-demand tools through
+`setActiveToolsByName`, the way the server does, rather than subtracting them afterwards:
+pi rebuilds the system prompt around the active set, so a withheld tool takes its
+guidelines with it — 2 074 characters that a subtraction would have counted anyway. Reading the sources
 instead would miss where a tool's guidelines actually land, which is in the prompt.
 
 Tokens are **characters ÷ 4**. That is an order of magnitude, not a bill: the real count
@@ -110,6 +125,9 @@ enough to tell a 4k tool from a 0.2k one, which is the decision this page is for
 - **Skills, extensions and project context files.** Discovery is off in the probe. A
   deployment that loads skills pays for them on top, and that cost belongs to the
   deployment rather than to the software.
+- **What a conversation goes on to publish.** The resting figure is the floor, not the
+  average: a session that opens a work plan adds ~1.3k tokens for the rest of it, and one
+  that reads a spreadsheet adds ~0.6k until five turns pass without another.
 - **The sandbox.** It replaces the built-in tools with path-scoped equivalents of much
   the same size, so the figure moves little.
 - **Two methods, one comparison.** pi and pi-outpost are read from their own sessions

--- a/server/scripts/probe-context-baseline.mts
+++ b/server/scripts/probe-context-baseline.mts
@@ -1,0 +1,91 @@
+/**
+ * What a session carries before the first word of conversation: the assembled system
+ * prompt plus every tool's name, description, guidelines and parameter schema.
+ *
+ * Two configurations — pi's own defaults, and pi-outpost's toolset on top — read from
+ * real `AgentSession`s rather than from the sources, so the prompt guidelines a tool
+ * contributes are counted where they actually land.
+ *
+ * Run it with `npx tsx server/scripts/probe-context-baseline.mts`. It is what the
+ * figures in `docs/comparison.md` come from, and re-running it is how they are checked
+ * after a tool or a prompt changes.
+ *
+ * Two things it deliberately does not count, because both depend on the deployment
+ * rather than on the software: skills and extensions (discovery is off here) and the
+ * project context files a real workspace carries. A sandboxed deployment swaps the
+ * built-in tools for path-scoped equivalents of much the same size.
+ *
+ * Tokens are chars / 4 — an order of magnitude, not a bill.
+ */
+import { mkdtemp, realpath } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  createAgentSessionFromServices,
+  createAgentSessionServices,
+  SessionManager,
+} from "@earendil-works/pi-coding-agent";
+import { createPdfExtractToolDefinition } from "../src/pdfTool.ts";
+import { createDocxExtractToolDefinition } from "../src/docxTool.ts";
+import { createXlsxExtractToolDefinition } from "../src/xlsxTool.ts";
+import { createPptxExtractToolDefinition } from "../src/pptxTool.ts";
+import { createWorkPlanToolDefinition } from "../src/workPlanTool.ts";
+import { createStructuredExchangeToolDefinition } from "../src/structuredExchangeTool.ts";
+import { createStructuredExchangeFigureToolDefinition } from "../src/structuredExchangeFigureTool.ts";
+import { composeAppendSystemPrompt } from "../src/systemPrompt.ts";
+
+const chars = (s: string) => s.length;
+const tok = (n: number) => `${(n / 4 / 1000).toFixed(1)}k`;
+
+async function measure(label: string, options: { outpost: boolean }) {
+  const cwd = await realpath(await mkdtemp(path.join(tmpdir(), "baseline-")));
+  const agentDir = path.join(cwd, "agent");
+  const appendSystemPrompt = options.outpost
+    ? composeAppendSystemPrompt({ webContext: true, appendSystemPrompt: [] } as never)
+    : [];
+  const services = await createAgentSessionServices({
+    cwd,
+    agentDir,
+    resourceLoaderOptions: {
+      noExtensions: true,
+      noSkills: true,
+      noPromptTemplates: true,
+      ...(appendSystemPrompt.length > 0 ? { appendSystemPrompt } : {}),
+    },
+  });
+  const extras = options.outpost
+    ? [
+        createPdfExtractToolDefinition({ cwd, allowedRoots: [cwd], maxBytes: 26214400, writableRoot: cwd }),
+        createDocxExtractToolDefinition({ cwd, allowedRoots: [cwd], maxBytes: 26214400, writableRoot: cwd }),
+        createXlsxExtractToolDefinition({ cwd, allowedRoots: [cwd], maxBytes: 26214400, writableRoot: cwd }),
+        createPptxExtractToolDefinition({ cwd, allowedRoots: [cwd], maxBytes: 26214400, writableRoot: cwd }),
+        createWorkPlanToolDefinition(),
+        createStructuredExchangeToolDefinition(),
+        createStructuredExchangeFigureToolDefinition({ cwd, allowedRoots: [cwd], writableRoot: cwd }),
+      ]
+    : [];
+  const session = await createAgentSessionFromServices({
+    services,
+    sessionManager: SessionManager.create(cwd, path.join(cwd, "sessions")),
+    ...(extras.length > 0 ? { customTools: extras } : {}),
+  });
+  const s = (session as { session?: unknown }).session ?? session;
+  const prompt = (s as { systemPrompt: string }).systemPrompt;
+  const tools = (s as { getAllTools: () => unknown[] }).getAllTools();
+  const sized = (tools as { name?: string }[])
+    .map((tool) => ({ name: tool.name ?? "?", chars: chars(JSON.stringify(tool)) }))
+    .sort((a, b) => b.chars - a.chars);
+  const toolChars = sized.reduce((n, tool) => n + tool.chars, 0);
+  console.log(
+    `\n${label} — prompt ${chars(prompt)} chars (~${tok(chars(prompt))}), ` +
+      `${sized.length} tools ${toolChars} chars (~${tok(toolChars)}), total ~${tok(chars(prompt) + toolChars)} tok`,
+  );
+  // Per tool, largest first: which definitions are worth trimming is the whole point.
+  for (const tool of sized) {
+    console.log(`  ${tool.name.padEnd(28)} ${String(tool.chars).padStart(6)} chars  ~${tok(tool.chars)}`);
+  }
+  return { prompt: chars(prompt), tools: toolChars, count: sized.length };
+}
+
+await measure("pi (defaults)", { outpost: false });
+await measure("pi-outpost", { outpost: true });

--- a/server/scripts/probe-context-baseline.mts
+++ b/server/scripts/probe-context-baseline.mts
@@ -3,14 +3,16 @@
  * prompt plus every tool's name, description, guidelines and parameter schema.
  *
  * Three configurations — pi's own defaults, what a pi-outpost session publishes at rest,
- * and everything it can publish — read from real `AgentSession`s rather than from the
- * sources, so the prompt guidelines a tool contributes are counted where they actually
- * land.
+ * and what it publishes once a Work Plan is open — read from real `AgentSession`s rather
+ * than from the sources, so the prompt guidelines a tool contributes are counted where
+ * they actually land.
  *
- * "At rest" is the figure that matters, because it is what almost every turn of almost
- * every conversation carries: no `work_plan_extended` (published once a session has a
- * plan) and no document extractor (published once a document is named). The full set is
- * what a session that plans and reads documents ends up with.
+ * Those are the two states a conversation actually sits in. "At rest" is most turns of
+ * most conversations: no `work_plan_extended`, no document extractor. "A Work Plan open"
+ * is what real work settles into, since a plan is opened once and kept for the session.
+ *
+ * There is deliberately no "everything published" row: an extractor is forgotten five
+ * turns after its last call, so holding all four at once is a moment, not a state.
  *
  * Run it with `npx tsx server/scripts/probe-context-baseline.mts`. It is what the
  * figures in `docs/comparison.md` come from, and re-running it is how they are checked
@@ -45,6 +47,8 @@ const tok = (n: number) => `${(n / 4 / 1000).toFixed(1)}k`;
 
 /** What a session withholds until something asks for it. */
 const ON_DEMAND = ["work_plan_extended", "pdf_extract", "docx_extract", "xlsx_extract", "pptx_extract"];
+/** The document extractors alone: transient, forgotten five turns after their last call. */
+const EXTRACTORS = ["pdf_extract", "docx_extract", "xlsx_extract", "pptx_extract"];
 
 async function measure(label: string, options: { outpost: boolean; withheld?: string[] }) {
   const cwd = await realpath(await mkdtemp(path.join(tmpdir(), "baseline-")));
@@ -108,4 +112,6 @@ async function measure(label: string, options: { outpost: boolean; withheld?: st
 
 await measure("pi (defaults)", { outpost: false });
 await measure("pi-outpost (at rest)", { outpost: true, withheld: ON_DEMAND });
-await measure("pi-outpost (everything published)", { outpost: true });
+// The state real work settles into: a plan is opened once and kept, where an extractor
+// comes and goes with the document that called for it.
+await measure("pi-outpost (a Work Plan open)", { outpost: true, withheld: EXTRACTORS });

--- a/server/scripts/probe-context-baseline.mts
+++ b/server/scripts/probe-context-baseline.mts
@@ -2,9 +2,15 @@
  * What a session carries before the first word of conversation: the assembled system
  * prompt plus every tool's name, description, guidelines and parameter schema.
  *
- * Two configurations — pi's own defaults, and pi-outpost's toolset on top — read from
- * real `AgentSession`s rather than from the sources, so the prompt guidelines a tool
- * contributes are counted where they actually land.
+ * Three configurations — pi's own defaults, what a pi-outpost session publishes at rest,
+ * and everything it can publish — read from real `AgentSession`s rather than from the
+ * sources, so the prompt guidelines a tool contributes are counted where they actually
+ * land.
+ *
+ * "At rest" is the figure that matters, because it is what almost every turn of almost
+ * every conversation carries: no `work_plan_extended` (published once a session has a
+ * plan) and no document extractor (published once a document is named). The full set is
+ * what a session that plans and reads documents ends up with.
  *
  * Run it with `npx tsx server/scripts/probe-context-baseline.mts`. It is what the
  * figures in `docs/comparison.md` come from, and re-running it is how they are checked
@@ -29,7 +35,7 @@ import { createPdfExtractToolDefinition } from "../src/pdfTool.ts";
 import { createDocxExtractToolDefinition } from "../src/docxTool.ts";
 import { createXlsxExtractToolDefinition } from "../src/xlsxTool.ts";
 import { createPptxExtractToolDefinition } from "../src/pptxTool.ts";
-import { createWorkPlanToolDefinition } from "../src/workPlanTool.ts";
+import { createWorkPlanExtendedToolDefinition, createWorkPlanToolDefinition } from "../src/workPlanTool.ts";
 import { createStructuredExchangeToolDefinition } from "../src/structuredExchangeTool.ts";
 import { createStructuredExchangeFigureToolDefinition } from "../src/structuredExchangeFigureTool.ts";
 import { composeAppendSystemPrompt } from "../src/systemPrompt.ts";
@@ -37,7 +43,10 @@ import { composeAppendSystemPrompt } from "../src/systemPrompt.ts";
 const chars = (s: string) => s.length;
 const tok = (n: number) => `${(n / 4 / 1000).toFixed(1)}k`;
 
-async function measure(label: string, options: { outpost: boolean }) {
+/** What a session withholds until something asks for it. */
+const ON_DEMAND = ["work_plan_extended", "pdf_extract", "docx_extract", "xlsx_extract", "pptx_extract"];
+
+async function measure(label: string, options: { outpost: boolean; withheld?: string[] }) {
   const cwd = await realpath(await mkdtemp(path.join(tmpdir(), "baseline-")));
   const agentDir = path.join(cwd, "agent");
   const appendSystemPrompt = options.outpost
@@ -60,6 +69,7 @@ async function measure(label: string, options: { outpost: boolean }) {
         createXlsxExtractToolDefinition({ cwd, allowedRoots: [cwd], maxBytes: 26214400, writableRoot: cwd }),
         createPptxExtractToolDefinition({ cwd, allowedRoots: [cwd], maxBytes: 26214400, writableRoot: cwd }),
         createWorkPlanToolDefinition(),
+        createWorkPlanExtendedToolDefinition(),
         createStructuredExchangeToolDefinition(),
         createStructuredExchangeFigureToolDefinition({ cwd, allowedRoots: [cwd], writableRoot: cwd }),
       ]
@@ -70,9 +80,18 @@ async function measure(label: string, options: { outpost: boolean }) {
     ...(extras.length > 0 ? { customTools: extras } : {}),
   });
   const s = (session as { session?: unknown }).session ?? session;
+  const withheld = new Set(options.withheld ?? []);
+  if (withheld.size > 0) {
+    // Withhold them the way the server does. Filtering the list afterwards would count
+    // the prompt of a session that still had them: pi rebuilds the system prompt around
+    // the active set, and a withheld tool takes its guidelines with it.
+    const active = (s as { getActiveToolNames: () => string[] }).getActiveToolNames();
+    (s as { setActiveToolsByName: (names: string[]) => void })
+      .setActiveToolsByName(active.filter((name) => !withheld.has(name)));
+  }
   const prompt = (s as { systemPrompt: string }).systemPrompt;
-  const tools = (s as { getAllTools: () => unknown[] }).getAllTools();
-  const sized = (tools as { name?: string }[])
+  const sized = (s as { getAllTools: () => { name?: string }[] }).getAllTools()
+    .filter((tool) => !withheld.has(tool.name ?? ""))
     .map((tool) => ({ name: tool.name ?? "?", chars: chars(JSON.stringify(tool)) }))
     .sort((a, b) => b.chars - a.chars);
   const toolChars = sized.reduce((n, tool) => n + tool.chars, 0);
@@ -88,4 +107,5 @@ async function measure(label: string, options: { outpost: boolean }) {
 }
 
 await measure("pi (defaults)", { outpost: false });
-await measure("pi-outpost", { outpost: true });
+await measure("pi-outpost (at rest)", { outpost: true, withheld: ON_DEMAND });
+await measure("pi-outpost (everything published)", { outpost: true });


### PR DESCRIPTION
> **Working notes, not a published claim.** The page is deliberately **not linked from the README**: it names other projects and its figures deserve more than one machine and one run behind them before it goes out. It is kept because it is worth maintaining — and because it is what prompted the work below.

## What is in it

- **`docs/comparison.md`** — what each tool includes, what a session costs before anyone types, a per-tool breakdown, the method, and what is deliberately not measured.
- **`server/scripts/probe-context-baseline.mts`** — how the figures are produced, so they can be re-checked whenever a tool or a prompt changes. It is the script every number below comes from.

Nothing else. No README change, no source touched.

## The measurement

Three real `AgentSession`s, read through `session.systemPrompt` and `session.getAllTools()` rather than from the sources — a tool's prompt guidelines land in the prompt, and counting the files would miss that. opencode was **installed and run**: pointed at a local OpenAI-compatible endpoint that logged the request, so its row is the `system` messages and `tools` array it actually sent. Tokens are chars ÷ 4, an order of magnitude.

| | system prompt | tools | baseline |
|---|---|---|---|
| pi, default toolset | ~0.7k tokens | 8 tools, ~1.7k | **~2.4k tokens** |
| **Pi Outpost, at rest** | ~1.5k tokens | 11 tools, ~3.8k | **~5.2k tokens** |
| **Pi Outpost, a Work Plan open** | ~1.7k tokens | 12 tools, ~4.9k | **~6.6k tokens** |
| opencode 1.18.27, default agent | ~2.4k tokens | 10 tools, ~5.2k | **~7.6k tokens** |

Those are the two states a conversation sits in. **6.6k** is the figure to put beside opencode's 7.6k — a plan is opened once and kept — while opencode sends every tool it has on every request. There is deliberately no "everything published" row: a document extractor is forgotten five turns after its last call, so holding all four at once is a moment, not a state.

## What this page changed

It was written against a **~10.7k** baseline, where `work_plan` alone was 16 160 characters — 37% of the floor, more than everything pi sends by default. That reading is what produced #162, #164, #166 and #167, all merged:

| | then | now |
|---|---|---|
| resting baseline | ~10.7k tokens | **~5.2k** |
| `work_plan` | 16 160 chars | **4 331** |
| opencode's comparable `todowrite` | 2 686 chars | 2 686 |

Six times `todowrite`, down to 1.6× — while carrying dependencies, evidence and review states it does not have.

## Documentation impact

This *is* the documentation change. `docs/comparison.md` is new and unlinked; the probe is a measurement script with no effect on the product. No behaviour, command, flag or configuration key changes.

Not sent to Codex: the standing review rule excludes documentation-only changes. If you want the probe script reviewed on its own — 111 lines that only measure — say so and I will.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PryLsHtHcqbkjAqsxVH8rQ