### PR TITLE
test(resources): cover the manager callbacks the coverage gate was missing

### DIFF
--- a/ui/src/components/AgentResourceManager.test.tsx
+++ b/ui/src/components/AgentResourceManager.test.tsx
@@ -276,6 +276,90 @@ describe("AgentResourceManager", () => {
     expect(onUpdate).toHaveBeenCalledWith("repo-team", "token-repo-team", "1111111111111111111111111111111111111111", "2222222222222222222222222222222222222222", true);
   });
 
+  it("lets a discovered root be deselected before anything is enrolled", () => {
+    // Every root arrives selected, and the point of a preview is that the user may want
+    // only some of them. Nothing had exercised unticking one.
+    const { onEnrollRepository, rerenderWith } = setup();
+    fireEvent.click(screen.getByRole("button", { name: "Add Git repository…" }));
+    fireEvent.change(screen.getByRole("textbox", { name: "Repository address" }), { target: { value: "https://example.test/team/resources.git" } });
+    rerenderWith({ operations: operations({ preview: { requestId: "preview", status: "ready", preview: {
+      token: "preview-token",
+      repositoryPath: "/srv/resources",
+      repositoryName: "resources",
+      headRevision: "abc",
+      roots: [
+        { kind: "skill", path: "/srv/resources/skills", name: "skills" },
+        { kind: "skill", path: "/srv/resources/.agents/skills", name: ".agents/skills" },
+      ],
+    } } }) });
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes).toHaveLength(2);
+    fireEvent.click(checkboxes[1]);
+    fireEvent.click(screen.getByRole("button", { name: "Activate selected resources" }));
+    expect(onEnrollRepository).toHaveBeenCalledWith("preview-token", ["/srv/resources/skills"], []);
+
+    // ...and unticking the last one leaves nothing to activate.
+    fireEvent.click(checkboxes[0]);
+    expect(screen.getByRole("button", { name: "Activate selected resources" })).toBeDisabled();
+  });
+
+  it("closes on Escape and on a click outside the dialog, but not on a click inside it", () => {
+    const { onClose } = setup();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    fireEvent.mouseDown(screen.getByRole("dialog", { name: "Agent resources" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    fireEvent.mouseDown(screen.getByRole("presentation"));
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it("asks for a refresh, and says nothing while one is running", () => {
+    const { onRefresh, rerenderWith } = setup();
+    fireEvent.click(screen.getByRole("button", { name: "Refresh all" }));
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+
+    rerenderWith({ operations: operations({ refresh: { requestId: "refresh", status: "loading" } }) });
+    expect(screen.getByRole("button", { name: "Refresh all" })).toBeDisabled();
+  });
+
+  it("removes a user-owned extension root from the extension paths, not the skill paths", () => {
+    // The skill half of this branch was covered; the extension half sends a different
+    // config key, and sending the wrong one would drop an unrelated skill.
+    const { onUpdateConfig } = setup({
+      userExtensionPaths: ["/repos/team/extensions"],
+      inventory: {
+        capabilities: { skills: "available", extensions: "available" },
+        resources: [
+          { id: "extension:deploy", kind: "extension", name: "deploy", origin: "user", path: "/repos/team/extensions/deploy.ts", userRoot: "/repos/team/extensions" },
+        ],
+        repositories: [],
+      },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Remove /repos/team/extensions" }));
+    expect(onUpdateConfig).toHaveBeenCalledWith({ userExtensionPaths: [] });
+  });
+
+  it("leaves the update alone when the executable confirmation is declined", () => {
+    // The confirming half is covered; declining must not fall through to the update.
+    const { onUpdate } = setup();
+    fireEvent.click(screen.getByRole("button", { name: "Update repository" }));
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onUpdate).not.toHaveBeenCalled();
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("abandons the add flow and closes the server browser with it", () => {
+    const { onCloseServerBrowser } = setup();
+    fireEvent.click(screen.getByRole("button", { name: "Add Git repository…" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onCloseServerBrowser).toHaveBeenCalled();
+    expect(screen.queryByRole("textbox", { name: "Repository address" })).not.toBeInTheDocument();
+  });
+
   it("keeps an in-flight result keyed to its repository and falls back after stale identity", () => {
     const { rerenderWith } = setup({ operations: operations({ updates: { "repo-team": { requestId: "update", status: "loading" } } }) });
     fireEvent.click(screen.getByRole("button", { name: /Provenance unavailable/ }));


### PR DESCRIPTION
For #168, whose `check` job fails on coverage rather than on a test: **1 492 pass, functions at 92.43% against a 93% threshold**, the resource manager itself at 83.75%.

Six tests, on behaviours that were genuinely unexercised — not on whatever moved the number fastest:

| Test | Why it is worth having |
|---|---|
| a discovered root can be deselected before enrolling | the preview exists so the user can take *some* of what was found; unticking had never been driven, nor the disabled state when nothing is left |
| Escape and backdrop close it, a click inside does not | two dismissal paths, one of which must not fire |
| Refresh asks once and is disabled while running | the disabled state is what stops a second fetch landing on the first |
| removing a user-owned **extension** root | the skill half was covered; this half writes a different config key, and confusing them would drop an unrelated skill |
| declining the executable-update confirmation | the confirming half was covered; declining must not fall through to `onUpdate` |
| abandoning the add flow closes the server browser | a browser left open behind a closed flow is a stuck panel |

## Result

```
Tests   1498 passed
Funcs   93.15%   (threshold 93)
Branch  87.16%   (85)
Lines   94.62%   (91)
gate exit=0
```

## What I did not do

Four callbacks stay uncovered — the local-path field's `onChange` and the two `ServerPathPicker` `onSelect`s. They sit on flows the suite already walks (`adds a local skill folder once through the picker` clicks the very button that fires one), so the uncovered count reads as an attribution quirk in the v8 provider rather than a real gap. Chasing it would be padding; the threshold is met on behaviour that matters.

I did not lower the threshold, and I did not push into `codex/manage-agent-resources` — it is checked out in another worktree, and two agents writing one branch is a morning I would rather not repeat. Merge this into it, or cherry-pick.

The review comments on #168 still stand separately, the P1 among them: `dev:ino` identity collides on ext4 after a replace-in-place, which is why that test is red on CI and green on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PryLsHtHcqbkjAqsxVH8rQ