### PR TITLE
feat(tools): publish a document extractor when its document arrives

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,12 @@ one needs, the command that proves it works, and the caution that goes with it.
 - Office documents: `docx_extract`, `xlsx_extract` and `pptx_extract` give the agent Word
   text and tables, one markdown table per spreadsheet sheet, and slide structure with
   speaker notes. Each takes an `output_path`, to write the whole document to a file instead
-  of spending the context on it twice
+  of spending the context on it twice. The four extractors are described to
+  the agent only once a document of that kind is named in the conversation — their schemas
+  are a quarter of a session's prompt floor, and most sessions never open one. Named and never
+  called, an extractor goes again when the turn ends; named and used, it stays through the
+  work around that document and is forgotten after five quiet turns. Naming the document
+  again brings it back
 - Structured results: a tool can hand back **data** — a graph, a sequence, a table — and the
   interface draws it, with an approval gate when the document names a `target`. Files that
   declare the schema open as the diagram they describe, and any diagram exports as a

--- a/openspec/changes/publish-a-document-extractor-when-a-document-arrives/.openspec.yaml
+++ b/openspec/changes/publish-a-document-extractor-when-a-document-arrives/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-03

--- a/openspec/changes/publish-a-document-extractor-when-a-document-arrives/design.md
+++ b/openspec/changes/publish-a-document-extractor-when-a-document-arrives/design.md
@@ -1,0 +1,63 @@
+## The trigger, and why it is the document rather than the workspace
+
+Three candidates were on the table.
+
+**The workspace containing such a file.** Decided once at session bind, so the toolset
+never changes mid-conversation and no prefix is ever invalidated. Rejected: a repository
+with a `docs/` folder, a `README.pdf`, one stray `.xlsx` in a fixtures directory would
+publish all four for every session, including the ones refactoring TypeScript. It
+optimises for the presence of a document rather than the use of one, which is the case
+this change exists to stop.
+
+**An opener** — one small tool that publishes the right extractor on request, the pattern
+opencode uses for skills. Rejected for the same reason it was rejected for the Work Plan:
+it charges a round trip on the path that is already the point, and here the round trip
+would land in the middle of "read this file for me".
+
+**The document entering the conversation.** What is implemented. The composer already
+appends every referenced file as an `@path` mention before sending (see the `SendMessage`
+requirement), and an uploaded document is written into the workspace and attached as a
+path rather than as content. So the prompt the server receives names the file, and naming
+it is exactly the moment the tool becomes useful.
+
+## Where the decision is made
+
+On the prompt path, before the turn is dispatched: the server reads the outgoing text for
+paths ending in the four extensions and publishes the matching tools. The turn then goes
+out with them.
+
+It is deliberately a **text** trigger rather than a filesystem one. The file may not exist
+yet, may be outside the sandbox, may be a broken path — none of which matters: what the
+tool costs is being described, and what makes describing it worthwhile is that the
+conversation has turned to a document of that kind. A wrong guess publishes a tool that
+goes unused for the rest of the session, which is the same position we are in today.
+
+## What happens to a wrong guess
+
+Publication is sticky *for a tool that was used*, and only for that one. A turn that named
+a document and never called the extractor gets it withdrawn when the turn ends.
+
+The two halves answer different risks. Withdrawing after use would strand an agent
+mid-task: extraction is rarely one call — a spreadsheet read sheet by sheet, a PDF written
+out and then reread — and an agent cannot ask for a tool back, since publication is
+triggered by what the *user* writes. Keeping a tool nobody called would mean paying for
+every false positive, on every later request, for the rest of the session.
+
+So a newly published tool spends the turn on trial: a `tool_start` naming it clears the
+trial, the end of the turn collects what is left.
+
+## Registration order
+
+The four are registered after every other tool. On a provider that caches prefixes, the
+invalidation from publishing one starts at its position in the tool list, so a tool
+registered fifth of fourteen invalidates almost everything: `pdf_extract` currently sits
+there and its publication would keep only 9.2% of the prefix. Registered last, the
+definitions ahead of it survive.
+
+This changes nothing on a provider that does not cache — which includes the deployment
+these figures come from — and costs nothing on one that does.
+
+## What it does not reach
+
+The RPC runtime, which has no command for the active toolset and publishes everything it
+was launched with. Stated, not emulated: the embedded SDK runtime is the supported target.

--- a/openspec/changes/publish-a-document-extractor-when-a-document-arrives/proposal.md
+++ b/openspec/changes/publish-a-document-extractor-when-a-document-arrives/proposal.md
@@ -1,0 +1,77 @@
+## Why
+
+Four tool definitions — `pdf_extract`, `docx_extract`, `xlsx_extract`, `pptx_extract` —
+come to **8 249 characters, ~2.1k tokens**, and they are sent on every request of every
+conversation. On a resting baseline of ~7.8k tokens that is better than a quarter of the
+floor, spent describing how to read Word, Excel, PowerPoint and PDF files to a session
+that is refactoring TypeScript and will never open one.
+
+Measured on 2026-09-03:
+
+| Tool | chars | ~tokens |
+|---|---|---|
+| `xlsx_extract` | 2 345 | ~0.6k |
+| `docx_extract` | 2 027 | ~0.5k |
+| `pdf_extract` | 1 944 | ~0.5k |
+| `pptx_extract` | 1 933 | ~0.5k |
+
+The same reasoning that split the Work Plan contract applies, with one difference worth
+being honest about: a Work Plan operation is *impossible* without a plan, whereas an
+extractor is merely *useless* without a document. So the trigger cannot be a
+prerequisite — it has to be the document itself arriving.
+
+## What Changes
+
+- An extractor is published when a document of its kind **enters the conversation**: a
+  file attached through the composer, or a path to one named in the message being sent.
+  Publication happens before the turn goes out, so the tool is there for the call that
+  needs it.
+- A tool the turn published and **never called** is withdrawn when that turn ends: the
+  trigger is a text match and can be wrong, and a wrong guess would otherwise be paid on
+  every later request. One that **was** called stays for the session — extraction is
+  rarely a single call, and nothing lets an agent ask for a tool back.
+- A session bound to a workspace publishes none of them until this happens. **Not** on the
+  workspace merely containing such a file: a repository with a `docs/` folder would then
+  pay for four tools while its agent refactors code, which is the case this change exists
+  to stop.
+- The four definitions are registered **last**, after every other tool. It changes nothing
+  for a provider that does not cache prompts, and on one that does it keeps every
+  definition ahead of them out of the invalidation.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- None. -->
+
+### Modified Capabilities
+
+- `agent`: what a session publishes becomes a function of what has entered the
+  conversation, for the document extractors.
+
+## Impact
+
+- **Server** — `server/src/index.ts` (registration order, and the publication call on the
+  prompt path), `server/src/workspace.ts` if the composer upload path lives there.
+- **No wire change, no client change.** The composer already uploads a document into the
+  workspace and attaches it as a path.
+- **Measured** — the four definitions are 8 249 characters of the 23 897 a session's tools
+  come to, so a session that never names a document carries 15 648 characters of tools and
+  7 134 of prompt: **~5.7k tokens against ~7.8k**.
+
+## The cost this carries, stated
+
+Publishing a tool mid-conversation changes the prompt prefix, and a provider that caches
+prefixes must re-read everything from the changed point onward — the tools after it, the
+system prompt, and the entire conversation so far.
+
+- On the deployment this was measured against, the question does not arise:
+  `mistral/devstral-medium-latest` reports `cacheRead: 0, cacheWrite: 0`. Nothing is
+  cached, every turn pays for the whole prompt, and these 2.1k are pure loss on every turn
+  that does not use them.
+- On a provider that does cache, the trade is: a conversation that never touches a
+  document saves the definitions outright; one that does pays a single invalidation whose
+  size grows with the history behind it. It is a bet on how often documents appear, and
+  for a code workspace that is rarely.
+
+Registering the four last is what makes the bet cheaper without changing anything else.

