### PR TITLE
chore(release): v0.21.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-outpost",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "type": "module",
   "description": "A web interface for the pi coding agent: a browser chat UI you run with npx — no clone, no build.",
   "license": "MIT",

--- a/embed/package.json
+++ b/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-outpost/embed",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "type": "module",
   "description": "Mount pi-outpost as a Shadow-DOM-isolated widget inside another web app.",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "cli": {
       "name": "pi-outpost",
-      "version": "0.20.1",
+      "version": "0.21.0",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "^0.84.4",
@@ -45,7 +45,7 @@
     },
     "embed": {
       "name": "@pi-outpost/embed",
-      "version": "0.20.1",
+      "version": "0.21.0",
       "license": "MIT",
       "devDependencies": {
         "@microsoft/api-extractor": "^7.58.9",


### PR DESCRIPTION
## Release summary

- Manage skills and extensions from local folders and multiple Git repositories, including clone, update, and committing local changes.
- Harden repository identity, credential handling, path confinement, refresh behavior, and cross-platform paths.
- Publish document extraction tools only when relevant and split the work-plan contract so extended operations are loaded on demand.
- Include terminal lifecycle and focus fixes shipped since v0.20.1.

## Validation

- PR #168: browser, Ubuntu, Windows, CodeQL, and dependency-security checks passed.
- Published package versions and lockfile are aligned at 0.21.0.
- Release channel resolves to latest.
- The tag-triggered release workflow will rerun the full publish gates and build platform executables.

## Documentation impact

None — this PR only aligns published package versions.