### PR TITLE
fix(terminal): stop two races that made the terminal flaky in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
   "devDependencies": {
     "@playwright/test": "^1.61.1",
     "concurrently": "^10.0.4"
+  },
+  "allowScripts": {
+    "node-pty@1.1.0": true
   }
 }

--- a/server/src/terminalManager.ts
+++ b/server/src/terminalManager.ts
@@ -152,6 +152,52 @@ export interface TerminalSession {
   ptyProcess: pty.IPty;
   socket: WebSocket;
   cwd: string;
+  /**
+   * The `onData` and `onExit` subscriptions, so closing can take them off.
+   *
+   * `kill()` only *starts* a shutdown — on Windows ConPTY it drains for a while
+   * afterwards, with a helper process of its own. A listener still attached is a
+   * listener still calling back, into a socket the caller has by then given up on:
+   * that is `write EAGAIN`, and, in a test, "asynchronous activity after the test
+   * ended". Detaching first makes the shutdown silent, whatever it takes.
+   */
+  listeners: pty.IDisposable[];
+}
+
+/**
+ * Detach, then kill — in that order, and never the other way.
+ *
+ * A killed pty goes on producing for a while: ConPTY drains asynchronously and keeps a
+ * helper process alive to do it. Killing first and detaching later leaves a window in
+ * which `onData` fires into a socket nobody is reading, which surfaces as `write EAGAIN`
+ * and, under `node:test`, as activity outliving the test that started it.
+ */
+function endSession(session: TerminalSession): void {
+  for (const listener of session.listeners.splice(0)) {
+    try {
+      listener.dispose();
+    } catch {
+      // A subscription the pty has already torn down on its own side.
+    }
+  }
+  try {
+    session.ptyProcess.kill();
+  } catch {
+    // Process might already be dead
+  }
+}
+
+/**
+ * Swap the pty implementation, for tests that have no business spawning a shell.
+ *
+ * `node-pty` is an optional dependency carrying a native build, so a checkout that
+ * skipped its install script has no terminal tests at all — and the ones that do run
+ * spawn real shells whose teardown is exactly the thing being tested. Pass `null` to
+ * restore the real module.
+ */
+export function setPtyModuleForTesting(module: typeof pty | null): void {
+  ptyModule = module;
+  ptyLoadError = null;
 }
 
 export class TerminalManager {
@@ -304,15 +350,16 @@ export class TerminalManager {
         ptyProcess,
         socket,
         cwd: resolvedCwd,
+        listeners: [],
       };
 
       userSessions.set(terminalId, session);
 
-      ptyProcess.onData((data: string) => {
+      session.listeners.push(ptyProcess.onData((data: string) => {
         onData(terminalId, data);
-      });
+      }));
 
-      ptyProcess.onExit(({ exitCode }) => {
+      session.listeners.push(ptyProcess.onExit(({ exitCode }) => {
         // Guard against sequential reopen: only clean up if this session is still the active registered one!
         const currentMap = this.socketSessions.get(socket);
         if (currentMap && currentMap.get(terminalId) === session) {
@@ -322,7 +369,7 @@ export class TerminalManager {
           }
         }
         onExit(terminalId, exitCode);
-      });
+      }));
 
       return session;
     })();