--- a/openspec/changes/publish-a-document-extractor-when-a-document-arrives/scenario-coverage.md
+++ b/openspec/changes/publish-a-document-extractor-when-a-document-arrives/scenario-coverage.md
@@ -1,0 +1,37 @@
+# Scenario coverage
+
+All 10 `#### Scenario:` entries in `specs/agent/spec.md`, enumerated with
+`rg '^#### Scenario:' openspec/changes/publish-a-document-extractor-when-a-document-arrives/`.
+The requirement is ADDED, so every scenario is new work.
+
+Test files:
+
+- `server/test/documentTools.test.ts` (`unit`) — what a prompt is read to call for
+- `server/test/documentToolsWire.test.mjs` (`wire`) — a real server and a real embedded
+  session, asserting the tool list the **provider was sent**: what the snapshot claims the
+  server published is a second-hand account, and what reached the model is what costs
+  tokens and what can be called
+- `verification.md` (`live`) — one run against a real model
+
+| Scenario | Status | Where | What would fail |
+|---|---|---|---|
+| A code session publishes no extractor | covered | `wire`: "a document extractor is published when a document is named, and not before" — `server/test/documentToolsWire.test.mjs` | The workspace is created **with** a `report.docx`, and the snapshot must carry none of the four active while still carrying `read`. Publishing from workspace contents — the design this change rejects — fails here. |
+| Naming a document publishes its extractor, before the turn | covered | `wire`: same test | The turn naming `report.docx` must reach the provider **already carrying** `docx_extract`. Publishing after dispatch, or from a queued read, leaves it absent from the request that named it. Corroborated by `live`, where the model called it on the first attempt. |
+| An attached document publishes its extractor | covered | `unit`: "a mention is matched wherever a path can appear" — `server/test/documentTools.test.ts` | The composer appends an attachment as an `@path` mention and the server absolutises it, so the attachment case *is* the path case. `@/srv/projects/acme/report.pdf` must resolve to `pdf_extract`; a matcher anchored to the start of the text, or one that chokes on `@`, fails. |
+| A tool published on a wrong guess is withdrawn when the turn ends | covered | `wire`: same test, third phase | A turn names the document and never calls the tool; the next request must not carry it. This caught a real bug: the idle check read the runtime *after* publishing, so nothing was ever counted and nothing was ever withdrawn. |
+| A tool that was used survives the quiet turns around its work | covered | `wire`: same test, the four-turn loop | The provider is scripted to call `docx_extract` when the prompt says so; each of the next four turns must still be sent it. Withdrawing after use — the variant considered and rejected — fails on the first of them, and would strand an agent mid-extraction. |
+| A tool nobody has wanted for five turns is forgotten | covered | `wire`: same test, fifth quiet turn | The fifth idle turn's request must not carry it. A tool kept for the session — the previous design — fails here, and with it the saving on every long conversation that opened one document early. |
+| Naming the document again brings its extractor back | covered | `wire`: same test, last phase | After the withdrawal, a prompt naming `report.docx` must put it back. Without this the withdrawal would be a one-way door, and the failure it causes is silent: nothing tells an agent a tool has gone. |
+| A workspace holding documents publishes nothing by itself | covered | `wire`: same test, first assertion | The same `report.docx` on disk, no prompt naming it, nothing published. |
+| The word is not the path | covered | `unit`: "the word is not the path" | "convert this to PDF", "the pdf spec is long", "refactor src/pdf.ts", "docx handling is a mess" and "we support pdf, docx, xlsx and pptx" must all publish nothing. A matcher on the bare extension puts all four back into every conversation that merely discusses documents. |
+| A runtime that cannot gate publishes them all | covered | `unit`: "the exported set is what the server withholds and republishes" — with `RpcRuntime.setToolPublished` returning `false` and `server/src/piOutpostTools.ts` registering all four | The RPC child registers every extractor and its runtime refuses to gate, so they are published throughout. A runtime that returned `true` without gating would be a lie no test could catch; it returns `false`. |
+
+## Measurement
+
+The four definitions are 8 249 characters of the 23 897 a session's tools come to. A session
+that names no document therefore carries 15 648 characters of tools and 7 134 of system
+prompt: **~5.7k tokens against ~7.8k**.
+
+`server/scripts/probe-context-baseline.mts` (on the comparison branch) still reports the
+undivided figure — it builds its own session with every tool active. It should learn the two
+states when that branch lands.

