### PR TITLE
feat(work_plan): split the contract, and publish half of it only when it can be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,12 @@ one needs, the command that proves it works, and the caution that goes with it.
 - Office documents: `docx_extract`, `xlsx_extract` and `pptx_extract` give the agent Word
   text and tables, one markdown table per spreadsheet sheet, and slide structure with
   speaker notes. Each takes an `output_path`, to write the whole document to a file instead
-  of spending the context on it twice
+  of spending the context on it twice. The four extractors are described to
+  the agent only once a document of that kind is named in the conversation — their schemas
+  are a quarter of a session's prompt floor, and most sessions never open one. Named and never
+  called, an extractor goes again when the turn ends; named and used, it stays through the
+  work around that document and is forgotten after five quiet turns. Naming the document
+  again brings it back
 - Structured results: a tool can hand back **data** — a graph, a sequence, a table — and the
   interface draws it, with an approval gate when the document names a `target`. Files that
   declare the schema open as the diagram they describe, and any diagram exports as a

--- a/README.md
+++ b/README.md
@@ -730,6 +730,14 @@ or review state can carry a reason, and tasks can link to resources; workspace r
 directly in the file viewer. The panel is read-only for now, so the conversation stays your
 control surface while the agent owns the plan through its `work_plan` tool.
 
+The agent sees that tool in two halves. `work_plan` — creating a plan, adding, updating,
+moving and removing tasks — is always there. `work_plan_extended`, which sets a task's
+dependencies, resources and verification evidence or replaces the plan wholesale, appears
+only once the session has a plan: every one of those operations acts on a task that must
+already exist, and their schemas are the expensive half to send on turns that never use
+them. A supervised `pi --mode rpc` child gets both at all times, having no way to change
+its published toolset.
+
 When a non-empty plan contains at least one `needs_review` task and every other task is either
 `needs_review` or `done`, the project becomes **ready for review** in the project selector.
 This is derived from the persisted plan, not from a turn or tool merely ending. Opening or

--- a/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/.openspec.yaml
+++ b/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-03

--- a/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/design.md
+++ b/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/design.md
@@ -1,0 +1,75 @@
+## Why two tools rather than one gated tool
+
+`AgentSession` builds its tool registry when the session is created. There is
+`setActiveToolsByName(names)` — which rebuilds the system prompt, so an inactive tool is
+not described — and nothing that registers a definition afterwards. One tool cannot
+therefore have a small schema at rest and a complete one later: whatever is published for
+a name is fixed for the session's life.
+
+An earlier draft of this change worked around that with an *opener*: a tiny tool whose only
+job was to create a plan and switch the full contract on. It works, and it makes the agent
+pay a round trip on the turn it decided to plan, for operations — add a task, move a status
+on — that are the whole point and cost almost nothing to publish.
+
+Splitting by *what an operation carries* is better on both counts. The common path stays
+published at all times, so nothing is discovered twice; what is withheld is the part that
+is both expensive and unusable without a plan.
+
+## Where the line falls
+
+| | `work_plan` | `work_plan_extended` |
+|---|---|---|
+| Actions | `get`, `create`, `add_task`, `update_task`, `move_task`, `remove_task`, `clear` | `replace`, `set_dependencies`, `set_resources`, `set_evidence` |
+| Carries | a title, a task tree of titles, descriptions, statuses and reasons | a complete normalized plan, evidence records, resource lists, dependency sets |
+| Schema | 3 071 characters | 5 894 characters |
+| Published | always | only while the session has a plan |
+
+The rule that decides the line is not frequency but **prerequisite**: every operation in the
+extended tool acts on a task that must already exist. `set_evidence` on no plan is not a
+call anyone can make. A tool that cannot be called is a tool nobody needs to read.
+
+That the four are also the least-used operations is what makes the split pay; that they are
+impossible without a plan is what makes it *correct*.
+
+## Evidence and resources leave the creation shape
+
+They are the reason a creation task costs 1 009 characters twice over — once per nesting
+level. Setting them at creation is possible today and rare: a task acquires evidence when
+something has been run, which is not the moment the plan is drawn.
+
+After this change they are set on a task that exists, through the tool whose schema already
+describes them. `mutateWorkPlan` keeps accepting them in a creation draft — nothing stored
+changes, and a plan written by an older client still normalises — but the schema stops
+advertising them, which is where the cost was.
+
+## When the extended tool becomes active
+
+Derived from the persisted plan, never from a flag held beside it:
+
+1. **A plan is created** — by `create` on the slim tool. The extended tool is activated
+   before the call returns, so the agent's next call in the same turn can already record
+   evidence.
+2. **A session with a plan is bound** — restore, resume, switch, fork. `loadWorkPlan`
+   already runs there.
+3. **`clear`** puts the session back to publishing the slim tool alone, and a new session
+   starts there.
+
+## Two names, and what the agent makes of them
+
+The risk of a split is a model that calls the wrong one, or hunts for an operation in the
+tool that does not have it. Three things keep that in hand:
+
+- The slim tool's description names the extended one and says what lives there.
+- A refusal already names the field it refuses; an action that belongs to the other tool is
+  refused by name, the same way.
+- The extended tool is only ever published beside the slim one, never alone, so "the tool I
+  know does not have this action" always has a visible answer.
+
+This is the part no unit test settles. Task 5 drives a real model through opening a plan and
+then recording evidence, and reads the transcript rather than the suite.
+
+## Prompt-cache cost
+
+Activating the extended tool changes the system prompt, which invalidates a provider's
+prefix cache for that conversation — once, on the turn a plan is created. Conversations that
+never open a plan save ~2.3k tokens on every turn. The trade is not close.

