### PR TITLE
feat(ui): replace the tool toggle with a conversation filter menu

### DIFF
--- a/openspec/changes/replace-tool-toggle-with-filter-menu/.openspec.yaml
+++ b/openspec/changes/replace-tool-toggle-with-filter-menu/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-04

--- a/openspec/changes/replace-tool-toggle-with-filter-menu/design.md
+++ b/openspec/changes/replace-tool-toggle-with-filter-menu/design.md
@@ -1,0 +1,61 @@
+## Context
+
+See proposal.md — Why.
+
+Two mechanisms sit behind what looks like one feature, and they are not the same shape. A tool call is a whole `ChatItem` (`kind: "tool"`), filtered out with a single early return in the application's item loop (`ui/src/App.tsx`, the `item.kind === "tool"` branch). Reasoning is not an item: it is a block inside an assistant item (`block.type === "thinking"`), rendered by `ThinkingBlock` inside `ui/src/components/AssistantMessage.tsx`. So one filter acts on the list and the other acts inside a renderer, and only the second one can leave a message with nothing in it.
+
+The header's current control is a `<button aria-pressed>` in `ui/src/components/Header.tsx` with an `onToggleHideTools` callback, and the state it renders lives in `App.tsx` as `hideTools`, seeded from `localStorage` in a `try/catch` because storage can throw. The application already has a popover idiom: `ui/src/util/clickOutside.ts`, used by eight components.
+
+`App.tsx` already meets the "an item that renders to nothing is still a position" problem for tool-call-only assistant messages, and solves it by emitting a bare scroll anchor. That existing solution is the one to extend, not a new one.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One control that names the act (filtering) and reports what is currently filtered without being opened.
+- Filtering that is purely a rendering decision, reversible with no data loss, on both kinds.
+- The reasoning filter never producing a blank card or a dead scroll target.
+
+**Non-Goals:**
+
+- Filtering any other content kind (user messages, custom extension messages, errors). The menu is built to take a third entry later; this change ships two.
+- A server-side or per-session preference. These stay per-browser, like the current toggle.
+- Changing how `ThinkingBlock` renders when it *is* shown — it stays collapsed-by-default.
+- Migrating the existing `pi-outpost:hide-tools` key. It keeps its name and meaning.
+
+## Decisions
+
+### Checked means shown, and the stored keys stay hide-shaped
+
+The menu presents *what the conversation contains*: `Tool calls ✓`, `Reasoning ✓`. Clearing a box removes that kind. A menu whose boxes mean "hide this" forces the reader through a double negative on every glance, and the current button's `aria-pressed`-means-hiding is precisely the confusion being fixed.
+
+The persisted keys stay in the hiding polarity — `pi-outpost:hide-tools` keeps its exact name and semantics, and reasoning joins it as `pi-outpost:hide-reasoning`. Inverting the stored value would silently flip the preference of every existing user on first load, which is a worse outcome than a small mismatch between the UI's polarity and the storage key's name. The inversion happens once, where the state is read.
+
+Alternative considered: a tri-state segmented control ("All / No tools / Reading view"). It reads faster but cannot express the four combinations two independent filters give, and it makes a third kind a redesign rather than a fourth entry.
+
+### The filter state is one object passed down, not two booleans threaded
+
+`App.tsx` holds `{ tools: boolean; reasoning: boolean }` (shown-semantics) and passes it, plus one `onFilterChange(kind, shown)` callback, to `Header`. Two independent boolean props and two callbacks would work today and would need editing at every layer for a third kind. `Header` stays stateless about filtering — it holds only whether its own popover is open.
+
+### The reasoning filter is applied inside AssistantMessage, and emptiness is reported upward
+
+`AssistantMessage` receives `hideReasoning` and skips those blocks. It must not be the one to decide "this turn does not exist" — that is the list's job, because the list owns the scroll anchor. So the emptiness decision is made where the item is rendered: an assistant item whose blocks are all `thinking`, with reasoning hidden, takes the same bare-anchor path `App.tsx` already uses for tool-call-only messages, and `AssistantMessage` is not rendered at all for it.
+
+Alternative considered: letting `AssistantMessage` return `null`. That keeps the check in one place but puts a hole in the list where the anchor should be — the exact defect the existing bare-anchor path was written to avoid.
+
+Streaming is the case that makes this ordering matter: an assistant item that currently holds only a `thinking` block may grow a text block a second later. The decision is therefore made per render from the blocks present, never latched.
+
+### The menu reuses clickOutside, and closes on Escape
+
+Not a new popover mechanism. Escape is added because a filter menu is opened by keyboard as easily as by mouse, and because a menu stranded open over a conversation that has since changed is the failure this project has already hit once with the per-repository git menu.
+
+## Risks / Trade-offs
+
+- **One click becomes two for the most common action.** → The trigger keeps a visible filtered state, so the round trip is only needed to *change* the filter, not to check it. If this proves annoying in the running app, a middle-click or a modifier shortcut can restore one-click "hide tools" later without changing the contract.
+- **The stored key's name no longer matches the UI's polarity.** → Confined to the two `localStorage` reads, each of which inverts once, and documented where it happens. The alternative silently flips existing users' preference.
+- **A streaming assistant message can flicker between "nothing" and "a card"** as its first text block arrives while reasoning is hidden. → Per-render decision from the blocks present makes this correct rather than latched; the bench pass has to watch a live turn with reasoning hidden, not just a seeded transcript.
+- **Tests that drive the old `⚒ tools` button break.** → Intended: they encode the label being replaced. They are rewritten against the menu, not adapted with a selector change.
+
+## Migration Plan
+
+None needed at runtime. The stored `pi-outpost:hide-tools` value carries over unchanged, and a browser with no `pi-outpost:hide-reasoning` key shows reasoning, which is today's behaviour.

--- a/openspec/changes/replace-tool-toggle-with-filter-menu/proposal.md
+++ b/openspec/changes/replace-tool-toggle-with-filter-menu/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The header's `⚒ tools` button is not understood by the people using it. It names its subject rather than its action, and what it actually does — hide tool cards — lives only in a `title` attribute nobody hovers. Its state is carried by a background shade and `aria-pressed`, which reads as "selected" more than "filtering". Meanwhile the other source of conversation noise, the model's reasoning, has no filter at all: a long session of collapsed `thinking` headers cannot be turned off.
+
+## What Changes
+
+- Replace the single toggle with a **Filter** menu in the header: a button that opens a small popover with two checkboxes, **Tool calls** and **Reasoning**.
+- **Checked means shown.** The current control is pressed when it is *hiding*; a menu of checkboxes has to read as "what the conversation contains", or every item is a double negative.
+- Keep the filtering state readable while the menu is closed — the button reports that at least one kind is hidden, so the "am I looking at everything?" question is answerable without opening it.
+- Add a reasoning filter that removes `thinking` blocks from assistant messages, persisted like the tool filter.
+- Handle the message that a reasoning filter can empty: an assistant item whose only blocks are `thinking` blocks must not render as an empty bubble. The application already solves this shape for tool-call-only messages by rendering a bare scroll anchor; the same treatment applies here so conversation navigation never lands on nothing.
+- Persist both preferences separately in `localStorage`, each tolerant of storage being unavailable, as the tool filter already is.
+- Not breaking: this is a UI surface with no wire protocol, no configuration key, and no server involvement. An existing `pi-outpost:hide-tools` value keeps its meaning.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `conversation-filter`: `ToolCardToggle` becomes a two-filter contract — it currently specifies a single tool toggle, and must now specify both filters, the shown-not-hidden polarity, the visible-while-closed state, independent persistence, and the empty-assistant-message case.
+- `components`: `RuntimeControls` gains the `Header` filter-menu contract (a menu reporting intent through callbacks, closing on outside click and Escape, and remaining correct when the conversation changes underneath it). `ConversationItemRendering` gains `AssistantMessage`'s obligation to omit reasoning blocks when its consumer asks, and to render nothing rather than an empty container when that leaves the item with no content.
+
+## Impact
+
+- `ui/src/components/Header.tsx` — the `⚒ tools` button and its `onToggleHideTools` prop become a filter menu with two callbacks; reuses the existing `ui/src/util/clickOutside.ts` idiom already used by eight components.
+- `ui/src/App.tsx` — `hideTools` state gains a sibling for reasoning, both persisted; the item loop at the tool-card branch is joined by a decision about assistant items left empty.
+- `ui/src/components/AssistantMessage.tsx` — takes a prop to skip `thinking` blocks, and reports emptiness rather than rendering an empty frame.
+- Tests: `ui/src/components/Header.test.tsx`, `ui/src/components/AssistantMessage.test.tsx`, `ui/src/App.test.tsx` (or the conversation-filter tests that cover the current toggle), plus a Playwright pass in the running widget — this is a UI surface, and the failure modes here are the menu left open while the conversation changes and the empty bubble, neither of which a unit test observes.
+- No server, protocol, or configuration change.

