### PR TITLE
openspec: split work_plan into a common tool and an extended one

### DIFF
--- a/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/.openspec.yaml
+++ b/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-03

--- a/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/design.md
+++ b/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/design.md
@@ -1,0 +1,69 @@
+## The constraint that shapes everything
+
+`AgentSession` builds its tool registry when the session is created. There is
+`setActiveToolsByName(names)` — which rebuilds the system prompt, so an inactive tool is
+not described — and `getAllTools()`, and nothing that registers a definition afterwards.
+
+So "publish a small `work_plan` at rest and a complete one once there is a plan" cannot be
+one tool with two schemas. Both definitions exist from the start, and only their active
+flag changes. Two definitions mean two names, which is the whole design question: what does
+the agent see when there is no plan?
+
+## What the resting state offers
+
+**An opener, not a smaller `work_plan`.** One tool, `start_work_plan`, whose parameters are
+a title and nothing else, and whose description says when to reach for it — the same
+sentence the system prompt spends on the subject today. Roughly 300 characters against
+12 480.
+
+The alternatives considered:
+
+*Nothing at all, and a line in the prompt.* Cheapest, and it does not work: an agent cannot
+call what is not published, so the plan would only ever be opened by a human asking for
+one. The capability exists precisely for the moments the agent notices the work is
+non-trivial.
+
+*A create-only `work_plan`, renamed to something else once complete.* The name would change
+under the agent mid-conversation, with the earlier name still in the transcript. Names are
+how a model addresses a tool; changing one is worse than adding one.
+
+*The full contract, always, and accept the cost.* What we do today, and what this change
+exists to stop.
+
+The opener is the pattern opencode uses for skills: a small always-present tool that brings
+the large thing into scope on demand. The cost is one extra round trip, on the turn where
+the agent has already decided it is doing something substantial.
+
+## When the full contract becomes active
+
+Three moments, all server-side, none requiring the agent to ask twice:
+
+1. **The opener runs.** It creates the plan and activates `work_plan` before returning, so
+   the agent's next call in the same turn can already use `set_status` or `add_task`.
+2. **A session with a plan is bound.** Restore, resume, switch, fork: `loadWorkPlan` already
+   runs there, and a session that has a plan starts with the contract active. An agent
+   resuming work never sees the opener.
+3. **Never otherwise.** `clear` puts the session back to resting, and a new session starts
+   there.
+
+The state is derived from the persisted plan, not from a flag someone has to remember to
+set — the same rule the review state already follows.
+
+## What this does not do
+
+**It does not shrink the contract.** `work_plan` is 12 480 characters and its shape is a
+separate problem: the `plan` and `task` properties each serialise a complete task tree, the
+evidence record appears five times, and eleven actions share one flat object. Gating hides
+that cost from conversations that never open a plan; it does nothing for the ones that do.
+Both are worth doing and they are independent.
+
+**It does not reach the RPC runtime.** That dialect has no command for the active toolset,
+so an RPC child publishes the full contract at all times. Stated in the capability, and
+consistent with the embedded SDK runtime being the supported target.
+
+## Why this is not a prompt-cache regression
+
+Changing the active toolset mid-session changes the system prompt, which invalidates a
+provider's prefix cache for that conversation — once, on the turn a plan is opened. A
+conversation that opens a plan pays one cache miss; a conversation that never opens one
+saves ~3k tokens on every turn. The trade is not close.

--- a/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/design.md
+++ b/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/design.md
@@ -1,69 +1,75 @@
-## The constraint that shapes everything
+## Why two tools rather than one gated tool
 
 `AgentSession` builds its tool registry when the session is created. There is
 `setActiveToolsByName(names)` — which rebuilds the system prompt, so an inactive tool is
-not described — and `getAllTools()`, and nothing that registers a definition afterwards.
+not described — and nothing that registers a definition afterwards. One tool cannot
+therefore have a small schema at rest and a complete one later: whatever is published for
+a name is fixed for the session's life.
 
-So "publish a small `work_plan` at rest and a complete one once there is a plan" cannot be
-one tool with two schemas. Both definitions exist from the start, and only their active
-flag changes. Two definitions mean two names, which is the whole design question: what does
-the agent see when there is no plan?
+An earlier draft of this change worked around that with an *opener*: a tiny tool whose only
+job was to create a plan and switch the full contract on. It works, and it makes the agent
+pay a round trip on the turn it decided to plan, for operations — add a task, move a status
+on — that are the whole point and cost almost nothing to publish.
 
-## What the resting state offers
+Splitting by *what an operation carries* is better on both counts. The common path stays
+published at all times, so nothing is discovered twice; what is withheld is the part that
+is both expensive and unusable without a plan.
 
-**An opener, not a smaller `work_plan`.** One tool, `start_work_plan`, whose parameters are
-a title and nothing else, and whose description says when to reach for it — the same
-sentence the system prompt spends on the subject today. Roughly 300 characters against
-12 480.
+## Where the line falls
 