@@ -405,11 +452,7 @@ export class TerminalManager {
     if (!userSessions) return false;
     const session = userSessions.get(terminalId);
     if (!session) return false;
-    try {
-      session.ptyProcess.kill();
-    } catch {
-      // Process might already be dead
-    }
+    endSession(session);
     userSessions.delete(terminalId);
     if (userSessions.size === 0) {
       this.socketSessions.delete(socket);
@@ -423,13 +466,7 @@ export class TerminalManager {
   closeAllForSocket(socket: WebSocket): void {
     const userSessions = this.socketSessions.get(socket);
     if (!userSessions) return;
-    for (const session of userSessions.values()) {
-      try {
-        session.ptyProcess.kill();
-      } catch {
-        // Ignore
-      }
-    }
+    for (const session of userSessions.values()) endSession(session);
     this.socketSessions.delete(socket);
   }
 
@@ -438,13 +475,7 @@ export class TerminalManager {
    */
   closeAll(): void {
     for (const userSessions of this.socketSessions.values()) {
-      for (const session of userSessions.values()) {
-        try {
-          session.ptyProcess.kill();
-        } catch {
-          // Ignore
-        }
-      }
+      for (const session of userSessions.values()) endSession(session);
     }
     this.socketSessions.clear();
   }

--- a/server/test/terminalListeners.test.ts
+++ b/server/test/terminalListeners.test.ts
@@ -1,0 +1,101 @@
+/**
+ * What happens to a terminal's listeners when it is closed.
+ *
+ * `kill()` starts a shutdown, it does not finish one: ConPTY drains afterwards, with a
+ * helper process of its own. A subscription still attached during that drain calls back
+ * into a socket the caller has already given up on — `write EAGAIN` on Windows CI, and
+ * "asynchronous activity after the test ended" under `node:test`, which is how three of
+ * today's red runs presented.
+ *
+ * These drive a stand-in pty rather than a shell: the behaviour under test is our
+ * teardown, and spawning a real terminal to observe it is what made the observation
+ * flaky in the first place.
+ */
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import type { WebSocket } from "ws";
+import { setPtyModuleForTesting, TerminalManager } from "../src/terminalManager.ts";
+
+/** A pty that keeps producing after `kill()`, exactly as ConPTY does. */
+function fakePty() {
+  const data: Array<(chunk: string) => void> = [];
+  const exit: Array<(event: { exitCode: number }) => void> = [];
+  const process = {
+    killed: false,
+    pid: 4242,
+    onData(listener: (chunk: string) => void) {
+      data.push(listener);
+      return { dispose: () => void data.splice(data.indexOf(listener), 1) };
+    },
+    onExit(listener: (event: { exitCode: number }) => void) {
+      exit.push(listener);
+      return { dispose: () => void exit.splice(exit.indexOf(listener), 1) };
+    },
+    write() {},
+    resize() {},
+    kill() {
+      this.killed = true;
+    },
+    /** Output, as a live pty produces it — and as a killed one goes on producing. */
+    emit(chunk: string) {
+      for (const listener of [...data]) listener(chunk);
+    },
+    /** The exit, which a real pty reports once its shutdown finishes. */
+    finish(exitCode = 0) {
+      for (const listener of [...exit]) listener({ exitCode });
+    },
+    attached: () => data.length + exit.length,
+  };
+  return process;
+}
+
+function managerWith(process: ReturnType<typeof fakePty>) {
+  setPtyModuleForTesting({ spawn: () => process } as never);
+  return new TerminalManager();
+}
+
+describe("closing a terminal", () => {
+  afterEach(() => setPtyModuleForTesting(null));
+
+  it("detaches every listener before killing the process", async () => {
+    const process = fakePty();
+    const manager = managerWith(process);
+    const socket = {} as WebSocket;
+    const seen: string[] = [];
+    let exited = 0;
+
+    await manager.open(socket, "t1", "/tmp", 80, 24, (_id, chunk) => seen.push(chunk), () => (exited += 1));
+    process.emit("hello");
+    assert.deepEqual(seen, ["hello"], "an open terminal is heard");
+
+    assert.equal(manager.close(socket, "t1"), true);
+    assert.equal(process.killed, true, "the process is killed");
+    assert.equal(process.attached(), 0, "and nothing is still listening to it");
+
+    // The drain a killed ConPTY performs, then its late exit. Before this fix both
+    // reached the caller — the first as a write to a socket nobody was reading.
+    process.emit("goodbye");
+    process.finish();
+    assert.deepEqual(seen, ["hello"], "nothing from the shutdown reaches the caller");
+    assert.equal(exited, 0, "and the exit of a terminal the caller already closed is not reported");
+  });
+
+  it("detaches when a socket goes away, and when the server shuts down", async () => {
+    for (const closer of ["closeAllForSocket", "closeAll"] as const) {
+      const process = fakePty();
+      const manager = managerWith(process);
+      const socket = {} as WebSocket;
+      const seen: string[] = [];
+
+      await manager.open(socket, "t1", "/tmp", 80, 24, (_id, chunk) => seen.push(chunk), () => {});
+      if (closer === "closeAllForSocket") manager.closeAllForSocket(socket);
+      else manager.closeAll();
+
+      assert.equal(process.killed, true, `${closer} kills the process`);
+      assert.equal(process.attached(), 0, `${closer} detaches its listeners`);
+      process.emit("after");
+      process.finish();
+      assert.deepEqual(seen, [], `${closer} leaves nothing to call back`);
+    }
+  });
+});

--- a/ui/src/components/TerminalPanel.test.tsx
+++ b/ui/src/components/TerminalPanel.test.tsx
@@ -80,6 +80,35 @@ describe("TerminalPanel", () => {
     expect(screen.getByText("API Server")).toBeInTheDocument();
   });
 
+  it("does not let the terminal take focus back while a tab is being renamed", async () => {
+    // The flake this fixes, as a defect rather than a race: a tab becoming active
+    // schedules `terminal.focus()` 50 ms later, and double-clicking to rename also
+    // activates. The timer landed mid-typing, the input blurred, `onBlur` committed, and
+    // the field was unmounted from under whoever was typing — with a half-written name.
+    vi.useFakeTimers();
+    const focusSpy = vi.spyOn(Terminal.prototype, "focus").mockImplementation(() => {});
+    try {
+      render(<TerminalPanel {...defaultProps} />);
+      focusSpy.mockClear();
+
+      fireEvent.doubleClick(screen.getByText("terminal 1"));
+      const input = screen.getByDisplayValue("terminal 1");
+      fireEvent.change(input, { target: { value: "Build Ser" } });
+
+      // Everything the focus timer would have fired, while the name is half typed.
+      act(() => void vi.advanceTimersByTime(500));
+      expect(focusSpy).not.toHaveBeenCalled();
+      expect(screen.getByTestId("terminal-tab-rename-input")).toBe(input);
+
+      fireEvent.change(input, { target: { value: "Build Server" } });
+      fireEvent.keyDown(input, { key: "Enter" });
+      expect(screen.getByText("Build Server")).toBeInTheDocument();
+    } finally {
+      focusSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
   it("calls onSetWorkspaceRoot when clicking open as project button", () => {
     const onSetWorkspaceRoot = vi.fn();
     render(

--- a/ui/src/components/TerminalPanel.tsx
+++ b/ui/src/components/TerminalPanel.tsx
@@ -41,6 +41,16 @@ interface SingleTerminalViewProps {
   cwd?: string;
   isActive: boolean;
   isPanelOpen: boolean;
+  /**
+   * True while a tab is being renamed anywhere in the panel.
+   *
+   * The terminal takes focus back when it becomes the active tab, 50 ms after the fact.
+   * Double-clicking a tab to rename it also activates it, so that timer lands in the
+   * middle of typing: the rename input blurs, `onBlur` commits, and the field is
+   * unmounted from under the user — with whatever they had typed so far. Focus is worth
+   * having, and not at the price of a name.
+   */
+  renaming: boolean;
   openTerminal?: TerminalPanelProps["openTerminal"];
   sendTerminalInput?: TerminalPanelProps["sendTerminalInput"];
   getTerminalCwd?: TerminalPanelProps["getTerminalCwd"];
@@ -111,6 +121,7 @@ function SingleTerminalView({
   cwd,
   isActive,
   isPanelOpen,
+  renaming,
   openTerminal,
   sendTerminalInput,
   getTerminalCwd,
@@ -268,6 +279,7 @@ function SingleTerminalView({
 
   // When active tab changes or panel becomes visible, refit, focus, and refresh cwd
   useEffect(() => {
+    if (renaming) return;
     if (isPanelOpen && isActive && fitAddonRef.current && terminalRef.current && containerRef.current) {
       callbacksRef.current.getTerminalCwd?.(id);
       const timer = setTimeout(() => {
@@ -280,7 +292,7 @@ function SingleTerminalView({
       }, 50);
       return () => clearTimeout(timer);
     }
-  }, [isPanelOpen, isActive, id]);
+  }, [isPanelOpen, isActive, id, renaming]);
 
   return (
     <div
@@ -557,6 +569,7 @@ export function TerminalPanel({
             cwd={cwd}
             isActive={tab.id === activeTabId}
             isPanelOpen={open}
+            renaming={editingTabId !== null}
             openTerminal={openTerminal}
             sendTerminalInput={sendTerminalInput}
             getTerminalCwd={getTerminalCwd}


### PR DESCRIPTION
Four red CI runs today came from the terminal, on branches touching neither the terminal nor the UI. Two distinct races, one install problem behind the fact that nobody noticed.

## 1. A killed terminal kept talking

`kill()` starts a shutdown; it does not finish one. ConPTY drains for a while afterwards, with a helper process of its own (`conpty_console_list_agent`), and our subscriptions stayed attached the whole time — calling back into a socket the caller had already given up on. That is `write EAGAIN`, and under `node:test` *"generated asynchronous activity after the test ended"*: exactly what the Windows failures printed.

One `endSession()`, shared by `close`, `closeAllForSocket` and `closeAll`, now disposes the subscriptions **first** and kills second.

A shell that exits on its own still reports it; only a close the caller asked for goes quiet. Checked before relying on it: the UI's exit handler writes `[Process completed]` into the buffer and nothing else — tab removal is the component's own unmount path.

## 2. The terminal stole focus from a rename

```
double-click a tab → onClick activates it → effect [isActive] → 50 ms later
terminal.focus() → the rename input blurs → onBlur commits → the input unmounts
```

Whether you keep your name depends on whether you finish typing inside 50 ms. Playwright loses that race about one run in five — `element was detached from the DOM` while pressing Enter on an input whose value had already been filled — and **a person typing slowly loses it too, silently**. The view now skips the focus while any tab is being renamed.

## 3. Why none of this was caught

npm 12 blocks install scripts by default, so `node-pty` — optional, with a native binding — silently did not install. The four `TerminalManager` tests have been red all day for that reason alone, `terminalWire` never ran at all, and neither could the tests written for the two fixes above. A suite that cannot run is not a suite that passes.

`allowScripts` records the approval in the repository, by exact version, so a fresh clone gets a terminal it can test. The lockfile is deliberately untouched: `npm install node-pty --workspace server` had also written node-pty into the server's *dependencies*, where its manifest keeps it optional — that would make a native build mandatory on platforms with no prebuild.

## Verification

- `server/test/terminalListeners.test.ts` (new, 2 tests): a stand-in pty that keeps producing after `kill()`, asserting nothing from the shutdown reaches the caller and the exit is not reported for a terminal the caller closed. `setPtyModuleForTesting()` is the seam; it needs no native build.
- `TerminalPanel.test.tsx` (new test): the focus timer fires mid-rename and must not steal focus. **Fails on the code before the fix** — "expected focus to not be called at all, but actually been called 1 times".
- With node-pty installed: 13 server terminal tests and 20 `TerminalPanel` tests, all green — including the four that had been red since this morning.
- `codex-review --base main`: **no findings**.

The `browser` job that failed on this PR ran before the second fix existed; its failure is the very defect fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PryLsHtHcqbkjAqsxVH8rQ