### PR TITLE
openspec: publish a document extractor when its document arrives

### DIFF
--- a/openspec/changes/publish-a-document-extractor-when-a-document-arrives/.openspec.yaml
+++ b/openspec/changes/publish-a-document-extractor-when-a-document-arrives/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-03

--- a/openspec/changes/publish-a-document-extractor-when-a-document-arrives/design.md
+++ b/openspec/changes/publish-a-document-extractor-when-a-document-arrives/design.md
@@ -1,0 +1,53 @@
+## The trigger, and why it is the document rather than the workspace
+
+Three candidates were on the table.
+
+**The workspace containing such a file.** Decided once at session bind, so the toolset
+never changes mid-conversation and no prefix is ever invalidated. Rejected: a repository
+with a `docs/` folder, a `README.pdf`, one stray `.xlsx` in a fixtures directory would
+publish all four for every session, including the ones refactoring TypeScript. It
+optimises for the presence of a document rather than the use of one, which is the case
+this change exists to stop.
+
+**An opener** — one small tool that publishes the right extractor on request, the pattern
+opencode uses for skills. Rejected for the same reason it was rejected for the Work Plan:
+it charges a round trip on the path that is already the point, and here the round trip
+would land in the middle of "read this file for me".
+
+**The document entering the conversation.** What is implemented. The composer already
+appends every referenced file as an `@path` mention before sending (see the `SendMessage`
+requirement), and an uploaded document is written into the workspace and attached as a
+path rather than as content. So the prompt the server receives names the file, and naming
+it is exactly the moment the tool becomes useful.
+
+## Where the decision is made
+
+On the prompt path, before the turn is dispatched: the server reads the outgoing text for
+paths ending in the four extensions and publishes the matching tools. The turn then goes
+out with them.
+
+It is deliberately a **text** trigger rather than a filesystem one. The file may not exist
+yet, may be outside the sandbox, may be a broken path — none of which matters: what the
+tool costs is being described, and what makes describing it worthwhile is that the
+conversation has turned to a document of that kind. A wrong guess publishes a tool that
+goes unused for the rest of the session, which is the same position we are in today.
+
+Publication is sticky: once a session has seen a PDF it keeps `pdf_extract`. Withdrawing
+it again would invalidate the prefix a second time for no gain, and a conversation that
+has handled one document usually handles another.
+
+## Registration order
+
+The four are registered after every other tool. On a provider that caches prefixes, the
+invalidation from publishing one starts at its position in the tool list, so a tool
+registered fifth of fourteen invalidates almost everything: `pdf_extract` currently sits
+there and its publication would keep only 9.2% of the prefix. Registered last, the
+definitions ahead of it survive.
+
+This changes nothing on a provider that does not cache — which includes the deployment
+these figures come from — and costs nothing on one that does.
+
+## What it does not reach
+
+The RPC runtime, which has no command for the active toolset and publishes everything it
+was launched with. Stated, not emulated: the embedded SDK runtime is the supported target.

--- a/openspec/changes/publish-a-document-extractor-when-a-document-arrives/proposal.md
+++ b/openspec/changes/publish-a-document-extractor-when-a-document-arrives/proposal.md
@@ -1,0 +1,74 @@
+## Why
+
+Four tool definitions — `pdf_extract`, `docx_extract`, `xlsx_extract`, `pptx_extract` —
+come to **8 249 characters, ~2.1k tokens**, and they are sent on every request of every
+conversation. On a resting baseline of ~7.8k tokens that is better than a quarter of the
+floor, spent describing how to read Word, Excel, PowerPoint and PDF files to a session
+that is refactoring TypeScript and will never open one.
+
+Measured on 2026-09-03:
+
+| Tool | chars | ~tokens |
+|---|---|---|
+| `xlsx_extract` | 2 345 | ~0.6k |
+| `docx_extract` | 2 027 | ~0.5k |
+| `pdf_extract` | 1 944 | ~0.5k |
+| `pptx_extract` | 1 933 | ~0.5k |
+
+The same reasoning that split the Work Plan contract applies, with one difference worth
+being honest about: a Work Plan operation is *impossible* without a plan, whereas an
+extractor is merely *useless* without a document. So the trigger cannot be a
+prerequisite — it has to be the document itself arriving.
+
+## What Changes
+
+- An extractor is published when a document of its kind **enters the conversation**: a
+  file attached through the composer, or a path to one named in the message being sent.
+  Publication happens before the turn goes out, so the tool is there for the call that
+  needs it.
+- Once published, it stays for the rest of the session. A conversation that has handled
+  one PDF will handle another.
+- A session bound to a workspace publishes none of them until this happens. **Not** on the
+  workspace merely containing such a file: a repository with a `docs/` folder would then
+  pay for four tools while its agent refactors code, which is the case this change exists
+  to stop.
+- The four definitions are registered **last**, after every other tool. It changes nothing
+  for a provider that does not cache prompts, and on one that does it keeps every
+  definition ahead of them out of the invalidation.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- None. -->
+
+### Modified Capabilities
+
+- `agent`: what a session publishes becomes a function of what has entered the
+  conversation, for the document extractors.
+
+## Impact
+
+- **Server** — `server/src/index.ts` (registration order, and the publication call on the
+  prompt path), `server/src/workspace.ts` if the composer upload path lives there.
+- **No wire change, no client change.** The composer already uploads a document into the
+  workspace and attaches it as a path.
+- **Expected** — a resting baseline of ~7.8k tokens down to **~5.7k** for a session that
+  never touches a document.
+
+## The cost this carries, stated
+
+Publishing a tool mid-conversation changes the prompt prefix, and a provider that caches
+prefixes must re-read everything from the changed point onward — the tools after it, the
+system prompt, and the entire conversation so far.
+
+- On the deployment this was measured against, the question does not arise:
+  `mistral/devstral-medium-latest` reports `cacheRead: 0, cacheWrite: 0`. Nothing is
+  cached, every turn pays for the whole prompt, and these 2.1k are pure loss on every turn
+  that does not use them.
+- On a provider that does cache, the trade is: a conversation that never touches a
+  document saves the definitions outright; one that does pays a single invalidation whose
+  size grows with the history behind it. It is a bet on how often documents appear, and
+  for a code workspace that is rarely.
+
+Registering the four last is what makes the bet cheaper without changing anything else.