-The alternatives considered:
+| | `work_plan` | `work_plan_extended` |
+|---|---|---|
+| Actions | `get`, `create`, `add_task`, `update_task`, `move_task`, `remove_task`, `clear` | `replace`, `set_dependencies`, `set_resources`, `set_evidence` |
+| Carries | a title, a task tree of titles, descriptions, statuses and reasons | a complete normalized plan, evidence records, resource lists, dependency sets |
+| Schema | 3 071 characters | 5 894 characters |
+| Published | always | only while the session has a plan |
 
-*Nothing at all, and a line in the prompt.* Cheapest, and it does not work: an agent cannot
-call what is not published, so the plan would only ever be opened by a human asking for
-one. The capability exists precisely for the moments the agent notices the work is
-non-trivial.
+The rule that decides the line is not frequency but **prerequisite**: every operation in the
+extended tool acts on a task that must already exist. `set_evidence` on no plan is not a
+call anyone can make. A tool that cannot be called is a tool nobody needs to read.
 
-*A create-only `work_plan`, renamed to something else once complete.* The name would change
-under the agent mid-conversation, with the earlier name still in the transcript. Names are
-how a model addresses a tool; changing one is worse than adding one.
+That the four are also the least-used operations is what makes the split pay; that they are
+impossible without a plan is what makes it *correct*.
 
-*The full contract, always, and accept the cost.* What we do today, and what this change
-exists to stop.
+## Evidence and resources leave the creation shape
 
-The opener is the pattern opencode uses for skills: a small always-present tool that brings
-the large thing into scope on demand. The cost is one extra round trip, on the turn where
-the agent has already decided it is doing something substantial.
+They are the reason a creation task costs 1 009 characters twice over — once per nesting
+level. Setting them at creation is possible today and rare: a task acquires evidence when
+something has been run, which is not the moment the plan is drawn.
 
-## When the full contract becomes active
+After this change they are set on a task that exists, through the tool whose schema already
+describes them. `mutateWorkPlan` keeps accepting them in a creation draft — nothing stored
+changes, and a plan written by an older client still normalises — but the schema stops
+advertising them, which is where the cost was.
 
-Three moments, all server-side, none requiring the agent to ask twice:
+## When the extended tool becomes active
 
-1. **The opener runs.** It creates the plan and activates `work_plan` before returning, so
-   the agent's next call in the same turn can already use `set_status` or `add_task`.
-2. **A session with a plan is bound.** Restore, resume, switch, fork: `loadWorkPlan` already
-   runs there, and a session that has a plan starts with the contract active. An agent
-   resuming work never sees the opener.
-3. **Never otherwise.** `clear` puts the session back to resting, and a new session starts
-   there.
+Derived from the persisted plan, never from a flag held beside it:
 
-The state is derived from the persisted plan, not from a flag someone has to remember to
-set — the same rule the review state already follows.
+1. **A plan is created** — by `create` on the slim tool. The extended tool is activated
+   before the call returns, so the agent's next call in the same turn can already record
+   evidence.
+2. **A session with a plan is bound** — restore, resume, switch, fork. `loadWorkPlan`
+   already runs there.
+3. **`clear`** puts the session back to publishing the slim tool alone, and a new session
+   starts there.
 
-## What this does not do
+## Two names, and what the agent makes of them
 
-**It does not shrink the contract.** `work_plan` is 12 480 characters and its shape is a
-separate problem: the `plan` and `task` properties each serialise a complete task tree, the
-evidence record appears five times, and eleven actions share one flat object. Gating hides
-that cost from conversations that never open a plan; it does nothing for the ones that do.
-Both are worth doing and they are independent.
+The risk of a split is a model that calls the wrong one, or hunts for an operation in the
+tool that does not have it. Three things keep that in hand:
 
-**It does not reach the RPC runtime.** That dialect has no command for the active toolset,
-so an RPC child publishes the full contract at all times. Stated in the capability, and
-consistent with the embedded SDK runtime being the supported target.
+- The slim tool's description names the extended one and says what lives there.
+- A refusal already names the field it refuses; an action that belongs to the other tool is
+  refused by name, the same way.
+- The extended tool is only ever published beside the slim one, never alone, so "the tool I
+  know does not have this action" always has a visible answer.
 
-## Why this is not a prompt-cache regression
+This is the part no unit test settles. Task 5 drives a real model through opening a plan and
+then recording evidence, and reads the transcript rather than the suite.
 
-Changing the active toolset mid-session changes the system prompt, which invalidates a
-provider's prefix cache for that conversation — once, on the turn a plan is opened. A
-conversation that opens a plan pays one cache miss; a conversation that never opens one
-saves ~3k tokens on every turn. The trade is not close.
+## Prompt-cache cost
+
+Activating the extended tool changes the system prompt, which invalidates a provider's
+prefix cache for that conversation — once, on the turn a plan is created. Conversations that
+never open a plan save ~2.3k tokens on every turn. The trade is not close.