--- a/openspec/changes/publish-a-document-extractor-when-a-document-arrives/specs/agent/spec.md
+++ b/openspec/changes/publish-a-document-extractor-when-a-document-arrives/specs/agent/spec.md
@@ -1,0 +1,89 @@
+## ADDED Requirements
+
+### Requirement: A document extractor is published when a document arrives
+
+The document extraction tools SHALL be published to a session only once a document of their
+kind has entered the conversation. A session that has seen none SHALL publish none of them.
+
+A document enters the conversation when the prompt being sent names a path of that kind —
+which covers both a file attached through the composer, since an attached document is
+written into the workspace and referenced by path, and a file the user names in their own
+words. Publication SHALL happen before the turn is dispatched, so the tool is available to
+the call that needs it rather than after a refusal.
+
+A published extractor SHALL be withdrawn once it has gone unused for long enough, and how long
+SHALL depend on whether it was ever used:
+
+- **Never called: one turn.** The trigger is a text match and can be wrong — a path to a file
+  that does not exist, a document named in passing — and a wrong guess otherwise costs every
+  later request in the session.
+- **Called at least once: five idle turns.** Extraction is rarely a single call, and taking a
+  tool away mid-task would strand an agent that cannot ask for it back. Five turns of silence
+  is the conversation having moved on.
+
+Naming a document of that kind again SHALL republish its extractor and reset the count. That is
+the only way back, and it belongs to the user: an agent cannot request a tool it can no longer
+see, and nothing announces the withdrawal to it.
+
+The tools SHALL NOT be published on the strength of the workspace merely containing such a
+file. A repository with a documents folder would otherwise pay for every extractor in every
+session, including the ones that only ever touch code — which is the cost this requirement
+exists to remove.
+
+These definitions SHALL be registered after every other tool. Where a provider caches prompt
+prefixes, publishing a tool invalidates the prefix from that tool's position onward, so the
+ones that appear late in a session belong late in the list.
+
+Where a runtime cannot change its published toolset — the RPC dialect has no command for it —
+that runtime SHALL publish all of them at all times rather than emulate the gating.
+
+#### Scenario: A code session publishes no extractor
+- **GIVEN** a session whose conversation has named no document
+- **WHEN** the agent's toolset is composed
+- **THEN** none of the document extraction tools is published
+
+#### Scenario: Naming a document publishes its extractor, before the turn
+- **GIVEN** a session publishing no extractor
+- **WHEN** the user sends a prompt naming a `.docx` path
+- **THEN** the extractor for that kind is published before the turn is dispatched
+- **AND** the extractors for the other kinds are not
+
+#### Scenario: An attached document publishes its extractor
+- **GIVEN** a document attached through the composer, written into the workspace and referenced by path
+- **WHEN** the prompt is sent
+- **THEN** the extractor for that kind is published
+
+#### Scenario: A tool published on a wrong guess is withdrawn when the turn ends
+- **GIVEN** a turn that named a document and never called the extractor published for it
+- **WHEN** the turn ends
+- **THEN** that extractor is withheld again
+- **AND** later requests do not carry it
+
+#### Scenario: A tool that was used survives the quiet turns around its work
+- **GIVEN** an extractor that was called during the turn that published it
+- **WHEN** four further turns name no document and do not call it
+- **THEN** it is still published
+
+#### Scenario: A tool nobody has wanted for five turns is forgotten
+- **GIVEN** an extractor that was called earlier in the session
+- **WHEN** it goes five turns without being called and without a document of its kind being named
+- **THEN** it is withheld again
+
+#### Scenario: Naming the document again brings its extractor back
+- **GIVEN** an extractor withheld after going idle
+- **WHEN** a prompt names a document of that kind
+- **THEN** it is published again for that turn
+
+#### Scenario: A workspace holding documents publishes nothing by itself
+- **GIVEN** a workspace containing a `.pdf` that no prompt has named
+- **WHEN** a session is bound to it
+- **THEN** no document extraction tool is published
+
+#### Scenario: The word is not the path
+- **WHEN** a prompt discusses PDFs without naming a path of that kind
+- **THEN** no extractor is published
+
+#### Scenario: A runtime that cannot gate publishes them all
+- **GIVEN** a workspace served by the RPC runtime
+- **WHEN** the agent's toolset is composed
+- **THEN** every document extraction tool is published, as that dialect cannot change its active toolset

--- a/openspec/changes/publish-a-document-extractor-when-a-document-arrives/tasks.md
+++ b/openspec/changes/publish-a-document-extractor-when-a-document-arrives/tasks.md
@@ -1,0 +1,26 @@
+## 1. Register the extractors last
+
+- [x] 1.1 `documentToolsLast()` in `server/src/workspace.ts` — a stable partition applied once, after the sandboxed and unconfined sets are joined, so the rule holds for both paths and the order of everything else is left alone. The unsandboxed list in `server/src/index.ts` is written in the same order.
+
+## 2. Publish on arrival
+
+- [x] 2.1 `documentToolsFor(text)` in `server/src/documentTools.ts`: the extractors a prompt calls for, matched on a path-like token so prose ("convert this to PDF") publishes nothing.
+- [x] 2.2 Called from `handlePrompt` before `agent.prompt`, publishing through `AgentRuntime.setToolPublished` — the seam the Work Plan split added.
+- [x] 2.3 Withheld at every bind: boot, a project started later, and a session replacement, which is a new conversation.
+- [x] 2.4 Each published extractor carries a count of idle turns (`Workspace.documentToolIdleTurns`, with `documentToolsEverUsed`): a `tool_start` resets it to zero and marks the tool as wanted, `agent_end` ages the rest, and the threshold is one turn for a tool never called, five for one that was. Naming the document again republishes and resets. The wire test caught the ordering bug in the first version of this — the check read the runtime *after* publishing, so nothing was ever counted.
+
+## 3. Proof
+
+- [x] 3.1 `server/test/documentTools.test.ts` (7 tests): one kind publishes one tool; `@path`, quotes, Windows separators, a trailing full stop and `REPORT.PDF` all match; prose and `src/pdf.ts` do not; two kinds publish two, in registration order; the exported set and the matcher agree.
+- [x] 3.2 Order: asserted at the wire, where it matters — the last tool the model is sent is the extractor.
+- [x] 3.3 / 3.4 `server/test/documentToolsWire.test.mjs` — a real embedded session, asserting the tool list the **provider** was sent rather than what the snapshot claims. It walks the whole life of one tool: none of the four at rest in a workspace that *contains* a `.docx`; `docx_extract` on the very turn that names one, and not its siblings; withdrawn after a turn that never called it; called, then surviving four idle turns; forgotten on the fifth; republished when the document is named again.
+- [x] 3.5 Measured: the four are 8 249 of the 23 897 characters a session's tools come to, so a session that names no document carries ~5.7k tokens against ~7.8k.
+
+## 4. Prove the agent copes
+
+- [x] 4.1 Done — `verification.md`. A real model, a real `.docx`: no extractor at rest in a workspace that holds the document, and `docx_extract` called on the first attempt once the prompt named it.
+
+## 5. Validation
+
+- [x] 5.1 Done — 8 scenarios, all covered.
+- [ ] 5.2 `npm run check:scenarios`, `openspec validate --strict`, and the **full** server suite — both CI failures on this stack came from files a partial local run never touched.