--- a/openspec/changes/replace-tool-toggle-with-filter-menu/scenario-coverage.md
+++ b/openspec/changes/replace-tool-toggle-with-filter-menu/scenario-coverage.md
@@ -1,0 +1,35 @@
+Enumerated with `rg '^#### Scenario:' openspec/`. All 15 delta scenarios are covered by assertions that exercise their observable contract. The scenarios inherited from `ToolCardToggle` are covered at the same boundary they were before — the conversation the user reads — now driven through the menu that replaced the toggle.
+
+## Conversation filter delta
+
+| Scenario | Coverage | Assertion evidence |
+|---|---|---|
+| `conversation-filter / HideTools` | covered | `ui/src/App.test.tsx` — “hides tool cards and leaves the messages around them alone” clears the filter through the header menu and asserts the tool card is gone from the DOM while the user text and the assistant answer remain. |
+| `conversation-filter / HideReasoning` | covered | `ui/src/App.test.tsx` — “hides reasoning and keeps the answer that came with it” asserts the thinking control disappears from a message whose answer text is still rendered. |
+| `conversation-filter / FiltersAreIndependent` | covered | `ui/src/App.test.tsx` — “remembers each filter across mounts, independently” asserts the reasoning entry reads unchecked and the tool entry checked after a remount; `ui/src/conversationFilters.test.ts` — “writes one kind without touching the other” asserts each write leaves the other key as it was. |
+| `conversation-filter / PersistedAcrossReload` | covered | `ui/src/App.test.tsx` — “remembers each filter across mounts, independently” unmounts and remounts the app and reads the state back from the menu; `ui/src/conversationFilters.test.ts` — “keeps the meaning of a preference set before the second filter existed” asserts a pre-existing `pi-outpost:hide-tools=1` still means tools hidden. |
+| `conversation-filter / StateIsVisibleWithoutOpeningTheMenu` | covered | `ui/src/components/Header.test.tsx` — “says on the closed trigger whether the conversation is filtered” asserts the trigger reads `Filter` with nothing hidden and names the count for one and two hidden kinds. |
+| `conversation-filter / NothingLostOnRestore` | covered | `ui/src/App.test.tsx` — “gives every tool card back, including the ones that arrived while hidden” adds a second tool call while the filter is on and asserts both cards render once it is cleared. |
+| `conversation-filter / NoEmptyMessageIsLeftBehind` | covered | `ui/src/App.test.tsx` — “leaves no empty card where a reasoning-only turn was, but keeps its place” asserts no thinking control and no reasoning text render, and that the turn's `data-item-index` anchor is still present and carries no visible card; `ui/src/components/AssistantMessage.test.tsx` — “renders nothing at all when hiding reasoning empties the message” asserts an empty container at the component boundary. |
+| `conversation-filter / ActivityStillVisible` | covered | `ui/src/App.test.tsx` — “still shows that the agent is working while tool cards are hidden” asserts the working indicator with the filter cleared and a turn streaming. |
+
+## Components delta
+
+| Scenario | Coverage | Assertion evidence |
+|---|---|---|
+| `components / The filter menu reports intent rather than holding state` | covered | `ui/src/components/Header.test.tsx` — “reports the kind that was toggled rather than holding the state” asserts the callback receives `("tools", false)` and that the entry still reads checked until the parent re-renders it with new state. |
+| `components / The closed trigger says whether the conversation is filtered` | covered | `ui/src/components/Header.test.tsx` — “says on the closed trigger whether the conversation is filtered”. |
+| `components / The menu closes on outside click and Escape` | covered | `ui/src/components/Header.test.tsx` — “closes on an outside click without changing anything” and “closes on Escape without changing anything” each assert the menu leaves the DOM and the change callback was never invoked. |
+| `components / Filter entries are checkboxes to assistive technology` | covered | `ui/src/components/Header.test.tsx` — “exposes each entry as a checkbox carrying whether that kind is shown” queries by the `menuitemcheckbox` role and asserts `aria-checked` matches the supplied filters. |
+| `components / AssistantMessage omits hidden reasoning` | covered | `ui/src/components/AssistantMessage.test.tsx` — “omits reasoning when its consumer hides it, and keeps the answer”. |
+| `components / A message left with nothing renders nothing` | covered | `ui/src/components/AssistantMessage.test.tsx` — “renders nothing at all when hiding reasoning empties the message” asserts the rendered container is empty. |
+| `components / Hidden content is not discarded` | covered | `ui/src/components/AssistantMessage.test.tsx` — “does not discard what it hid” re-renders the same item with reasoning shown and expands the restored block. |
+
+## Applicable main-spec scenarios
+
+These existing contracts are directly touched by the new surface and remain covered.
+
+| Scenario | Coverage | Assertion evidence |
+|---|---|---|
+| `components / AssistantContentIsRendered` | covered | `ui/src/components/AssistantMessage.test.tsx` — the markdown, image, workspace-reference and copy tests still assert the unfiltered rendering, which the reasoning filter leaves untouched by default. |
+| `conversation-tree / jump to a filtered tool call` (`useConversationJump`) | covered | `ui/src/useConversationJump.test.tsx` and `ui/src/App.test.tsx` — “reveals a hidden tool call before scrolling to it” asserts the jump still un-hides tool cards now that the hook reads the filter state rather than its own flag. |