--- a/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/proposal.md
+++ b/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/proposal.md
@@ -1,0 +1,70 @@
+## Why
+
+`work_plan`'s schema is sent to the provider on every request of every conversation,
+whether or not a plan is ever made. Measured 2026-09-03, after the trimming in #162:
+**12 480 characters, ~3.1k tokens**, against a whole default baseline of ~9.8k. A
+conversation that never opens a plan pays a third of its floor for a capability it does
+not use, on every turn. opencode's comparable `todowrite` is 2 686 characters.
+
+The cost is not spread evenly across what the tool does. Four of its eleven actions carry
+almost all of it — `replace` serialises a complete normalized plan, and `set_evidence`,
+`set_resources` and `set_dependencies` carry collections whose shapes are also inlined
+into every creation task. They are also the four an agent reaches for least: a plan is
+opened, tasks are added, statuses move on. Evidence and dependency edits come later, if at
+all.
+
+## What Changes
+
+Split the capability in two, and publish the second only when it can be used.
+
+- **`work_plan`** — the common path: `get`, `create`, `add_task`, `update_task`,
+  `move_task`, `remove_task`, `clear`. Creation tasks carry title, description, status,
+  reason and subtasks. **3 071 characters** of schema, measured on the partition.
+- **`work_plan_extended`** — the rest: `replace`, `set_dependencies`, `set_resources`,
+  `set_evidence`, and the collection shapes they need. **5 894 characters**, published
+  only to a session that has a plan, since every one of its operations acts on tasks that
+  must already exist.
+- Evidence and resources leave the creation shape **and the added-task shape**. They are
+  set on a task that exists, through the extended tool, where their shapes already live.
+  The persisted representation is unchanged — a draft carrying them still normalises —
+  but the schema is authoritative for an agent: pi validates a call against it before the
+  handler runs, so this is a narrowing, not a hint.
+
+Both funnel into `mutateWorkPlan` unchanged: the split is in what is published, not in
+what is validated or stored.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- None. -->
+
+### Modified Capabilities
+
+- `work-plan`: what a session publishes becomes two tools rather than one, and the second
+  is a function of whether the session has a plan. `Self-describing Work Plan tool
+  contract` is amended to say what each publishes; a new requirement covers the split and
+  the transition.
+
+## Impact
+
+- **Server** — `server/src/workPlanTool.ts` (two definitions over one action partition),
+  `server/src/index.ts` (register both), `server/src/embeddedRuntime.ts` (activate the
+  extended tool from the persisted plan's existence).
+- **Prompt** — `server/src/systemPrompt.ts`: the guidance for evidence follows the tool
+  that carries it.
+- **No wire change, no client change.**
+- **Measured** — `work_plan` alone is 5 003 characters (~1.3k tokens) against 12 480
+  before; both together 10 404 (~2.6k), still below. The whole resting baseline goes
+  from ~9.8k tokens to **~7.8k**, read from
+  `server/scripts/probe-context-baseline.mts`.
+
+## What this does not do
+
+- **RPC.** That dialect has no command for the active toolset, so an RPC child publishes
+  both tools at all times. Stated rather than emulated: the embedded SDK runtime is the
+  supported target.
+- **`$defs`/`$ref`.** The resource shape still appears in both tools and the evidence
+  record five times inside the extended one. Factoring them is worth another ~4k
+  characters and needs checking against a constrained-decoding gateway first — separate
+  change.

--- a/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/scenario-coverage.md
+++ b/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/scenario-coverage.md
@@ -1,0 +1,47 @@
+# Scenario coverage
+
+All 13 `#### Scenario:` entries in `specs/work-plan/spec.md`, enumerated with
+`rg '^#### Scenario:' openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/`.
+`Self-describing Work Plan tool contract` is MODIFIED, so its five scenarios are reproduced;
+one of them is untouched by the split and its existing test still proves it.
+
+Test files:
+
+- `server/test/work-plan.test.ts` (`unit`) — the published definitions and the runtime method
+- `server/test/work-plan-server.test.mjs` (`wire`) — a real server, a real provider inside a real embedded session, and a real `pi --mode rpc` child
+- `server/test/fixtures/work-plan-rpc-provider.mjs` (`provider`) — the assertions that run *inside* the model provider, on the tools it was actually sent
+
+## work-plan — Self-describing Work Plan tool contract (MODIFIED)
+
+| Scenario | Status | Where | What would fail |
+|---|---|---|---|
+| Creation schema declares its complete input | covered | `unit`: "publishes bounded action-specific schemas, in both tools…" | Walks both schemas for empty nodes, asserts the creation shape declares title, status, subtasks and `dependsOn` at both depths, and that no node is an unconstrained `{}`. A collection quietly re-added to creation fails the two `assert.equal(taskProperties.evidence, undefined)` lines. |
+| Mutation branches require their own arguments | covered | `unit`: same test | Every operation-specific property must name its action in its description, checked per tool — `plan` names `replace` in the extended schema, `tasks` names `create` in the common one. A property moved between tools without its description fails. |
+| A refusal names the field it refuses | covered | `unit`: "answers a refused property by naming it, and says nothing about other actions" | Unchanged by this split, and still asserted: a call carrying a property its action does not accept is answered with that property's name and path, and with nothing about the operations it did not request. |
+| Clearing optional values is discoverable | covered | `unit`: same first test | `description`, `statusReason` and `parentId` must still declare their `null` branch — now read from the common tool's flat properties, where `update_task` takes them. |
+| The tool carries a worked example | covered | `unit`: "ships a worked example the model can copy" | The creation example is parsed out of the guidelines and run through `normalizeWorkPlanDraft`: it must still produce one dependency and one subtask. An example that no longer matches the narrowed creation shape fails there rather than in a model's face. |
+
+## work-plan — The Work Plan contract is split by what an operation needs (ADDED)
+
+| Scenario | Status | Where | What would fail |
+|---|---|---|---|
+| A session with no plan publishes only the common operations | covered | `wire` + `provider`: "the embedded SDK provider receives the same fully typed work_plan schema" | The provider runs inside the real session and throws `work_plan_extended reached a provider before any plan existed` if the tool is sent on the first request. The gating is asserted where it matters — in the payload the model receives — not in a snapshot field. |
+| Creating a plan publishes the rest within the same turn | covered | `wire` + `provider`: same test | After the first `create`, every later request must carry the extended tool (`expectExtended`), and the scripted turn then calls `set_evidence` **on `work_plan_extended` in that same turn**. Publishing from the queued sidecar reload instead of the tool result fails this exactly as it did during development. |
+| A session that already has a plan publishes both | covered | `unit`: "adds the extended tool to the active set and takes nothing else out" | `EmbeddedRuntime.setToolPublished` is what every bind path calls (`publishWorkPlanTools` at boot, at project start, and on session replacement). The test drives the real method and asserts the resulting active set. |
+| Clearing a plan withdraws the extended operations | covered | `unit`: "withdraws it again when the plan is cleared, leaving the common tool published" | The same method with `published: false` must remove that name and leave `work_plan` and everything else in place. |
+| Every action belongs to exactly one tool | covered | `unit`: "gives every action exactly one home…" | Built from `WORK_PLAN_ACTIONS` rather than a hand-written list: an action added to the shared enum and to neither tool, or to both, fails the `carriers.length === 1` assertion. |
+| An action asked of the wrong tool is refused by name | covered | `unit`: same test | `work_plan` is asked for `set_evidence`; the result must be an error naming both `set_evidence` and `work_plan_extended`. Falling back to a schema-level enum error — which names neither — fails. |
+| Creation no longer advertises evidence, and the store still accepts it | covered | `unit`: "still normalises a creation draft that carries evidence…" plus the schema assertions above | The schema must not declare the collections, and `mutateWorkPlan` must still persist a draft that carries them (one evidence record, one resource). Tightening the normaliser as well as the schema would break the second half. |
+| A runtime that cannot gate says so rather than pretending | covered | `wire`: "a real Pi RPC child executes work_plan and synchronizes its persisted result" | The same provider runs inside a real `pi --mode rpc` child with both tools registered by `piOutpostTools.ts`, and the absence assertion is deliberately not enforced there (`WORK_PLAN_EXPECT_GATED` is set only for the embedded server). `RpcRuntime.setToolPublished` returning `true` would be a lie no test could then catch — it returns `false`. |
+
+## Measurement
+
+`npx tsx server/scripts/probe-context-baseline.mts` — resting baseline **~7.8k tokens**
+(prompt 7 134 chars, 15 tools 23 897 chars), from ~9.8k before this change and ~10.7k before
+the trimming that preceded it. `work_plan` alone is 5 003 characters against 12 480.
+
+## What is not proven here
+
+Task 5 is open: no test says whether a model **finds** `work_plan_extended` after knowing
+`work_plan`. The mechanism is proven; its use by a real model is not, and a scripted provider
+cannot stand in for that.

--- a/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/specs/work-plan/spec.md
+++ b/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/specs/work-plan/spec.md
@@ -1,0 +1,104 @@
+## MODIFIED Requirements
+
+### Requirement: Self-describing Work Plan tool contract
+The structured Work Plan interface SHALL expose object schemas whose `action` property enumerates the operations that schema carries and whose remaining properties are optional, individually typed, and documented with the actions that use them. Every nested input field, accepted status, and nullable clearing value SHALL be declared. An agent SHALL be able to construct a valid call from the tool name, description, schema, and prompt guidelines without learning required fields from rejected mutations. A refused call SHALL be answered with a diagnosis that names the refused field, and SHALL NOT enumerate the failures of operations the call did not request.
+
+The interface SHALL be published as two tools, described under **The Work Plan contract is split by what an operation needs**. Each SHALL be self-describing on its own terms: an agent reading either SHALL be able to call every action that tool carries, and SHALL be told where the others live. The prompt guidelines that accompany an operation SHALL follow the tool that carries it, so what an agent is told matches what it is currently able to call.
+#### Scenario: Creation schema declares its complete input
+- **WHEN** an agent inspects the Work Plan tool schema
+- **THEN** the schema declares the plan title and the recursively nested task shape, including the task dependency list
+- **AND** no creation field is hidden behind an unconstrained schema object
+
+#### Scenario: Mutation branches require their own arguments
+- **WHEN** an agent inspects any operation-specific argument
+- **THEN** the schema declares which actions require it
+- **AND** it is not presented as a requirement of unrelated actions
+
+#### Scenario: A refusal names the field it refuses
+- **WHEN** a call carries a property the requested action does not accept
+- **THEN** the diagnosis names that property and its path within the call
+- **AND** it does not report the requirements of operations the call did not request
+
+#### Scenario: Clearing optional values is discoverable
+- **WHEN** an operation can clear an optional parent, description, or status reason
+- **THEN** its schema declares the accepted JSON `null` value for that field
+
+#### Scenario: The tool carries a worked example
+- **WHEN** the agent's prompt is composed
+- **THEN** the Work Plan tool contributes guidelines containing a literal, valid creation call with dependencies and one level of subtasks
+
+## ADDED Requirements
+
+### Requirement: The Work Plan contract is split by what an operation needs
+
+The Work Plan interface SHALL be published as two tools. The first SHALL carry the operations
+that need nothing to exist first — inspecting, creating, adding, updating, moving and removing
+tasks, and clearing the plan — and SHALL be published to every session. The second SHALL carry
+the operations that act on tasks that must already exist: whole-plan replacement, dependency
+sets, resource sets and evidence collections. It SHALL be published only while the session has
+a Work Plan.
+
+The schema is sent on every request of every conversation. The withheld operations are both
+the expensive ones — they carry complete plans, evidence records and resource lists — and the
+impossible ones, since none of them can be called against a session with no plan. A tool that
+cannot be called is one no conversation should be charged for reading.
+
+The task shapes the first tool accepts — at creation and when adding a task — SHALL NOT
+advertise evidence or resource collections; those are set on tasks that exist, through the
+second tool. The persisted representation SHALL be unchanged: a draft carrying those
+collections SHALL still normalise, so stored plans, forks and every non-tool caller keep
+working. Withdrawing them from the schema is nonetheless a narrowing for an agent, since a
+tool call is validated against the published schema before it reaches the handler.
+
+Publication SHALL be derived from the persisted plan rather than from separately held state,
+and a change SHALL take effect within the turn that causes it: an agent that creates a plan
+SHALL be able to record evidence against it without waiting for the next turn.
+
+Each tool SHALL name the other and say what it carries, and an action refused because it
+belongs to the other tool SHALL be refused by name, saying where it lives.
+
+Where a runtime cannot change its published toolset — the RPC dialect has no command for it —
+that runtime SHALL publish both tools at all times rather than emulate the gating. The
+embedded SDK runtime is the supported target for this behaviour.
+
+#### Scenario: A session with no plan publishes only the common operations
+- **GIVEN** a session whose workspace holds no Work Plan
+- **WHEN** the agent's toolset is composed
+- **THEN** the tool carrying creation and task updates is published
+- **AND** the tool carrying evidence, resources, dependencies and replacement is not
+
+#### Scenario: Creating a plan publishes the rest within the same turn
+- **GIVEN** a session with no Work Plan
+- **WHEN** the agent creates one
+- **THEN** the second tool is published
+- **AND** the agent can record evidence against a task in its next call of that same turn
+
+#### Scenario: A session that already has a plan publishes both
+- **GIVEN** a session whose workspace holds a Work Plan
+- **WHEN** the session is bound, resumed, switched to, or forked
+- **THEN** both tools are published
+
+#### Scenario: Clearing a plan withdraws the extended operations
+- **GIVEN** a session publishing both tools
+- **WHEN** the plan is cleared
+- **THEN** only the tool carrying the common operations remains published
+
+#### Scenario: Every action belongs to exactly one tool
+- **WHEN** the published tools are compared against the enumerated Work Plan actions
+- **THEN** each action appears in exactly one of them
+- **AND** none is absent from both
+
+#### Scenario: An action asked of the wrong tool is refused by name
+- **WHEN** an agent asks one tool for an action the other carries
+- **THEN** the refusal names the action and the tool that carries it
+- **AND** it does not enumerate the requirements of unrelated operations
+
+#### Scenario: Creation no longer advertises evidence, and the store still accepts it
+- **WHEN** an agent inspects the creation task shape
+- **THEN** it declares no evidence or resource collection
+- **AND** a creation draft that carries them is still normalised into the persisted plan
+
+#### Scenario: A runtime that cannot gate says so rather than pretending
+- **GIVEN** a workspace served by the RPC runtime
+- **WHEN** the agent's toolset is composed for a session with no plan
+- **THEN** both tools are published, as that dialect cannot change its active toolset

--- a/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/tasks.md
+++ b/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/tasks.md
@@ -1,0 +1,36 @@
+## 1. Partition the contract
+
+- [x] 1.1 Two definitions from one action partition in `server/src/workPlanTool.ts` — `WORK_PLAN_COMMON_ACTIONS` and `WORK_PLAN_EXTENDED_ACTIONS`, both `satisfies readonly WorkPlanAction[]`, with one shared executor so the split is in what is published and never in what runs.
+- [x] 1.2 `evidence` and `resources` dropped from the creation task shape at both nesting levels **and** from `add_task`'s task shape. `mutateWorkPlan` still normalises a draft carrying them, so stored plans and non-tool callers are unaffected; a tool call carrying them is refused by pi's own validation, which is the narrowing this buys.
+- [x] 1.3 Budget tests: `work_plan` under 5 200 characters, `work_plan_extended` under 6 000 (`keeps each published definition under its context budget`).
+- [x] 1.4 An action asked of the wrong tool is refused by name, saying which tool carries it (`workPlanToolFor`, asserted in `gives every action exactly one home…`).
+
+## 2. Publication follows the plan
+
+- [x] 2.1 Both registered in `makeCreateRuntime` and in `workspaceOptions`' unconfined set (`server/src/index.ts`), and in `piOutpostTools.ts` for an RPC child.
+- [x] 2.2 `AgentRuntime.setToolPublished(name, published)`: `EmbeddedRuntime` flips the SDK's active set (which rebuilds the system prompt, so the schema goes with it); `RpcRuntime` returns `false`.
+- [x] 2.3 `publishWorkPlanTools(workspace, plan)` is called wherever the plan can change — the boot bind, a project started later, a session replacement, and a work_plan tool result. Always derived from the plan, never from a flag.
+- [x] 2.4 Within the turn: publication happens **synchronously in the `tool_end` handler**, from the plan the result already carries. Doing it in the queued sidecar reload was too late — the agent's next request went out first, and the live provider test caught exactly that (`work_plan_extended was not published once a plan existed`).
+
+## 3. The prompt follows the tools
+
+- [x] 3.1 Each tool's `promptGuidelines` carry its own operations: the evidence example and the replacement rule moved to `work_plan_extended`, and the common tool names where they went. `WORK_PLAN_SYSTEM_GUIDANCE` stays whole and always sent — it is behavioural selection guidance ("skip a plan for trivial interactions"), the system prompt is fixed at session creation and cannot vary with plan state, and this repo deliberately keeps that guidance out of tool contracts (`keeps behavioral selection guidance out of the mechanical tool contract`).
+
+## 4. Proof
+
+- [x] 4.1 `work-plan.test.ts` — both schemas bounded, action enums partition the actions, creation advertises no collections.
+- [x] 4.2 `publishing the extended tool` — the real `EmbeddedRuntime.setToolPublished` over a stand-in session: adds, withdraws, leaves the rest of the set alone, does nothing when already correct, reports `false` for an unregistered name.
+- [x] 4.3 `gives every action exactly one home…` — checked against `WORK_PLAN_ACTIONS`, so a new action cannot be forgotten by both tools.
+- [x] 4.4 `still normalises a creation draft that carries evidence…`.
+- [x] 4.5 Wire: `work-plan-server.test.mjs` "the embedded SDK provider receives the same fully typed work_plan schema" now asserts, from inside a real provider, that `work_plan_extended` is absent before any plan exists and present afterwards — and the turn goes on to call it. The RPC test asserts the same tools reach a real `pi --mode rpc` child, ungated.
+- [x] 4.6 Measured with `server/scripts/probe-context-baseline.mts`: resting baseline ~9.8k → **~7.8k tokens**.
+
+## 5. Prove the agent copes, not only the code
+
+- [ ] 5.1 A live run: ask a model to plan a small piece of work, then to record a test result against one of its tasks, and read the transcript for whether it finds `work_plan_extended` on its own.
+- [ ] 5.2 The same in the bench, with the plan panel watched while it happens.
+
+## 6. Validation
+
+- [x] 6.1 `scenario-coverage.md` for all 13 scenarios.
+- [x] 6.2 `openspec validate --strict` valid; `npm run check:scenarios` clean; focused suites green (`work-plan` 53, `work-plan-server` 4, `pi-rpc`/`extensionPathsWire`/`pi-rpc-server` 43, `sandbox-tools`/`toolProgress`/`agent-runtime-config` included: 131).

--- a/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/tasks.md
+++ b/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/tasks.md
@@ -27,8 +27,8 @@
 
 ## 5. Prove the agent copes, not only the code
 
-- [ ] 5.1 A live run: ask a model to plan a small piece of work, then to record a test result against one of its tasks, and read the transcript for whether it finds `work_plan_extended` on its own.
-- [ ] 5.2 The same in the bench, with the plan panel watched while it happens.
+- [x] 5.1 Done — `verification.md`. A real `mistral/devstral-medium-latest` through a real server: the resting toolset carries no `work_plan_extended`, the model created the plan with `work_plan`, then called `work_plan_extended` for the evidence **in the same turn**, unprompted and at the first attempt. No wrong-tool call, no repair loop.
+- [x] 5.2 Not run, deliberately: the change alters what the agent is sent, not what the interface renders — the Work Plan panel is untouched — and 5.1 exercises the surface that actually changed. Recorded in `verification.md` rather than left implied.
 
 ## 6. Validation
 

--- a/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/verification.md
+++ b/openspec/changes/offer-the-work-plan-contract-only-once-it-is-used/verification.md
@@ -1,0 +1,41 @@
+# Live verification
+
+One run, a real model, nothing scripted. `mistral/devstral-medium-latest` through a real
+server and WebSocket, in a throwaway workspace with a throwaway `agentDir` carrying only
+the API key — no skills, no extensions, no session history.
+
+The prompt asked for a plan of two tasks with a dependency, then for a passing test result
+to be recorded against the second one. It did not name a tool.
+
+```
+model: mistral/devstral-medium-latest
+tools published at rest: docx_extract, edit, find, grep, ls, pdf_extract, pptx_extract,
+                         present_structure, read, work_plan, write, write_structure_figure,
+                         xlsx_extract
+→ work_plan          {"action":"create","title":"Add --json flag to CLI","tasks":[{"id":"impl",…},
+                      {"id":"test",…,"dependsOn":["impl"]}]}
+→ work_plan_extended {"action":"set_evidence","taskId":"test","evidence":[{"id":"focused-tests",
+                      "type":"test","result":"passed","summary":"Focused tests passed"}]}
+```
+
+What this settles, and no unit test could:
+
+- **`work_plan_extended` is absent from the resting toolset** — read from the snapshot, not
+  inferred.
+- **The model reached for it unprompted**, in the same turn, immediately after creating the
+  plan. Nothing told it the tool existed except the common tool's description and one
+  guideline line saying where evidence lives.
+- **No wrong-tool attempt, no repair loop, no refusal.** The risk a split carries — a model
+  hunting for an operation in the tool that does not have it — did not materialise on the
+  first try.
+- The dependency was expressed at creation, so narrowing the creation shape did not cost the
+  thing creation is for.
+
+The final plan carries both tasks, the dependency, and the evidence record on the second.
+
+## Not run
+
+The bench (`npm run bench`) was not driven for this. The change alters what the *agent* is
+sent, not what the interface renders — the Work Plan panel is untouched — and the live run
+above exercises exactly the surface that changed, through a running server, with the
+transcript read back rather than a screenshot taken.

--- a/openspec/changes/publish-a-document-extractor-when-a-document-arrives/.openspec.yaml
+++ b/openspec/changes/publish-a-document-extractor-when-a-document-arrives/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-03

--- a/openspec/changes/publish-a-document-extractor-when-a-document-arrives/design.md
+++ b/openspec/changes/publish-a-document-extractor-when-a-document-arrives/design.md
@@ -1,0 +1,63 @@
+## The trigger, and why it is the document rather than the workspace
+
+Three candidates were on the table.
+
+**The workspace containing such a file.** Decided once at session bind, so the toolset
+never changes mid-conversation and no prefix is ever invalidated. Rejected: a repository
+with a `docs/` folder, a `README.pdf`, one stray `.xlsx` in a fixtures directory would
+publish all four for every session, including the ones refactoring TypeScript. It
+optimises for the presence of a document rather than the use of one, which is the case
+this change exists to stop.
+
+**An opener** — one small tool that publishes the right extractor on request, the pattern
+opencode uses for skills. Rejected for the same reason it was rejected for the Work Plan:
+it charges a round trip on the path that is already the point, and here the round trip
+would land in the middle of "read this file for me".
+
+**The document entering the conversation.** What is implemented. The composer already
+appends every referenced file as an `@path` mention before sending (see the `SendMessage`
+requirement), and an uploaded document is written into the workspace and attached as a
+path rather than as content. So the prompt the server receives names the file, and naming
+it is exactly the moment the tool becomes useful.
+
+## Where the decision is made
+
+On the prompt path, before the turn is dispatched: the server reads the outgoing text for
+paths ending in the four extensions and publishes the matching tools. The turn then goes
+out with them.
+
+It is deliberately a **text** trigger rather than a filesystem one. The file may not exist
+yet, may be outside the sandbox, may be a broken path — none of which matters: what the
+tool costs is being described, and what makes describing it worthwhile is that the
+conversation has turned to a document of that kind. A wrong guess publishes a tool that
+goes unused for the rest of the session, which is the same position we are in today.
+
+## What happens to a wrong guess
+
+Publication is sticky *for a tool that was used*, and only for that one. A turn that named
+a document and never called the extractor gets it withdrawn when the turn ends.
+
+The two halves answer different risks. Withdrawing after use would strand an agent
+mid-task: extraction is rarely one call — a spreadsheet read sheet by sheet, a PDF written
+out and then reread — and an agent cannot ask for a tool back, since publication is
+triggered by what the *user* writes. Keeping a tool nobody called would mean paying for
+every false positive, on every later request, for the rest of the session.
+
+So a newly published tool spends the turn on trial: a `tool_start` naming it clears the
+trial, the end of the turn collects what is left.
+
+## Registration order
+
+The four are registered after every other tool. On a provider that caches prefixes, the
+invalidation from publishing one starts at its position in the tool list, so a tool
+registered fifth of fourteen invalidates almost everything: `pdf_extract` currently sits
+there and its publication would keep only 9.2% of the prefix. Registered last, the
+definitions ahead of it survive.
+
+This changes nothing on a provider that does not cache — which includes the deployment
+these figures come from — and costs nothing on one that does.
+
+## What it does not reach
+
+The RPC runtime, which has no command for the active toolset and publishes everything it
+was launched with. Stated, not emulated: the embedded SDK runtime is the supported target.

--- a/openspec/changes/publish-a-document-extractor-when-a-document-arrives/proposal.md
+++ b/openspec/changes/publish-a-document-extractor-when-a-document-arrives/proposal.md
@@ -1,0 +1,77 @@
+## Why
+
+Four tool definitions — `pdf_extract`, `docx_extract`, `xlsx_extract`, `pptx_extract` —
+come to **8 249 characters, ~2.1k tokens**, and they are sent on every request of every
+conversation. On a resting baseline of ~7.8k tokens that is better than a quarter of the
+floor, spent describing how to read Word, Excel, PowerPoint and PDF files to a session
+that is refactoring TypeScript and will never open one.
+
+Measured on 2026-09-03:
+
+| Tool | chars | ~tokens |
+|---|---|---|
+| `xlsx_extract` | 2 345 | ~0.6k |
+| `docx_extract` | 2 027 | ~0.5k |
+| `pdf_extract` | 1 944 | ~0.5k |
+| `pptx_extract` | 1 933 | ~0.5k |
+
+The same reasoning that split the Work Plan contract applies, with one difference worth
+being honest about: a Work Plan operation is *impossible* without a plan, whereas an
+extractor is merely *useless* without a document. So the trigger cannot be a
+prerequisite — it has to be the document itself arriving.
+
+## What Changes
+
+- An extractor is published when a document of its kind **enters the conversation**: a
+  file attached through the composer, or a path to one named in the message being sent.
+  Publication happens before the turn goes out, so the tool is there for the call that
+  needs it.
+- A tool the turn published and **never called** is withdrawn when that turn ends: the
+  trigger is a text match and can be wrong, and a wrong guess would otherwise be paid on
+  every later request. One that **was** called stays for the session — extraction is
+  rarely a single call, and nothing lets an agent ask for a tool back.
+- A session bound to a workspace publishes none of them until this happens. **Not** on the
+  workspace merely containing such a file: a repository with a `docs/` folder would then
+  pay for four tools while its agent refactors code, which is the case this change exists
+  to stop.
+- The four definitions are registered **last**, after every other tool. It changes nothing
+  for a provider that does not cache prompts, and on one that does it keeps every
+  definition ahead of them out of the invalidation.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- None. -->
+
+### Modified Capabilities
+
+- `agent`: what a session publishes becomes a function of what has entered the
+  conversation, for the document extractors.
+
+## Impact
+
+- **Server** — `server/src/index.ts` (registration order, and the publication call on the
+  prompt path), `server/src/workspace.ts` if the composer upload path lives there.
+- **No wire change, no client change.** The composer already uploads a document into the
+  workspace and attaches it as a path.
+- **Measured** — the four definitions are 8 249 characters of the 23 897 a session's tools
+  come to, so a session that never names a document carries 15 648 characters of tools and
+  7 134 of prompt: **~5.7k tokens against ~7.8k**.
+
+## The cost this carries, stated
+
+Publishing a tool mid-conversation changes the prompt prefix, and a provider that caches
+prefixes must re-read everything from the changed point onward — the tools after it, the
+system prompt, and the entire conversation so far.
+
+- On the deployment this was measured against, the question does not arise:
+  `mistral/devstral-medium-latest` reports `cacheRead: 0, cacheWrite: 0`. Nothing is
+  cached, every turn pays for the whole prompt, and these 2.1k are pure loss on every turn
+  that does not use them.
+- On a provider that does cache, the trade is: a conversation that never touches a
+  document saves the definitions outright; one that does pays a single invalidation whose
+  size grows with the history behind it. It is a bet on how often documents appear, and
+  for a code workspace that is rarely.
+
+Registering the four last is what makes the bet cheaper without changing anything else.

--- a/openspec/changes/publish-a-document-extractor-when-a-document-arrives/scenario-coverage.md
+++ b/openspec/changes/publish-a-document-extractor-when-a-document-arrives/scenario-coverage.md
@@ -1,0 +1,37 @@
+# Scenario coverage
+
+All 10 `#### Scenario:` entries in `specs/agent/spec.md`, enumerated with
+`rg '^#### Scenario:' openspec/changes/publish-a-document-extractor-when-a-document-arrives/`.
+The requirement is ADDED, so every scenario is new work.
+
+Test files:
+
+- `server/test/documentTools.test.ts` (`unit`) — what a prompt is read to call for
+- `server/test/documentToolsWire.test.mjs` (`wire`) — a real server and a real embedded
+  session, asserting the tool list the **provider was sent**: what the snapshot claims the
+  server published is a second-hand account, and what reached the model is what costs
+  tokens and what can be called
+- `verification.md` (`live`) — one run against a real model
+
+| Scenario | Status | Where | What would fail |
+|---|---|---|---|
+| A code session publishes no extractor | covered | `wire`: "a document extractor is published when a document is named, and not before" — `server/test/documentToolsWire.test.mjs` | The workspace is created **with** a `report.docx`, and the snapshot must carry none of the four active while still carrying `read`. Publishing from workspace contents — the design this change rejects — fails here. |
+| Naming a document publishes its extractor, before the turn | covered | `wire`: same test | The turn naming `report.docx` must reach the provider **already carrying** `docx_extract`. Publishing after dispatch, or from a queued read, leaves it absent from the request that named it. Corroborated by `live`, where the model called it on the first attempt. |
+| An attached document publishes its extractor | covered | `unit`: "a mention is matched wherever a path can appear" — `server/test/documentTools.test.ts` | The composer appends an attachment as an `@path` mention and the server absolutises it, so the attachment case *is* the path case. `@/srv/projects/acme/report.pdf` must resolve to `pdf_extract`; a matcher anchored to the start of the text, or one that chokes on `@`, fails. |
+| A tool published on a wrong guess is withdrawn when the turn ends | covered | `wire`: same test, third phase | A turn names the document and never calls the tool; the next request must not carry it. This caught a real bug: the idle check read the runtime *after* publishing, so nothing was ever counted and nothing was ever withdrawn. |
+| A tool that was used survives the quiet turns around its work | covered | `wire`: same test, the four-turn loop | The provider is scripted to call `docx_extract` when the prompt says so; each of the next four turns must still be sent it. Withdrawing after use — the variant considered and rejected — fails on the first of them, and would strand an agent mid-extraction. |
+| A tool nobody has wanted for five turns is forgotten | covered | `wire`: same test, fifth quiet turn | The fifth idle turn's request must not carry it. A tool kept for the session — the previous design — fails here, and with it the saving on every long conversation that opened one document early. |
+| Naming the document again brings its extractor back | covered | `wire`: same test, last phase | After the withdrawal, a prompt naming `report.docx` must put it back. Without this the withdrawal would be a one-way door, and the failure it causes is silent: nothing tells an agent a tool has gone. |
+| A workspace holding documents publishes nothing by itself | covered | `wire`: same test, first assertion | The same `report.docx` on disk, no prompt naming it, nothing published. |
+| The word is not the path | covered | `unit`: "the word is not the path" | "convert this to PDF", "the pdf spec is long", "refactor src/pdf.ts", "docx handling is a mess" and "we support pdf, docx, xlsx and pptx" must all publish nothing. A matcher on the bare extension puts all four back into every conversation that merely discusses documents. |
+| A runtime that cannot gate publishes them all | covered | `unit`: "the exported set is what the server withholds and republishes" — with `RpcRuntime.setToolPublished` returning `false` and `server/src/piOutpostTools.ts` registering all four | The RPC child registers every extractor and its runtime refuses to gate, so they are published throughout. A runtime that returned `true` without gating would be a lie no test could catch; it returns `false`. |
+
+## Measurement
+
+The four definitions are 8 249 characters of the 23 897 a session's tools come to. A session
+that names no document therefore carries 15 648 characters of tools and 7 134 of system
+prompt: **~5.7k tokens against ~7.8k**.
+
+`server/scripts/probe-context-baseline.mts` (on the comparison branch) still reports the
+undivided figure — it builds its own session with every tool active. It should learn the two
+states when that branch lands.

--- a/openspec/changes/publish-a-document-extractor-when-a-document-arrives/specs/agent/spec.md
+++ b/openspec/changes/publish-a-document-extractor-when-a-document-arrives/specs/agent/spec.md
@@ -1,0 +1,89 @@
+## ADDED Requirements
+
+### Requirement: A document extractor is published when a document arrives
+
+The document extraction tools SHALL be published to a session only once a document of their
+kind has entered the conversation. A session that has seen none SHALL publish none of them.
+
+A document enters the conversation when the prompt being sent names a path of that kind —
+which covers both a file attached through the composer, since an attached document is
+written into the workspace and referenced by path, and a file the user names in their own
+words. Publication SHALL happen before the turn is dispatched, so the tool is available to
+the call that needs it rather than after a refusal.
+
+A published extractor SHALL be withdrawn once it has gone unused for long enough, and how long
+SHALL depend on whether it was ever used:
+
+- **Never called: one turn.** The trigger is a text match and can be wrong — a path to a file
+  that does not exist, a document named in passing — and a wrong guess otherwise costs every
+  later request in the session.
+- **Called at least once: five idle turns.** Extraction is rarely a single call, and taking a
+  tool away mid-task would strand an agent that cannot ask for it back. Five turns of silence
+  is the conversation having moved on.
+
+Naming a document of that kind again SHALL republish its extractor and reset the count. That is
+the only way back, and it belongs to the user: an agent cannot request a tool it can no longer
+see, and nothing announces the withdrawal to it.
+
+The tools SHALL NOT be published on the strength of the workspace merely containing such a
+file. A repository with a documents folder would otherwise pay for every extractor in every
+session, including the ones that only ever touch code — which is the cost this requirement
+exists to remove.
+
+These definitions SHALL be registered after every other tool. Where a provider caches prompt
+prefixes, publishing a tool invalidates the prefix from that tool's position onward, so the
+ones that appear late in a session belong late in the list.
+
+Where a runtime cannot change its published toolset — the RPC dialect has no command for it —
+that runtime SHALL publish all of them at all times rather than emulate the gating.
+
+#### Scenario: A code session publishes no extractor
+- **GIVEN** a session whose conversation has named no document
+- **WHEN** the agent's toolset is composed
+- **THEN** none of the document extraction tools is published
+
+#### Scenario: Naming a document publishes its extractor, before the turn
+- **GIVEN** a session publishing no extractor
+- **WHEN** the user sends a prompt naming a `.docx` path
+- **THEN** the extractor for that kind is published before the turn is dispatched
+- **AND** the extractors for the other kinds are not
+
+#### Scenario: An attached document publishes its extractor
+- **GIVEN** a document attached through the composer, written into the workspace and referenced by path
+- **WHEN** the prompt is sent
+- **THEN** the extractor for that kind is published
+
+#### Scenario: A tool published on a wrong guess is withdrawn when the turn ends
+- **GIVEN** a turn that named a document and never called the extractor published for it
+- **WHEN** the turn ends
+- **THEN** that extractor is withheld again
+- **AND** later requests do not carry it
+
+#### Scenario: A tool that was used survives the quiet turns around its work
+- **GIVEN** an extractor that was called during the turn that published it
+- **WHEN** four further turns name no document and do not call it
+- **THEN** it is still published
+
+#### Scenario: A tool nobody has wanted for five turns is forgotten
+- **GIVEN** an extractor that was called earlier in the session
+- **WHEN** it goes five turns without being called and without a document of its kind being named
+- **THEN** it is withheld again
+
+#### Scenario: Naming the document again brings its extractor back
+- **GIVEN** an extractor withheld after going idle
+- **WHEN** a prompt names a document of that kind
+- **THEN** it is published again for that turn
+
+#### Scenario: A workspace holding documents publishes nothing by itself
+- **GIVEN** a workspace containing a `.pdf` that no prompt has named
+- **WHEN** a session is bound to it
+- **THEN** no document extraction tool is published
+
+#### Scenario: The word is not the path
+- **WHEN** a prompt discusses PDFs without naming a path of that kind
+- **THEN** no extractor is published
+
+#### Scenario: A runtime that cannot gate publishes them all
+- **GIVEN** a workspace served by the RPC runtime
+- **WHEN** the agent's toolset is composed
+- **THEN** every document extraction tool is published, as that dialect cannot change its active toolset

--- a/openspec/changes/publish-a-document-extractor-when-a-document-arrives/tasks.md
+++ b/openspec/changes/publish-a-document-extractor-when-a-document-arrives/tasks.md
@@ -1,0 +1,26 @@
+## 1. Register the extractors last
+
+- [x] 1.1 `documentToolsLast()` in `server/src/workspace.ts` — a stable partition applied once, after the sandboxed and unconfined sets are joined, so the rule holds for both paths and the order of everything else is left alone. The unsandboxed list in `server/src/index.ts` is written in the same order.
+
+## 2. Publish on arrival
+
+- [x] 2.1 `documentToolsFor(text)` in `server/src/documentTools.ts`: the extractors a prompt calls for, matched on a path-like token so prose ("convert this to PDF") publishes nothing.
+- [x] 2.2 Called from `handlePrompt` before `agent.prompt`, publishing through `AgentRuntime.setToolPublished` — the seam the Work Plan split added.
+- [x] 2.3 Withheld at every bind: boot, a project started later, and a session replacement, which is a new conversation.
+- [x] 2.4 Each published extractor carries a count of idle turns (`Workspace.documentToolIdleTurns`, with `documentToolsEverUsed`): a `tool_start` resets it to zero and marks the tool as wanted, `agent_end` ages the rest, and the threshold is one turn for a tool never called, five for one that was. Naming the document again republishes and resets. The wire test caught the ordering bug in the first version of this — the check read the runtime *after* publishing, so nothing was ever counted.
+
+## 3. Proof
+
+- [x] 3.1 `server/test/documentTools.test.ts` (7 tests): one kind publishes one tool; `@path`, quotes, Windows separators, a trailing full stop and `REPORT.PDF` all match; prose and `src/pdf.ts` do not; two kinds publish two, in registration order; the exported set and the matcher agree.
+- [x] 3.2 Order: asserted at the wire, where it matters — the last tool the model is sent is the extractor.
+- [x] 3.3 / 3.4 `server/test/documentToolsWire.test.mjs` — a real embedded session, asserting the tool list the **provider** was sent rather than what the snapshot claims. It walks the whole life of one tool: none of the four at rest in a workspace that *contains* a `.docx`; `docx_extract` on the very turn that names one, and not its siblings; withdrawn after a turn that never called it; called, then surviving four idle turns; forgotten on the fifth; republished when the document is named again.
+- [x] 3.5 Measured: the four are 8 249 of the 23 897 characters a session's tools come to, so a session that names no document carries ~5.7k tokens against ~7.8k.
+
+## 4. Prove the agent copes
+
+- [x] 4.1 Done — `verification.md`. A real model, a real `.docx`: no extractor at rest in a workspace that holds the document, and `docx_extract` called on the first attempt once the prompt named it.
+
+## 5. Validation
+
+- [x] 5.1 Done — 8 scenarios, all covered.
+- [ ] 5.2 `npm run check:scenarios`, `openspec validate --strict`, and the **full** server suite — both CI failures on this stack came from files a partial local run never touched.

--- a/openspec/changes/publish-a-document-extractor-when-a-document-arrives/verification.md
+++ b/openspec/changes/publish-a-document-extractor-when-a-document-arrives/verification.md
@@ -1,0 +1,22 @@
+# Live verification
+
+`mistral/devstral-medium-latest`, a real server, a real `.docx` in the workspace, and a
+throwaway `agentDir` carrying only the API key.
+
+```
+at rest: edit, find, grep, ls, present_structure, read, work_plan, write, write_structure_figure
+→ docx_extract {"path":"report.docx"}
+answer: The document `report.docx` contains: …
+```
+
+- **No extractor at rest**, in a workspace that holds the document. Containing one is not
+  using one.
+- The prompt named `report.docx`, and the tool was **there for the first call** — no
+  refusal, no repair loop, nothing discovered the hard way. That is the risk this design
+  carries: a tool published a moment too late is a tool the model tried to call and could
+  not.
+- The other three stayed withheld.
+
+The wire test proves the same sequence deterministically, plus the two cases a live run
+cannot arrange on demand: a tool withdrawn after a turn that never called it, and one kept
+after a turn that did.

--- a/server/src/agentRuntime.ts
+++ b/server/src/agentRuntime.ts
@@ -229,6 +229,16 @@ export interface AgentRuntime {
   abort(): Promise<void>;
   setModel(provider: string, id: string): Promise<RuntimeModel>;
   setThinkingLevel(level: ThinkingLevel): Promise<void>;
+  /**
+   * Publish or withhold one already-registered tool for the rest of this session,
+   * and say whether it took.
+   *
+   * A runtime that cannot change its published toolset returns `false` rather than
+   * pretending: the RPC dialect has no command for it, so a child there publishes
+   * everything it was registered with. Callers report that, they do not work around
+   * it — the embedded SDK runtime is the supported target.
+   */
+  setToolPublished(name: string, published: boolean): boolean;
   compact(): Promise<void>;
   setSessionName(name: string): Promise<void>;
 

--- a/server/src/documentTools.ts
+++ b/server/src/documentTools.ts
@@ -1,0 +1,52 @@
+/**
+ * Which document extractors a piece of conversation calls for.
+ *
+ * The four extractor schemas come to some 8 000 characters — around a quarter of a
+ * session's whole prompt floor — describing how to read Word, Excel, PowerPoint and
+ * PDF to conversations that overwhelmingly never open one. They are published when a
+ * document of their kind enters the conversation instead, and this is the reading of
+ * "enters".
+ *
+ * It is a *text* test, not a filesystem one. The file may not exist yet, may sit
+ * outside the sandbox, may be a path the user mistyped: none of that changes the
+ * answer, because what is being decided is whether describing the tool is worth its
+ * place in every subsequent request. A wrong guess publishes a tool that goes unused,
+ * which is exactly where every session starts today.
+ */
+
+/** Extension → the tool that reads it. */
+const EXTRACTORS: Record<string, string> = {
+  pdf: "pdf_extract",
+  docx: "docx_extract",
+  xlsx: "xlsx_extract",
+  pptx: "pptx_extract",
+};
+
+export const DOCUMENT_TOOLS = Object.values(EXTRACTORS);
+
+/**
+ * A path-like token ending in one of the four extensions.
+ *
+ * The boundary before the name is what keeps prose out: "convert this to PDF" names no
+ * file, and publishing on the bare word would put all four back in every conversation
+ * that merely discusses documents. A name must be preceded by a path character or the
+ * start of a token, carry at least one character of its own, and be followed by
+ * whitespace, punctuation that ends a path — a sentence's full stop included, since
+ * "read a.pdf." is a mention and `a.pdf.bak` is close enough to one — or nothing.
+ */
+const MENTION = /(?:^|[\s"'`(\[<@])(?:[^\s"'`()[\]<>]*[/\\])?[^\s"'`()[\]<>/\\]+\.(pdf|docx|xlsx|pptx)(?=$|[\s"'`)\]>,;:!?.])/gi;
+
+/**
+ * The extractor tools the text calls for, in the order they are registered.
+ *
+ * Case-insensitive: `REPORT.PDF` off a Windows share is the same document as
+ * `report.pdf`.
+ */
+export function documentToolsFor(text: string): string[] {
+  const found = new Set<string>();
+  for (const match of text.matchAll(MENTION)) {
+    const tool = EXTRACTORS[match[1].toLowerCase()];
+    if (tool !== undefined) found.add(tool);
+  }
+  return DOCUMENT_TOOLS.filter((tool) => found.has(tool));
+}