--- a/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/proposal.md
+++ b/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/proposal.md
@@ -1,0 +1,52 @@
+## Why
+
+`work_plan`'s schema is sent to the provider on every turn of every conversation,
+whether or not a plan is ever made. Measured on 2026-09-03: **12 480 characters, ~3.1k
+tokens** — after the 4k-token version was trimmed — against a whole default baseline of
+~9.8k. A conversation that never opens a plan pays about a third of its floor for a
+capability it does not use, on every single turn.
+
+Most conversations never open one. The tool's own guidance says so: "trivial exchanges
+need no plan."
+
+The pi SDK can already stop paying for it. `AgentSession.setActiveToolsByName()` changes
+the active toolset and, in the SDK's words, "rebuilds the system prompt to reflect the new
+tool set" — a tool that is not active is not described. What it cannot do is register a
+definition after the session exists, so the resting state cannot simply be a smaller
+`work_plan`: both definitions have to be registered up front, and one of them made active.
+
+## What Changes
+
+- A session with no Work Plan offers a **small opener** instead of the full contract: one
+  tool, no operations to enumerate, whose only job is to say that this work needs a plan.
+- Calling it activates the full `work_plan` contract for that session, available to the
+  very next call — the agent opens the plan in the same turn it decided to.
+- A session that **already has a plan** — restored, resumed, forked — starts with the full
+  contract active. Nothing is discovered twice.
+- `clear` returns the session to the resting state, and so does starting a new session.
+- The RPC runtime keeps the full contract at all times: its dialect has no command for
+  changing the active toolset. This is stated rather than worked around — the embedded SDK
+  runtime is the supported target and `rpc` is best effort.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- None. -->
+
+### Modified Capabilities
+
+- `work-plan`: the tool contract a session publishes becomes a function of whether that
+  session has a plan. `Self-describing Work Plan tool contract` is amended to say what is
+  published in each state, and a new requirement covers the transition between them.
+
+## Impact
+
+- **Server** — `server/src/workPlanTool.ts` (the opener definition), `server/src/index.ts`
+  (register both, choose the initially active one), `server/src/embeddedRuntime.ts` (flip
+  on `applyWorkPlanMutation` and on session restore).
+- **Prompt** — `server/src/systemPrompt.ts`: the resting guidance is one sentence, not the
+  work-plan guidance block, which follows the full contract.
+- **No wire change, no client change.** The interface already renders whatever plan exists.
+- **Expected saving** — ~3k tokens per turn on any conversation that never opens a plan,
+  taking the default baseline from ~9.8k to ~7k.

--- a/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/proposal.md
+++ b/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/proposal.md
@@ -1,32 +1,34 @@
 ## Why
 
-`work_plan`'s schema is sent to the provider on every turn of every conversation,
-whether or not a plan is ever made. Measured on 2026-09-03: **12 480 characters, ~3.1k
-tokens** — after the 4k-token version was trimmed — against a whole default baseline of
-~9.8k. A conversation that never opens a plan pays about a third of its floor for a
-capability it does not use, on every single turn.
+`work_plan`'s schema is sent to the provider on every request of every conversation,
+whether or not a plan is ever made. Measured 2026-09-03, after the trimming in #162:
+**12 480 characters, ~3.1k tokens**, against a whole default baseline of ~9.8k. A
+conversation that never opens a plan pays a third of its floor for a capability it does
+not use, on every turn. opencode's comparable `todowrite` is 2 686 characters.
 
-Most conversations never open one. The tool's own guidance says so: "trivial exchanges
-need no plan."
-
-The pi SDK can already stop paying for it. `AgentSession.setActiveToolsByName()` changes
-the active toolset and, in the SDK's words, "rebuilds the system prompt to reflect the new
-tool set" — a tool that is not active is not described. What it cannot do is register a
-definition after the session exists, so the resting state cannot simply be a smaller
-`work_plan`: both definitions have to be registered up front, and one of them made active.
+The cost is not spread evenly across what the tool does. Four of its eleven actions carry
+almost all of it — `replace` serialises a complete normalized plan, and `set_evidence`,
+`set_resources` and `set_dependencies` carry collections whose shapes are also inlined
+into every creation task. They are also the four an agent reaches for least: a plan is
+opened, tasks are added, statuses move on. Evidence and dependency edits come later, if at
+all.
 
 ## What Changes
 
-- A session with no Work Plan offers a **small opener** instead of the full contract: one
-  tool, no operations to enumerate, whose only job is to say that this work needs a plan.
-- Calling it activates the full `work_plan` contract for that session, available to the
-  very next call — the agent opens the plan in the same turn it decided to.
-- A session that **already has a plan** — restored, resumed, forked — starts with the full
-  contract active. Nothing is discovered twice.
-- `clear` returns the session to the resting state, and so does starting a new session.
-- The RPC runtime keeps the full contract at all times: its dialect has no command for
-  changing the active toolset. This is stated rather than worked around — the embedded SDK
-  runtime is the supported target and `rpc` is best effort.
+Split the capability in two, and publish the second only when it can be used.
+
+- **`work_plan`** — the common path: `get`, `create`, `add_task`, `update_task`,
+  `move_task`, `remove_task`, `clear`. Creation tasks carry title, description, status,
+  reason and subtasks. **3 071 characters** of schema, measured on the partition.
+- **`work_plan_extended`** — the rest: `replace`, `set_dependencies`, `set_resources`,
+  `set_evidence`, and the collection shapes they need. **5 894 characters**, published
+  only to a session that has a plan, since every one of its operations acts on tasks that
+  must already exist.
+- Evidence and resources leave the creation shape. They are set on a task that exists,
+  through the extended tool, which is where their shapes already live.
+
+Both funnel into `mutateWorkPlan` unchanged: the split is in what is published, not in
+what is validated or stored.
 
 ## Capabilities
 
