### PR TITLE
fix(resources): report a vetoed reload instead of claiming success

### DIFF
--- a/openspec/changes/manage-git-backed-agent-resources/scenario-coverage.md
+++ b/openspec/changes/manage-git-backed-agent-resources/scenario-coverage.md
@@ -39,7 +39,7 @@ Enumerated with `rg '^#### Scenario:' openspec/`. All 61 delta scenarios and the
 | `agent-resource-management / Confirmation becomes stale` | covered | `server/test/resourceRepositories.test.ts` — the revision/expiry test asserts expired and changed-revision confirmations are refused. |
 | `agent-resource-management / Affected workspace is busy` | covered | `server/test/agentResourcesWire.test.mjs` — busy-workspace test asserts refusal occurs before remote HEAD is applied. |
 | `agent-resource-management / Shared repository reloads all affected idle workspaces` | covered | `server/test/agentResourcesWire.test.mjs` — shared-repository test asserts both sessions are rebuilt and both receive inventories with additions/removals. |
-| `agent-resource-management / Reload fails after Git succeeds` | covered | `server/test/agentResourcesWire.test.mjs` — partial-failure test asserts Git stays advanced and the failed workspace is reported. |
+| `agent-resource-management / Reload fails after Git succeeds` | covered | `server/test/agentResourcesWire.test.mjs` — partial-failure test asserts Git stays advanced and the failed workspace is reported; “a vetoed session replacement reports partial failure instead of claiming the runtime reloaded” drives a real extension veto and asserts the outcome is `updated-reload-failed`, that the reload names the refusal, that the worktree stayed advanced, and that a second socket is still told the same session id. |
 | `agent-resource-management / Unstarted workspace loads later` | covered | `server/test/agentResourcesWire.test.mjs` — dormant-workspace test asserts it is not started by update and later loads the new resource. |
 
 ## API delta

--- a/openspec/changes/manage-git-backed-agent-resources/specs/agent-resource-management/spec.md
+++ b/openspec/changes/manage-git-backed-agent-resources/specs/agent-resource-management/spec.md
@@ -197,7 +197,7 @@ A repository that supplies any applicable extension SHALL be treated as executab
 
 Before changing a repository, the system SHALL identify every started workspace whose configured roots or loaded resource provenance overlap that repository. It SHALL refuse the update while any such workspace is streaming a turn or replacing its session. After a successful fast-forward, it SHALL rebuild the resources for every affected started workspace whose runtime is idle and broadcast the resulting inventories. Workspaces that are not started SHALL discover the new resources when they next start.
 
-An update that succeeds on disk but whose runtime rebuild fails SHALL be reported as an updated-reload-failed outcome, including the affected workspace failures. The system MUST NOT claim that Git was rolled back or that all runtimes use the new resources.
+An update that succeeds on disk but whose runtime rebuild fails SHALL be reported as an updated-reload-failed outcome, including the affected workspace failures. A session replacement that is refused rather than thrown — an extension vetoing the fresh session — SHALL count as such a failure and name that refusal: the worktree has advanced while the retained session still holds the previous revision's resources. The system MUST NOT claim that Git was rolled back or that all runtimes use the new resources.
 
 #### Scenario: Affected workspace is busy
 - **WHEN** any started workspace affected by a repository is streaming a turn or replacing its session

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1650,19 +1650,15 @@ function snapshot(workspace: Workspace): SessionSnapshot {
       piOutpost: VERSION,
       ...(workspace.agent.agentLabel ? { agent: workspace.agent.agentLabel } : { piSdk: PI_SDK_VERSION }),
     },