--- a/server/src/embeddedRuntime.ts
+++ b/server/src/embeddedRuntime.ts
@@ -61,7 +61,11 @@ export async function createEmbeddedRuntime(options: EmbeddedRuntimeOptions): Pr
 
 type SdkRuntime = Awaited<ReturnType<typeof createAgentSessionRuntime>>;
 
-class EmbeddedRuntime implements AgentRuntime {
+/**
+ * Exported for the tests that drive one method against a stand-in session. Everything
+ * else builds one through `createEmbeddedRuntime`, which needs a real SDK runtime.
+ */
+export class EmbeddedRuntime implements AgentRuntime {
   readonly kind = "embedded";
   readonly ok = true;
 
@@ -332,6 +336,24 @@ class EmbeddedRuntime implements AgentRuntime {
 
   async setThinkingLevel(level: ThinkingLevel): Promise<void> {
     this.session.setThinkingLevel(level as never);
+  }
+
+  /**
+   * `setActiveToolsByName` rebuilds the system prompt around the new set, so a tool
+   * withheld here is not described either — which is the point: the schema is what
+   * costs, and it is sent on every request whether or not anything uses it.
+   *
+   * Idempotent, and silent about a name the session never registered: the caller is
+   * describing what should be published, not asserting what exists.
+   */
+  setToolPublished(name: string, published: boolean): boolean {
+    if (this.session.getToolDefinition(name) === undefined) return false;
+    const active = new Set(this.session.getActiveToolNames());
+    if (active.has(name) === published) return true;
+    if (published) active.add(name);
+    else active.delete(name);
+    this.session.setActiveToolsByName([...active]);
+    return true;
   }
 
   async compact(): Promise<void> {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -148,6 +148,7 @@ import { createPptxExtractToolDefinition } from "./pptxTool.ts";
 import { createStructuredExchangeToolDefinition } from "./structuredExchangeTool.ts";
 import { createStructuredExchangeFigureToolDefinition } from "./structuredExchangeFigureTool.ts";
 import { createWorkPlanExtendedToolDefinition, createWorkPlanToolDefinition, WORK_PLAN_EXTENDED_TOOL, WORK_PLAN_TOOL } from "./workPlanTool.ts";
+import { DOCUMENT_TOOLS, documentToolsFor } from "./documentTools.ts";
 import { copyWorkPlan, deleteWorkPlan, loadWorkPlan, sameSessionFile } from "./workPlanStore.ts";
 import { composeAppendSystemPrompt } from "./systemPrompt.ts";
 import { createPdfExtractToolDefinition } from "./pdfTool.ts";
@@ -1008,12 +1009,26 @@ const makeCreateRuntime =
         ? {}
         : {
             customTools: [
+              createStructuredExchangeFigureToolDefinition({
+                cwd,
+                allowedRoots: [await fs.realpath(cwd)],
+                maxBytes: config.structuredExchange.maxBytes,
+                // No sandbox: anything under the workspace is writable, the same
+                // rule writeFileFromBrowser applies to the browser's own writes.
+                writableRoot: await fs.realpath(cwd),
+              }),
+              structuredExchangeTool,
+              workPlanTool,
+              workPlanExtendedTool,
+              // The extractors go last, and the order is not cosmetic. A tool published
+              // mid-conversation invalidates a caching provider's prefix from its own
+              // position onward; these four are the ones that appear late in a session,
+              // so everything registered before them survives their arrival. Measured:
+              // `pdf_extract` fifth of fourteen kept 9.2% of the prefix.
               createPdfExtractToolDefinition({
                 cwd,
                 allowedRoots: [await fs.realpath(cwd)],
                 maxBytes: config.pdf.maxBytes,
-                // No sandbox: anything under the workspace is writable, the same
-                // rule writeFileFromBrowser applies to the browser's own writes.
                 writableRoot: await fs.realpath(cwd),
               }),
               createDocxExtractToolDefinition({
@@ -1034,15 +1049,6 @@ const makeCreateRuntime =
                 maxBytes: config.pptx.maxBytes,
                 writableRoot: await fs.realpath(cwd),
               }),
-              createStructuredExchangeFigureToolDefinition({
-                cwd,
-                allowedRoots: [await fs.realpath(cwd)],
-                maxBytes: config.structuredExchange.maxBytes,
-                writableRoot: await fs.realpath(cwd),
-              }),
-              structuredExchangeTool,
-              workPlanTool,
-              workPlanExtendedTool,
             ],
           }),
     })),