--- a/openspec/changes/replace-tool-toggle-with-filter-menu/specs/components/spec.md
+++ b/openspec/changes/replace-tool-toggle-with-filter-menu/specs/components/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: ConversationFilterControls
+
+`Header` SHALL expose the conversation's content filters as a single labelled menu rather than one button per kind. The menu SHALL render only the filter state supplied to it and SHALL report each requested change through a callback, holding no filtering state of its own. Its trigger SHALL carry the filtered/unfiltered state so it is legible while the menu is closed, and the menu SHALL be dismissible the way the application's other popovers are — a click outside it and the Escape key — so it cannot be stranded open over a conversation that has moved on.
+
+Each entry SHALL be an accessible checkbox-like control reporting its checked state to assistive technology, where checked means the kind is shown.
+
+`AssistantMessage` SHALL omit reasoning blocks when its consumer asks for them to be hidden, and SHALL render no visible container at all when that leaves the message with nothing to show, rather than an empty frame. Filtering SHALL be a rendering decision only: the component SHALL NOT discard the blocks it was given, so the same item renders in full once the filter is cleared.
+
+#### Scenario: The filter menu reports intent rather than holding state
+- **GIVEN** `Header` is supplied with filter state and a change callback
+- **WHEN** the user toggles a kind in the menu
+- **THEN** the requested kind and its new value are reported through the callback
+- **AND** the header renders the state it was supplied rather than a state of its own
+
+#### Scenario: The closed trigger says whether the conversation is filtered
+- **GIVEN** `Header` is supplied with at least one kind hidden
+- **WHEN** the menu is closed
+- **THEN** the trigger presents the conversation as filtered
+
+#### Scenario: The menu closes on outside click and Escape
+- **GIVEN** the filter menu is open
+- **WHEN** the user clicks outside it, or presses Escape
+- **THEN** the menu closes and no filter change is reported
+
+#### Scenario: Filter entries are checkboxes to assistive technology
+- **GIVEN** the filter menu is open
+- **WHEN** it is inspected through the accessibility tree
+- **THEN** each entry exposes a checked state that matches whether that kind is shown
+
+#### Scenario: AssistantMessage omits hidden reasoning
+- **GIVEN** an assistant item carrying reasoning and answer blocks
+- **WHEN** `AssistantMessage` renders it with reasoning hidden
+- **THEN** the answer is rendered and no reasoning block is present
+
+#### Scenario: A message left with nothing renders nothing
+- **GIVEN** an assistant item whose only blocks are reasoning
+- **WHEN** `AssistantMessage` renders it with reasoning hidden
+- **THEN** it renders no visible message container
+
+#### Scenario: Hidden content is not discarded
+- **GIVEN** an assistant item rendered with reasoning hidden
+- **WHEN** the same item is rendered again with reasoning shown
+- **THEN** its reasoning is present in full

--- a/openspec/changes/replace-tool-toggle-with-filter-menu/specs/conversation-filter/spec.md
+++ b/openspec/changes/replace-tool-toggle-with-filter-menu/specs/conversation-filter/spec.md
@@ -1,0 +1,57 @@
+## RENAMED Requirements
+
+- FROM: `### Requirement: ToolCardToggle`
+- TO: `### Requirement: ConversationContentFilters`
+
+## MODIFIED Requirements
+
+### Requirement: ConversationContentFilters
+
+The conversation SHALL offer filters that remove noisy content kinds from the message list: tool cards, and the model's reasoning. Each filter SHALL be presented as a checked-when-shown control, so that a checked box means the conversation contains that kind and clearing it removes that kind. The control that opens them SHALL state that it filters — not the name of one kind it acts on — and SHALL remain readable as "something is hidden" while it is closed, so the user can tell whether they are looking at the whole conversation without opening it.
+
+Each filter's preference SHALL persist across reloads independently of the other (localStorage), and SHALL survive storage being unavailable by falling back to showing that kind for the session.
+
+While any filter hides content, agent activity SHALL remain observable through the existing working indicator and streaming text, and error notifications SHALL still be shown. Clearing a filter SHALL restore all content of that kind, including content emitted while it was hidden — nothing is dropped from the session, only from the rendering.
+
+Filtering SHALL NOT leave an empty frame where a message was. An assistant message whose only content is reasoning SHALL, while reasoning is hidden, occupy no visible card while remaining a navigable position in the conversation, so a jump to that turn does not land on nothing.
+
+#### Scenario: HideTools
+- **GIVEN** a conversation containing tool cards
+- **WHEN** the user clears the tool-calls filter
+- **THEN** tool cards disappear from the list; user and assistant messages are unaffected
+
+#### Scenario: HideReasoning
+- **GIVEN** a conversation whose assistant messages carry reasoning alongside their answers
+- **WHEN** the user clears the reasoning filter
+- **THEN** the reasoning disappears from those messages and their answer text remains
+
+#### Scenario: FiltersAreIndependent
+- **GIVEN** the reasoning filter is cleared and the tool-calls filter is not
+- **WHEN** the conversation renders
+- **THEN** tool cards are present and reasoning is absent
+
+#### Scenario: PersistedAcrossReload
+- **GIVEN** either filter is cleared
+- **WHEN** the page reloads
+- **THEN** that filter is still cleared and the other is in the state it was left in
+
+#### Scenario: StateIsVisibleWithoutOpeningTheMenu
+- **GIVEN** at least one kind is hidden
+- **WHEN** the user looks at the closed filter control
+- **THEN** it reports that the conversation is filtered
+
+#### Scenario: NothingLostOnRestore
+- **GIVEN** the tool-calls filter was cleared while the agent ran several tools
+- **WHEN** the user checks it again
+- **THEN** every tool card from the session is visible again
+
+#### Scenario: NoEmptyMessageIsLeftBehind
+- **GIVEN** an assistant message whose only blocks are reasoning
+- **WHEN** reasoning is hidden
+- **THEN** no empty message card is rendered for it
+- **AND** navigating to that turn still lands at its position in the conversation
+
+#### Scenario: ActivityStillVisible
+- **GIVEN** the tool-calls filter is cleared
+- **WHEN** the agent is running a tool
+- **THEN** the working indicator still shows activity