@@ -36,17 +38,29 @@ definition after the session exists, so the resting state cannot simply be a sma
 
 ### Modified Capabilities
 
-- `work-plan`: the tool contract a session publishes becomes a function of whether that
-  session has a plan. `Self-describing Work Plan tool contract` is amended to say what is
-  published in each state, and a new requirement covers the transition between them.
+- `work-plan`: what a session publishes becomes two tools rather than one, and the second
+  is a function of whether the session has a plan. `Self-describing Work Plan tool
+  contract` is amended to say what each publishes; a new requirement covers the split and
+  the transition.
 
 ## Impact
 
-- **Server** — `server/src/workPlanTool.ts` (the opener definition), `server/src/index.ts`
-  (register both, choose the initially active one), `server/src/embeddedRuntime.ts` (flip
-  on `applyWorkPlanMutation` and on session restore).
-- **Prompt** — `server/src/systemPrompt.ts`: the resting guidance is one sentence, not the
-  work-plan guidance block, which follows the full contract.
-- **No wire change, no client change.** The interface already renders whatever plan exists.
-- **Expected saving** — ~3k tokens per turn on any conversation that never opens a plan,
-  taking the default baseline from ~9.8k to ~7k.
+- **Server** — `server/src/workPlanTool.ts` (two definitions over one action partition),
+  `server/src/index.ts` (register both), `server/src/embeddedRuntime.ts` (activate the
+  extended tool from the persisted plan's existence).
+- **Prompt** — `server/src/systemPrompt.ts`: the guidance for evidence follows the tool
+  that carries it.
+- **No wire change, no client change.**
+- **Expected** — a conversation that never opens a plan: ~3.1k tokens down to ~0.8k. One
+  that does: ~2.2k, still below today's 3.1k, because the creation shape no longer
+  inlines the collections twice.
+
+## What this does not do
+
+- **RPC.** That dialect has no command for the active toolset, so an RPC child publishes
+  both tools at all times. Stated rather than emulated: the embedded SDK runtime is the
+  supported target.
+- **`$defs`/`$ref`.** The resource shape still appears in both tools and the evidence
+  record five times inside the extended one. Factoring them is worth another ~4k
+  characters and needs checking against a constrained-decoding gateway first — separate
+  change.

--- a/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/specs/work-plan/spec.md
+++ b/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/specs/work-plan/spec.md
@@ -1,9 +1,9 @@
 ## MODIFIED Requirements
 
 ### Requirement: Self-describing Work Plan tool contract
-The structured Work Plan interface SHALL expose a single object schema whose `action` property enumerates every operation and whose remaining properties are optional, individually typed, and documented with the actions that use them. Every nested input field, accepted status, and nullable clearing value SHALL be declared. An agent SHALL be able to construct a valid call from the tool name, description, schema, and prompt guidelines without learning required fields from rejected mutations. A refused call SHALL be answered with a diagnosis that names the refused field, and SHALL NOT enumerate the failures of operations the call did not request.
+The structured Work Plan interface SHALL expose object schemas whose `action` property enumerates the operations that schema carries and whose remaining properties are optional, individually typed, and documented with the actions that use them. Every nested input field, accepted status, and nullable clearing value SHALL be declared. An agent SHALL be able to construct a valid call from the tool name, description, schema, and prompt guidelines without learning required fields from rejected mutations. A refused call SHALL be answered with a diagnosis that names the refused field, and SHALL NOT enumerate the failures of operations the call did not request.
 
-This contract SHALL be published to a session that has a Work Plan. A session that has none SHALL publish the opener described under **The Work Plan contract is published only to sessions that use it** instead, and the guidelines that accompany the full contract SHALL follow it: what an agent is told about managing a plan SHALL match what it is currently able to call.
+The interface SHALL be published as two tools, described under **The Work Plan contract is split by what an operation needs**. Each SHALL be self-describing on its own terms: an agent reading either SHALL be able to call every action that tool carries, and SHALL be told where the others live. The prompt guidelines that accompany an operation SHALL follow the tool that carries it, so what an agent is told matches what it is currently able to call.
 #### Scenario: Creation schema declares its complete input
 - **WHEN** an agent inspects the Work Plan tool schema
 - **THEN** the schema declares the plan title and the recursively nested task shape, including the task dependency list
@@ -29,52 +29,73 @@ This contract SHALL be published to a session that has a Work Plan. A session th
 
 ## ADDED Requirements
 
-### Requirement: The Work Plan contract is published only to sessions that use it
+### Requirement: The Work Plan contract is split by what an operation needs
 
-The full Work Plan tool contract SHALL be published to a session only while that session has
-a Work Plan. A session without one SHALL publish an opener instead: one tool that creates a
-plan and nothing else, whose description says when an agent should reach for it.
+The Work Plan interface SHALL be published as two tools. The first SHALL carry the operations
+that need nothing to exist first — inspecting, creating, adding, updating, moving and removing
+tasks, and clearing the plan — and SHALL be published to every session. The second SHALL carry
+the operations that act on tasks that must already exist: whole-plan replacement, dependency
+sets, resource sets and evidence collections. It SHALL be published only while the session has
+a Work Plan.
 
-The schema is sent on every request of every conversation, and most conversations never open
-a plan. The opener is what keeps the capability reachable without charging every trivial
-exchange for the whole contract.
+The schema is sent on every request of every conversation. The withheld operations are both
+the expensive ones — they carry complete plans, evidence records and resource lists — and the
+impossible ones, since none of them can be called against a session with no plan. A tool that
+cannot be called is one no conversation should be charged for reading.
 
-Activation SHALL be derived from the persisted plan rather than from separately held state,
-and SHALL take effect within the turn that opens the plan: an agent that decides mid-turn
-that the work needs a plan SHALL be able to open it and then use the contract, without
-waiting for the next turn or being told twice.
+The task shape accepted at creation SHALL NOT advertise evidence or resource collections;
+those are set on tasks that exist, through the second tool. A creation draft that carries them
+anyway SHALL still normalise, so a client written against the previous contract keeps working.
 
-Where a runtime cannot change its published toolset — the RPC dialect has no command for it
-— that runtime SHALL publish the full contract at all times rather than emulate the gating.
-The embedded SDK runtime is the supported target for this behaviour.
+Publication SHALL be derived from the persisted plan rather than from separately held state,
+and a change SHALL take effect within the turn that causes it: an agent that creates a plan
+SHALL be able to record evidence against it without waiting for the next turn.
 
-#### Scenario: A session with no plan publishes the opener
+Each tool SHALL name the other and say what it carries, and an action refused because it
+belongs to the other tool SHALL be refused by name, saying where it lives.
+
+Where a runtime cannot change its published toolset — the RPC dialect has no command for it —
+that runtime SHALL publish both tools at all times rather than emulate the gating. The
+embedded SDK runtime is the supported target for this behaviour.
+
+#### Scenario: A session with no plan publishes only the common operations
 - **GIVEN** a session whose workspace holds no Work Plan
 - **WHEN** the agent's toolset is composed
-- **THEN** the opener is published and the full Work Plan contract is not
+- **THEN** the tool carrying creation and task updates is published
+- **AND** the tool carrying evidence, resources, dependencies and replacement is not
 
-#### Scenario: Opening a plan publishes the contract within the same turn
+#### Scenario: Creating a plan publishes the rest within the same turn
 - **GIVEN** a session with no Work Plan
-- **WHEN** the agent calls the opener
-- **THEN** the plan is created
-- **AND** the full contract is available to the agent's next call in that same turn
+- **WHEN** the agent creates one
+- **THEN** the second tool is published
+- **AND** the agent can record evidence against a task in its next call of that same turn
 
-#### Scenario: A session that already has a plan starts with the contract
+#### Scenario: A session that already has a plan publishes both
 - **GIVEN** a session whose workspace holds a Work Plan
 - **WHEN** the session is bound, resumed, switched to, or forked
-- **THEN** the full contract is published and the opener is not
+- **THEN** both tools are published
 
-#### Scenario: Clearing a plan returns the session to the opener
-- **GIVEN** a session publishing the full contract
+#### Scenario: Clearing a plan withdraws the extended operations
+- **GIVEN** a session publishing both tools
 - **WHEN** the plan is cleared
-- **THEN** the opener is published again and the full contract is not
+- **THEN** only the tool carrying the common operations remains published
 
-#### Scenario: The guidance follows the published tools
-- **WHEN** the agent's prompt is composed for a session with no plan
-- **THEN** it carries the sentence that says when to open one
-- **AND** it does not carry the guidance for operations the session cannot call
+#### Scenario: Every action belongs to exactly one tool
+- **WHEN** the published tools are compared against the enumerated Work Plan actions
+- **THEN** each action appears in exactly one of them
+- **AND** none is absent from both
+
+#### Scenario: An action asked of the wrong tool is refused by name
+- **WHEN** an agent asks one tool for an action the other carries
+- **THEN** the refusal names the action and the tool that carries it
+- **AND** it does not enumerate the requirements of unrelated operations
+
+#### Scenario: Creation no longer advertises evidence, but still accepts it
+- **WHEN** an agent inspects the creation task shape
+- **THEN** it declares no evidence or resource collection
+- **AND** a creation draft that carries them is still normalised into the persisted plan
 
 #### Scenario: A runtime that cannot gate says so rather than pretending
 - **GIVEN** a workspace served by the RPC runtime
 - **WHEN** the agent's toolset is composed for a session with no plan
-- **THEN** the full contract is published, as that dialect cannot change its active toolset
+- **THEN** both tools are published, as that dialect cannot change its active toolset

--- a/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/specs/work-plan/spec.md
+++ b/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/specs/work-plan/spec.md
@@ -1,0 +1,80 @@
+## MODIFIED Requirements
+
+### Requirement: Self-describing Work Plan tool contract
+The structured Work Plan interface SHALL expose a single object schema whose `action` property enumerates every operation and whose remaining properties are optional, individually typed, and documented with the actions that use them. Every nested input field, accepted status, and nullable clearing value SHALL be declared. An agent SHALL be able to construct a valid call from the tool name, description, schema, and prompt guidelines without learning required fields from rejected mutations. A refused call SHALL be answered with a diagnosis that names the refused field, and SHALL NOT enumerate the failures of operations the call did not request.
+
+This contract SHALL be published to a session that has a Work Plan. A session that has none SHALL publish the opener described under **The Work Plan contract is published only to sessions that use it** instead, and the guidelines that accompany the full contract SHALL follow it: what an agent is told about managing a plan SHALL match what it is currently able to call.
+#### Scenario: Creation schema declares its complete input
+- **WHEN** an agent inspects the Work Plan tool schema
+- **THEN** the schema declares the plan title and the recursively nested task shape, including the task dependency list
+- **AND** no creation field is hidden behind an unconstrained schema object
+
+#### Scenario: Mutation branches require their own arguments
+- **WHEN** an agent inspects any operation-specific argument
+- **THEN** the schema declares which actions require it
+- **AND** it is not presented as a requirement of unrelated actions
+
+#### Scenario: A refusal names the field it refuses
+- **WHEN** a call carries a property the requested action does not accept
+- **THEN** the diagnosis names that property and its path within the call
+- **AND** it does not report the requirements of operations the call did not request
+
+#### Scenario: Clearing optional values is discoverable
+- **WHEN** an operation can clear an optional parent, description, or status reason
+- **THEN** its schema declares the accepted JSON `null` value for that field
+
+#### Scenario: The tool carries a worked example
+- **WHEN** the agent's prompt is composed
+- **THEN** the Work Plan tool contributes guidelines containing a literal, valid creation call with dependencies and one level of subtasks
+
+## ADDED Requirements
+
+### Requirement: The Work Plan contract is published only to sessions that use it
+
+The full Work Plan tool contract SHALL be published to a session only while that session has
+a Work Plan. A session without one SHALL publish an opener instead: one tool that creates a
+plan and nothing else, whose description says when an agent should reach for it.
+
+The schema is sent on every request of every conversation, and most conversations never open
+a plan. The opener is what keeps the capability reachable without charging every trivial
+exchange for the whole contract.
+
+Activation SHALL be derived from the persisted plan rather than from separately held state,
+and SHALL take effect within the turn that opens the plan: an agent that decides mid-turn
+that the work needs a plan SHALL be able to open it and then use the contract, without
+waiting for the next turn or being told twice.
+
+Where a runtime cannot change its published toolset — the RPC dialect has no command for it
+— that runtime SHALL publish the full contract at all times rather than emulate the gating.
+The embedded SDK runtime is the supported target for this behaviour.
+
+#### Scenario: A session with no plan publishes the opener
+- **GIVEN** a session whose workspace holds no Work Plan
+- **WHEN** the agent's toolset is composed
+- **THEN** the opener is published and the full Work Plan contract is not
+
+#### Scenario: Opening a plan publishes the contract within the same turn
+- **GIVEN** a session with no Work Plan
+- **WHEN** the agent calls the opener
+- **THEN** the plan is created
+- **AND** the full contract is available to the agent's next call in that same turn
+
+#### Scenario: A session that already has a plan starts with the contract
+- **GIVEN** a session whose workspace holds a Work Plan
+- **WHEN** the session is bound, resumed, switched to, or forked
+- **THEN** the full contract is published and the opener is not
+
+#### Scenario: Clearing a plan returns the session to the opener
+- **GIVEN** a session publishing the full contract
+- **WHEN** the plan is cleared
+- **THEN** the opener is published again and the full contract is not
+
+#### Scenario: The guidance follows the published tools
+- **WHEN** the agent's prompt is composed for a session with no plan
+- **THEN** it carries the sentence that says when to open one
+- **AND** it does not carry the guidance for operations the session cannot call
+
+#### Scenario: A runtime that cannot gate says so rather than pretending
+- **GIVEN** a workspace served by the RPC runtime
+- **WHEN** the agent's toolset is composed for a session with no plan
+- **THEN** the full contract is published, as that dialect cannot change its active toolset

--- a/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/tasks.md
+++ b/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/tasks.md
@@ -1,29 +1,36 @@
-## 1. The opener
+## 1. Partition the contract
 
-- [ ] 1.1 Add `createWorkPlanOpenerToolDefinition()` beside the full definition in `server/src/workPlanTool.ts`: a `title` and an optional first task list, nothing else. Assert its published size stays under 600 characters, the way the full contract is budgeted.
-- [ ] 1.2 Its execution creates the plan through the same `applyWorkPlanMutation` path as `action=create`, so normalisation, limits and refusals are unchanged and untested code does not appear behind a second door.
-- [ ] 1.3 Its result names the tool that is now available and what it can do, so the agent's next call needs no guesswork.
+- [ ] 1.1 In `server/src/workPlanTool.ts`, derive two definitions from one action partition: `work_plan` (`get`, `create`, `add_task`, `update_task`, `move_task`, `remove_task`, `clear`) and `work_plan_extended` (`replace`, `set_dependencies`, `set_resources`, `set_evidence`). One list, two schemas — not two hand-maintained copies.
+- [ ] 1.2 Drop `evidence` and `resources` from the creation task shape at both nesting levels. `mutateWorkPlan` keeps accepting them, so an older client's draft still normalises; only the advertisement goes.
+- [ ] 1.3 Budget tests, as in `work-plan.test.ts` today: `work_plan` under 4 000 characters, `work_plan_extended` under 7 000. Raising a ceiling is allowed; raising one silently is not.
+- [ ] 1.4 An action refused because it belongs to the other tool SHALL be refused by name, saying which tool carries it.
 
-## 2. Registration and activation
+## 2. Publication follows the plan
 
-- [ ] 2.1 Register both definitions in `makeCreateRuntime` (`server/src/index.ts`); the initially active set excludes `work_plan` when the bound session has no plan, and excludes the opener when it has one.
-- [ ] 2.2 In `server/src/embeddedRuntime.ts`, flip the active set when the plan state changes: after the opener runs, after any mutation that clears the plan, and on every session bind.
-- [ ] 2.3 Derive the state from the persisted plan (`loadWorkPlan`), never from a flag held beside it.
-- [ ] 2.4 The RPC runtime keeps both inactive-free: it publishes the full contract always, and says so in one comment rather than pretending to gate.
+- [ ] 2.1 Register both definitions in `makeCreateRuntime` (`server/src/index.ts`).
+- [ ] 2.2 In `server/src/embeddedRuntime.ts`, activate `work_plan_extended` when the bound session has a plan, after a `create`, and deactivate it after `clear` — always derived from `loadWorkPlan`, never from separate state.
+- [ ] 2.3 Activation takes effect within the turn: the call that creates a plan returns after the toolset has changed.
+- [ ] 2.4 The RPC runtime publishes both at all times, with a comment saying why rather than emulating the gating.
 
-## 3. The prompt follows the toolset
+## 3. The prompt follows the tools
 
-- [ ] 3.1 `server/src/systemPrompt.ts`: the work-plan guidance block belongs to the full contract. At rest, one sentence about when to open a plan; the block returns with the tool.
+- [ ] 3.1 `server/src/systemPrompt.ts`: evidence guidance belongs with the tool that carries evidence. A session with no plan is told a plan can be opened, not how to record evidence on it.
 
 ## 4. Proof
 
-- [ ] 4.1 Unit: a session with no plan publishes the opener and not `work_plan`; one with a plan publishes the reverse.
-- [ ] 4.2 Unit: opening a plan activates the full contract, and `clear` returns to the opener.
-- [ ] 4.3 Wire: a real server over a real WebSocket, where the agent's tool inventory is what the snapshot reports before and after a plan is opened.
-- [ ] 4.4 Measure: re-run `server/scripts/probe-context-baseline.mts` and record the resting baseline in `scenario-coverage.md`. The claim is ~9.8k → ~7k.
-- [ ] 4.5 Running app: open a plan from the bench and confirm the agent's next call uses the full contract without being told twice — the mechanism can be right while the *use* of it is not.
+- [ ] 4.1 Unit: a session with no plan publishes `work_plan` alone; one with a plan publishes both.
+- [ ] 4.2 Unit: `create` activates the extended tool, `clear` withdraws it.
+- [ ] 4.3 Unit: every action appears in exactly one tool, checked against `WORK_PLAN_ACTIONS` rather than a list written by hand — a new action must land somewhere on purpose.
+- [ ] 4.4 Unit: a creation draft carrying evidence still normalises, though the schema no longer advertises it.
+- [ ] 4.5 Wire: a real server and WebSocket, tool inventory before and after a plan is opened.
+- [ ] 4.6 Measure: re-run `server/scripts/probe-context-baseline.mts`; record the resting baseline in `scenario-coverage.md`. The claim is ~9.8k → ~7.5k for a conversation with no plan.
 
-## 5. Validation
+## 5. Prove the agent copes, not only the code
 
-- [ ] 5.1 `scenario-coverage.md` for every scenario in the delta.
-- [ ] 5.2 `npm run check:scenarios`, `openspec validate --strict`, focused suites.
+- [ ] 5.1 A live run: ask a model to plan a small piece of work, then to record a test result against one of its tasks. Read the transcript. What is being tested is whether it finds `work_plan_extended` after knowing `work_plan` — the mechanism can be right while the use of it is not.
+- [ ] 5.2 The same in the bench, so the plan panel is watched while it happens.
+
+## 6. Validation
+
+- [ ] 6.1 `scenario-coverage.md` for every scenario in the delta.
+- [ ] 6.2 `npm run check:scenarios`, `openspec validate --strict`, focused suites.

--- a/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/tasks.md
+++ b/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/tasks.md
@@ -1,0 +1,29 @@
+## 1. The opener
+
+- [ ] 1.1 Add `createWorkPlanOpenerToolDefinition()` beside the full definition in `server/src/workPlanTool.ts`: a `title` and an optional first task list, nothing else. Assert its published size stays under 600 characters, the way the full contract is budgeted.
+- [ ] 1.2 Its execution creates the plan through the same `applyWorkPlanMutation` path as `action=create`, so normalisation, limits and refusals are unchanged and untested code does not appear behind a second door.
+- [ ] 1.3 Its result names the tool that is now available and what it can do, so the agent's next call needs no guesswork.
+
+## 2. Registration and activation
+
+- [ ] 2.1 Register both definitions in `makeCreateRuntime` (`server/src/index.ts`); the initially active set excludes `work_plan` when the bound session has no plan, and excludes the opener when it has one.
+- [ ] 2.2 In `server/src/embeddedRuntime.ts`, flip the active set when the plan state changes: after the opener runs, after any mutation that clears the plan, and on every session bind.
+- [ ] 2.3 Derive the state from the persisted plan (`loadWorkPlan`), never from a flag held beside it.
+- [ ] 2.4 The RPC runtime keeps both inactive-free: it publishes the full contract always, and says so in one comment rather than pretending to gate.
+
+## 3. The prompt follows the toolset
+
+- [ ] 3.1 `server/src/systemPrompt.ts`: the work-plan guidance block belongs to the full contract. At rest, one sentence about when to open a plan; the block returns with the tool.
+
+## 4. Proof
+
+- [ ] 4.1 Unit: a session with no plan publishes the opener and not `work_plan`; one with a plan publishes the reverse.
+- [ ] 4.2 Unit: opening a plan activates the full contract, and `clear` returns to the opener.
+- [ ] 4.3 Wire: a real server over a real WebSocket, where the agent's tool inventory is what the snapshot reports before and after a plan is opened.
+- [ ] 4.4 Measure: re-run `server/scripts/probe-context-baseline.mts` and record the resting baseline in `scenario-coverage.md`. The claim is ~9.8k → ~7k.
+- [ ] 4.5 Running app: open a plan from the bench and confirm the agent's next call uses the full contract without being told twice — the mechanism can be right while the *use* of it is not.
+
+## 5. Validation
+
+- [ ] 5.1 `scenario-coverage.md` for every scenario in the delta.
+- [ ] 5.2 `npm run check:scenarios`, `openspec validate --strict`, focused suites.


### PR DESCRIPTION
**Proposal only — no code, tasks unchecked.** Rewritten around the split rather than the opener the first draft proposed.

`work_plan`'s schema goes to the provider on every request of every conversation, whether or not a plan is ever made: 12 480 characters, ~3.1k tokens after #162, about a third of a default baseline. opencode's comparable `todowrite` is 2 686.

## The line, and what draws it

| | `work_plan` | `work_plan_extended` |
|---|---|---|
| Actions | `get`, `create`, `add_task`, `update_task`, `move_task`, `remove_task`, `clear` | `replace`, `set_dependencies`, `set_resources`, `set_evidence` |
| Carries | a title, a task tree of titles, descriptions, statuses and reasons | a complete normalized plan, evidence records, resource lists, dependency sets |
| Schema | **3 071 chars** | **5 894 chars** |
| Published | always | only while the session has a plan |

Measured on the partition, against today's 10 598 in one tool.

The rule is **prerequisite, not frequency**: every withheld operation acts on a task that must already exist — `set_evidence` against no plan is not a call anyone can make. That the four are also the least-used is what makes the split pay; that they are impossible without a plan is what makes it correct.

Evidence and resources also leave the *creation* shape — they are what makes a creation task cost 1 009 characters at each of two nesting levels — and are set through the extended tool on tasks that exist. `mutateWorkPlan` keeps accepting them, so an older client's draft still normalises; only the advertisement goes.

## Why not the opener

The first draft withheld the whole contract behind a tiny tool that switched it on. It works, and it charges a round trip on the turn the agent decided to plan, for operations — add a task, move a status on — that cost almost nothing to publish. Splitting by what an operation *carries* keeps the common path always visible and withholds only what is expensive **and** unusable.

## Expected

- A conversation that never opens a plan: ~3.1k tokens → **~0.8k**.
- One that does: ~2.2k — still under today's 3.1k, because the creation shape no longer inlines the collections twice.

Measured for real in task 4.6, not claimed before then.

## The risk this carries

Two names for one capability. The design says how it is kept in hand — each tool names the other, a misdirected action is refused by name — and task 5 drives a **live model** through opening a plan and then recording evidence, reading the transcript. No unit test settles whether a model finds the second tool.

## Not in scope

- **RPC**: no command for the active toolset, so both tools are published there always. Stated rather than emulated; the embedded SDK runtime is the supported target.
- **`$defs`/`$ref`**: another ~4k characters, needs checking against a constrained-decoding gateway first.

## Spec

`work-plan`: `Self-describing Work Plan tool contract` amended for two tools; a new requirement covers the split, the transition and the RPC exception. 13 scenarios, `openspec validate --strict` valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PryLsHtHcqbkjAqsxVH8rQ