-    sandbox: (() => {
-      const v = config.sandbox
-        ? {
-            root: config.sandbox.root,
-            allowWrite: config.sandbox.allowWrite ?? false,
-            allowBash: config.sandbox.allowBash ?? false,
-            writableRoot: config.sandbox.writableRoot,
-            locks: config.sandboxLocks,
-          }
-        : undefined;
-      console.log("[snapshot] sandbox =", JSON.stringify(v));
-      return v;
-    })(),
+    sandbox: config.sandbox
+      ? {
+          root: config.sandbox.root,
+          allowWrite: config.sandbox.allowWrite ?? false,
+          allowBash: config.sandbox.allowBash ?? false,
+          writableRoot: config.sandbox.writableRoot,
+          locks: config.sandboxLocks,
+        }
+      : undefined,
     terminal: {
       enabled: config.terminal?.enabled ?? false,
       ...(config.sandboxLocks?.terminal ? { locked: true } : {}),
@@ -3621,7 +3617,19 @@ async function handleUpdateAgentResourceRepository(
       }
       try {
         resourceRefreshHints.set(target.root, repositoryPath);
-        await rebuild.call(target.agent);
+        // A vetoed replacement is a failed reload, not a silent one: the worktree
+        // has already advanced, and the retained session still holds the resources
+        // of the revision the user just left. Reporting "reloaded" here would make
+        // the interface claim every runtime uses the new ones.
+        const reload = await rebuild.call(target.agent);
+        if (reload.cancelled) {
+          reloads.push({
+            workspaceRoot: target.root,
+            status: "failed",
+            message: "An extension cancelled the session replacement, so this runtime still uses the previous resources",
+          });
+          continue;
+        }
         const inventory = await (resourceReloadSyncs.get(target.root) ?? refreshResourceInventory(target, repositoryPath));
         broadcast(target, { type: "agent_resource_inventory", inventory });
         if (target === workspace) requesterInventoryRefreshed = true;

--- a/server/test/agentResourcesWire.test.mjs
+++ b/server/test/agentResourcesWire.test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { mkdir, readFile, realpath, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import test from "node:test";
 import { connect, makeWorkspace, startServer } from "./harness.mjs";
 import { startScriptedServer } from "./multiProjectHarness.mjs";
@@ -422,4 +422,52 @@ test("a runtime reload failure reports partial failure after preserving the Git 
   assert.equal(result.result.reloads[0].status, "failed");
   assert.match(result.result.reloads[0].message, /unavailable/i);
   assert.equal(run(checkout, ["rev-parse", "HEAD"]), expected);
+});
+
+// openlore: scenario=ReloadFailsAfterGitSucceeds spec=agent-resource-management
+test("a vetoed session replacement reports partial failure instead of claiming the runtime reloaded", async (t) => {
+  const root = await realpath(await makeWorkspace());
+  const { remote, seed } = await makeRemote(root);
+  const checkout = path.join(root, "veto-reload-resources");
+  run(root, ["clone", "-q", remote, checkout]);
+  const server = await startServer(root, {
+    skillPaths: [path.join(checkout, "skills", "review")],
+    extensionPaths: [fileURLToPath(new URL("./fixtures/veto-session-switch.mjs", import.meta.url))],
+  });
+  t.after(() => server.stop());
+  const client = connect(server.wsUrl());
+  t.after(() => client.close());
+  const hello = await client.waitFor("hello", 30_000);
+  const sessionBefore = hello.sessionId;
+  const repository = (await resourceInventory(client, hello)).repositories.find((candidate) => candidate.path === checkout);
+  const expected = await advanceRemote(seed, "Vetoed reload update.\n");
+  client.send({ type: "refresh_agent_resource_repositories", repositoryId: repository.id, requestId: "veto-assess" });
+  const checked = await client.waitFor((message) => message.type === "agent_resource_assessments" && message.requestId === "veto-assess");
+  const assessment = checked.assessments[0];
+  client.send({
+    type: "update_agent_resource_repository",
+    repositoryId: repository.id,
+    assessmentToken: assessment.token,
+    localRevision: assessment.localRevision,
+    upstreamRevision: assessment.upstreamRevision,
+    requestId: "veto-update",
+  });
+  const result = await client.waitFor((message) => message.type === "agent_resource_update_result" && message.requestId === "veto-update", 60_000);
+
+  assert.equal(result.result.status, "updated-reload-failed", "a retained session must not be reported as reloaded");
+  assert.equal(result.result.reloads.length, 1);
+  assert.equal(result.result.reloads[0].status, "failed");
+  assert.match(result.result.reloads[0].message, /cancelled the session replacement/i);
+  // The worktree really did advance: the failure is the runtime's, and the result
+  // must not suggest Git was rolled back.
+  assert.equal(run(checkout, ["rev-parse", "HEAD"]), expected);
+  // The retained session is the whole point of the failure: nothing announced a
+  // replacement, and the session in front of the user is the one that was there.
+  assert.equal(client.received.some((message) => message.type === "session_replaced"), false, "the vetoed session was never replaced");
+  // Asked fresh rather than inferred from the absence of a broadcast: a second
+  // socket is told which session is live now.
+  const observer = connect(server.wsUrl());
+  t.after(() => observer.close());
+  const after = await observer.waitFor("hello", 30_000);
+  assert.equal(after.sessionId, sessionBefore, "the session that refused replacement is still the live one");
 });

--- a/server/test/fixtures/veto-session-switch.mjs
+++ b/server/test/fixtures/veto-session-switch.mjs
@@ -1,0 +1,13 @@
+/**
+ * Cancels every fresh session the server asks for, and nothing else.
+ *
+ * The SDK honours this veto by keeping the current session alive, which is the
+ * state a resource reload has to notice: the worktree has moved, the running
+ * agent has not. Only `new` is refused, so the server's own first session — which
+ * is not a switch — still starts.
+ */
+export default function (pi) {
+  pi.on("session_before_switch", async (event) => {
+    if (event.reason === "new") return { cancel: true };
+  });
+}


### PR DESCRIPTION
Two pre-existing defects found while reviewing #174, one of them a false success message.

## A refused session replacement was reported as a reload

Updating a Git-backed resource repository fast-forwards the worktree, then replaces the session of every affected workspace so the agent picks up the new revision. An extension can veto that replacement on `session_before_switch`, and the SDK honours the veto by keeping the current session alive.

`handleUpdateConfig` reads that refusal and rolls everything back. The Git reload path threw the return value away: `await rebuild.call(target.agent)`. So a veto produced `status: "reloaded"`, the result came back `updated` rather than `updated-reload-failed`, and the dialog said **"Repository updated and runtimes reloaded."** — while the worktree had advanced and the running agent still held the previous revision's skills and extensions. That is exactly the state `updated-reload-failed` exists to describe.

The reload now reads the result and reports the refusal against the workspace it belongs to.

## Debug log left in the snapshot builder

`3c08e7f` (18 July) added `console.log("[snapshot] sandbox =", …)` and it has been on `main` since. `snapshot()` runs on every `hello`, every session replacement, every project switch and every settings acknowledgement, so every connection prints the user's sandbox paths to the server's stdout. Removed; the expression is a plain object again.

## Verification

- New wire test in `server/test/agentResourcesWire.test.mjs`: a real embedded server with an extension that cancels `session_before_switch`, a real remote fast-forwarded underneath it. It asserts the outcome is `updated-reload-failed`, that the reload names the refusal, that `git rev-parse HEAD` really advanced (the failure is the runtime's, not Git's), that no `session_replaced` was broadcast, and that a second socket connecting afterwards is told the same session id.
- Confirmed red before the fix: reverting the two-line read makes it fail on `a retained session must not be reported as reloaded`.
- `server`: 1909 tests pass. `npm run typecheck`, `npm run lint`, `npx openspec validate manage-git-backed-agent-resources --strict` and `npm run check:scenarios` (61 scenarios) are clean.

The `Affected runtime reload` requirement now states that a refused replacement counts as a failed reload; the existing `Reload fails after Git succeeds` scenario covers it, so the scenario count is unchanged.

## Documentation impact

None. Neither behaviour is documented: the reload outcome is described only in the spec, and the removed line was debug output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SKMFb6sofkNugUcuzVdFf