--- a/openspec/changes/replace-tool-toggle-with-filter-menu/tasks.md
+++ b/openspec/changes/replace-tool-toggle-with-filter-menu/tasks.md
@@ -1,0 +1,28 @@
+## 1. Filter state in the application
+
+- [x] 1.1 Replace `hideTools` in `ui/src/App.tsx` with a single filter object in shown-semantics (`{ tools, reasoning }`), each seeded from its own `localStorage` key (`pi-outpost:hide-tools` unchanged, `pi-outpost:hide-reasoning` new) inside the existing `try/catch`, and one change handler that persists in the stored hiding polarity; verify with tests asserting a pre-existing `pi-outpost:hide-tools=1` value still yields tool cards hidden on first render, that a throwing storage falls back to showing both kinds, and that toggling each kind writes only its own key — covers PersistedAcrossReload and FiltersAreIndependent.
+- [x] 1.2 Apply the reasoning filter where the item list is rendered: an assistant item whose blocks are all `thinking`, while reasoning is hidden, takes the existing bare-anchor path used for tool-call-only messages instead of rendering `AssistantMessage`; verify with a test asserting no message card is rendered for such an item and that its scroll anchor is still present — covers NoEmptyMessageIsLeftBehind.
+- [x] 1.3 Verify the decision is made per render rather than latched: a test that renders an assistant item holding only a `thinking` block with reasoning hidden, then re-renders it after a text block arrives, asserts the message appears — the streaming case named in design.md.
+
+## 2. Header filter menu
+
+- [x] 2.1 Replace the `⚒ tools` button in `ui/src/components/Header.tsx` with a labelled `Filter` trigger opening a popover of checkbox entries (Tool calls, Reasoning), rendering only supplied state and reporting each change through one callback; verify with component tests asserting the callback receives the toggled kind and its new value, and that the component holds no filter state of its own — covers The filter menu reports intent rather than holding state.
+- [x] 2.2 Make the closed trigger report that the conversation is filtered whenever at least one kind is hidden; verify with a component test asserting the filtered presentation with one kind hidden and its absence with both shown — covers The closed trigger says whether the conversation is filtered.
+- [x] 2.3 Dismiss the menu through the existing `ui/src/util/clickOutside.ts` idiom and on Escape, reporting no filter change on either; verify with component tests for both dismissals asserting the change callback was not invoked — covers The menu closes on outside click and Escape.
+- [x] 2.4 Expose each entry with a checked state in the accessibility tree, checked meaning shown; verify with a test querying by checkbox role and asserting the checked state matches the supplied filter — covers Filter entries are checkboxes to assistive technology.
+
+## 3. Assistant message rendering
+
+- [x] 3.1 Add the reasoning-hidden prop to `ui/src/components/AssistantMessage.tsx` so `thinking` blocks are skipped while every other block renders unchanged; verify with tests asserting the answer text is present and no thinking control is, and that re-rendering the same item with reasoning shown restores it in full — covers AssistantMessage omits hidden reasoning and Hidden content is not discarded.
+- [x] 3.2 Render no visible container when hiding reasoning leaves the message with nothing; verify with a test asserting the component produces no message frame for a reasoning-only item — covers A message left with nothing renders nothing.
+
+## 4. Existing behaviour preserved
+
+- [x] 4.1 Rewrite the tests that drive the old `⚒ tools` button against the new menu, keeping their contracts: hiding tool cards leaves user and assistant messages untouched, restoring shows every card emitted while hidden, and the working indicator still reports activity while tools are hidden — covers HideTools, NothingLostOnRestore and ActivityStillVisible.
+- [x] 4.2 Add the reasoning equivalent: reasoning hidden removes it from messages that also carry answers, leaving their text intact — covers HideReasoning.
+- [x] 4.3 Run `npm run lint`, `npm run typecheck`, the `ui` suite, and `npm run check:scenarios` with the scenario-coverage matrix written to `openspec/changes/replace-tool-toggle-with-filter-menu/scenario-coverage.md`.
+
+## 5. Exercise it in the running app
+
+- [ ] 5.1 Rebuild `web`, then `@pi-outpost/embed`, then `build:e2e-host`, and drive the feature in the bench (`npm run bench`, host 4321 on 127.0.0.1): open the menu, clear each kind, read the DOM back to confirm what disappeared and that the trigger reports the filtered state, then reload and confirm both preferences survived.
+- [ ] 5.2 Monkey-test the transitions rather than the walkthrough: spam the trigger and the entries, leave the menu open while a turn streams and while the session or project is switched underneath it, clear reasoning mid-stream on a turn that has produced only reasoning so far, and jump to a filtered-away turn from the conversation navigation. Read back the DOM after each burst and report what broke, not that it works.

--- a/openspec/changes/replace-tool-toggle-with-filter-menu/tasks.md
+++ b/openspec/changes/replace-tool-toggle-with-filter-menu/tasks.md
@@ -24,5 +24,5 @@
 
 ## 5. Exercise it in the running app
 
-- [ ] 5.1 Rebuild `web`, then `@pi-outpost/embed`, then `build:e2e-host`, and drive the feature in the bench (`npm run bench`, host 4321 on 127.0.0.1): open the menu, clear each kind, read the DOM back to confirm what disappeared and that the trigger reports the filtered state, then reload and confirm both preferences survived.
-- [ ] 5.2 Monkey-test the transitions rather than the walkthrough: spam the trigger and the entries, leave the menu open while a turn streams and while the session or project is switched underneath it, clear reasoning mid-stream on a turn that has produced only reasoning so far, and jump to a filtered-away turn from the conversation navigation. Read back the DOM after each burst and report what broke, not that it works.
+- [x] 5.1 Rebuild `web`, then `@pi-outpost/embed`, then `build:e2e-host`, and drive the feature in the bench (`npm run bench`, host 4321 on 127.0.0.1): open the menu, clear each kind, read the DOM back to confirm what disappeared and that the trigger reports the filtered state, then reload and confirm both preferences survived.
+- [x] 5.2 Monkey-test the transitions rather than the walkthrough: spam the trigger and the entries, leave the menu open while a turn streams and while the session or project is switched underneath it, clear reasoning mid-stream on a turn that has produced only reasoning so far, and jump to a filtered-away turn from the conversation navigation. Read back the DOM after each burst and report what broke, not that it works.

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -529,15 +529,153 @@ describe("App — panes and handovers", () => {
     expect(screen.getByText("Proceed?")).toBeInTheDocument();
   });
 