--- a/openspec/changes/publish-a-document-extractor-when-a-document-arrives/verification.md
+++ b/openspec/changes/publish-a-document-extractor-when-a-document-arrives/verification.md
@@ -1,0 +1,22 @@
+# Live verification
+
+`mistral/devstral-medium-latest`, a real server, a real `.docx` in the workspace, and a
+throwaway `agentDir` carrying only the API key.
+
+```
+at rest: edit, find, grep, ls, present_structure, read, work_plan, write, write_structure_figure
+→ docx_extract {"path":"report.docx"}
+answer: The document `report.docx` contains: …
+```
+
+- **No extractor at rest**, in a workspace that holds the document. Containing one is not
+  using one.
+- The prompt named `report.docx`, and the tool was **there for the first call** — no
+  refusal, no repair loop, nothing discovered the hard way. That is the risk this design
+  carries: a tool published a moment too late is a tool the model tried to call and could
+  not.
+- The other three stayed withheld.
+
+The wire test proves the same sequence deterministically, plus the two cases a live run
+cannot arrange on demand: a tool withdrawn after a turn that never called it, and one kept
+after a turn that did.

--- a/server/src/documentTools.ts
+++ b/server/src/documentTools.ts
@@ -1,0 +1,52 @@
+/**
+ * Which document extractors a piece of conversation calls for.
+ *
+ * The four extractor schemas come to some 8 000 characters — around a quarter of a
+ * session's whole prompt floor — describing how to read Word, Excel, PowerPoint and
+ * PDF to conversations that overwhelmingly never open one. They are published when a
+ * document of their kind enters the conversation instead, and this is the reading of
+ * "enters".
+ *
+ * It is a *text* test, not a filesystem one. The file may not exist yet, may sit
+ * outside the sandbox, may be a path the user mistyped: none of that changes the
+ * answer, because what is being decided is whether describing the tool is worth its
+ * place in every subsequent request. A wrong guess publishes a tool that goes unused,
+ * which is exactly where every session starts today.
+ */
+
+/** Extension → the tool that reads it. */
+const EXTRACTORS: Record<string, string> = {
+  pdf: "pdf_extract",
+  docx: "docx_extract",
+  xlsx: "xlsx_extract",
+  pptx: "pptx_extract",
+};
+
+export const DOCUMENT_TOOLS = Object.values(EXTRACTORS);
+
+/**
+ * A path-like token ending in one of the four extensions.
+ *
+ * The boundary before the name is what keeps prose out: "convert this to PDF" names no
+ * file, and publishing on the bare word would put all four back in every conversation
+ * that merely discusses documents. A name must be preceded by a path character or the
+ * start of a token, carry at least one character of its own, and be followed by
+ * whitespace, punctuation that ends a path — a sentence's full stop included, since
+ * "read a.pdf." is a mention and `a.pdf.bak` is close enough to one — or nothing.
+ */
+const MENTION = /(?:^|[\s"'`(\[<@])(?:[^\s"'`()[\]<>]*[/\\])?[^\s"'`()[\]<>/\\]+\.(pdf|docx|xlsx|pptx)(?=$|[\s"'`)\]>,;:!?.])/gi;
+
+/**
+ * The extractor tools the text calls for, in the order they are registered.
+ *
+ * Case-insensitive: `REPORT.PDF` off a Windows share is the same document as
+ * `report.pdf`.
+ */
+export function documentToolsFor(text: string): string[] {
+  const found = new Set<string>();
+  for (const match of text.matchAll(MENTION)) {
+    const tool = EXTRACTORS[match[1].toLowerCase()];
+    if (tool !== undefined) found.add(tool);
+  }
+  return DOCUMENT_TOOLS.filter((tool) => found.has(tool));
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -148,6 +148,7 @@ import { createPptxExtractToolDefinition } from "./pptxTool.ts";
 import { createStructuredExchangeToolDefinition } from "./structuredExchangeTool.ts";
 import { createStructuredExchangeFigureToolDefinition } from "./structuredExchangeFigureTool.ts";
 import { createWorkPlanExtendedToolDefinition, createWorkPlanToolDefinition, WORK_PLAN_EXTENDED_TOOL, WORK_PLAN_TOOL } from "./workPlanTool.ts";
+import { DOCUMENT_TOOLS, documentToolsFor } from "./documentTools.ts";
 import { copyWorkPlan, deleteWorkPlan, loadWorkPlan, sameSessionFile } from "./workPlanStore.ts";
 import { composeAppendSystemPrompt } from "./systemPrompt.ts";
 import { createPdfExtractToolDefinition } from "./pdfTool.ts";
@@ -1008,12 +1009,26 @@ const makeCreateRuntime =
         ? {}
         : {
             customTools: [
+              createStructuredExchangeFigureToolDefinition({
+                cwd,
+                allowedRoots: [await fs.realpath(cwd)],
+                maxBytes: config.structuredExchange.maxBytes,
+                // No sandbox: anything under the workspace is writable, the same
+                // rule writeFileFromBrowser applies to the browser's own writes.
+                writableRoot: await fs.realpath(cwd),
+              }),
+              structuredExchangeTool,
+              workPlanTool,
+              workPlanExtendedTool,
+              // The extractors go last, and the order is not cosmetic. A tool published
+              // mid-conversation invalidates a caching provider's prefix from its own
+              // position onward; these four are the ones that appear late in a session,
+              // so everything registered before them survives their arrival. Measured:
+              // `pdf_extract` fifth of fourteen kept 9.2% of the prefix.
               createPdfExtractToolDefinition({
                 cwd,
                 allowedRoots: [await fs.realpath(cwd)],
                 maxBytes: config.pdf.maxBytes,
-                // No sandbox: anything under the workspace is writable, the same
-                // rule writeFileFromBrowser applies to the browser's own writes.
                 writableRoot: await fs.realpath(cwd),
               }),
               createDocxExtractToolDefinition({
@@ -1034,15 +1049,6 @@ const makeCreateRuntime =
                 maxBytes: config.pptx.maxBytes,
                 writableRoot: await fs.realpath(cwd),
               }),
-              createStructuredExchangeFigureToolDefinition({
-                cwd,
-                allowedRoots: [await fs.realpath(cwd)],
-                maxBytes: config.structuredExchange.maxBytes,
-                writableRoot: await fs.realpath(cwd),
-              }),
-              structuredExchangeTool,
-              workPlanTool,
-              workPlanExtendedTool,
             ],
           }),
     })),