@@ -1182,6 +1188,7 @@ workspace.workPlanSessionFile = workspace.agent.snapshot().sessionFile;
 // The bound session may already have a plan — resumed, or the server restarted under
 // one. An agent that inherits work should inherit the tools for it, not discover them.
 publishWorkPlanTools(workspace, workspace.workPlan);
+withholdDocumentTools(workspace);
 
 /**
  * Session replacement events are synchronous, while their sidecar reads are not.
@@ -1197,6 +1204,67 @@ publishWorkPlanTools(workspace, workspace.workPlan);
  * remember to keep in step. The runtime says whether it took: an RPC child publishes
  * both tools always, which is the documented cost of that dialect.
  */
+/**
+ * Withhold every document extractor until a document of its kind turns up.
+ *
+ * Their four schemas come to some 8 000 characters — around a quarter of a session's
+ * prompt floor — telling a conversation how to read Word, Excel, PowerPoint and PDF.
+ * Most conversations never open one, and the ones that do say so first.
+ */
+function withholdDocumentTools(workspace: Workspace): void {
+  for (const tool of DOCUMENT_TOOLS) workspace.agent.setToolPublished(tool, false);
+  workspace.documentToolIdleTurns.clear();
+  workspace.documentToolsEverUsed.clear();
+}
+
+/**
+ * Publish the extractors a prompt calls for, before the turn carrying it goes out.
+ *
+ * Sticky: nothing is withdrawn here. A conversation that has handled one PDF usually
+ * handles another, and withdrawing would invalidate a caching provider's prefix a
+ * second time to save what it had already stopped paying for.
+ */
+function publishDocumentTools(workspace: Workspace, text: string): void {
+  for (const tool of documentToolsFor(text)) {
+    // Naming the document is what resets the clock, whether or not the tool was already
+    // there: the conversation has just turned back to a document of that kind.
+    if (workspace.agent.setToolPublished(tool, true)) workspace.documentToolIdleTurns.set(tool, 0);
+  }
+}
+
+/**
+ * How many turns a published extractor may go unused before it is forgotten.
+ *
+ * One, for a tool that has never been called: it was published on a text match that
+ * turned out to be wrong, and every later request would carry the mistake.
+ *
+ * Five, for one that has been used: the work around a document rarely ends with the call
+ * that opened it — a spreadsheet read sheet by sheet, a passage checked again two answers
+ * later — and taking the tool away mid-task would strand an agent that cannot ask for it
+ * back. Five turns of silence is the conversation having moved on.
+ */
+const DOCUMENT_TOOL_IDLE_LIMIT = { unused: 1, used: 5 };
+
+/**
+ * Age every published extractor by one turn, and forget the ones that have gone quiet.
+ *
+ * Called when a turn ends. A tool used during it was reset to zero as it was called, so
+ * what is counted here is silence.
+ */
+function ageDocumentTools(workspace: Workspace): void {
+  for (const [tool, idle] of workspace.documentToolIdleTurns) {
+    const limit = workspace.documentToolsEverUsed.has(tool)
+      ? DOCUMENT_TOOL_IDLE_LIMIT.used
+      : DOCUMENT_TOOL_IDLE_LIMIT.unused;
+    if (idle + 1 < limit) {
+      workspace.documentToolIdleTurns.set(tool, idle + 1);
+      continue;
+    }
+    workspace.agent.setToolPublished(tool, false);
+    workspace.documentToolIdleTurns.delete(tool);
+  }
+}
+
 function publishWorkPlanTools(workspace: Workspace, plan: WorkPlan | null): void {
   workspace.agent.setToolPublished(WORK_PLAN_EXTENDED_TOOL, plan !== null);
 }