-  it("remembers the tool-noise filter across mounts", () => {
-    localStorage.clear();
+});
+
+// ---------------------------------------------------------------------------
+// Conversation filters: what the list shows. Driven through the header menu the
+// user actually operates, not through the state behind it.
+// ---------------------------------------------------------------------------
+describe("App — conversation filters", () => {
+  // The menu stays open across a selection — both kinds can be set in one visit —
+  // so opening it again would close it.
+  const openFilters = () => {
+    if (!screen.queryByRole("menu")) fireEvent.click(screen.getByRole("button", { name: /^Filter/ }));
+  };
+  const toggleFilter = (name: RegExp) => {
+    openFilters();
+    fireEvent.click(screen.getByRole("menuitemcheckbox", { name }));
+  };
+
+  function mount(overrides: Record<string, unknown> = {}) {
+    mockUseAgent.mockReturnValue(agentApi(agentState(overrides)));
+    return render(<App />);
+  }
+
+  const anchor = (index: number) => document.querySelector(`[data-item-index="${index}"]`);
+
+  afterEach(() => localStorage.clear());
+
+  it("hides tool cards and leaves the messages around them alone", () => {
+    mount({
+      items: [
+        { kind: "user", text: "read the config" },
+        { kind: "tool", toolCallId: "call-1", toolName: "read", args: { path: "a.ts" }, output: "contents" },
+        { kind: "assistant", blocks: [{ type: "text", text: "done" }] },
+      ] as ChatItem[],
+    });
+    expect(screen.getByText("read")).toBeInTheDocument();
+
+    toggleFilter(/Tool calls/);
+    expect(screen.queryByText("read")).not.toBeInTheDocument();
+    expect(screen.getByText("read the config")).toBeInTheDocument();
+    expect(screen.getByText("done")).toBeInTheDocument();
+  });
+
+  it("gives every tool card back, including the ones that arrived while hidden", () => {
+    const { rerender } = mount({
+      items: [{ kind: "tool", toolCallId: "call-1", toolName: "read", args: {}, output: "a" }] as ChatItem[],
+    });
+    toggleFilter(/Tool calls/);
+    expect(screen.queryByText("read")).not.toBeInTheDocument();
+
+    // A second call lands while the filter is on.
+    mockUseAgent.mockReturnValue(
+      agentApi(
+        agentState({
+          items: [
+            { kind: "tool", toolCallId: "call-1", toolName: "read", args: {}, output: "a" },
+            { kind: "tool", toolCallId: "call-2", toolName: "grep", args: {}, output: "b" },
+          ] as ChatItem[],
+        }),
+      ),
+    );
+    rerender(<App />);
+    expect(screen.queryByText("grep")).not.toBeInTheDocument();
+
+    toggleFilter(/Tool calls/);
+    expect(screen.getByText("read")).toBeInTheDocument();
+    expect(screen.getByText("grep")).toBeInTheDocument();
+  });
+
+  it("still shows that the agent is working while tool cards are hidden", () => {
+    mount({ isStreaming: true, items: [{ kind: "user", text: "go" }] as ChatItem[] });
+    toggleFilter(/Tool calls/);
+    expect(screen.getByText("working…")).toBeInTheDocument();
+  });
+
+  it("hides reasoning and keeps the answer that came with it", () => {
+    mount({
+      items: [
+        {
+          kind: "assistant",
+          blocks: [
+            { type: "thinking", text: "weighing the options" },
+            { type: "text", text: "the answer" },
+          ],
+        },
+      ] as ChatItem[],
+    });
+    expect(screen.getByRole("button", { name: /thinking/ })).toBeInTheDocument();
+
+    toggleFilter(/Reasoning/);
+    expect(screen.queryByRole("button", { name: /thinking/ })).not.toBeInTheDocument();
+    expect(screen.getByText("the answer")).toBeInTheDocument();
+  });
+
+  it("leaves no empty card where a reasoning-only turn was, but keeps its place", () => {
+    mount({
+      items: [
+        { kind: "user", text: "go" },
+        { kind: "assistant", blocks: [{ type: "thinking", text: "hmm" }] },
+        { kind: "assistant", blocks: [{ type: "text", text: "the answer" }] },
+      ] as ChatItem[],
+    });
+    toggleFilter(/Reasoning/);
+
+    expect(screen.queryByRole("button", { name: /thinking/ })).not.toBeInTheDocument();
+    expect(screen.queryByText("hmm")).not.toBeInTheDocument();
+    // The turn is still a position the analysis and the jump can point at.
+    expect(anchor(1)).not.toBeNull();
+    expect(anchor(1)?.className).toContain("sr-only");
+  });
+
+  it("shows a reasoning-only turn again as soon as it grows an answer", () => {
+    // The streaming case: emptiness is decided per render, never latched, or a
+    // turn that started with reasoning would stay invisible after its text lands.
+    const { rerender } = mount({
+      items: [{ kind: "assistant", blocks: [{ type: "thinking", text: "hmm" }] }] as ChatItem[],
+    });
+    toggleFilter(/Reasoning/);
+    expect(screen.queryByText("still thinking")).not.toBeInTheDocument();
+
+    mockUseAgent.mockReturnValue(
+      agentApi(
+        agentState({
+          items: [
+            {
+              kind: "assistant",
+              blocks: [
+                { type: "thinking", text: "hmm" },
+                { type: "text", text: "the answer" },
+              ],
+            },
+          ] as ChatItem[],
+        }),
+      ),
+    );
+    rerender(<App />);
+    expect(screen.getByText("the answer")).toBeInTheDocument();
+  });
+
+  it("remembers each filter across mounts, independently", () => {
     const first = mount();
-    fireEvent.click(screen.getByRole("button", { name: /tools/ }));
+    toggleFilter(/Reasoning/);
     first.unmount();
 
     mount();
-    expect(screen.getByRole("button", { name: /tools/ })).toHaveAttribute("aria-pressed", "true");
-    localStorage.clear();
+    openFilters();
+    expect(screen.getByRole("menuitemcheckbox", { name: /Reasoning/ })).toHaveAttribute("aria-checked", "false");
+    expect(screen.getByRole("menuitemcheckbox", { name: /Tool calls/ })).toHaveAttribute("aria-checked", "true");
   });
 });
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -5,6 +5,12 @@ import { CustomMessageCard } from "./components/CustomMessageCard";
 import { SessionAnalysisPanel } from "./components/SessionAnalysis";
 import { ThemeContext } from "./theme/ThemeContext";
 import { useConversationJump } from "./useConversationJump";
+import {
+  persistConversationFilter,
+  readConversationFilters,
+  type ConversationFilterKind,
+  type ConversationFilters,
+} from "./conversationFilters";
 import { analyzeSession } from "./util/sessionAnalysis";
 import { sessionUsage } from "./util/sessionUsage";
 import { repoForPath } from "./util/gitRepos";
@@ -213,25 +219,15 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
   const dismissedPreviewPathRef = useRef<string | null>(null);
   // Badge click in the tree opens the file straight onto its uncommitted diff
   const [diffOnOpen, setDiffOnOpen] = useState(false);
-  // Tool-noise filter: skip tool cards in the list (long sessions drown in them).
-  // Cards aren't CSS-hidden — hidden ones must not cost layout.
-  const [hideTools, setHideTools] = useState(() => {
-    try {
-      return localStorage.getItem("pi-outpost:hide-tools") === "1";
-    } catch {
-      return false;
-    }
-  });
-  function toggleHideTools() {
-    setHideTools((current) => {
-      try {
-        localStorage.setItem("pi-outpost:hide-tools", current ? "0" : "1");
-      } catch {
-        // Storage unavailable — the toggle still works for this session
-      }
-      return !current;
-    });
-  }
+  // Conversation noise filters: tool cards and the model's reasoning (long
+  // sessions drown in both). Nothing is CSS-hidden — filtered content must not
+  // cost layout — and nothing is dropped from state, so clearing a filter
+  // restores everything, including what arrived while it was hidden.
+  const [filters, setFilters] = useState<ConversationFilters>(readConversationFilters);
+  const setFilter = useCallback((kind: ConversationFilterKind, shown: boolean) => {
+    persistConversationFilter(kind, shown);
+    setFilters((current) => ({ ...current, [kind]: shown }));
+  }, []);
   // Session analysis drawer: closed until asked for, from the model bar's usage indicator.
   const [analysisOpen, setAnalysisOpen] = useState(false);
   const [workPlanOpen, setWorkPlanOpen] = useState(true);
@@ -653,7 +649,7 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
       }),
     [readFile, fetchGitFileHistory, searchFiles],
   );