--- a/openspec/changes/publish-a-document-extractor-when-a-document-arrives/specs/agent/spec.md
+++ b/openspec/changes/publish-a-document-extractor-when-a-document-arrives/specs/agent/spec.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: A document extractor is published when a document arrives
+
+The document extraction tools SHALL be published to a session only once a document of their
+kind has entered the conversation. A session that has seen none SHALL publish none of them.
+
+A document enters the conversation when the prompt being sent names a path of that kind —
+which covers both a file attached through the composer, since an attached document is
+written into the workspace and referenced by path, and a file the user names in their own
+words. Publication SHALL happen before the turn is dispatched, so the tool is available to
+the call that needs it rather than after a refusal.
+
+Publication SHALL be sticky for the rest of the session: a conversation that has handled one
+document of a kind keeps that tool.
+
+The tools SHALL NOT be published on the strength of the workspace merely containing such a
+file. A repository with a documents folder would otherwise pay for every extractor in every
+session, including the ones that only ever touch code — which is the cost this requirement
+exists to remove.
+
+These definitions SHALL be registered after every other tool. Where a provider caches prompt
+prefixes, publishing a tool invalidates the prefix from that tool's position onward, so the
+ones that appear late in a session belong late in the list.
+
+Where a runtime cannot change its published toolset — the RPC dialect has no command for it —
+that runtime SHALL publish all of them at all times rather than emulate the gating.
+
+#### Scenario: A code session publishes no extractor
+- **GIVEN** a session whose conversation has named no document
+- **WHEN** the agent's toolset is composed
+- **THEN** none of the document extraction tools is published
+
+#### Scenario: Naming a document publishes its extractor, before the turn
+- **GIVEN** a session publishing no extractor
+- **WHEN** the user sends a prompt naming a `.docx` path
+- **THEN** the extractor for that kind is published before the turn is dispatched
+- **AND** the extractors for the other kinds are not
+
+#### Scenario: An attached document publishes its extractor
+- **GIVEN** a document attached through the composer, written into the workspace and referenced by path
+- **WHEN** the prompt is sent
+- **THEN** the extractor for that kind is published
+
+#### Scenario: Publication survives the rest of the session
+- **GIVEN** a session that published an extractor after a document was named
+- **WHEN** later prompts name no document
+- **THEN** that extractor stays published
+
+#### Scenario: A workspace holding documents publishes nothing by itself
+- **GIVEN** a workspace containing a `.pdf` that no prompt has named
+- **WHEN** a session is bound to it
+- **THEN** no document extraction tool is published
+
+#### Scenario: The word is not the path
+- **WHEN** a prompt discusses PDFs without naming a path of that kind
+- **THEN** no extractor is published
+
+#### Scenario: A runtime that cannot gate publishes them all
+- **GIVEN** a workspace served by the RPC runtime
+- **WHEN** the agent's toolset is composed
+- **THEN** every document extraction tool is published, as that dialect cannot change its active toolset