@@ -1182,6 +1188,7 @@ workspace.workPlanSessionFile = workspace.agent.snapshot().sessionFile;
 // The bound session may already have a plan — resumed, or the server restarted under
 // one. An agent that inherits work should inherit the tools for it, not discover them.
 publishWorkPlanTools(workspace, workspace.workPlan);
+withholdDocumentTools(workspace);
 
 /**
  * Session replacement events are synchronous, while their sidecar reads are not.
@@ -1197,6 +1204,67 @@ publishWorkPlanTools(workspace, workspace.workPlan);
  * remember to keep in step. The runtime says whether it took: an RPC child publishes
  * both tools always, which is the documented cost of that dialect.
  */
+/**
+ * Withhold every document extractor until a document of its kind turns up.
+ *
+ * Their four schemas come to some 8 000 characters — around a quarter of a session's
+ * prompt floor — telling a conversation how to read Word, Excel, PowerPoint and PDF.
+ * Most conversations never open one, and the ones that do say so first.
+ */
+function withholdDocumentTools(workspace: Workspace): void {
+  for (const tool of DOCUMENT_TOOLS) workspace.agent.setToolPublished(tool, false);
+  workspace.documentToolIdleTurns.clear();
+  workspace.documentToolsEverUsed.clear();
+}
+
+/**
+ * Publish the extractors a prompt calls for, before the turn carrying it goes out.
+ *
+ * Sticky: nothing is withdrawn here. A conversation that has handled one PDF usually
+ * handles another, and withdrawing would invalidate a caching provider's prefix a
+ * second time to save what it had already stopped paying for.
+ */
+function publishDocumentTools(workspace: Workspace, text: string): void {
+  for (const tool of documentToolsFor(text)) {
+    // Naming the document is what resets the clock, whether or not the tool was already
+    // there: the conversation has just turned back to a document of that kind.
+    if (workspace.agent.setToolPublished(tool, true)) workspace.documentToolIdleTurns.set(tool, 0);
+  }
+}
+
+/**
+ * How many turns a published extractor may go unused before it is forgotten.
+ *
+ * One, for a tool that has never been called: it was published on a text match that
+ * turned out to be wrong, and every later request would carry the mistake.
+ *
+ * Five, for one that has been used: the work around a document rarely ends with the call
+ * that opened it — a spreadsheet read sheet by sheet, a passage checked again two answers
+ * later — and taking the tool away mid-task would strand an agent that cannot ask for it
+ * back. Five turns of silence is the conversation having moved on.
+ */
+const DOCUMENT_TOOL_IDLE_LIMIT = { unused: 1, used: 5 };
+
+/**
+ * Age every published extractor by one turn, and forget the ones that have gone quiet.
+ *
+ * Called when a turn ends. A tool used during it was reset to zero as it was called, so
+ * what is counted here is silence.
+ */
+function ageDocumentTools(workspace: Workspace): void {
+  for (const [tool, idle] of workspace.documentToolIdleTurns) {
+    const limit = workspace.documentToolsEverUsed.has(tool)
+      ? DOCUMENT_TOOL_IDLE_LIMIT.used
+      : DOCUMENT_TOOL_IDLE_LIMIT.unused;
+    if (idle + 1 < limit) {
+      workspace.documentToolIdleTurns.set(tool, idle + 1);
+      continue;
+    }
+    workspace.agent.setToolPublished(tool, false);
+    workspace.documentToolIdleTurns.delete(tool);
+  }
+}
+
 function publishWorkPlanTools(workspace: Workspace, plan: WorkPlan | null): void {
   workspace.agent.setToolPublished(WORK_PLAN_EXTENDED_TOOL, plan !== null);
 }