-  const showTools = useCallback(() => setHideTools(false), []);
+  const showTools = useCallback(() => setFilter("tools", true), [setFilter]);
   /**
    * Stop following the bottom, because a jump has taken the reader elsewhere.
    *
@@ -685,7 +681,7 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
   const { jumpToItem, highlightIndex } = useConversationJump({
     items: state.items,
     scrollerRef: mainRef,
-    hideTools,
+    hideTools: !filters.tools,
     onShowTools: showTools,
     onJump: handleJump,
   });
@@ -855,10 +851,10 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
             statuses={state.statuses}
             sidebarOpen={sidebarOpen}
             outcomeOpen={outcomeOpen}
-            hideTools={hideTools}
+            filters={filters}
             onToggleSidebar={() => setSidebarOpen(!sidebarOpen)}
             onToggleOutcome={toggleOutcome}
-            onToggleHideTools={toggleHideTools}
+            onFilterChange={setFilter}
             onToggleTheme={toggleTheme}
             onNewSession={newSession}
             onSwitchSession={switchSession}
@@ -1046,7 +1042,7 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
                   );
                 }
                 if (item.kind === "tool") {
-                  if (hideTools) return null;
+                  if (!filters.tools) return null;
                   return anchor(
                     <ToolCard item={item} dispatch={toolActions} />,
                     item.toolCallId ? `${state.sessionId}:${item.toolCallId}` : key,
@@ -1055,15 +1051,23 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
                 if (item.kind === "custom") {
                   return anchor(<CustomMessageCard item={item} />);
                 }
-                // Tool-call-only messages produce empty assistant items — nothing to
-                // show, but they are turns and carry usage, so the analysis can point
-                // at one. A bare anchor keeps that jump from landing nowhere.
-                if (item.blocks.length === 0 && !item.errorMessage) {
+                // Tool-call-only messages produce empty assistant items — and a
+                // reasoning-only message is empty too while reasoning is hidden.
+                // Nothing to show, but they are turns and carry usage, so the
+                // analysis can point at one: a bare anchor keeps that jump from
+                // landing nowhere. Decided per render from the blocks present, never
+                // latched — a turn that holds only reasoning now may grow its answer
+                // a token later.
+                const visibleBlocks = filters.reasoning
+                  ? item.blocks
+                  : item.blocks.filter((block) => block.type !== "thinking");
+                if (visibleBlocks.length === 0 && !item.errorMessage) {
                   return <div key={key} data-item-index={i} className="sr-only" aria-hidden />;
                 }
                 return anchor(
                   <AssistantMessage
                     item={item}
+                    hideReasoning={!filters.reasoning}
                     serverUrl={serverUrl}
                     token={authToken}
                     onOpenFile={(path) => {

--- a/ui/src/components/AssistantMessage.test.tsx
+++ b/ui/src/components/AssistantMessage.test.tsx
@@ -38,6 +38,40 @@ describe("AssistantMessage", () => {
       expect(screen.getByText("second")).toBeInTheDocument();
     });
 
+    it("omits reasoning when its consumer hides it, and keeps the answer", () => {
+      setup({
+        item: item({
+          blocks: [
+            { type: "thinking", text: "weighing the options" },
+            { type: "text", text: "Here is the answer." },
+          ],
+        }),
+        hideReasoning: true,
+      });
+      expect(screen.getByText("Here is the answer.")).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /thinking/ })).not.toBeInTheDocument();
+    });
+
+    it("renders nothing at all when hiding reasoning empties the message", () => {
+      const { container } = render(
+        <AssistantMessage item={item({ blocks: [{ type: "thinking", text: "hmm" }] })} hideReasoning />,
+      );
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it("does not discard what it hid", () => {
+      const blocks: AssistantItem["blocks"] = [
+        { type: "thinking", text: "weighing the options" },
+        { type: "text", text: "Here is the answer." },
+      ];
+      const { rerender } = render(<AssistantMessage item={item({ blocks })} hideReasoning />);
+      expect(screen.queryByRole("button", { name: /thinking/ })).not.toBeInTheDocument();
+
+      rerender(<AssistantMessage item={item({ blocks })} />);
+      fireEvent.click(screen.getByRole("button", { name: /thinking/ }));
+      expect(screen.getByText("weighing the options")).toBeInTheDocument();
+    });
+
     it("keeps thinking folded away until asked for", () => {
       setup({ item: item({ blocks: [{ type: "thinking", text: "weighing the options" }] }) });
       expect(screen.queryByText("weighing the options")).not.toBeInTheDocument();

--- a/ui/src/components/AssistantMessage.tsx
+++ b/ui/src/components/AssistantMessage.tsx
@@ -19,6 +19,11 @@ interface AssistantMessageProps {
   token?: string | null;
   /** Opens a workspace-relative path in the file viewer. */
   onOpenFile?: (path: string) => void;
+  /**
+   * Drop the model's reasoning from the rendering. A view decision only: the
+   * blocks are still here, so clearing the filter shows the message in full.
+   */
+  hideReasoning?: boolean;
 }
 
 function ThinkingBlock({ text }: { text: string }) {
@@ -42,7 +47,8 @@ function ThinkingBlock({ text }: { text: string }) {
   );
 }
 