--- a/openspec/changes/publish-a-document-extractor-when-a-document-arrives/tasks.md
+++ b/openspec/changes/publish-a-document-extractor-when-a-document-arrives/tasks.md
@@ -1,0 +1,27 @@
+## 1. Register the extractors last
+
+- [ ] 1.1 In `server/src/index.ts`, order the custom tools so the four extractors come after every other definition, in both the sandboxed and unsandboxed paths. A test pins the order, with the reason: what is published late should sit late.
+
+## 2. Publish on arrival
+
+- [ ] 2.1 A `documentToolsFor(text)` helper in the server: the extensions a prompt names, mapped to tool names. `.pdf` → `pdf_extract`, `.docx` → `docx_extract`, `.xlsx` → `xlsx_extract`, `.pptx` → `pptx_extract`, case-insensitive, matched on a path-like token rather than anywhere in prose.
+- [ ] 2.2 Called on the prompt path before the turn is dispatched, publishing through `AgentRuntime.setToolPublished` — the same seam the Work Plan split added.
+- [ ] 2.3 Sticky for the session: a tool once published is never withdrawn.
+- [ ] 2.4 The initial active set excludes all four, unless the runtime cannot gate.
+
+## 3. Proof
+
+- [ ] 3.1 Unit: `documentToolsFor` — a `.docx` mention publishes one tool and not the other three; `report.pdf` and `@/srv/report.PDF` both match; the word "pdf" in prose does not; a prompt naming two kinds publishes two.
+- [ ] 3.2 Unit: registration order puts the four last.
+- [ ] 3.3 Wire: a real embedded session — the snapshot's tool inventory carries none of the four, then a prompt naming a `.docx` and the inventory carries `docx_extract` and still not the others.
+- [ ] 3.4 Wire: the tool is published *before* the turn goes out, asserted from inside a provider that reads the tools it was actually sent — the Work Plan split proved this ordering matters and a queued publication is too late.
+- [ ] 3.5 Measure: `server/scripts/probe-context-baseline.mts`, resting baseline ~7.8k → ~5.7k tokens.
+
+## 4. Prove the agent copes
+
+- [ ] 4.1 A live run: attach a real `.docx` through the composer and ask for its content. Read the transcript — the tool must be there for the first call, not discovered after a refusal.
+
+## 5. Validation
+
+- [ ] 5.1 `scenario-coverage.md` for every scenario in the delta.
+- [ ] 5.2 `npm run check:scenarios`, `openspec validate --strict`, the **full** server suite — this branch's two CI failures both came from files a partial local run never touched.


### PR DESCRIPTION
**Proposal only — no code, tasks unchecked.**

`pdf_extract`, `docx_extract`, `xlsx_extract` and `pptx_extract` come to **8 249 characters, ~2.1k tokens**, sent on every request of every conversation. On a ~7.8k resting baseline that is better than a quarter of the floor, spent describing how to read Word, Excel, PowerPoint and PDF to a session that is refactoring TypeScript.

## The trigger

**The document entering the conversation** — not the workspace containing one. A repository with a `docs/` folder or a stray `README.pdf` would otherwise publish all four in every session, including the ones that only touch code; that optimises for presence rather than use, and is the cost this change exists to remove.

The composer already appends every referenced file as an `@path` mention, and an attached document is written into the workspace and referenced by path rather than inlined. So the prompt the server receives names the file, and naming it is the moment the tool becomes worth describing. Publication happens **before the turn is dispatched** — the Work Plan split proved a queued publication is too late — and is sticky for the session.

An opener tool was rejected: it charges a round trip in the middle of "read this file for me".

## Measured, and stated in the proposal

Publishing a tool mid-conversation invalidates a caching provider's prefix from that tool's position onward — tools after it, the system prompt, and the whole history:

| Published mid-conversation | prefix kept |
|---|---|
| `pdf_extract` (5th of 14 today) | **9.2%** |
| `docx_extract` | 14.5% |
| `work_plan_extended` (last) | 60.9% |

Hence: register the four **last**. Free on a provider that does not cache, and it keeps every definition ahead of them out of the invalidation on one that does.

**On the deployment these figures come from, the question does not arise**: `mistral/devstral-medium-latest` reports `cacheRead: 0, cacheWrite: 0` — nothing is cached, every turn pays for the whole prompt, and these 2.1k are pure loss on every turn that does not use them. Where a provider does cache, the trade is a bet on how often documents appear, and the proposal says so rather than hiding it.

## Expected

Resting baseline ~7.8k → **~5.7k tokens** for a session that never touches a document.

## Spec

`agent`: one new requirement, 7 scenarios — including the two negatives that keep the trigger honest (a workspace holding documents publishes nothing; the word "PDF" in prose is not a path). `openspec validate --strict` valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PryLsHtHcqbkjAqsxVH8rQ