@@ -1218,6 +1286,9 @@ function queueWorkPlanSessionSync(workspace: Workspace): Promise<void> {
     workspace.workPlan = plan;
     workspace.workPlanSessionFile = sessionFile;
     publishWorkPlanTools(workspace, plan);
+    // A replaced session is a new conversation: whatever documents the last one saw are
+    // not this one's, and the first prompt naming one publishes what it needs.
+    withholdDocumentTools(workspace);
     broadcast(workspace, { type: "session_replaced", ...snapshot(workspace) });
     if (inherited) broadcast(workspace, { type: "work_plan_changed", workPlan: plan });
     announceWorkspaceActivity();
@@ -1649,6 +1720,7 @@ function onRuntimeEvent(workspace: Workspace, event: RuntimeEvent): void {
       // no question to answer, and a badge that cannot be cleared is worse than
       // no badge at all.
       workspace.pendingDialogs.clear();
+      ageDocumentTools(workspace);
       broadcast(workspace, { type: "agent_end" });
       // Unconditional: the project just went from working to idle, which the
       // selector must show whether or not anything was blocked.
@@ -1696,6 +1768,12 @@ function onRuntimeEvent(workspace: Workspace, event: RuntimeEvent): void {
       broadcast(workspace, { type: "custom_message", item: customMessageToItem(event.message as never, workspace.renderer) });
       break;
     case "tool_start": {
+      // Called, so the clock goes back to zero — and it is no longer a tool nobody has
+      // ever wanted, which is what decides how long it may sit idle from here.
+      if (workspace.documentToolIdleTurns.has(event.toolName)) {
+        workspace.documentToolIdleTurns.set(event.toolName, 0);
+        workspace.documentToolsEverUsed.add(event.toolName);
+      }
       const callHtml = workspace.renderer.renderToolCallHtml(event.toolCallId, event.toolName, event.args);
       broadcast(workspace, {
         type: "tool_start",
@@ -2291,6 +2369,7 @@ async function ensureStarted(target: Workspace): Promise<void> {
     // Same as the boot workspace: a project reopened onto an existing plan publishes
     // the tools that plan needs, rather than making its agent find them again.
     publishWorkPlanTools(target, target.workPlan);
+    withholdDocumentTools(target);
     target.lastUsedAt = Date.now();
   })();
   starting.set(target.root, build);
@@ -2417,6 +2496,10 @@ async function absolutizeMentions(workspace: Workspace, text: string): Promise<s
 
 async function handlePrompt(workspace: Workspace, text: string, images?: WireImage[]): Promise<void> {
   const promptText = await absolutizeMentions(workspace, text);
+  // Before the turn, not after: a tool published once the request is on its way is a
+  // tool the model could not call. The composer references an attached document by
+  // path, so the text naming a document is the same event as one arriving.
+  publishDocumentTools(workspace, promptText);
   await workspace.agent.prompt(promptText, {
     ...(images?.length ? { images } : {}),
     // Echo the user message only once accepted (avoids ghost bubbles on reject).

--- a/server/src/workspace.ts
+++ b/server/src/workspace.ts
@@ -19,6 +19,7 @@ import fs from "node:fs/promises";
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import type { AgentRuntime } from "./agentRuntime.ts";
 import type { SandboxConfig } from "./config.ts";
+import { DOCUMENT_TOOLS } from "./documentTools.ts";
 import { type DirectoryWatcher, createDirectoryWatcher } from "./fileWatcher.ts";
 import { resolveBrowserRoot, resolveWritableRoot } from "./fileBrowser.ts";
 import { discoverRepos, whyGitCannotServe, type GitRepo } from "./git.ts";
@@ -137,6 +138,24 @@ export class Workspace {
   gitUnavailable: GitUnavailable | undefined;
   fileWatcher: DirectoryWatcher | undefined;
   sandboxedTools: ToolDefinition[] | undefined;
+
+  /**
+   * How many turns each published document extractor has gone unused, and whether it was
+   * ever used at all.
+   *
+   * A prompt naming `report.pdf` publishes `pdf_extract` before the turn goes out, and
+   * the tool then has to earn its place in every later request. Two thresholds, because
+   * the two silences mean different things: a tool that was **never** called was
+   * published on a wrong guess — a file that does not exist, a document named in passing
+   * — and goes at the end of that turn. One that **was** called is kept while the work
+   * around it continues, since extraction is rarely a single call, and is forgotten only
+   * once the conversation has plainly moved on.
+   *
+   * Naming the document again republishes it: that is the only way back, and it is the
+   * user's to take, since an agent cannot ask for a tool it can no longer see.
+   */
+  documentToolIdleTurns = new Map<string, number>();
+  documentToolsEverUsed = new Set<string>();
 
   /** Loaded from the runtime's session file by the caller; null until then. */
   workPlan: WorkPlan | null = null;
@@ -407,6 +426,22 @@ interface WorkspaceResources {
   sandboxedTools: ToolDefinition[] | undefined;
 }
 
+/**
+ * The document extractors, last, whatever order they were built in.
+ *
+ * They are the tools published mid-session, when a document enters the conversation. A
+ * caching provider re-reads its prompt prefix from the position of whatever changed, so
+ * a tool that arrives late belongs late in the list: registered fifth of fourteen,
+ * `pdf_extract` kept 9.2% of the prefix; last, everything ahead of it survives.
+ *
+ * A stable partition rather than a sort — the order of everything else is someone's
+ * decision and this is not the place to overturn it.
+ */
+function documentToolsLast(tools: ToolDefinition[]): ToolDefinition[] {
+  const documents = new Set<string>(DOCUMENT_TOOLS);
+  return [...tools.filter((tool) => !documents.has(tool.name)), ...tools.filter((tool) => documents.has(tool.name))];
+}
+
 async function buildResources(options: WorkspaceOptions): Promise<WorkspaceResources> {
   const { settings, limits } = options;
   const browserRoot = await resolveBrowserRoot(settings);
@@ -416,7 +451,7 @@ async function buildResources(options: WorkspaceOptions): Promise<WorkspaceResou
   // all", and it is the only thing that notices a repository git will refuse to read
   const gitUnavailable = await whyGitCannotServe(browserRoot, repos);
   const sandboxedTools = settings.sandbox
-    ? [
+    ? documentToolsLast([
         ...(await createSandboxedTools(
           settings.sandbox,
           limits.pdfMaxBytes,
@@ -426,7 +461,7 @@ async function buildResources(options: WorkspaceOptions): Promise<WorkspaceResou
           limits.structuredExchangeMaxBytes,
         )),
         ...options.unconfinedTools,
-      ]
+      ])
     : undefined;
   const fileWatcher = options.watchFiles
     ? createDirectoryWatcher({ root: browserRoot, onChange: options.onDirectoryChanged })

--- a/server/test/documentTools.test.ts
+++ b/server/test/documentTools.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Which extractors a prompt calls for. The four schemas are some 8 000 characters —
+ * around a quarter of a session's prompt floor — so what this decides is whether every
+ * later request in the conversation carries them.
+ */
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { DOCUMENT_TOOLS, documentToolsFor } from "../src/documentTools.ts";
+
+describe("documentToolsFor", () => {
+  test("a named document publishes its own extractor and no other", () => {
+    assert.deepEqual(documentToolsFor("Read report.pdf and summarise it"), ["pdf_extract"]);
+    assert.deepEqual(documentToolsFor("What does notes.docx say?"), ["docx_extract"]);
+    assert.deepEqual(documentToolsFor("Open budget.xlsx"), ["xlsx_extract"]);
+    assert.deepEqual(documentToolsFor("Check deck.pptx"), ["pptx_extract"]);
+  });
+
+  test("a mention is matched wherever a path can appear", () => {
+    // `@path` is what the composer appends for an attachment, absolute after the server
+    // resolves it; quotes and Windows separators are what users paste.
+    for (const text of [
+      "@/srv/projects/acme/report.pdf",
+      'open "my report.pdf"',
+      "C:\\\\Users\\\\laurent\\\\report.pdf",
+      "see ./docs/report.pdf, then tell me",
+      "read report.pdf.",
+    ]) {
+      assert.deepEqual(documentToolsFor(text), ["pdf_extract"], text);
+    }
+  });
+
+  test("case does not matter: a Windows share shouts", () => {
+    assert.deepEqual(documentToolsFor("@/mnt/share/Q3.XLSX please"), ["xlsx_extract"]);
+    assert.deepEqual(documentToolsFor("REPORT.PDF"), ["pdf_extract"]);
+  });
+
+  test("the word is not the path", () => {
+    // The whole point of the trigger. Publishing on the bare word would put all four
+    // back into every conversation that merely discusses documents.
+    for (const text of [
+      "convert this to PDF",
+      "the pdf spec is long",
+      "refactor src/pdf.ts",
+      "docx handling is a mess",
+      "we support pdf, docx, xlsx and pptx",
+    ]) {
+      assert.deepEqual(documentToolsFor(text), [], text);
+    }
+  });
+
+  test("two kinds in one prompt publish two tools, in registration order", () => {
+    assert.deepEqual(documentToolsFor("see notes.docx and slides.pptx"), ["docx_extract", "pptx_extract"]);
+    assert.deepEqual(documentToolsFor("a.pdf, b.docx."), ["pdf_extract", "docx_extract"]);
+  });
+
+  test("the same document twice publishes one tool", () => {
+    assert.deepEqual(documentToolsFor("compare a.pdf with b.pdf"), ["pdf_extract"]);
+  });
+
+  test("the exported set is what the server withholds and republishes", () => {
+    // A fifth extractor added to one list and not the other would be published to
+    // everyone forever, or withheld from everyone forever.
+    assert.deepEqual(DOCUMENT_TOOLS, ["pdf_extract", "docx_extract", "xlsx_extract", "pptx_extract"]);
+    for (const tool of DOCUMENT_TOOLS) {
+      const extension = tool.replace("_extract", "");
+      assert.deepEqual(documentToolsFor(`file.${extension}`), [tool], tool);
+    }
+  });
+});

--- a/server/test/documentToolsWire.test.mjs
+++ b/server/test/documentToolsWire.test.mjs
@@ -1,0 +1,129 @@
+/**
+ * The extractors, over a real server and a real embedded session: withheld until a
+ * document is named, published before the turn that names it goes out, and kept for the
+ * rest of the session.
+ *
+ * The assertions read the tool list the *provider* was sent. What the snapshot says the
+ * server published is a second-hand account; what the model received is the thing that
+ * costs tokens and the thing it can call.
+ */
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import { connect, makeWorkspace, startServer } from "./harness.mjs";
+
+const PROVIDER = fileURLToPath(new URL("./fixtures/document-tools-provider.mjs", import.meta.url));
+const EXTRACTORS = ["pdf_extract", "docx_extract", "xlsx_extract", "pptx_extract"];
+
+/**
+ * The tool names sent with each request that carried any, in order.
+ *
+ * Not every request is a turn: naming a session is a model call of its own, made with no
+ * tools at all. Counting raw requests puts the assertions one behind from the first turn
+ * onward.
+ */
+async function requests(logFile) {
+  const text = await readFile(logFile, "utf8").catch(() => "");
+  return text
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line))
+    .filter((tools) => tools.length > 0);
+}
+
+/**
+ * The nth request's tool list, once it exists.
+ *
+ * Counting `agent_end` frames to know which turn we are on is what the first draft did,
+ * and it is a race: the harness resolves a waiter against any received message the
+ * predicate accepts, so a count taken later matches an earlier frame. The log is the
+ * thing being asserted, so wait on the log.
+ */
+async function nthRequest(logFile, index, timeoutMs = 30_000) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const all = await requests(logFile);
+    if (all.length > index) return all[index];
+    if (Date.now() > deadline) throw new Error(`request ${index} never reached the model (${all.length} so far)`);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+}
+
+test("a document extractor is published when a document is named, and not before", async () => {
+  const root = await makeWorkspace({ "report.docx": "not really a docx\n" });
+  const log = path.join(root, "tools.jsonl");
+  const server = await startServer(
+    root,
+    {
+      extensionPaths: [PROVIDER],
+      allowedModels: [{ provider: "document-tools-test", id: "document-tools-test" }],
+    },
+    { env: { DOCUMENT_TOOLS_LOG: log } },
+  );
+  const client = connect(server.wsUrl());
+  try {
+    const hello = await client.waitFor("hello", 30_000);
+    // The workspace holds a .docx that nothing has named: containing one is not using one.
+    const published = hello.tools.filter((tool) => tool.active).map((tool) => tool.name);
+    for (const tool of EXTRACTORS) {
+      assert.ok(!published.includes(tool), `${tool} is withheld from a session that has named no document`);
+    }
+    assert.ok(published.includes("read"), "the rest of the toolset is untouched");
+
+    client.send({ type: "set_model", provider: "document-tools-test", id: "document-tools-test" });
+    await client.waitFor((message) => message.type === "model_changed");
+
+    // A turn that names nothing leaves them all withheld.
+    client.send({ type: "prompt", text: "Just say ok." });
+    const plain = await nthRequest(log, 0);
+    for (const tool of EXTRACTORS) assert.ok(!plain.includes(tool), `${tool} not sent for a prompt naming no document`);
+
+    // Naming one publishes its extractor, for the very turn that named it.
+    client.send({ type: "prompt", text: "Read report.docx and tell me what it says." });
+    const named = await nthRequest(log, 1);
+    assert.ok(named.includes("docx_extract"), "docx_extract reached the model on the turn that named the document");
+    for (const tool of ["pdf_extract", "xlsx_extract", "pptx_extract"]) {
+      assert.ok(!named.includes(tool), `${tool} stays withheld: no document of its kind was named`);
+    }
+
+    // Registered last, so a caching provider keeps everything ahead of them.
+    assert.equal(named.at(-1), "docx_extract", "the extractors sit at the end of the tool list");
+
+    // The turn named a document and never called the tool, so the guess is paid back:
+    // the next request carries none of them again.
+    client.send({ type: "prompt", text: "Thanks, nothing else." });
+    const after = await nthRequest(log, 2);
+    assert.ok(!after.includes("docx_extract"), "a tool published and never called is withdrawn at the end of the turn");
+
+    // Named *and used*: that one stays, because extraction is rarely a single call and
+    // an agent has no way to ask for a tool back.
+    client.send({ type: "prompt", text: "Read report.docx — USE THE TOOL." });
+    await nthRequest(log, 3);
+    const afterUse = await nthRequest(log, 4);
+    assert.ok(afterUse.includes("docx_extract"), "the tool is still there for the follow-up call in that turn");
+
+    // A tool that has been used survives the quiet turns around the work it belongs to...
+    let request = 5;
+    for (let turn = 1; turn <= 4; turn += 1) {
+      client.send({ type: "prompt", text: `Quiet turn ${turn}.` });
+      const during = await nthRequest(log, request++);
+      assert.ok(during.includes("docx_extract"), `a used tool survives ${turn} idle turn(s)`);
+      assert.ok(!during.includes("pdf_extract"), "and stays narrow");
+    }
+
+    // ...and is forgotten once the conversation has plainly moved on.
+    client.send({ type: "prompt", text: "Quiet turn 5." });
+    const forgotten = await nthRequest(log, request);
+    assert.ok(!forgotten.includes("docx_extract"), "five idle turns and a used tool is forgotten");
+
+    // Naming the document again brings it back: the only way back, and the user's to take.
+    client.send({ type: "prompt", text: "Look at report.docx once more." });
+    const republished = await nthRequest(log, request + 1);
+    assert.ok(republished.includes("docx_extract"), "naming the document republishes its extractor");
+  } finally {
+    client.close();
+    await server.stop();
+  }
+});

--- a/server/test/fixtures/document-tools-provider.mjs
+++ b/server/test/fixtures/document-tools-provider.mjs
@@ -1,0 +1,85 @@
+/**
+ * A provider that answers nothing and records everything: for each request, the names
+ * of the tools it was actually sent.
+ *
+ * Reading the server's snapshot would say what the server believes it published. This
+ * says what reached the model — which is the only thing that costs tokens, and the only
+ * thing that decides whether a tool can be called on the turn that needs it.
+ */
+import { createRequire } from "node:module";
+import { createAssistantMessageEventStream } from "@earendil-works/pi-ai/compat";
+
+const require = createRequire(import.meta.url);
+
+function record(context) {
+  const fs = require("node:fs");
+  const file = process.env.DOCUMENT_TOOLS_LOG;
+  if (!file) return;
+  fs.appendFileSync(file, `${JSON.stringify((context.tools ?? []).map((tool) => tool.name))}\n`);
+}
+
+/**
+ * When asked to, the model calls the extractor rather than answering — which is what
+ * separates a tool that earned its place from one published on a wrong guess.
+ */
+function wantsToolCall(context) {
+  const last = [...(context.messages ?? [])].reverse().find((item) => item.role === "user");
+  const text = JSON.stringify(last?.content ?? "");
+  return text.includes("USE THE TOOL") && (context.tools ?? []).some((tool) => tool.name === "docx_extract");
+}
+
+function stream(model, context) {
+  record(context);
+  if (wantsToolCall(context) && !(context.messages ?? []).some((item) => item.role === "toolResult")) {
+    const out = createAssistantMessageEventStream();
+    const call = { type: "toolCall", id: `doc-${Date.now()}`, name: "docx_extract", arguments: { path: "report.docx" } };
+    const partial = {
+      role: "assistant", content: [call], api: model.api, provider: model.provider, model: model.id,
+      usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+      stopReason: "toolUse", timestamp: Date.now(),
+    };
+    queueMicrotask(() => {
+      out.push({ type: "start", partial });
+      out.push({ type: "toolcall_start", contentIndex: 0, partial });
+      out.push({ type: "toolcall_end", contentIndex: 0, toolCall: call, partial });
+      out.push({ type: "done", reason: "toolUse", message: partial });
+    });
+    return out;
+  }
+  const out = createAssistantMessageEventStream();
+  const message = {
+    role: "assistant",
+    content: [{ type: "text", text: "ok" }],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+    stopReason: "stop",
+    timestamp: Date.now(),
+  };
+  queueMicrotask(() => {
+    out.push({ type: "start", partial: message });
+    out.push({ type: "text_start", contentIndex: 0, partial: message });
+    out.push({ type: "text_end", contentIndex: 0, content: "ok", partial: message });
+    out.push({ type: "done", reason: "stop", message });
+  });
+  return out;
+}
+
+export default function (pi) {
+  pi.registerProvider("document-tools-test", {
+    baseUrl: "http://127.0.0.1",
+    apiKey: "test",
+    api: "document-tools-test-api",
+    models: [{
+      id: "document-tools-test",
+      name: "Document Tools Test",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 16_000,
+      maxTokens: 1_000,
+    }],
+    streamSimple: stream,
+  });
+}


### PR DESCRIPTION
Implements #165. **Based on #164**, which added the `setToolPublished` seam.

The four extractor schemas are **8 249 characters** — a quarter of a session's prompt floor — telling every conversation how to read Word, Excel, PowerPoint and PDF. Most conversations never open one.

**A session that names no document: ~7.8k tokens → ~5.7k.**

## When a tool appears, and when it goes

| | |
|---|---|
| Published | when the prompt names a path of that kind, **before the turn is dispatched** |
| Withdrawn, never called | at the end of that turn — the text match was simply wrong |
| Withdrawn, called at least once | after **five idle turns** |
| Brought back | by naming a document of that kind again |

Two thresholds because the two silences mean different things. A tool nobody ever called was published on a bad guess and would otherwise be paid for on every later request. A tool that *was* called is kept through the work around it — a spreadsheet read sheet by sheet, a passage checked again two answers later — because taking it away mid-task would strand an agent that **cannot ask for it back**: publication is triggered by what the user writes, and nothing announces a withdrawal to the model. That cost is stated in the design rather than hidden.

**Not** the workspace containing such a file. A repository with a `docs/` folder would then pay for all four in every session, including the ones that only touch code. Presence is not use.

## Registered last

A caching provider re-reads its prefix from the position of whatever changed. These are the definitions that arrive late, so they belong late: measured, `pdf_extract` fifth of fourteen kept **9.2%** of the prefix; last, everything ahead of it survives. One rule, `documentToolsLast()`, applied after the sandboxed and unconfined sets are joined, so it holds for both paths.

On the deployment these figures come from the question does not arise: `mistral/devstral-medium-latest` reports `cacheRead: 0, cacheWrite: 0`.

## Proof

- `server/test/documentTools.test.ts` (7): `@path`, quotes, Windows separators, a trailing full stop and `REPORT.PDF` all match; "convert this to PDF", "the pdf spec is long" and `src/pdf.ts` publish nothing.
- `server/test/documentToolsWire.test.mjs` — a real embedded session, asserting **the tool list the provider was sent**, not what the snapshot claims. It walks one tool's whole life: absent at rest in a workspace that holds a `.docx`; published on the turn that names it, siblings withheld; withdrawn after a turn that never called it; called, then surviving four idle turns; forgotten on the fifth; republished when the document is named again. It also caught the ordering bug in the first version — the idle check read the runtime *after* publishing, so nothing was ever counted.
- **Live** (`verification.md`): a real model, a real `.docx`. No extractor at rest, and `docx_extract` called on the **first attempt** once the prompt named it — no refusal, no repair loop.
- Full server suite: **1861 pass, 4 fail** — all four `TerminalManager`, from `node-pty` missing in this checkout (the lockfile drift in #160), red on `main` alike.
- 10 scenarios, `check:scenarios` clean, `openspec validate --strict` valid.

## Documentation impact

`README.md` — the Office-documents bullet says when the extractors are described to the agent and when they are forgotten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PryLsHtHcqbkjAqsxVH8rQ