-export function AssistantMessage({ item, serverUrl = "", token = null, onOpenFile }: AssistantMessageProps) {
+export function AssistantMessage({ item, serverUrl = "", token = null, onOpenFile, hideReasoning = false }: AssistantMessageProps) {
+  const blocks = hideReasoning ? item.blocks.filter((block) => block.type !== "thinking") : item.blocks;
   const fullText = item.blocks
     .filter((b) => b.type === "text")
     .map((b) => b.text)
@@ -93,6 +99,11 @@ export function AssistantMessage({ item, serverUrl = "", token = null, onOpenFil
     return { pre: MarkdownPre, img: MarkdownImg, a: MarkdownLink };
   }, [serverUrl, token]);
 
+  // Nothing left to draw — a filtered-away message must not leave an empty frame
+  // in the conversation. The list still keeps its scroll position: it renders a
+  // bare anchor for this item rather than calling this component at all.
+  if (blocks.length === 0 && !item.errorMessage) return null;
+
   return (
     <div className="group max-w-none">
       {fullText && !item.streaming && (
@@ -100,7 +111,7 @@ export function AssistantMessage({ item, serverUrl = "", token = null, onOpenFil
           <CopyButton text={fullText} />
         </div>
       )}
-      {item.blocks.map((block, i) =>
+      {blocks.map((block, i) =>
         block.type === "thinking" ? (
           <ThinkingBlock key={block.contentIndex ?? i} text={block.text} />
         ) : (

--- a/ui/src/components/Header.test.tsx
+++ b/ui/src/components/Header.test.tsx
@@ -28,7 +28,7 @@ function setup(overrides: Partial<Props> = {}) {
     onCloseServerBrowser: vi.fn(),
     onToggleSidebar: vi.fn(),
     onToggleOutcome: vi.fn(),
-    onToggleHideTools: vi.fn(),
+    onFilterChange: vi.fn(),
     onToggleTheme: vi.fn(),
     onNewSession: vi.fn(),
     onSwitchSession: vi.fn(),
@@ -61,7 +61,7 @@ function setup(overrides: Partial<Props> = {}) {
     statuses: {},
     sidebarOpen: false,
     outcomeOpen: false,
-    hideTools: false,
+    filters: { tools: true, reasoning: true },
     gitAvailable: false,
     gitStatus: null,
     gitLog: null,
@@ -325,15 +325,55 @@ describe("Header", () => {
     });
   });
 
-  describe("tool noise", () => {
-    it("toggles the tool filter and says which state it is in", () => {
-      const { onToggleHideTools, rerenderWith } = setup({ hideTools: false });
-      const toggle = screen.getByRole("button", { name: /tools/ });
-      expect(toggle).toHaveAttribute("aria-pressed", "false");
-      fireEvent.click(toggle);
-      expect(onToggleHideTools).toHaveBeenCalled();
-      rerenderWith({ hideTools: true });
-      expect(screen.getByRole("button", { name: /tools/ })).toHaveAttribute("aria-pressed", "true");
+  describe("conversation filters", () => {
+    const trigger = () => screen.getByRole("button", { name: /^Filter/ });
+    const openMenu = () => fireEvent.click(trigger());
+
+    it("reports the kind that was toggled rather than holding the state", () => {
+      const { onFilterChange, rerenderWith } = setup({ filters: { tools: true, reasoning: true } });
+      openMenu();
+      fireEvent.click(screen.getByRole("menuitemcheckbox", { name: /Tool calls/ }));
+      expect(onFilterChange).toHaveBeenCalledWith("tools", false);
+
+      // The header did not decide anything on its own: it still shows both kinds
+      // until its consumer says otherwise.
+      expect(screen.getByRole("menuitemcheckbox", { name: /Tool calls/ })).toHaveAttribute("aria-checked", "true");
+      rerenderWith({ filters: { tools: false, reasoning: true } });
+      expect(screen.getByRole("menuitemcheckbox", { name: /Tool calls/ })).toHaveAttribute("aria-checked", "false");
+    });
+
+    it("says on the closed trigger whether the conversation is filtered", () => {
+      const { rerenderWith } = setup({ filters: { tools: true, reasoning: true } });
+      expect(trigger()).toHaveTextContent(/^Filter$/);
+
+      rerenderWith({ filters: { tools: false, reasoning: true } });
+      expect(trigger()).toHaveTextContent(/1 hidden/);
+      rerenderWith({ filters: { tools: false, reasoning: false } });
+      expect(trigger()).toHaveTextContent(/2 hidden/);
+    });
+
+    it("exposes each entry as a checkbox carrying whether that kind is shown", () => {
+      setup({ filters: { tools: true, reasoning: false } });
+      openMenu();
+      expect(screen.getByRole("menuitemcheckbox", { name: /Tool calls/ })).toHaveAttribute("aria-checked", "true");
+      expect(screen.getByRole("menuitemcheckbox", { name: /Reasoning/ })).toHaveAttribute("aria-checked", "false");
+    });
+
+    it("closes on an outside click without changing anything", () => {
+      const { onFilterChange } = setup();
+      openMenu();
+      expect(screen.getByRole("menu")).toBeInTheDocument();
+      fireEvent.mouseDown(document.body);
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+      expect(onFilterChange).not.toHaveBeenCalled();
+    });
+
+    it("closes on Escape without changing anything", () => {
+      const { onFilterChange } = setup();
+      openMenu();
+      fireEvent.keyDown(screen.getByRole("menu"), { key: "Escape" });
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+      expect(onFilterChange).not.toHaveBeenCalled();
     });
   });
 

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -5,6 +5,13 @@ import { WorkspaceRootControl, type WorkspaceRootSandbox } from "./WorkspaceRoot
 import type { AgentResourceOperationState, GitLogState, GitStatusState, ServerBrowseState, SessionSearch, SettingsApplyState } from "../useAgent";
 import { stripAnsi } from "../util/ansi";
 import { useClickOutside } from "../util/clickOutside";
+import {
+  CONVERSATION_FILTER_KINDS,
+  CONVERSATION_FILTER_LABELS,
+  hiddenCount,
+  type ConversationFilterKind,
+  type ConversationFilters,
+} from "../conversationFilters";
 import { GitMenu } from "./GitMenu";
 import { SettingsMenu } from "./SettingsMenu";
 import { TreeMenu } from "./TreeMenu";
@@ -47,8 +54,8 @@ interface HeaderProps {
   statuses: Record<string, string>;
   sidebarOpen: boolean;
   outcomeOpen: boolean;
-  /** Tool-noise filter: tool cards are hidden from the conversation. */
-  hideTools: boolean;
+  /** What the conversation shows; true means the kind is present. */
+  filters: ConversationFilters;
   gitAvailable: boolean;
   gitStatus: GitStatusState | null;
   gitLog: GitLogState | null;
@@ -94,7 +101,7 @@ interface HeaderProps {
   ) => void;
   onToggleSidebar: () => void;
   onToggleOutcome: () => void;
-  onToggleHideTools: () => void;
+  onFilterChange: (kind: ConversationFilterKind, shown: boolean) => void;
   onToggleTheme: () => void;
   onNewSession: () => void;
   onSwitchSession: (path: string) => void;
@@ -335,6 +342,79 @@ function SessionMenu({
   );
 }
 
+/**
+ * What the conversation shows, as one menu rather than a button per kind.
+ *
+ * Checked means shown. The control this replaced was pressed when it was
+ * *hiding*, which is what nobody could read off it: a row of checkboxes meaning
+ * "hide this" is a double negative on every glance.
+ *
+ * Stateless about filtering — it renders what it is given and reports intent —
+ * so nothing here can disagree with the conversation it sits above.
+ */
+function ConversationFilterMenu({
+  filters,
+  onFilterChange,
+}: {
+  filters: ConversationFilters;
+  onFilterChange: (kind: ConversationFilterKind, shown: boolean) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useClickOutside(() => setOpen(false));
+  const hidden = hiddenCount(filters);
+  // The count is the whole point of the closed state: "am I looking at all of
+  // it?" has to be answerable without opening the menu.
+  const label = hidden > 0 ? `Filter · ${hidden} hidden` : "Filter";
+
+  return (
+    <div
+      className="relative"
+      ref={ref}
+      onKeyDown={(event) => {
+        if (event.key === "Escape" && open) {
+          event.stopPropagation();
+          setOpen(false);
+        }
+      }}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        title="Choose what the conversation shows"
+        className={`rounded-md border px-2 py-1 text-xs ${
+          hidden > 0
+            ? "border-zinc-400 bg-zinc-100 text-zinc-700 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-200"
+            : "border-zinc-300 text-zinc-500 hover:border-zinc-400 hover:text-zinc-700 dark:border-zinc-800 dark:text-zinc-400 dark:hover:border-zinc-600 dark:hover:text-zinc-200"
+        }`}
+      >
+        {label}
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 z-30 mt-1 w-48 rounded-md border border-zinc-200 bg-white py-1 shadow-lg dark:border-zinc-700 dark:bg-zinc-900"
+        >
+          {CONVERSATION_FILTER_KINDS.map((kind) => (
+            <button
+              key={kind}
+              type="button"
+              role="menuitemcheckbox"
+              aria-checked={filters[kind]}
+              onClick={() => onFilterChange(kind, !filters[kind])}
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-zinc-600 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
+            >
+              <span aria-hidden className="w-3">{filters[kind] ? "✓" : ""}</span>
+              <span>{CONVERSATION_FILTER_LABELS[kind]}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function ThemeToggle({ theme, onToggle }: { theme: "light" | "dark"; onToggle: () => void }) {
   return (
     <button
@@ -440,19 +520,7 @@ export function Header(props: HeaderProps) {
       ))}
 
       <div className="ml-auto flex items-center gap-2">
-        <button
-          type="button"
-          onClick={props.onToggleHideTools}
-          title={props.hideTools ? "Show tool cards in the conversation" : "Hide tool cards (long sessions read better without them)"}
-          aria-pressed={props.hideTools}
-          className={`rounded-md border px-2 py-1 text-xs ${
-            props.hideTools
-              ? "border-zinc-400 bg-zinc-100 text-zinc-700 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-200"
-              : "border-zinc-300 text-zinc-500 hover:border-zinc-400 hover:text-zinc-700 dark:border-zinc-800 dark:text-zinc-400 dark:hover:border-zinc-600 dark:hover:text-zinc-200"
-          }`}
-        >
-          ⚒ tools
-        </button>
+        <ConversationFilterMenu filters={props.filters} onFilterChange={props.onFilterChange} />
         {props.onToggleTerminal && (
           <button
             type="button"

--- a/ui/src/conversationFilters.test.ts
+++ b/ui/src/conversationFilters.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import {
+  hiddenCount,
+  persistConversationFilter,
+  readConversationFilters,
+} from "./conversationFilters";
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("conversation filters", () => {
+  it("shows both kinds in a browser that has never been told otherwise", () => {
+    expect(readConversationFilters()).toEqual({ tools: true, reasoning: true });
+  });
+
+  it("keeps the meaning of a preference set before the second filter existed", () => {
+    // The key that shipped with the tool toggle, in the polarity it shipped in.
+    // Reading it as anything but "tools hidden" would flip the preference of
+    // everyone who already set it.
+    localStorage.setItem("pi-outpost:hide-tools", "1");
+    expect(readConversationFilters()).toEqual({ tools: false, reasoning: true });
+  });
+
+  it("reads each kind from its own key", () => {
+    localStorage.setItem("pi-outpost:hide-reasoning", "1");
+    expect(readConversationFilters()).toEqual({ tools: true, reasoning: false });
+  });
+
+  it("writes one kind without touching the other", () => {
+    localStorage.setItem("pi-outpost:hide-reasoning", "1");
+    persistConversationFilter("tools", false);
+    expect(localStorage.getItem("pi-outpost:hide-tools")).toBe("1");
+    expect(localStorage.getItem("pi-outpost:hide-reasoning")).toBe("1");
+
+    persistConversationFilter("tools", true);
+    expect(localStorage.getItem("pi-outpost:hide-tools")).toBe("0");
+    expect(localStorage.getItem("pi-outpost:hide-reasoning")).toBe("1");
+  });
+
+  it("shows everything when storage throws rather than failing to read", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("storage blocked");
+    });
+    expect(readConversationFilters()).toEqual({ tools: true, reasoning: true });
+  });
+
+  it("survives a write to storage that throws", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("storage blocked");
+    });
+    expect(() => persistConversationFilter("reasoning", false)).not.toThrow();
+  });
+
+  it("counts the hidden kinds for the closed menu", () => {
+    expect(hiddenCount({ tools: true, reasoning: true })).toBe(0);
+    expect(hiddenCount({ tools: false, reasoning: true })).toBe(1);
+    expect(hiddenCount({ tools: false, reasoning: false })).toBe(2);
+  });
+});

--- a/ui/src/conversationFilters.ts
+++ b/ui/src/conversationFilters.ts
@@ -1,0 +1,59 @@
+/**
+ * What the conversation shows.
+ *
+ * The values here are in *shown* semantics — `tools: true` means tool cards are
+ * in the list — because that is what the filter menu presents, and a menu whose
+ * checkboxes mean "hide this" reads as a double negative.
+ *
+ * The stored keys are the opposite polarity, and deliberately so: the tool
+ * filter shipped as `pi-outpost:hide-tools`, and inverting the stored value
+ * would silently flip the preference of everyone who already set it. The
+ * inversion happens here, once, at the boundary.
+ */
+export type ConversationFilterKind = "tools" | "reasoning";
+
+/** True means the kind is shown. */
+export type ConversationFilters = Record<ConversationFilterKind, boolean>;
+
+const HIDE_KEYS: Record<ConversationFilterKind, string> = {
+  tools: "pi-outpost:hide-tools",
+  reasoning: "pi-outpost:hide-reasoning",
+};
+
+export const CONVERSATION_FILTER_KINDS: ConversationFilterKind[] = ["tools", "reasoning"];
+
+export const CONVERSATION_FILTER_LABELS: Record<ConversationFilterKind, string> = {
+  tools: "Tool calls",
+  reasoning: "Reasoning",
+};
+
+/**
+ * Storage can throw outright — a private window, a browser set to block site
+ * data, an embed on a third-party origin. Showing everything is the right answer
+ * there: it is what an unconfigured browser sees, and it loses nothing.
+ */
+function hidden(kind: ConversationFilterKind): boolean {
+  try {
+    return localStorage.getItem(HIDE_KEYS[kind]) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function readConversationFilters(): ConversationFilters {
+  return { tools: !hidden("tools"), reasoning: !hidden("reasoning") };
+}
+
+/** Writes one kind's preference; the other's key is never touched. */
+export function persistConversationFilter(kind: ConversationFilterKind, shown: boolean): void {
+  try {
+    localStorage.setItem(HIDE_KEYS[kind], shown ? "0" : "1");
+  } catch {
+    // Storage unavailable — the filter still works for this session.
+  }
+}
+
+/** How many kinds are hidden, for the closed menu's own label. */
+export function hiddenCount(filters: ConversationFilters): number {
+  return CONVERSATION_FILTER_KINDS.filter((kind) => !filters[kind]).length;
+}


### PR DESCRIPTION
The header's `⚒ tools` button was not understood: it named its subject rather than its action, and what it did — hide tool cards — lived in a `title` attribute nobody hovers. Its state was carried by `aria-pressed` and a background shade, which read as "selected" rather than "filtering". Meanwhile the other source of conversation noise, the model's reasoning, had no filter at all.

It becomes a **Filter** menu with one entry per noisy kind: **Tool calls** and **Reasoning**.

## Decisions worth reviewing

**Checked means shown.** The control this replaces was pressed when it was *hiding* — the reading nobody could get off it. A menu of boxes meaning "hide this" is a double negative on every glance.

**The stored keys keep the opposite polarity.** `pi-outpost:hide-tools` keeps its exact name and meaning, and `pi-outpost:hide-reasoning` joins it. Inverting the stored value would silently flip the preference of everyone who already set it, which is worse than a mismatch between the UI's polarity and a key's name. The inversion happens once, in `ui/src/conversationFilters.ts`, where the value is read.

**Emptiness is the list's decision, not the renderer's.** Reasoning is not a conversation item but a block inside one, so hiding it can leave a message with nothing to show. Such a turn takes the bare-anchor path `App.tsx` already uses for tool-call-only messages: no empty card, and a jump to that turn still lands at its place. `AssistantMessage` also renders nothing rather than an empty frame, but it never decides the item does not exist — that would put a hole where the scroll anchor belongs.

**Decided per render, never latched.** A turn holding only reasoning now may grow its answer a token later.

## Verified in the running app

Not just green suites. A bench server with a scripted transcript holding a reasoning-only turn, driven in the real widget inside its Shadow DOM:

- Clearing **Tool calls** removes the tool card, leaves the messages around it, and the trigger reads `Filter · 1 hidden`; clearing **Reasoning** too gives `Filter · 2 hidden`, no reasoning text anywhere in the DOM, and the reasoning-only turn collapses from a 38px card to its **1px anchor** — no empty frame.
- Both preferences survive a real page reload.
- Clearing reasoning **mid-stream**, on a turn that has so far produced only reasoning, collapses it; when its answer arrives the card comes back carrying the answer and no reasoning.
- Monkey pass: 9 rapid trigger clicks, a double click, 7 rapid entry clicks, and a session replaced underneath an open menu — after every burst the entries, the trigger's count, `localStorage` and the conversation still agree.
- A real trusted click outside (through the Shadow DOM, which is where `clickOutside`'s `composedPath` handling earns its keep) closes the menu, as does Escape.

One path could not be driven there: the analysis panel's jump to a filtered-away tool call, because the scripted transcript reports no usage and the control that opens the panel is not rendered. It is covered by `ui/src/App.test.tsx` — "reveals a hidden tool call before scrolling to it" — which still passes with the hook reading the new filter state.

The menu stays open across a new session. Judged correct rather than left unnoticed: the filter is not session-scoped and the menu's two entries cannot go stale under a new context.

## Checks

`ui`: 1518 tests pass (+20). `npm run lint`, `npm run typecheck`, `npx openspec validate --strict` and `npm run check:scenarios` (15 scenarios, all covered) are clean.

## Documentation impact

None. `README.md` and `docs/how-to.md` describe the sandbox, projects and settings; neither documents the conversation's noise filter or the header control this replaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SKMFb6sofkNugUcuzVdFf