@@ -1218,6 +1286,9 @@ function queueWorkPlanSessionSync(workspace: Workspace): Promise<void> {
     workspace.workPlan = plan;
     workspace.workPlanSessionFile = sessionFile;
     publishWorkPlanTools(workspace, plan);
+    // A replaced session is a new conversation: whatever documents the last one saw are
+    // not this one's, and the first prompt naming one publishes what it needs.
+    withholdDocumentTools(workspace);
     broadcast(workspace, { type: "session_replaced", ...snapshot(workspace) });
     if (inherited) broadcast(workspace, { type: "work_plan_changed", workPlan: plan });
     announceWorkspaceActivity();
@@ -1649,6 +1720,7 @@ function onRuntimeEvent(workspace: Workspace, event: RuntimeEvent): void {
       // no question to answer, and a badge that cannot be cleared is worse than
       // no badge at all.
       workspace.pendingDialogs.clear();
+      ageDocumentTools(workspace);
       broadcast(workspace, { type: "agent_end" });
       // Unconditional: the project just went from working to idle, which the
       // selector must show whether or not anything was blocked.
@@ -1696,6 +1768,12 @@ function onRuntimeEvent(workspace: Workspace, event: RuntimeEvent): void {
       broadcast(workspace, { type: "custom_message", item: customMessageToItem(event.message as never, workspace.renderer) });
       break;
     case "tool_start": {
+      // Called, so the clock goes back to zero — and it is no longer a tool nobody has
+      // ever wanted, which is what decides how long it may sit idle from here.
+      if (workspace.documentToolIdleTurns.has(event.toolName)) {
+        workspace.documentToolIdleTurns.set(event.toolName, 0);
+        workspace.documentToolsEverUsed.add(event.toolName);
+      }
       const callHtml = workspace.renderer.renderToolCallHtml(event.toolCallId, event.toolName, event.args);
       broadcast(workspace, {
         type: "tool_start",
@@ -2291,6 +2369,7 @@ async function ensureStarted(target: Workspace): Promise<void> {
     // Same as the boot workspace: a project reopened onto an existing plan publishes
     // the tools that plan needs, rather than making its agent find them again.
     publishWorkPlanTools(target, target.workPlan);
+    withholdDocumentTools(target);
     target.lastUsedAt = Date.now();
   })();
   starting.set(target.root, build);
@@ -2417,6 +2496,10 @@ async function absolutizeMentions(workspace: Workspace, text: string): Promise<s
 
 async function handlePrompt(workspace: Workspace, text: string, images?: WireImage[]): Promise<void> {
   const promptText = await absolutizeMentions(workspace, text);
+  // Before the turn, not after: a tool published once the request is on its way is a
+  // tool the model could not call. The composer references an attached document by
+  // path, so the text naming a document is the same event as one arriving.
+  publishDocumentTools(workspace, promptText);
   await workspace.agent.prompt(promptText, {
     ...(images?.length ? { images } : {}),
     // Echo the user message only once accepted (avoids ghost bubbles on reject).

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -147,7 +147,7 @@ import { createXlsxExtractToolDefinition } from "./xlsxTool.ts";
 import { createPptxExtractToolDefinition } from "./pptxTool.ts";
 import { createStructuredExchangeToolDefinition } from "./structuredExchangeTool.ts";
 import { createStructuredExchangeFigureToolDefinition } from "./structuredExchangeFigureTool.ts";
-import { createWorkPlanToolDefinition } from "./workPlanTool.ts";
+import { createWorkPlanExtendedToolDefinition, createWorkPlanToolDefinition, WORK_PLAN_EXTENDED_TOOL, WORK_PLAN_TOOL } from "./workPlanTool.ts";
 import { copyWorkPlan, deleteWorkPlan, loadWorkPlan, sameSessionFile } from "./workPlanStore.ts";
 import { composeAppendSystemPrompt } from "./systemPrompt.ts";
 import { createPdfExtractToolDefinition } from "./pdfTool.ts";
@@ -415,6 +415,13 @@ if (cli.command === "login") {
  */
 const structuredExchangeTool = createStructuredExchangeToolDefinition();
 const workPlanTool = createWorkPlanToolDefinition();
+/**
+ * Registered beside it and active only where its actions are possible — see the
+ * runtime's `setToolPublished`. Registration is not publication: the SDK builds its
+ * tool registry once per session, so a definition that might become active has to be
+ * there from the start.
+ */
+const workPlanExtendedTool = createWorkPlanExtendedToolDefinition();
 
 /**
  * Everything a workspace needs that is the server's rather than the project's:
@@ -439,7 +446,7 @@ function workspaceOptions(settings: WorkspaceSettings): Omit<WorkspaceOptions, "
       structuredExchangeMaxBytes: config.structuredExchange.maxBytes,
     },
     watchFiles: config.files.watch,
-    unconfinedTools: [structuredExchangeTool, workPlanTool],
+    unconfinedTools: [structuredExchangeTool, workPlanTool, workPlanExtendedTool],
     // Bound to the workspace being built, so a tree change reaches the clients
     // watching THAT project and no others.
     onDirectoryChanged: () => {},
@@ -1035,6 +1042,7 @@ const makeCreateRuntime =
               }),
               structuredExchangeTool,
               workPlanTool,
+              workPlanExtendedTool,
             ],
           }),
     })),
@@ -1171,6 +1179,9 @@ for (const root of config.openProjects) {
 
 workspace.workPlan = await loadWorkPlan(workspace.agent.snapshot().sessionFile);
 workspace.workPlanSessionFile = workspace.agent.snapshot().sessionFile;
+// The bound session may already have a plan — resumed, or the server restarted under
+// one. An agent that inherits work should inherit the tools for it, not discover them.
+publishWorkPlanTools(workspace, workspace.workPlan);
 
 /**
  * Session replacement events are synchronous, while their sidecar reads are not.
@@ -1178,6 +1189,18 @@ workspace.workPlanSessionFile = workspace.agent.snapshot().sessionFile;
  * copying and announcing its inherited plan. Without the queue, a late ENOENT read
  * could overwrite the copied plan with null.
  */
+/**
+ * The extended Work Plan tool is published exactly while there is a plan to act on.
+ *
+ * Derived from the plan itself at every point where the plan can change — a mutation,
+ * a session replacement, the initial bind — rather than from a flag someone has to
+ * remember to keep in step. The runtime says whether it took: an RPC child publishes
+ * both tools always, which is the documented cost of that dialect.
+ */
+function publishWorkPlanTools(workspace: Workspace, plan: WorkPlan | null): void {
+  workspace.agent.setToolPublished(WORK_PLAN_EXTENDED_TOOL, plan !== null);
+}
+
 function queueWorkPlanSessionSync(workspace: Workspace): Promise<void> {
   const sessionFile = workspace.agent.snapshot().sessionFile;
   workspace.workPlanSync = workspace.workPlanSync.catch(() => {}).then(async () => {
@@ -1194,6 +1217,7 @@ function queueWorkPlanSessionSync(workspace: Workspace): Promise<void> {
     if (!sameSessionFile(workspace.agent.snapshot().sessionFile, sessionFile)) return;
     workspace.workPlan = plan;
     workspace.workPlanSessionFile = sessionFile;
+    publishWorkPlanTools(workspace, plan);
     broadcast(workspace, { type: "session_replaced", ...snapshot(workspace) });
     if (inherited) broadcast(workspace, { type: "work_plan_changed", workPlan: plan });
     announceWorkspaceActivity();
@@ -1215,6 +1239,7 @@ function queueWorkPlanToolSync(workspace: Workspace, sessionFile: string, change
     if (!sameSessionFile(workspace.agent.snapshot().sessionFile, sessionFile)) return;
     workspace.workPlan = plan;
     workspace.workPlanSessionFile = sessionFile;
+    publishWorkPlanTools(workspace, plan);
     if (changed) {
       broadcast(workspace, { type: "work_plan_changed", workPlan: plan });
       announceWorkspaceActivity();
@@ -1726,7 +1751,7 @@ function onRuntimeEvent(workspace: Workspace, event: RuntimeEvent): void {
         | { type?: unknown; sessionFile?: unknown; plan?: WorkPlan | null; changed?: unknown }
         | undefined;
       if (
-        event.toolName === "work_plan" &&
+        (event.toolName === WORK_PLAN_TOOL || event.toolName === WORK_PLAN_EXTENDED_TOOL) &&
         !event.isError &&
         workPlanDetails?.type === "work_plan" &&
         typeof workPlanDetails.sessionFile === "string" &&
@@ -1737,6 +1762,11 @@ function onRuntimeEvent(workspace: Workspace, event: RuntimeEvent): void {
           // the sidecar: persistence, not an extension-supplied event payload,
           // is the authoritative state that must survive resume/compaction.
           if (workPlanDetails.plan !== null) validateWorkPlan(workPlanDetails.plan);
+          // Publish here, from the result in hand, rather than waiting for the queued
+          // reload: the agent's next request goes out before that read finishes, so a
+          // plan created mid-turn would leave the extended tool unpublished for the
+          // very call that needed it — which is the whole promise of "within the turn".
+          publishWorkPlanTools(workspace, workPlanDetails.plan ?? null);
           queueWorkPlanToolSync(workspace, workPlanDetails.sessionFile as string, workPlanDetails.changed === true);
         } catch (error) {
           reportError(new Error(`Ignoring invalid Work Plan tool result: ${error instanceof Error ? error.message : String(error)}`));
@@ -2258,6 +2288,9 @@ async function ensureStarted(target: Workspace): Promise<void> {
     refreshExtensionRender(target);
     target.workPlan = await loadWorkPlan(runtime.snapshot().sessionFile);
     target.workPlanSessionFile = runtime.snapshot().sessionFile;
+    // Same as the boot workspace: a project reopened onto an existing plan publishes
+    // the tools that plan needs, rather than making its agent find them again.
+    publishWorkPlanTools(target, target.workPlan);
     target.lastUsedAt = Date.now();
   })();
   starting.set(target.root, build);

--- a/server/src/piOutpostTools.ts
+++ b/server/src/piOutpostTools.ts
@@ -31,7 +31,7 @@ import { createPptxExtractToolDefinition } from "./pptxTool.ts";
 import { createStructuredExchangeFigureToolDefinition } from "./structuredExchangeFigureTool.ts";
 import { createStructuredExchangeToolDefinition } from "./structuredExchangeTool.ts";
 import { createXlsxExtractToolDefinition } from "./xlsxTool.ts";
-import { createWorkPlanToolDefinition } from "./workPlanTool.ts";
+import { createWorkPlanExtendedToolDefinition, createWorkPlanToolDefinition } from "./workPlanTool.ts";
 
 /** What the parent must tell the child. Mirrors the fields index.ts uses embedded. */
 export interface PiOutpostToolsSettings {
@@ -83,6 +83,12 @@ export async function createPiOutpostTools(settings: PiOutpostToolsSettings): Pr
     createStructuredExchangeFigureToolDefinition({ ...common, maxBytes: settings.maxBytes.structuredExchange }),
     createStructuredExchangeToolDefinition(),
     createWorkPlanToolDefinition(),
+    // Both, always. The server withholds the extended half from a session with no
+    // plan through the SDK's active-tool set; the RPC dialect has no command for
+    // that, so a child registers the pair and publishes them both. The cost of the
+    // gating being embedded-only is one extra tool in a child's prompt, stated here
+    // rather than discovered.
+    createWorkPlanExtendedToolDefinition(),
   ];
 }
 

--- a/server/src/rpcRuntime.ts
+++ b/server/src/rpcRuntime.ts
@@ -663,6 +663,15 @@ class RpcRuntime implements AgentRuntime {
     return model;
   }
 
+  /**
+   * Not expressible: the RPC dialect has no command for the active toolset, so the
+   * child publishes everything it was launched with. Saying so is the contract —
+   * emulating it here would mean lying about what the agent can see.
+   */
+  setToolPublished(): boolean {
+    return false;
+  }
+
   async setThinkingLevel(level: ThinkingLevel): Promise<void> {
     await this.command("set_thinking_level", { level });
     this.thinkingLevel = level;

--- a/server/src/workPlanTool.ts
+++ b/server/src/workPlanTool.ts
@@ -6,6 +6,7 @@ import {
   WORK_PLAN_EVIDENCE_RESULTS,
   WORK_PLAN_LIMITS,
   WORK_PLAN_STATUSES,
+  type WorkPlanAction,
 } from "@pi-outpost/shared/work-plan";
 import { applyWorkPlanMutation } from "./workPlanStore.ts";
 
@@ -90,8 +91,13 @@ const creationTaskSchema = (depth: number): TSchema => Type.Object({
   description: Type.Optional(descriptionSchema),
   status: Type.Optional(statusSchema),
   statusReason: Type.Optional(reasonSchema),
-  resources: Type.Optional(resourcesSchema),
-  evidence: Type.Optional(evidenceCollectionSchema),
+  // No `resources` or `evidence` here. Both are collections whose shapes are the
+  // expensive part of this schema, and both are inlined once per nesting level —
+  // 1 009 characters twice over, to describe something a task acquires *after* it
+  // has been worked on rather than while the plan is being drawn. They are set
+  // through `work_plan_extended`, on a task that exists. `mutateWorkPlan` still
+  // accepts them in a draft, so a client written against the old contract keeps
+  // working; only the advertisement is gone.
   dependsOn: Type.Optional(Type.Array(identifierSchema, {
     maxItems: WORK_PLAN_LIMITS.tasks,
     uniqueItems: true,
@@ -130,9 +136,46 @@ const creationTaskSchema = (depth: number): TSchema => Type.Object({
  * the per-action requirements are checked by `mutateWorkPlan`, which names the
  * offending field ("tasks[2].dependsOn is not accepted").
  */
+/**
+ * Which tool carries which action.
+ *
+ * The line is prerequisite, not frequency: every extended action operates on a task
+ * that must already exist, so none of them can be called against a session with no
+ * plan — and the extended tool is published only where they can. That they are also
+ * the four rarest operations, and the four carrying the expensive collection shapes,
+ * is what makes withholding them worth the second name.
+ */
+export const WORK_PLAN_COMMON_ACTIONS = [
+  "get",
+  "create",
+  "add_task",
+  "update_task",
+  "move_task",
+  "remove_task",
+  "clear",
+] as const satisfies readonly WorkPlanAction[];
+
+export const WORK_PLAN_EXTENDED_ACTIONS = [
+  "replace",
+  "set_dependencies",
+  "set_resources",
+  "set_evidence",
+] as const satisfies readonly WorkPlanAction[];
+
+export const WORK_PLAN_TOOL = "work_plan";
+export const WORK_PLAN_EXTENDED_TOOL = "work_plan_extended";
+
+/** Which tool an action belongs to, so a refusal can say where to find it. */
+export function workPlanToolFor(action: string): string | undefined {
+  if ((WORK_PLAN_COMMON_ACTIONS as readonly string[]).includes(action)) return WORK_PLAN_TOOL;
+  if ((WORK_PLAN_EXTENDED_ACTIONS as readonly string[]).includes(action)) return WORK_PLAN_EXTENDED_TOOL;
+  return undefined;
+}
+
+/** The common tool's payload: a plan of titles, and per-task edits that carry no collection. */
 export const workPlanParameters = Type.Object({
   action: stringEnum(
-    WORK_PLAN_ACTIONS,
+    WORK_PLAN_COMMON_ACTIONS,
     "What to do. Every property below is required by some actions and ignored by the rest.",
   ),
   title: Type.Optional(Type.String({ ...titleSchema, description: "Plan title (create), or the task's new title (update_task)." })),
@@ -140,13 +183,42 @@ export const workPlanParameters = Type.Object({
     maxItems: WORK_PLAN_LIMITS.tasks,
     description: `Top-level tasks (create); each may carry subtasks. At most ${WORK_PLAN_LIMITS.tasks} tasks total and ${WORK_PLAN_LIMITS.serializedBytes} serialized bytes across the complete plan.`,
   })),
-  plan: Type.Optional(Type.Object({ ...normalizedPlanSchema.properties }, { ...objectOptions, description: "A complete normalized plan (replace)." })),
-  task: Type.Optional(Type.Object({ ...normalizedTaskSchema.properties }, { ...objectOptions, description: "One complete task, id and status included (add_task)." })),
-  taskId: Type.Optional(Type.String({ ...identifierSchema, description: "Which task to act on (update_task, move_task, remove_task, set_dependencies, set_resources, set_evidence)." })),
+  task: Type.Optional(Type.Object({
+    // The normalized task shape minus its collections, for the same reason creation
+    // drops them: `resources` and `evidence` are what a task acquires once it is
+    // being worked on, they are the largest shapes in this schema, and they have a
+    // tool of their own. `mutateWorkPlan` defaults both to empty, so an added task is
+    // complete without them. A call that carries them anyway is refused by pi's own
+    // validation, before the handler — the schema is the contract, not a hint.
+    id: normalizedTaskSchema.properties.id,
+    title: normalizedTaskSchema.properties.title,
+    description: normalizedTaskSchema.properties.description,
+    status: normalizedTaskSchema.properties.status,
+    parentId: normalizedTaskSchema.properties.parentId,
+    statusReason: normalizedTaskSchema.properties.statusReason,
+    dependsOn: normalizedTaskSchema.properties.dependsOn,
+  }, { ...objectOptions, description: "One complete task, id and status included (add_task)." })),
+  taskId: Type.Optional(Type.String({ ...identifierSchema, description: "Which task to act on (update_task, move_task, remove_task)." })),
   status: Type.Optional(stringEnum(WORK_PLAN_STATUSES, "New status (update_task).")),
   description: Type.Optional(Type.Union([descriptionSchema, Type.Null()], { description: "New description, or null to clear it (update_task)." })),
   statusReason: Type.Optional(Type.Union([reasonSchema, Type.Null()], { description: "Why the task sits in its status, or null to clear it (update_task)." })),
   parentId: Type.Optional(Type.Union([identifierSchema, Type.Null()], { description: "New parent, or null for top level (move_task)." })),
+}, objectOptions);
+
+/**
+ * The extended tool's payload: the whole-plan document and the three collections.
+ *
+ * Every action here needs a task that already exists, which is why this schema is
+ * published only to a session that has a plan — and why it is the half worth
+ * withholding: these four properties carried most of the characters.
+ */
+export const workPlanExtendedParameters = Type.Object({
+  action: stringEnum(
+    WORK_PLAN_EXTENDED_ACTIONS,
+    "What to do. Every property below is required by some actions and ignored by the rest.",
+  ),
+  plan: Type.Optional(Type.Object({ ...normalizedPlanSchema.properties }, { ...objectOptions, description: "A complete normalized plan (replace)." })),
+  taskId: Type.Optional(Type.String({ ...identifierSchema, description: "Which task to act on (set_dependencies, set_resources, set_evidence)." })),
   dependsOn: Type.Optional(Type.Array(identifierSchema, { maxItems: WORK_PLAN_LIMITS.tasks, uniqueItems: true, description: "Complete dependency set for taskId (set_dependencies)." })),
   resources: Type.Optional(Type.Array(resourceSchema, { maxItems: WORK_PLAN_LIMITS.resourcesPerTask, description: "Complete resource set for taskId (set_resources)." })),
   evidence: Type.Optional(Type.Array(evidenceSchema, {
@@ -155,11 +227,48 @@ export const workPlanParameters = Type.Object({
   })),
 }, objectOptions);
 
+/**
+ * One executor for both tools: the split is in what is published, never in what is
+ * validated or stored. Everything still funnels through `applyWorkPlanMutation`.
+ */
+function executeWorkPlan(tool: string): ToolDefinition["execute"] {
+  return async (_toolCallId, params, _signal, _onUpdate, ctx) => {
+    const action = (params as { action?: unknown }).action;
+    const home = typeof action === "string" ? workPlanToolFor(action) : undefined;
+    if (home !== undefined && home !== tool) {
+      // The one failure a split invents: an action asked of the wrong half. Answer it
+      // the way every other refusal here is answered — name the thing and say where it
+      // is — rather than letting the schema report an unknown enum value.
+      return {
+        content: [{ type: "text", text: `Work Plan update refused: action=${action} belongs to the ${home} tool.` }],
+        details: undefined,
+        isError: true,
+      };
+    }
+    try {
+      const sessionFile = ctx.sessionManager.getSessionFile();
+      const plan = await applyWorkPlanMutation(sessionFile, params as never);
+      const summary = plan === null
+        ? "This session has no Work Plan."
+        : `Work Plan "${plan.title}": ${plan.tasks.length} tasks (${plan.tasks.filter((task) => task.status === "done").length} done).`;
+      return {
+        // `details` drives authoritative UI synchronization but is not model
+        // context. A resumed agent must receive the complete working state in
+        // content; otherwise post-compaction `get` would expose only a counter.
+        content: [{ type: "text", text: (action === "get" || action === "create") && plan !== null ? `${summary}\n${JSON.stringify(plan)}` : summary }],
+        details: { type: "work_plan", sessionFile, plan, changed: action !== "get" },
+      };
+    } catch (error) {
+      return { content: [{ type: "text", text: `Work Plan update refused: ${error instanceof Error ? error.message : String(error)}` }], details: undefined, isError: true };
+    }
+  };
+}
+
 export function createWorkPlanToolDefinition(): ToolDefinition {
   return {
-    name: "work_plan",
+    name: WORK_PLAN_TOOL,
     label: "Work Plan",
-    description: "Read or atomically update the persistent Work Plan for this session. Use create for a compact two-level task hierarchy (500 tasks total, 64 KiB normalized plan) whose tasks need only a title, set_evidence to replace one task's complete generic verification/support record collection, replace for a complete normalized version-1 document, and the other task operations for precise later mutations.",
+    description: `Read or atomically update the persistent Work Plan for this session. Use create for a compact two-level task hierarchy (${WORK_PLAN_LIMITS.tasks} tasks total, 64 KiB normalized plan) whose tasks need only a title, and the other task operations for precise later mutations. Dependencies, resources, evidence and whole-plan replacement live in ${WORK_PLAN_EXTENDED_TOOL}, which is available once this session has a plan.`,
     promptSnippet: "Create, inspect, and update the session's persistent Work Plan",
     // A worked call, because the schema alone left models repairing by guess. The
     // titles are deliberately meaningless: an example that reads like real work
@@ -169,35 +278,38 @@ export function createWorkPlanToolDefinition(): ToolDefinition {
       'Create the whole plan in one call, dependencies included: {"action":"create","title":"<plan title>","tasks":[{"id":"a","title":"<first task>"},{"id":"b","title":"<second task>","dependsOn":["a"],"subtasks":[{"title":"<a step of the second task>"}]}]}',
       "Give a task an explicit short id whenever something references it; ids are generated for the rest.",
       'Update one task with {"action":"update_task","taskId":"b","status":"in_progress"}. Statuses are todo, in_progress, done, blocked, needs_review.',
-      'Record verification explicitly with {"action":"set_evidence","taskId":"b","evidence":[{"id":"tests","type":"test","result":"passed","summary":"Focused tests passed"},{"id":"probe","type":"external-check","result":"failed","summary":"The external probe failed"}]}. Results are passed, failed, inconclusive, informational.',
-      "set_evidence replaces the complete evidence collection: include prior failures when appending a result, or use [] to clear it. Evidence never changes task status, and status changes never create evidence.",
+      `Dependencies, resources, evidence and whole-plan replacement are in ${WORK_PLAN_EXTENDED_TOOL}. It appears as soon as this session has a plan.`,
       // Pointing a small model at `replace` for this was a trap: that action wants
       // a complete normalized document, down to a plan id and an updatedAt it
       // would have to invent. `clear` then `create` reaches the same state through
       // the compact form it already knows.
-      "A session holds one plan: to start a different one, clear it and create the new one. replace is for handing back a complete normalized document you already have.",
+      "A session holds one plan: to start a different one, clear it and create the new one.",
     ],
     parameters: workPlanParameters,
     executionMode: "sequential",
-    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      const mutation = params as never;
-      try {
-        const sessionFile = ctx.sessionManager.getSessionFile();
-        const plan = await applyWorkPlanMutation(sessionFile, mutation);
-        const action = (params as { action: string }).action;
-        const summary = plan === null
-          ? "This session has no Work Plan."
-          : `Work Plan \"${plan.title}\": ${plan.tasks.length} tasks (${plan.tasks.filter((task) => task.status === "done").length} done).`;
-        return {
-          // `details` drives authoritative UI synchronization but is not model
-          // context. A resumed agent must receive the complete working state in
-          // content; otherwise post-compaction `get` would expose only a counter.
-          content: [{ type: "text", text: (action === "get" || action === "create") && plan !== null ? `${summary}\n${JSON.stringify(plan)}` : summary }],
-          details: { type: "work_plan", sessionFile, plan, changed: action !== "get" },
-        };
-      } catch (error) {
-        return { content: [{ type: "text", text: `Work Plan update refused: ${error instanceof Error ? error.message : String(error)}` }], details: undefined, isError: true };
-      }
-    },
+    execute: executeWorkPlan(WORK_PLAN_TOOL),
+  };
+}
+
+/**
+ * The half a session without a plan is never shown. Every action it carries acts on a
+ * task that must already exist, so publishing it earlier would describe calls nobody
+ * could make — at the price of the largest shapes in the whole schema.
+ */
+export function createWorkPlanExtendedToolDefinition(): ToolDefinition {
+  return {
+    name: WORK_PLAN_EXTENDED_TOOL,
+    label: "Work Plan (extended)",
+    description: "Set the collections of one task in this session's Work Plan — dependencies, resources, verification evidence — or replace the whole plan with a complete normalized version-1 document. Create the plan with work_plan first; every action here acts on a task that already exists.",
+    promptSnippet: "Set dependencies, resources and evidence on the session's Work Plan",
+    promptGuidelines: [
+      'Record verification explicitly with {"action":"set_evidence","taskId":"b","evidence":[{"id":"tests","type":"test","result":"passed","summary":"Focused tests passed"},{"id":"probe","type":"external-check","result":"failed","summary":"The external probe failed"}]}. Results are passed, failed, inconclusive, informational.',
+      "set_evidence replaces the complete evidence collection: include prior failures when appending a result, or use [] to clear it. Evidence never changes task status, and status changes never create evidence.",
+      'Declare order with {"action":"set_dependencies","taskId":"b","dependsOn":["a"]} — the complete set for that task, replacing what it had.',
+      "replace is for handing back a complete normalized document you already have; to start a different plan, clear it with work_plan and create the new one.",
+    ],
+    parameters: workPlanExtendedParameters,
+    executionMode: "sequential",
+    execute: executeWorkPlan(WORK_PLAN_EXTENDED_TOOL),
   };
 }

--- a/server/src/workspace.ts
+++ b/server/src/workspace.ts
@@ -19,6 +19,7 @@ import fs from "node:fs/promises";
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import type { AgentRuntime } from "./agentRuntime.ts";
 import type { SandboxConfig } from "./config.ts";
+import { DOCUMENT_TOOLS } from "./documentTools.ts";
 import { type DirectoryWatcher, createDirectoryWatcher } from "./fileWatcher.ts";
 import { resolveBrowserRoot, resolveWritableRoot } from "./fileBrowser.ts";
 import { discoverRepos, whyGitCannotServe, type GitRepo } from "./git.ts";
@@ -137,6 +138,24 @@ export class Workspace {
   gitUnavailable: GitUnavailable | undefined;
   fileWatcher: DirectoryWatcher | undefined;
   sandboxedTools: ToolDefinition[] | undefined;
+
+  /**
+   * How many turns each published document extractor has gone unused, and whether it was
+   * ever used at all.
+   *
+   * A prompt naming `report.pdf` publishes `pdf_extract` before the turn goes out, and
+   * the tool then has to earn its place in every later request. Two thresholds, because
+   * the two silences mean different things: a tool that was **never** called was
+   * published on a wrong guess — a file that does not exist, a document named in passing
+   * — and goes at the end of that turn. One that **was** called is kept while the work
+   * around it continues, since extraction is rarely a single call, and is forgotten only
+   * once the conversation has plainly moved on.
+   *
+   * Naming the document again republishes it: that is the only way back, and it is the
+   * user's to take, since an agent cannot ask for a tool it can no longer see.
+   */
+  documentToolIdleTurns = new Map<string, number>();
+  documentToolsEverUsed = new Set<string>();
 
   /** Loaded from the runtime's session file by the caller; null until then. */
   workPlan: WorkPlan | null = null;
@@ -407,6 +426,22 @@ interface WorkspaceResources {
   sandboxedTools: ToolDefinition[] | undefined;
 }
 
+/**
+ * The document extractors, last, whatever order they were built in.
+ *
+ * They are the tools published mid-session, when a document enters the conversation. A
+ * caching provider re-reads its prompt prefix from the position of whatever changed, so
+ * a tool that arrives late belongs late in the list: registered fifth of fourteen,
+ * `pdf_extract` kept 9.2% of the prefix; last, everything ahead of it survives.
+ *
+ * A stable partition rather than a sort — the order of everything else is someone's
+ * decision and this is not the place to overturn it.
+ */
+function documentToolsLast(tools: ToolDefinition[]): ToolDefinition[] {
+  const documents = new Set<string>(DOCUMENT_TOOLS);
+  return [...tools.filter((tool) => !documents.has(tool.name)), ...tools.filter((tool) => documents.has(tool.name))];
+}
+
 async function buildResources(options: WorkspaceOptions): Promise<WorkspaceResources> {
   const { settings, limits } = options;
   const browserRoot = await resolveBrowserRoot(settings);
@@ -416,7 +451,7 @@ async function buildResources(options: WorkspaceOptions): Promise<WorkspaceResou
   // all", and it is the only thing that notices a repository git will refuse to read
   const gitUnavailable = await whyGitCannotServe(browserRoot, repos);
   const sandboxedTools = settings.sandbox
-    ? [
+    ? documentToolsLast([
         ...(await createSandboxedTools(
           settings.sandbox,
           limits.pdfMaxBytes,
@@ -426,7 +461,7 @@ async function buildResources(options: WorkspaceOptions): Promise<WorkspaceResou
           limits.structuredExchangeMaxBytes,
         )),
         ...options.unconfinedTools,
-      ]
+      ])
     : undefined;
   const fileWatcher = options.watchFiles
     ? createDirectoryWatcher({ root: browserRoot, onChange: options.onDirectoryChanged })

--- a/server/test/documentTools.test.ts
+++ b/server/test/documentTools.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Which extractors a prompt calls for. The four schemas are some 8 000 characters —
+ * around a quarter of a session's prompt floor — so what this decides is whether every
+ * later request in the conversation carries them.
+ */
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { DOCUMENT_TOOLS, documentToolsFor } from "../src/documentTools.ts";
+
+describe("documentToolsFor", () => {
+  test("a named document publishes its own extractor and no other", () => {
+    assert.deepEqual(documentToolsFor("Read report.pdf and summarise it"), ["pdf_extract"]);
+    assert.deepEqual(documentToolsFor("What does notes.docx say?"), ["docx_extract"]);
+    assert.deepEqual(documentToolsFor("Open budget.xlsx"), ["xlsx_extract"]);
+    assert.deepEqual(documentToolsFor("Check deck.pptx"), ["pptx_extract"]);
+  });
+
+  test("a mention is matched wherever a path can appear", () => {
+    // `@path` is what the composer appends for an attachment, absolute after the server
+    // resolves it; quotes and Windows separators are what users paste.
+    for (const text of [
+      "@/srv/projects/acme/report.pdf",
+      'open "my report.pdf"',
+      "C:\\\\Users\\\\laurent\\\\report.pdf",
+      "see ./docs/report.pdf, then tell me",
+      "read report.pdf.",
+    ]) {
+      assert.deepEqual(documentToolsFor(text), ["pdf_extract"], text);
+    }
+  });
+
+  test("case does not matter: a Windows share shouts", () => {
+    assert.deepEqual(documentToolsFor("@/mnt/share/Q3.XLSX please"), ["xlsx_extract"]);
+    assert.deepEqual(documentToolsFor("REPORT.PDF"), ["pdf_extract"]);
+  });
+
+  test("the word is not the path", () => {
+    // The whole point of the trigger. Publishing on the bare word would put all four
+    // back into every conversation that merely discusses documents.
+    for (const text of [
+      "convert this to PDF",
+      "the pdf spec is long",
+      "refactor src/pdf.ts",
+      "docx handling is a mess",
+      "we support pdf, docx, xlsx and pptx",
+    ]) {
+      assert.deepEqual(documentToolsFor(text), [], text);
+    }
+  });
+
+  test("two kinds in one prompt publish two tools, in registration order", () => {
+    assert.deepEqual(documentToolsFor("see notes.docx and slides.pptx"), ["docx_extract", "pptx_extract"]);
+    assert.deepEqual(documentToolsFor("a.pdf, b.docx."), ["pdf_extract", "docx_extract"]);
+  });
+
+  test("the same document twice publishes one tool", () => {
+    assert.deepEqual(documentToolsFor("compare a.pdf with b.pdf"), ["pdf_extract"]);
+  });
+
+  test("the exported set is what the server withholds and republishes", () => {
+    // A fifth extractor added to one list and not the other would be published to
+    // everyone forever, or withheld from everyone forever.
+    assert.deepEqual(DOCUMENT_TOOLS, ["pdf_extract", "docx_extract", "xlsx_extract", "pptx_extract"]);
+    for (const tool of DOCUMENT_TOOLS) {
+      const extension = tool.replace("_extract", "");
+      assert.deepEqual(documentToolsFor(`file.${extension}`), [tool], tool);
+    }
+  });
+});

--- a/server/test/documentToolsWire.test.mjs
+++ b/server/test/documentToolsWire.test.mjs
@@ -1,0 +1,129 @@
+/**
+ * The extractors, over a real server and a real embedded session: withheld until a
+ * document is named, published before the turn that names it goes out, and kept for the
+ * rest of the session.
+ *
+ * The assertions read the tool list the *provider* was sent. What the snapshot says the
+ * server published is a second-hand account; what the model received is the thing that
+ * costs tokens and the thing it can call.
+ */
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import { connect, makeWorkspace, startServer } from "./harness.mjs";
+
+const PROVIDER = fileURLToPath(new URL("./fixtures/document-tools-provider.mjs", import.meta.url));
+const EXTRACTORS = ["pdf_extract", "docx_extract", "xlsx_extract", "pptx_extract"];
+
+/**
+ * The tool names sent with each request that carried any, in order.
+ *
+ * Not every request is a turn: naming a session is a model call of its own, made with no
+ * tools at all. Counting raw requests puts the assertions one behind from the first turn
+ * onward.
+ */
+async function requests(logFile) {
+  const text = await readFile(logFile, "utf8").catch(() => "");
+  return text
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line))
+    .filter((tools) => tools.length > 0);
+}
+
+/**
+ * The nth request's tool list, once it exists.
+ *
+ * Counting `agent_end` frames to know which turn we are on is what the first draft did,
+ * and it is a race: the harness resolves a waiter against any received message the
+ * predicate accepts, so a count taken later matches an earlier frame. The log is the
+ * thing being asserted, so wait on the log.
+ */
+async function nthRequest(logFile, index, timeoutMs = 30_000) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const all = await requests(logFile);
+    if (all.length > index) return all[index];
+    if (Date.now() > deadline) throw new Error(`request ${index} never reached the model (${all.length} so far)`);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+}
+
+test("a document extractor is published when a document is named, and not before", async () => {
+  const root = await makeWorkspace({ "report.docx": "not really a docx\n" });
+  const log = path.join(root, "tools.jsonl");
+  const server = await startServer(
+    root,
+    {
+      extensionPaths: [PROVIDER],
+      allowedModels: [{ provider: "document-tools-test", id: "document-tools-test" }],
+    },
+    { env: { DOCUMENT_TOOLS_LOG: log } },
+  );
+  const client = connect(server.wsUrl());
+  try {
+    const hello = await client.waitFor("hello", 30_000);
+    // The workspace holds a .docx that nothing has named: containing one is not using one.
+    const published = hello.tools.filter((tool) => tool.active).map((tool) => tool.name);
+    for (const tool of EXTRACTORS) {
+      assert.ok(!published.includes(tool), `${tool} is withheld from a session that has named no document`);
+    }
+    assert.ok(published.includes("read"), "the rest of the toolset is untouched");
+
+    client.send({ type: "set_model", provider: "document-tools-test", id: "document-tools-test" });
+    await client.waitFor((message) => message.type === "model_changed");
+
+    // A turn that names nothing leaves them all withheld.
+    client.send({ type: "prompt", text: "Just say ok." });
+    const plain = await nthRequest(log, 0);
+    for (const tool of EXTRACTORS) assert.ok(!plain.includes(tool), `${tool} not sent for a prompt naming no document`);
+
+    // Naming one publishes its extractor, for the very turn that named it.
+    client.send({ type: "prompt", text: "Read report.docx and tell me what it says." });
+    const named = await nthRequest(log, 1);
+    assert.ok(named.includes("docx_extract"), "docx_extract reached the model on the turn that named the document");
+    for (const tool of ["pdf_extract", "xlsx_extract", "pptx_extract"]) {
+      assert.ok(!named.includes(tool), `${tool} stays withheld: no document of its kind was named`);
+    }
+
+    // Registered last, so a caching provider keeps everything ahead of them.
+    assert.equal(named.at(-1), "docx_extract", "the extractors sit at the end of the tool list");
+
+    // The turn named a document and never called the tool, so the guess is paid back:
+    // the next request carries none of them again.
+    client.send({ type: "prompt", text: "Thanks, nothing else." });
+    const after = await nthRequest(log, 2);
+    assert.ok(!after.includes("docx_extract"), "a tool published and never called is withdrawn at the end of the turn");
+
+    // Named *and used*: that one stays, because extraction is rarely a single call and
+    // an agent has no way to ask for a tool back.
+    client.send({ type: "prompt", text: "Read report.docx — USE THE TOOL." });
+    await nthRequest(log, 3);
+    const afterUse = await nthRequest(log, 4);
+    assert.ok(afterUse.includes("docx_extract"), "the tool is still there for the follow-up call in that turn");
+
+    // A tool that has been used survives the quiet turns around the work it belongs to...
+    let request = 5;
+    for (let turn = 1; turn <= 4; turn += 1) {
+      client.send({ type: "prompt", text: `Quiet turn ${turn}.` });
+      const during = await nthRequest(log, request++);
+      assert.ok(during.includes("docx_extract"), `a used tool survives ${turn} idle turn(s)`);
+      assert.ok(!during.includes("pdf_extract"), "and stays narrow");
+    }
+
+    // ...and is forgotten once the conversation has plainly moved on.
+    client.send({ type: "prompt", text: "Quiet turn 5." });
+    const forgotten = await nthRequest(log, request);
+    assert.ok(!forgotten.includes("docx_extract"), "five idle turns and a used tool is forgotten");
+
+    // Naming the document again brings it back: the only way back, and the user's to take.
+    client.send({ type: "prompt", text: "Look at report.docx once more." });
+    const republished = await nthRequest(log, request + 1);
+    assert.ok(republished.includes("docx_extract"), "naming the document republishes its extractor");
+  } finally {
+    client.close();
+    await server.stop();
+  }
+});

--- a/server/test/fixtures/document-tools-provider.mjs
+++ b/server/test/fixtures/document-tools-provider.mjs
@@ -1,0 +1,85 @@
+/**
+ * A provider that answers nothing and records everything: for each request, the names
+ * of the tools it was actually sent.
+ *
+ * Reading the server's snapshot would say what the server believes it published. This
+ * says what reached the model — which is the only thing that costs tokens, and the only
+ * thing that decides whether a tool can be called on the turn that needs it.
+ */
+import { createRequire } from "node:module";
+import { createAssistantMessageEventStream } from "@earendil-works/pi-ai/compat";
+
+const require = createRequire(import.meta.url);
+
+function record(context) {
+  const fs = require("node:fs");
+  const file = process.env.DOCUMENT_TOOLS_LOG;
+  if (!file) return;
+  fs.appendFileSync(file, `${JSON.stringify((context.tools ?? []).map((tool) => tool.name))}\n`);
+}
+
+/**
+ * When asked to, the model calls the extractor rather than answering — which is what
+ * separates a tool that earned its place from one published on a wrong guess.
+ */
+function wantsToolCall(context) {
+  const last = [...(context.messages ?? [])].reverse().find((item) => item.role === "user");
+  const text = JSON.stringify(last?.content ?? "");
+  return text.includes("USE THE TOOL") && (context.tools ?? []).some((tool) => tool.name === "docx_extract");
+}
+
+function stream(model, context) {
+  record(context);
+  if (wantsToolCall(context) && !(context.messages ?? []).some((item) => item.role === "toolResult")) {
+    const out = createAssistantMessageEventStream();
+    const call = { type: "toolCall", id: `doc-${Date.now()}`, name: "docx_extract", arguments: { path: "report.docx" } };
+    const partial = {
+      role: "assistant", content: [call], api: model.api, provider: model.provider, model: model.id,
+      usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+      stopReason: "toolUse", timestamp: Date.now(),
+    };
+    queueMicrotask(() => {
+      out.push({ type: "start", partial });
+      out.push({ type: "toolcall_start", contentIndex: 0, partial });
+      out.push({ type: "toolcall_end", contentIndex: 0, toolCall: call, partial });
+      out.push({ type: "done", reason: "toolUse", message: partial });
+    });
+    return out;
+  }
+  const out = createAssistantMessageEventStream();
+  const message = {
+    role: "assistant",
+    content: [{ type: "text", text: "ok" }],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+    stopReason: "stop",
+    timestamp: Date.now(),
+  };
+  queueMicrotask(() => {
+    out.push({ type: "start", partial: message });
+    out.push({ type: "text_start", contentIndex: 0, partial: message });
+    out.push({ type: "text_end", contentIndex: 0, content: "ok", partial: message });
+    out.push({ type: "done", reason: "stop", message });
+  });
+  return out;
+}
+
+export default function (pi) {
+  pi.registerProvider("document-tools-test", {
+    baseUrl: "http://127.0.0.1",
+    apiKey: "test",
+    api: "document-tools-test-api",
+    models: [{
+      id: "document-tools-test",
+      name: "Document Tools Test",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 16_000,
+      maxTokens: 1_000,
+    }],
+    streamSimple: stream,
+  });
+}

--- a/server/test/fixtures/work-plan-rpc-provider.mjs
+++ b/server/test/fixtures/work-plan-rpc-provider.mjs
@@ -22,9 +22,20 @@ function message(model, content, stopReason) {
   };
 }
 
-function assertWorkPlanSchema(context) {
+function assertWorkPlanSchema(context, { expectExtended }) {
   const tool = context.tools?.find((candidate) => candidate.name === "work_plan");
   if (!tool) throw new Error("work_plan was not exposed to the provider");
+  const extended = context.tools?.find((candidate) => candidate.name === "work_plan_extended");
+  // The whole point of the split, seen from where it matters: a provider serving a
+  // session with no plan is never sent the collection shapes.
+  //
+  // Only the embedded runtime can withhold it. Inside a real RPC child both tools are
+  // published at all times — that dialect has no command for the active toolset — so
+  // the absence is asserted only where the test says it should hold.
+  const gated = process.env.WORK_PLAN_EXPECT_GATED === "1";
+  if (expectExtended && !extended) throw new Error("work_plan_extended was not published once a plan existed");
+  if (gated && !expectExtended && extended) throw new Error("work_plan_extended reached a provider before any plan existed");
+
   const empty = [];
   const walk = (value, at) => {
     if (!value || typeof value !== "object" || Array.isArray(value)) return;
@@ -34,17 +45,32 @@ function assertWorkPlanSchema(context) {
       else walk(child, `${at}.${key}`);
     }
   };
-  walk(tool.parameters, "$parameters");
+  for (const published of [tool, ...(extended ? [extended] : [])]) {
+    walk(published.parameters, `$${published.name}`);
+    // One object whose `action` enumerates the operations — not a union of
+    // branches, whose failures pi reports all at once.
+    if (published.parameters.anyOf) throw new Error(`${published.name} provider schema is a union again`);
+  }
   if (empty.length > 0) throw new Error(`unconstrained work_plan schemas reached provider: ${empty.join(", ")}`);
-  // One object whose `action` enumerates the operations — not a union of
-  // branches, whose failures pi reports all at once.
-  if (tool.parameters.anyOf) throw new Error("work_plan provider schema is a union again");
+
   const actions = tool.parameters.properties?.action?.enum;
-  for (const action of ["get", "clear", "create", "replace", "add_task", "update_task", "move_task", "remove_task", "set_dependencies", "set_resources", "set_evidence"]) {
+  for (const action of ["get", "clear", "create", "add_task", "update_task", "move_task", "remove_task"]) {
     if (!actions?.includes(action)) throw new Error(`work_plan provider schema does not offer ${action}`);
   }
-  const evidence = tool.parameters.properties?.evidence;
-  if (evidence?.type !== "array" || evidence.maxItems !== 100) throw new Error("work_plan provider schema does not bound evidence");
+  for (const action of ["replace", "set_dependencies", "set_resources", "set_evidence"]) {
+    if (actions?.includes(action)) throw new Error(`work_plan provider schema still carries ${action}`);
+  }
+  // Creation describes titles and statuses, never the collections a task acquires later.
+  const creationTask = tool.parameters.properties?.tasks?.items?.properties;
+  if (creationTask?.evidence || creationTask?.resources) throw new Error("creation still advertises its collections");
+  if (!extended) return;
+
+  const extendedActions = extended.parameters.properties?.action?.enum;
+  for (const action of ["replace", "set_dependencies", "set_resources", "set_evidence"]) {
+    if (!extendedActions?.includes(action)) throw new Error(`work_plan_extended does not offer ${action}`);
+  }
+  const evidence = extended.parameters.properties?.evidence;
+  if (evidence?.type !== "array" || evidence.maxItems !== 100) throw new Error("work_plan_extended does not bound evidence");
   const record = evidence.items;
   if (record?.additionalProperties !== false) throw new Error("work_plan evidence accepts provider-specific fields");
   const results = record?.properties?.result?.enum;
@@ -61,11 +87,15 @@ function assertWorkPlanGuidance(context) {
 }
 
 function streamWorkPlan(model, context) {
-  assertWorkPlanSchema(context);
+  const results = context.messages.filter(
+    (item) => item.role === "toolResult" && (item.toolName === "work_plan" || item.toolName === "work_plan_extended"),
+  );
+  // Publication follows the plan, and the plan is made by the first call: every
+  // request after it must carry the extended tool, and the first must not.
+  assertWorkPlanSchema(context, { expectExtended: results.length > 0 });
   assertWorkPlanGuidance(context);
   const stream = createAssistantMessageEventStream();
   queueMicrotask(() => {
-    const results = context.messages.filter((item) => item.role === "toolResult" && item.toolName === "work_plan");
     if (results.length >= 5) {
       const output = message(model, [{ type: "text", text: "Plan updated." }], "stop");
       stream.push({ type: "start", partial: output });
@@ -83,9 +113,13 @@ function streamWorkPlan(model, context) {
         },
         {
           action: "add_task",
-          task: { id: "release-note", title: "Write release note", status: "todo", dependsOn: [], resources: [] },
+          // No `resources` here any more: the published schema is authoritative — pi
+          // validates a call against it before the handler ever runs — and the
+          // collections belong to work_plan_extended.
+          task: { id: "release-note", title: "Write release note", status: "todo", dependsOn: [] },
         },
         {
+          tool: "work_plan_extended",
           action: "set_evidence",
           taskId: createdPlan?.tasks?.[0]?.id,
           evidence: [
@@ -104,11 +138,12 @@ function streamWorkPlan(model, context) {
         },
         { action: "get" },
       ];
+      const { tool: calledTool = "work_plan", ...args } = argumentsByStep[results.length];
       const toolCall = {
         type: "toolCall",
         id: `real-rpc-work-plan-${results.length}`,
-        name: "work_plan",
-        arguments: argumentsByStep[results.length],
+        name: calledTool,
+        arguments: args,
       };
       const output = message(model, [toolCall], "toolUse");
       stream.push({ type: "start", partial: output });

--- a/server/test/piOutpostTools.test.ts
+++ b/server/test/piOutpostTools.test.ts
@@ -5,8 +5,10 @@
  * child. The child builds its own toolset from `PI_OUTPOST_TOOLS`, so a missing
  * or malformed value must stop startup with a message that names the setting,
  * rather than an agent that silently runs with the wrong (or no) extractors.
- * The wiring test guards parity: the seven tools the embedded runtime registers
- * are the same seven the child gets, built the same way.
+ * The wiring test guards parity: the eight tools the embedded runtime registers are
+ * the same eight the child gets, built the same way. `work_plan_extended` is among
+ * them here even though a child never withholds it — the RPC dialect has no command
+ * for the active toolset, so registration is parity and publication is not.
  */
 import assert from "node:assert/strict";
 import { mkdtemp, rm } from "node:fs/promises";
@@ -137,9 +139,9 @@ describe("createPiOutpostTools", () => {
     await Promise.all(roots.map((r) => rm(r, { recursive: true, force: true })));
   });
 
-  test("returns the seven tools the agent needs, in the documented order", async () => {
+  test("returns the eight tools the agent needs, in the documented order", async () => {
     const tools = await createPiOutpostTools({ cwd: root, maxBytes: VALID.maxBytes });
-    assert.equal(tools.length, 7);
+    assert.equal(tools.length, 8);
     const names = tools.map((t) => t.name);
     assert.deepEqual(names, [
       "pdf_extract",
@@ -149,6 +151,10 @@ describe("createPiOutpostTools", () => {
       "write_structure_figure",
       "present_structure",
       "work_plan",
+      // Registered, not necessarily published: the server withholds this one from a
+      // session with no plan through the SDK's active-tool set. A child registers it
+      // and publishes it always, which is the stated cost of that dialect.
+      "work_plan_extended",
     ]);
   });
 
@@ -196,14 +202,14 @@ describe("default export (extension entry)", () => {
     });
   }
 
-  test("registers the seven tools when the env var is set", async () => {
+  test("registers the eight tools when the env var is set", async () => {
     await withEnv(JSON.stringify({ cwd: root, maxBytes: VALID.maxBytes }), async () => {
       const registered: ToolDefinition[] = [];
       const pi = { registerTool: (t: ToolDefinition) => void registered.push(t) } as unknown as ExtensionAPI;
 
       await piOutpostExtension(pi);
 
-      assert.equal(registered.length, 7);
+      assert.equal(registered.length, 8);
       assert.deepEqual(
         registered.map((t) => t.name),
         [
@@ -214,6 +220,7 @@ describe("default export (extension entry)", () => {
           "write_structure_figure",
           "present_structure",
           "work_plan",
+          "work_plan_extended",
         ],
       );
     });

--- a/server/test/work-plan-server.test.mjs
+++ b/server/test/work-plan-server.test.mjs
@@ -404,10 +404,16 @@ test("a real Pi RPC child executes work_plan and synchronizes its persisted resu
 
 test("the embedded SDK provider receives the same fully typed work_plan schema", async () => {
   const root = await makeWorkspace();
-  const server = await startServer(root, {
-    extensionPaths: [WORK_PLAN_PROVIDER],
-    allowedModels: [{ provider: "work-plan-test", id: "work-plan-test" }],
-  });
+  const server = await startServer(
+    root,
+    {
+      extensionPaths: [WORK_PLAN_PROVIDER],
+      allowedModels: [{ provider: "work-plan-test", id: "work-plan-test" }],
+    },
+    // Embedded: this is the runtime that can withhold the extended tool, so this is
+    // where its absence before a plan is a contract rather than an accident.
+    { env: { WORK_PLAN_EXPECT_GATED: "1" } },
+  );
   const client = connect(server.wsUrl());
   try {
     const hello = await client.waitFor("hello", 30_000);

--- a/server/test/work-plan.test.ts
+++ b/server/test/work-plan.test.ts
@@ -4,10 +4,16 @@ import os from "node:os";
 import path from "node:path";
 import { describe, it } from "node:test";
 import { Compile } from "typebox/compile";
-import { isWorkPlanReadyForReview, mutateWorkPlan, normalizeWorkPlanDraft, validateWorkPlan, WORK_PLAN_LIMITS, type WorkPlan } from "@pi-outpost/shared/work-plan";
+import { isWorkPlanReadyForReview, mutateWorkPlan, normalizeWorkPlanDraft, validateWorkPlan, WORK_PLAN_ACTIONS, WORK_PLAN_LIMITS, type WorkPlan } from "@pi-outpost/shared/work-plan";
 import { applyWorkPlanMutation, copyWorkPlan, deleteWorkPlan, loadWorkPlan, sameSessionFile, workPlanPath } from "../src/workPlanStore.ts";
+import { EmbeddedRuntime } from "../src/embeddedRuntime.ts";
 import { WORK_PLAN_SYSTEM_GUIDANCE } from "../src/systemPrompt.ts";
-import { createWorkPlanToolDefinition } from "../src/workPlanTool.ts";
+import {
+  createWorkPlanExtendedToolDefinition,
+  createWorkPlanToolDefinition,
+  WORK_PLAN_COMMON_ACTIONS,
+  WORK_PLAN_EXTENDED_ACTIONS,
+} from "../src/workPlanTool.ts";
 
 const base = (): WorkPlan => ({
   version: 1,
@@ -643,47 +649,51 @@ describe("Work Plan persistence", () => {
 });
 
 describe("work_plan tool", () => {
-  it("publishes a bounded action-specific schema with no unconstrained payload", () => {
-    const schema = createWorkPlanToolDefinition().parameters as unknown as Record<string, unknown>;
-    const emptySchemas: string[] = [];
-    const walk = (value: unknown, at: string): void => {
-      if (typeof value !== "object" || value === null || Array.isArray(value)) return;
-      const record = value as Record<string, unknown>;
-      if (Object.keys(record).length === 0) emptySchemas.push(at);
-      for (const [key, child] of Object.entries(record)) {
-        if (Array.isArray(child)) child.forEach((item, index) => walk(item, `${at}.${key}[${index}]`));
-        else walk(child, `${at}.${key}`);
-      }
-    };
-    walk(schema, "$parameters");
-    assert.deepEqual(emptySchemas, [], `unconstrained schema nodes: ${emptySchemas.join(", ")}`);
+  it("publishes bounded action-specific schemas, in both tools, with no unconstrained payload", () => {
+    for (const definition of [createWorkPlanToolDefinition(), createWorkPlanExtendedToolDefinition()]) {
+      const schema = definition.parameters as unknown as Record<string, unknown>;
+      const emptySchemas: string[] = [];
+      const walk = (value: unknown, at: string): void => {
+        if (typeof value !== "object" || value === null || Array.isArray(value)) return;
+        const record = value as Record<string, unknown>;
+        if (Object.keys(record).length === 0) emptySchemas.push(at);
+        for (const [key, child] of Object.entries(record)) {
+          if (Array.isArray(child)) child.forEach((item, index) => walk(item, `${at}.${key}[${index}]`));
+          else walk(child, `${at}.${key}`);
+        }
+      };
+      walk(schema, `$${definition.name}`);
+      assert.deepEqual(emptySchemas, [], `unconstrained schema nodes: ${emptySchemas.join(", ")}`);
 
-    // One object, not a union: pi validates a call against the whole schema and
-    // reports every branch that rejected it, so a union answers one wrong
-    // property with one "must be equal to constant" per action the caller never
-    // asked for — and never names the property. See the tool's own comment.
-    assert.equal(schema.anyOf, undefined, "the root is a single object, not a union of actions");
-    assert.equal(schema.type, "object");
-    assert.deepEqual(schema.required, ["action"]);
-    assert.equal(schema.additionalProperties, false);
+      // One object, not a union: pi validates a call against the whole schema and
+      // reports every branch that rejected it, so a union answers one wrong
+      // property with one "must be equal to constant" per action the caller never
+      // asked for — and never names the property. See the tool's own comment.
+      assert.equal(schema.anyOf, undefined, "the root is a single object, not a union of actions");
+      assert.equal(schema.type, "object");
+      assert.deepEqual(schema.required, ["action"]);
+      assert.equal(schema.additionalProperties, false);
+    }
 
-    const properties = schema.properties as Record<string, Record<string, unknown>>;
-    assert.deepEqual(
-      properties.action.enum,
-      ["get", "create", "replace", "add_task", "update_task", "move_task", "remove_task", "set_dependencies", "set_resources", "set_evidence", "clear"],
-      "every action is one enum node, so an unknown action fails once",
-    );
-    // Each operation-specific argument says which actions use it, since the
-    // schema no longer separates them into branches.
-    for (const [field, action] of [
-      ["title", /create/], ["tasks", /create/], ["plan", /replace/], ["task", /add_task/],
-      ["taskId", /update_task/], ["parentId", /move_task/],
-      ["dependsOn", /set_dependencies/], ["resources", /set_resources/], ["evidence", /set_evidence/],
+    const common = (createWorkPlanToolDefinition().parameters as unknown as Record<string, unknown>)
+      .properties as Record<string, Record<string, unknown>>;
+    const extended = (createWorkPlanExtendedToolDefinition().parameters as unknown as Record<string, unknown>)
+      .properties as Record<string, Record<string, unknown>>;
+    assert.deepEqual(common.action.enum, [...WORK_PLAN_COMMON_ACTIONS]);
+    assert.deepEqual(extended.action.enum, [...WORK_PLAN_EXTENDED_ACTIONS]);
+
+    // Each operation-specific argument says which actions use it, since neither
+    // schema separates them into branches.
+    for (const [properties, field, action] of [
+      [common, "title", /create/], [common, "tasks", /create/], [common, "task", /add_task/],
+      [common, "taskId", /update_task/], [common, "parentId", /move_task/],
+      [extended, "plan", /replace/], [extended, "dependsOn", /set_dependencies/],
+      [extended, "resources", /set_resources/], [extended, "evidence", /set_evidence/],
     ] as const) {
       assert.match(String(properties[field].description), action, `${field} names the action that uses it`);
     }
 
-    let tasks = properties.tasks;
+    let tasks = common.tasks;
     assert.match(String(tasks.description), /500 tasks total.*65536 serialized bytes/);
     for (let depth = 1; depth <= 2; depth += 1) {
       assert.equal(tasks.maxItems, WORK_PLAN_LIMITS.tasks, `task collection at depth ${depth} exposes its ceiling`);
@@ -691,11 +701,13 @@ describe("work_plan tool", () => {
       assert.deepEqual(draft.required, ["title"]);
       const taskProperties = draft.properties as Record<string, Record<string, unknown>>;
       assert.deepEqual(taskProperties.status.enum, ["todo", "in_progress", "done", "blocked", "needs_review"]);
-      assert.equal(taskProperties.evidence.type, "array");
-      assert.equal(taskProperties.evidence.maxItems, WORK_PLAN_LIMITS.evidencePerTask);
       // A plan that has dependencies says so where it is written, in one call.
       assert.equal(taskProperties.dependsOn.type, "array");
       assert.match(String(taskProperties.dependsOn.description), /same call/);
+      // ...and what a task acquires later is not described here. The collections are
+      // the largest shapes in this schema and they belong to the tool that sets them.
+      assert.equal(taskProperties.evidence, undefined, `creation at depth ${depth} does not advertise evidence`);
+      assert.equal(taskProperties.resources, undefined, `creation at depth ${depth} does not advertise resources`);
       if (depth < 2) tasks = taskProperties.subtasks;
       else assert.equal(taskProperties.subtasks, undefined, "subtasks cannot nest again");
     }
@@ -703,40 +715,67 @@ describe("work_plan tool", () => {
     // `update_task` takes its fields beside `taskId`. The `changes` wrapper said the
     // same thing a second way and is no longer advertised — the normaliser still
     // honours one that arrives, but the schema stops paying 1.2k characters for it.
-    assert.equal(properties.changes, undefined, "the redundant changes wrapper is not published");
+    assert.equal(common.changes, undefined, "the redundant changes wrapper is not published");
     for (const field of ["description", "statusReason", "parentId"]) {
       assert.ok(
-        (properties[field].anyOf as Array<Record<string, unknown>>).some((candidate) => candidate.type === "null"),
+        (common[field].anyOf as Array<Record<string, unknown>>).some((candidate) => candidate.type === "null"),
         `${field} declares JSON null clearing`,
       );
     }
   });
 
-  /**
-   * The schema is sent on every turn of every conversation, whether or not a plan
-   * is ever made. It was 16 160 characters — some 4k tokens, more than everything
-   * pi sends by default and 37% of this deployment's whole baseline — of which 2.5k
-   * was 73 copies of one regex and 1.2k a second way to spell `update_task`.
-   *
-   * The ceiling is what stops that coming back one property at a time. Raising it
-   * is allowed; doing so silently is what this is here to prevent. Re-measure with
-   * `npx tsx server/scripts/probe-context-baseline.mts`.
-   */
-  it("keeps the published definition under its context budget", () => {
-    const definition = createWorkPlanToolDefinition();
-    const size = JSON.stringify(definition).length;
-    assert.ok(
-      size <= 13_000,
-      `work_plan is ${size} characters (~${Math.round(size / 4 / 100) / 10}k tokens), over the 13 000 budget`,
+  it("gives every action exactly one home, and says where when asked of the wrong tool", async () => {
+    // Checked against the enumerated actions rather than a list written here: a new
+    // action must land in one of the tools on purpose, not be forgotten by both.
+    const homes = new Map<string, string[]>();
+    for (const action of WORK_PLAN_ACTIONS) {
+      const carriers = [
+        ...(WORK_PLAN_COMMON_ACTIONS.includes(action as never) ? ["work_plan"] : []),
+        ...(WORK_PLAN_EXTENDED_ACTIONS.includes(action as never) ? ["work_plan_extended"] : []),
+      ];
+      homes.set(action, carriers);
+    }
+    for (const [action, carriers] of homes) {
+      assert.equal(carriers.length, 1, `${action} is carried by exactly one tool, not ${carriers.length}`);
+    }
+
+    const refused = await createWorkPlanToolDefinition().execute(
+      "call-wrong-tool",
+      { action: "set_evidence", taskId: "build", evidence: [] },
+      undefined,
+      undefined,
+      { sessionManager: { getSessionFile: () => "/nowhere/session.jsonl" } } as never,
     );
+    assert.equal(refused.isError, true);
+    const text = (refused.content as Array<{ text: string }>)[0].text;
+    assert.match(text, /set_evidence/, "the refusal names the action");
+    assert.match(text, /work_plan_extended/, "and the tool that carries it");
   });
 
-  it("publishes finite evidence schemas for creation, replacement, addition, and mutation", () => {
-    const schema = createWorkPlanToolDefinition().parameters as unknown as Record<string, unknown>;
+  it("keeps each published definition under its context budget", () => {
+    // The schemas are sent on every request of every conversation. `work_plan` is the
+    // one a session with no plan pays for, so it carries the tighter ceiling; the
+    // extended tool is only published where its actions are possible. Raising either
+    // is allowed, raising one silently is what this prevents. Re-measure with
+    // `npx tsx server/scripts/probe-context-baseline.mts`.
+    for (const [definition, budget] of [
+      [createWorkPlanToolDefinition(), 5_200],
+      [createWorkPlanExtendedToolDefinition(), 6_000],
+    ] as const) {
+      const size = JSON.stringify(definition).length;
+      assert.ok(size <= budget, `${definition.name} is ${size} characters, over its ${budget} budget`);
+    }
+  });
+
+  it("publishes finite evidence schemas where evidence can be set", () => {
+    // Creation and addition no longer describe evidence at all; replacement and
+    // set_evidence do, and both live in the extended tool. Every one of them is
+    // bounded — an unbounded collection is how a plan grows past its own ceiling.
+    const schema = createWorkPlanExtendedToolDefinition().parameters as unknown as Record<string, unknown>;
     const properties = schema.properties as Record<string, Record<string, unknown>>;
-    const creationEvidence = ((properties.tasks.items as Record<string, unknown>).properties as Record<string, Record<string, unknown>>).evidence;
-    const completeEvidence = (((properties.task.properties as Record<string, Record<string, unknown>>).evidence));
-    for (const evidence of [creationEvidence, completeEvidence, properties.evidence]) {
+    const planTasks = (properties.plan.properties as Record<string, Record<string, unknown>>).tasks;
+    const replacementEvidence = ((planTasks.items as Record<string, unknown>).properties as Record<string, Record<string, unknown>>).evidence;
+    for (const evidence of [replacementEvidence, properties.evidence]) {
       assert.equal(evidence.type, "array");
       assert.equal(evidence.maxItems, WORK_PLAN_LIMITS.evidencePerTask);
       const record = evidence.items as Record<string, unknown>;
@@ -749,14 +788,19 @@ describe("work_plan tool", () => {
       assert.equal(recordProperties.summary.maxLength, WORK_PLAN_LIMITS.evidenceSummary);
       assert.equal((recordProperties.reference as Record<string, unknown>).additionalProperties, false);
     }
+  });
 
-    const validator = Compile(createWorkPlanToolDefinition().parameters as never);
-    const summaryOnly = { id: "tests", type: "test", result: "passed", summary: "All pass" };
-    const referenceOnly = { id: "report", type: "file", result: "informational", reference: { uri: "workspace:report.json" } };
-    assert.equal(validator.Check({ action: "create", title: "Evidence", tasks: [{ title: "Verify", evidence: [summaryOnly, referenceOnly] }] }), true);
-    assert.equal(validator.Check({ action: "set_evidence", taskId: "verify", evidence: [summaryOnly, referenceOnly] }), true);
-    assert.equal(validator.Check({ action: "set_evidence", taskId: "verify", evidence: [{ id: "empty", type: "test", result: "passed" }] }), false);
-    assert.equal(validator.Check({ action: "set_evidence", taskId: "verify", evidence: [{ ...summaryOnly, provider: "openlore" }] }), false);
+  it("still normalises a creation draft that carries evidence, though it no longer advertises it", () => {
+    // The advertisement went; the contract did not. A client written against the
+    // previous schema keeps working, which is what makes this a cheaper prompt
+    // rather than a breaking change.
+    const plan = mutateWorkPlan(null, {
+      action: "create",
+      title: "Ship it",
+      tasks: [{ title: "Build", evidence: [{ id: "t", type: "test", result: "passed", summary: "green" }], resources: [{ uri: "workspace:src/index.ts" }] }],
+    } as never);
+    assert.equal(plan?.tasks[0].evidence.length, 1);
+    assert.equal(plan?.tasks[0].resources.length, 1);
   });
 
   it("publishes no pattern at all, so there is none to anchor", () => {
@@ -859,7 +903,9 @@ describe("work_plan tool", () => {
   });
 
   it("ships valid evidence guidance with explicit replacement and status independence", () => {
-    const tool = createWorkPlanToolDefinition();
+    // On the tool that carries evidence: guidance follows the actions it describes,
+    // so a session that cannot set evidence is not told how to.
+    const tool = createWorkPlanExtendedToolDefinition();
     const example = (tool.promptGuidelines ?? []).find((line) => line.includes('"action":"set_evidence"'));
     assert.ok(example, "the guidelines carry a literal evidence call");
     const call = JSON.parse(example.slice(example.indexOf("{"), example.lastIndexOf("}") + 1));
@@ -892,8 +938,11 @@ describe("work_plan tool", () => {
       const sessionFile = path.join(root, "session.jsonl");
       await fs.writeFile(sessionFile, "original conversation\n");
       const tool = createWorkPlanToolDefinition();
+      // `replace` is the extended tool's; both write through the same store, which is
+      // the point of the split being in what is published rather than in what runs.
+      const extended = createWorkPlanExtendedToolDefinition();
       const ctx = { sessionManager: { getSessionFile: () => sessionFile } } as never;
-      const replaced = await tool.execute("call-1", { action: "replace", plan: base() }, undefined, undefined, ctx);
+      const replaced = await extended.execute("call-1", { action: "replace", plan: base() }, undefined, undefined, ctx);
       assert.equal((replaced.details as { type: string }).type, "work_plan");
       await fs.writeFile(sessionFile, "compacted conversation summary\n");
       const restored = await tool.execute("call-resume", { action: "get" }, undefined, undefined, ctx);
@@ -944,5 +993,63 @@ describe("work_plan tool", () => {
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }
+  });
+});
+
+describe("publishing the extended tool", () => {
+  /**
+   * A stand-in for the SDK session, exposing only what publication touches. The real
+   * `setActiveToolsByName` rebuilds the system prompt around the set it is given —
+   * which is why withholding a tool withholds its schema, and why this is worth doing
+   * at all.
+   */
+  function fakeSession(registered: string[], active: string[]) {
+    let current = [...active];
+    return {
+      calls: [] as string[][],
+      getToolDefinition: (name: string) => (registered.includes(name) ? ({ name } as never) : undefined),
+      getActiveToolNames: () => [...current],
+      setActiveToolsByName(names: string[]) {
+        current = [...names];
+        this.calls.push([...names]);
+      },
+    };
+  }
+
+  /**
+   * The real method, on a real `EmbeddedRuntime`, over a stand-in session. Re-implementing
+   * it here would test the copy: what has to hold is that *this* code adds and removes the
+   * right name and leaves the rest of the set alone.
+   */
+  function setToolPublished(session: ReturnType<typeof fakeSession>, name: string, published: boolean): boolean {
+    const runtime = new EmbeddedRuntime({ session } as never, "/nowhere");
+    return runtime.setToolPublished(name, published);
+  }
+
+  it("adds the extended tool to the active set and takes nothing else out", () => {
+    const session = fakeSession(["read", "work_plan", "work_plan_extended"], ["read", "work_plan"]);
+    assert.equal(setToolPublished(session, "work_plan_extended", true), true);
+    assert.deepEqual(session.calls, [["read", "work_plan", "work_plan_extended"]]);
+  });
+
+  it("withdraws it again when the plan is cleared, leaving the common tool published", () => {
+    const session = fakeSession(["read", "work_plan", "work_plan_extended"], ["read", "work_plan", "work_plan_extended"]);
+    assert.equal(setToolPublished(session, "work_plan_extended", false), true);
+    assert.deepEqual(session.calls, [["read", "work_plan"]]);
+  });
+
+  it("does nothing when the set already says what it should", () => {
+    // Publication is derived from the plan at every point the plan can change, so it
+    // is asked for far more often than it changes. Rebuilding the system prompt each
+    // time would invalidate the provider's prefix cache for no reason.
+    const session = fakeSession(["work_plan", "work_plan_extended"], ["work_plan"]);
+    assert.equal(setToolPublished(session, "work_plan_extended", false), true);
+    assert.deepEqual(session.calls, [], "no toolset rebuild");
+  });
+
+  it("reports that it could not publish a tool the session never registered", () => {
+    const session = fakeSession(["work_plan"], ["work_plan"]);
+    assert.equal(setToolPublished(session, "work_plan_extended", true), false);
+    assert.deepEqual(session.calls, []);
   });
 });


### PR DESCRIPTION
Implements #163. **Based on #162** — that branch is the base, so this diff is only the split.

## Measured

| | chars | ~tokens |
|---|---|---|
| `work_plan` before this change | 12 480 | ~3.1k |
| `work_plan` now (a session with no plan) | **5 003** | **~1.3k** |
| both tools (a session with a plan) | 10 404 | ~2.6k |

Resting baseline, from `server/scripts/probe-context-baseline.mts`: **~9.8k → ~7.8k tokens** — within a rounding error of opencode's 7.6k, while carrying document extraction, structured results and work plans.

## The line

`work_plan` keeps `get`, `create`, `add_task`, `update_task`, `move_task`, `remove_task`, `clear`. `work_plan_extended` takes `replace`, `set_dependencies`, `set_resources`, `set_evidence` — and is published only while the session has a plan, because every one of those acts on a task that must already exist. Evidence and resources also leave the creation *and* added-task shapes; they were inlined once per nesting level.

One executor serves both: the split is in what is published, never in what is validated or stored.

## Two things this turned up

**Publication has to be synchronous.** Doing it from the queued sidecar reload was too late — the agent's next request goes out before that read finishes, so a plan created mid-turn left the extended tool unpublished for the very call that needed it. The live provider test caught it (`work_plan_extended was not published once a plan existed`); it now publishes from the plan the tool result already carries.

**The schema is authoritative, not a hint.** pi validates a tool call against the published schema *before* the handler runs. So withdrawing a property is a real narrowing for an agent even where `mutateWorkPlan` still accepts it — #162's comment claimed a model sending the old shape would be honoured, and that was wrong. Corrected in the code comment, the spec text and the tests.

## Proof

- `work-plan.test.ts` (53 pass): both schemas bounded and budgeted, action enums partition `WORK_PLAN_ACTIONS`, an action asked of the wrong tool is refused **by name**, creation advertises no collections while the store still normalises them, and the real `EmbeddedRuntime.setToolPublished` is driven over a stand-in session.
- `work-plan-server.test.mjs` (4 pass): the assertions run **inside a real model provider**, on the tools it was actually sent — extended absent before any plan, present after, and called in the same turn. The RPC test proves both tools reach a real `pi --mode rpc` child, ungated.
- `pi-rpc`, `extensionPathsWire`, `pi-rpc-server`, `sandbox-tools`, `toolProgress`, `agent-runtime-config`: 43 + 131 pass.
- `openspec validate --strict` valid; `check:scenarios` clean, 13 scenarios.

## Still open, and deliberately so

Task 5 of the change: **no test says whether a model finds `work_plan_extended` after knowing `work_plan`.** The mechanism is proven; its use by a real model is not, and a scripted provider cannot stand in for that. It wants a live run and a read of the transcript.

RPC publishes both tools always — that dialect has no command for the active toolset, and `RpcRuntime.setToolPublished` returns `false` rather than pretending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PryLsHtHcqbkjAqsxVH8rQ