### PR TITLE
feat(viewer): add find-in-page (Ctrl+F) to the file viewer and PDF viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,15 +170,16 @@ one needs, the command that proves it works, and the caution that goes with it.
   get a browser notification when a background project needs an answer or is ready for review
 - File browser: lazy-loaded tree, syntax-highlighted viewer, Markdown rendering, and an
   editor that saves inside the writable zone. Create, rename, move, copy, delete, or open a
-  file with the system's own application; anything outside the writable zone is dimmed
+  file with the system's own application; anything outside the writable zone is dimmed.
+  Ctrl+F (Cmd+F) finds text in the open file — source, rendered Markdown, or a live edit
 - Split view: a Markdown or structured document renders beside the editor, following what
   you type rather than what was last saved
 - Git: uncommitted-change badges in the tree, per-file diffs, log and commit inspection, and
   a per-file history graph (renames followed) that diffs any two revisions, working tree
   included. A directory of independently versioned projects works too — each child
   repository answers for its own files. See [Git](#git)
-- PDF in the viewer (pages, zoom, keyboard paging); the agent reads its text and tables
-  through `pdf_extract` — no shell, no external binary, no OCR
+- PDF in the viewer (pages, zoom, keyboard paging, Ctrl+F search across the whole document);
+  the agent reads its text and tables through `pdf_extract` — no shell, no external binary, no OCR
 - Office documents: `docx_extract`, `xlsx_extract` and `pptx_extract` give the agent Word
   text and tables, one markdown table per spreadsheet sheet, and slide structure with
   speaker notes. Each takes an `output_path`, to write the whole document to a file instead

--- a/openspec/changes/add-viewer-find-in-page/.openspec.yaml
+++ b/openspec/changes/add-viewer-find-in-page/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-05

--- a/openspec/changes/add-viewer-find-in-page/design.md
+++ b/openspec/changes/add-viewer-find-in-page/design.md
@@ -1,0 +1,114 @@
+## Context
+
+See proposal.md - Why. Two viewers need find-in-page and they store text very differently:
+
+- `FileViewer.tsx` shows plain/highlighted text as real DOM text nodes (`CodeHighlight`'s
+  `dangerouslySetInnerHTML`, or `ReactMarkdown`'s output), or as a `<textarea>` value while editing.
+  DOM text is walkable and markable; a textarea's value is not.
+- `PdfViewer.tsx` shows each page as a `<canvas>` bitmap with a transparent, selectable text layer
+  (`pdfjs.TextLayer`) laid over it — but only for pages within `RENDER_WINDOW` of the current one
+  (`ui/src/components/PdfViewer.tsx:156`). A page outside that window has no DOM text at all.
+  pdf.js 6.2 exposes `page.getTextContent()` (a promise) independently of the streamed variant
+  used for the visible text layer, so a page's text can be read for indexing without rendering it.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One find-bar UX (query, count, next/prev, Enter/Shift+Enter, Escape) shared across text, code,
+  Markdown (both view modes), and PDF.
+- PDF search covers the whole document, with results usable before indexing finishes.
+- PDF match highlighting lands at the match's exact position on the page.
+- No new runtime dependency: build on `pdfjs-dist` (already a dependency) and plain DOM APIs.
+
+**Non-Goals:**
+- The side-by-side split mode and the git-diff view are not searchable in this change — both
+  already show two content areas at once, and defining "the current match" across two panes is a
+  separate design question left for later if requested.
+- Regular-expression or whole-word search. Plain case-insensitive substring only.
+- Cross-file search (searching files other than the one open). This is Ctrl+F, not a project
+  search.
+- Persisting the query across files or sessions.
+
+## Decisions
+
+### Shared highlight utility, DOM-based, not `window.find()` or the CSS Custom Highlight API
+
+Matches in rendered text (source view, rendered Markdown, a PDF page's text layer) are marked by
+walking the container's text nodes with a `TreeWalker`, locating substring matches against the
+concatenation of their text, and splitting/wrapping the matched ranges in `<mark>` elements —
+current match gets a distinguishing class.
+
+Alternatives considered:
+- `window.find()`: deprecated, inconsistent across browsers, and cannot be scoped to a container
+  (it searches the whole page) or report a match count.
+- CSS Custom Highlight API (`CSS.highlights`, `Range`-based, no DOM mutation): elegant and avoids
+  reflow from node splitting, but not supported on the full browser range this app targets; using
+  it would mean two separate highlighting code paths anyway (a fallback still needed). A single
+  `<mark>`-based path everywhere is simpler to reason about and to test, and file sizes here are
+  bounded (1 MiB preview limit), so the reflow cost is not a concern.
+
+This utility takes a container element, is re-run whenever the query or the container's content
+changes, and returns the ordered list of match elements so the caller can scroll to and style the
+current one. It is oblivious to whether the container holds highlighted code, rendered Markdown, or
+a PDF's text layer — it only needs a container and a query.
+
+### PDF: index built from `getTextContent()`, matches drawn through the existing text layer
+
+Rather than computing highlight rectangles from raw `TextItem.transform` matrices, a match is
+highlighted by re-using the *rendered* text layer: once the target page is within the render
+window, its `pdfjs.TextLayer` spans hold exactly the text `drawTextLayer` already places at the
+right screen position (`ui/src/components/PdfViewer.tsx:115`). The shared highlight utility runs
+against that container the same way it runs against source code. This means:
+- No second, independent coordinate system to keep in sync with rendering, zoom, and scroll.
+- Highlighting a PDF match and highlighting code share one implementation.
+- The cost is a wait for the target page to render before the highlight can appear, already true
+  today for `goTo()` scrolling to a page.
+
+The search index itself (separate from the text layer) is a plain array, built once per open
+document and invalidated when the path or revision changes: for each page, its concatenated
+`getTextContent()` string and the char-offset of each query match. It is built lazily, one page at
+a time, starting from the currently open page and expanding outward, yielding control between
+pages (e.g., `requestIdleCallback`/`setTimeout(0)`) so a long document does not block the main
+thread. This is the same "read ahead" shape as extraction elsewhere in this codebase (bounded,
+incremental, never all-at-once against an unbounded document), scaled down since this indexes text
+already fetched into the browser rather than calling a server tool.
+
+Alternative considered: adopt pdf.js's own `PDFFindController` from its `web/` viewer layer. It
+solves exactly this problem, but it is designed to run inside pdf.js's full `PDFViewer` component
+(`EventBus`, `PDFLinkService`, its own page-rendering pipeline), which this codebase deliberately
+does not use — `PdfViewer.tsx` renders pages itself for tight control over the render window and
+memory. Pulling in `PDFFindController` alone, without the rest of that viewer layer, is not a
+supported usage and would fight the existing rendering approach more than it would save.
+
+### Ctrl+F capture scope
+
+The keydown listener is added at the document level for the lifetime of the mounted file viewer,
+mirroring the existing Escape-to-close listener (`FileViewer.tsx:457-463`) — the viewer is a
+full-screen overlay while open (`className="absolute inset-0 z-20"`), so there is nothing else on
+screen for Ctrl+F to mean. `preventDefault()` is only called when the current view is searchable
+(see the `FindNotOfferedOutsideSupportedViews` scenario); otherwise the key passes through
+untouched.
+
+## Risks / Trade-offs
+
+- [Risk] Splitting text nodes to insert `<mark>` elements inside `CodeHighlight`'s
+  `dangerouslySetInnerHTML` output is undone whenever that `html` state updates (e.g., the file's
+  content changes) → Mitigation: the highlight effect re-runs after every render of the content
+  container, keyed on the same content the container was built from, so marks are always
+  reapplied against the latest DOM rather than assumed to persist.
+- [Risk] A pathological query (a very common single character) in a large source file produces
+  thousands of matches and thousands of `<mark>` elements → Mitigation: file previews are already
+  capped at 1 MiB; cap the marked-match count (e.g., a few thousand) and say so in the count
+  ("500+ matches") rather than degrade the page.
+- [Risk] Building the PDF text index competes with page rendering for main-thread time on a large
+  document → Mitigation: indexing yields between pages and starts from the page currently open, so
+  the pages the reader is most likely to search near are indexed first.
+- [Trade-off] PDF highlighting requires the target page to render before it can be shown, so
+  jumping to a far-away match has a brief delay while that page's canvas and text layer draw. This
+  matches the delay `goTo()` already has today for the same reason, so it is not a new class of
+  behavior.
+
+## Migration Plan
+
+Additive, client-only, one PR. No data migration, no server or protocol change, no flag needed —
+the find bar simply does not appear until Ctrl+F is pressed. Rollback is reverting the PR.

--- a/openspec/changes/add-viewer-find-in-page/proposal.md
+++ b/openspec/changes/add-viewer-find-in-page/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+The file viewer has no way to search within an open document. A PDF or a text/code/Markdown file
+of any real length can only be searched by scrolling and reading, because the browser's native
+Ctrl+F either does not reach the content (a PDF's canvas pages, an edit-mode textarea's value) or
+searches the whole page including chat history and other UI. Every other reading surface in the
+app that shows a document of length benefits from find-in-page; this is missing everywhere.
+
+## What Changes
+
+- Add a find-in-page bar to the full-size file viewer, opened with Ctrl+F / Cmd+F while the viewer
+  is focused, closed with Escape. It shows a query field, a match count ("3/17"), next/previous
+  controls, and Enter/Shift+Enter to step through matches.
+- Text, Markdown (both source and rendered view), and code files: matches are found in the
+  document's current text — the edit buffer when one is open, the file content otherwise — and the
+  current match is highlighted and scrolled into view. Search is case-insensitive by default.
+- PDF files: matches are found across the *whole* document, not only the pages currently rendered.
+  Opening find triggers a one-time, incremental text index of the document (reusing pdf.js's own
+  per-page text extraction); navigating to a match jumps to its page and highlights it at its exact
+  position on the page, the way a native PDF reader's find does.
+- In edit mode (textarea), the current match is selected via the textarea's native selection and
+  scrolled into view; other matches are not overlay-highlighted, since a textarea's value cannot
+  carry markup.
+- Ctrl+F is captured only while the file viewer has focus, so it does not shadow the browser's own
+  find elsewhere in the app.
+
+## Capabilities
+
+### New Capabilities
+- `viewer-find-in-page`: find-in-page search inside the full-size file viewer, covering plain
+  text/code, Markdown (source and rendered), the edit-mode textarea, and PDF documents.
+
+### Modified Capabilities
+(none — this adds a capability layered on top of the existing viewers without changing their
+existing requirements)
+
+## Impact
+
+- `ui/src/components/FileViewer.tsx`: owns the find bar's open/closed state and Ctrl+F/Escape
+  capture; wires the query to whichever text is currently displayed (source, rendered Markdown, or
+  edit buffer) and to `PdfViewer` when the open file is a PDF.
+- `ui/src/components/PdfViewer.tsx`: exposes a way to index a document's text per page, search it,
+  and highlight a match's bounding box on its (possibly not-yet-rendered) page; extends `goTo` so
+  navigating to a match's page happens before highlighting it.
+- New shared UI: a find-bar component and a text-highlighting utility (DOM-based for rendered text,
+  bounding-box based for PDF canvases), placed under `ui/src/components/` and `ui/src/util/`.
+- No server or protocol changes — this is client-only, since both the file's text and the PDF bytes
+  are already available in the browser.

--- a/openspec/changes/add-viewer-find-in-page/scenario-coverage.md
+++ b/openspec/changes/add-viewer-find-in-page/scenario-coverage.md
@@ -1,0 +1,40 @@
+# Scenario coverage — `viewer-find-in-page`
+
+Enumerated via `rg '^#### Scenario:' openspec/changes/add-viewer-find-in-page/specs/` (20 scenarios).
+All `covered`; none `partial` or `uncovered`.
+
+| Scenario | Status | Test file | Test |
+|---|---|---|---|
+| OpenWithCtrlF | covered | `ui/src/components/FileViewer.find.test.tsx` | "opens the find bar with Ctrl+F on a text file" |
+| ReopenKeepsThePreviousQuery | covered | `ui/src/components/FileViewer.find.test.tsx` | "reopens with the previous query preselected" |
+| EscapeClosesTheFindBarFirst | covered | `ui/src/components/FileViewer.find.test.tsx` | "closes the find bar first on Escape, leaving the viewer open" |
+| EscapeThenClosesTheViewer | covered | `ui/src/components/FileViewer.find.test.tsx` | "closes the viewer on a second Escape once the find bar is already closed" |
+| FindNotOfferedOutsideSupportedViews | covered | `ui/src/components/FileViewer.find.test.tsx` | "does nothing on an image file" / "does nothing while showing a git diff" / "does nothing in the side-by-side split view" |
+| StepForwardWraps | covered | `ui/src/components/FileViewer.find.test.tsx`, `ui/src/components/PdfViewer.test.tsx` | "moves to the next match with Enter and wraps around"; "wraps navigation from the last match back to the first" |
+| StepBackwardWraps | covered | `ui/src/components/PdfViewer.test.tsx` | "wraps navigation from the last match back to the first" |
+| CaseInsensitiveByDefault | covered | `ui/src/util/findInPage.test.ts` | "matches case-insensitively" (the exact utility both dom and pdf highlighting call) |
+| NoMatches | covered | `ui/src/components/FileViewer.find.test.tsx`, `ui/src/util/findInPage.test.ts` | "shows no matches, not an error, for a query the file does not contain"; "returns no matches for a query the text does not contain" |
+| SearchTracksEditsInProgress | covered | `ui/src/components/FileViewer.find.test.tsx` | "updates the match count as the buffer is edited, without moving the selection" |
+| SwitchingModeReEvaluatesTheQuery | covered | `ui/src/components/FileViewer.find.test.tsx` | "re-evaluates the query when switching from rendered to source view" |
+| AllMatchesMarkedCurrentOneStandsOut | covered | `ui/src/components/FileViewer.find.test.tsx` | "marks every match and distinguishes the current one" |
+| NavigatingScrollsTheMatchIntoView | covered | `ui/src/components/FileViewer.find.test.tsx` | "scrolls the current match into view when navigating" |
+| CurrentMatchIsSelectedInTheEditor | covered | `ui/src/components/FileViewer.find.test.tsx` | "selects the current match's exact text in the textarea" |
+| OtherMatchesAreNotMarkedWhileEditing | covered | `ui/src/components/FileViewer.find.test.tsx` | "does not mark the other matches while editing — a textarea's value carries no markup" |
+| MatchOnAPageNotYetRendered | covered | `ui/src/components/PdfViewer.test.tsx` | "finds matches on a page that has not been read yet only once indexing reaches it" |
+| PartialResultsWhileIndexingContinues | covered | `ui/src/components/PdfViewer.test.tsx` | "shows matches found so far as navigable while indexing still has pages left to read" |
+| ScannedPageContributesNoMatches | covered | `ui/src/components/PdfViewer.test.tsx`, `ui/src/util/pdfFindIndex.test.ts` | "treats a page whose text cannot be read as contributing no matches, not an error"; "reports no matches, not an error, for a page with no extractable text" |
+| NavigatingToADistantMatchJumpsPages | covered | `ui/src/components/PdfViewer.test.tsx` | "jumps to a page containing the next match when it is outside the render window" |
+| HighlightFollowsSubsequentMatchesOnTheSamePage | covered | `ui/src/components/PdfViewer.test.tsx` | "moves the highlight between matches on the same page without changing page" |
+
+Assertions were read, not just test titles: each test above exercises the real
+GIVEN/WHEN/THEN — e.g. `AllMatchesMarkedCurrentOneStandsOut` counts actual
+`<mark class="find-match">` elements and the single `find-match-current`, not
+merely that the find bar opened; `NavigatingToADistantMatchJumpsPages` waits
+for the page indicator and the highlighted mark's text, not just that `goTo`
+was called.
+
+Supporting unit coverage (not scenario-mapped, but exercised as part of the
+above): `ui/src/util/findInPage.test.ts` (the shared highlight/match utility),
+`ui/src/util/pdfFindIndex.test.ts` (page read order, incremental indexing,
+cancellation, search), `ui/src/components/FindBar.test.tsx` (the shared bar
+component in isolation).

--- a/openspec/changes/add-viewer-find-in-page/specs/viewer-find-in-page/spec.md
+++ b/openspec/changes/add-viewer-find-in-page/specs/viewer-find-in-page/spec.md
@@ -1,0 +1,174 @@
+## Purpose
+
+Lets a reader search within a document open in the full-size file viewer — plain text, code,
+Markdown (source or rendered), an in-progress edit, or a PDF — instead of scrolling to find a word
+by eye, the way Ctrl+F does in a native document reader.
+
+## ADDED Requirements
+
+### Requirement: OpenAndCloseFindBar
+
+The file viewer SHALL open a find bar when Ctrl+F or Cmd+F is pressed while the viewer is open and
+the displayed content is searchable (plain text, code, Markdown in either view, an in-progress
+edit, or a loaded PDF — not an image, not the git-diff view, not the side-by-side split view). The
+key SHALL be captured by the viewer, not left to the browser's own find. Opening the bar SHALL
+focus its query field; if a previous query exists, it SHALL be preselected so retyping replaces it.
+
+Pressing Escape while the find bar is open SHALL close the find bar and clear any match
+highlighting, without closing the file viewer. Escape pressed again afterward SHALL close the
+viewer, exactly as it does today when no find bar is open.
+
+#### Scenario: OpenWithCtrlF
+- **GIVEN** the file viewer is open on a text, Markdown, or PDF file
+- **WHEN** the user presses Ctrl+F (Cmd+F on macOS)
+- **THEN** the find bar appears with its query field focused, and the browser's own find is not triggered
+
+#### Scenario: ReopenKeepsThePreviousQuery
+- **GIVEN** the find bar was used and then closed, with a query still in it
+- **WHEN** the user presses Ctrl+F again
+- **THEN** the bar reopens with that query shown and selected
+
+#### Scenario: EscapeClosesTheFindBarFirst
+- **GIVEN** the find bar is open
+- **WHEN** the user presses Escape
+- **THEN** the find bar closes, its highlighting is cleared, and the file viewer stays open
+
+#### Scenario: EscapeThenClosesTheViewer
+- **GIVEN** the find bar is closed and the file viewer is open
+- **WHEN** the user presses Escape
+- **THEN** the file viewer closes, as it does without this feature
+
+#### Scenario: FindNotOfferedOutsideSupportedViews
+- **GIVEN** the viewer is showing an image, a git diff, or the side-by-side split mode
+- **WHEN** the user presses Ctrl+F
+- **THEN** no find bar opens and the browser's own find is not suppressed
+
+### Requirement: NavigateMatches
+
+The find bar SHALL show how many matches exist and which one is current (for example "3/17"), and
+SHALL let the user step to the next match (Enter, or a next control) or the previous one (Shift+Enter,
+or a previous control), wrapping from the last match to the first and back. Matching SHALL be a
+plain, case-insensitive substring search; it is not a regular-expression or whole-word search.
+
+#### Scenario: StepForwardWraps
+- **GIVEN** the find bar is showing the last of several matches as current
+- **WHEN** the user moves to the next match
+- **THEN** the first match becomes current
+
+#### Scenario: StepBackwardWraps
+- **GIVEN** the find bar is showing the first of several matches as current
+- **WHEN** the user moves to the previous match
+- **THEN** the last match becomes current
+
+#### Scenario: CaseInsensitiveByDefault
+- **GIVEN** a document containing "Outpost" but the typed query is "outpost"
+- **WHEN** the query is evaluated
+- **THEN** the occurrence of "Outpost" counts as a match
+
+#### Scenario: NoMatches
+- **GIVEN** a query that matches nothing in the document
+- **WHEN** the find bar evaluates it
+- **THEN** it shows "0/0" (or equivalent), no match is highlighted, and no error is reported
+
+### Requirement: SearchFollowsTheDisplayedText
+
+The find bar SHALL search whatever text the viewer is currently displaying for the open file: the
+rendered Markdown text in rendered mode, the highlighted source text in source mode, or the live
+edit buffer while a file is being edited — never a version of the text that is not what the reader
+is looking at. Switching between rendered and source mode, or starting or leaving an edit, while
+the find bar is open SHALL re-evaluate the query against the newly displayed text and SHALL NOT
+silently keep stale match positions.
+
+#### Scenario: SearchTracksEditsInProgress
+- **GIVEN** a writable file open for editing, with the find bar open and a query matching text in
+  the buffer
+- **WHEN** the user types more text into the buffer that changes which lines contain the query
+- **THEN** the match count and positions update to reflect the buffer's current content, not the
+  file as last saved
+
+#### Scenario: SwitchingModeReEvaluatesTheQuery
+- **GIVEN** the find bar is open on the rendered Markdown view with an active match
+- **WHEN** the user switches to source view
+- **THEN** the same query is re-evaluated against the source text and the match count reflects it
+
+### Requirement: HighlightAndScrollToMatch
+
+For plain text, code, and Markdown (either view), every match currently in the displayed text SHALL
+be visually marked, with the current match visually distinguished from the others (for example, a
+stronger highlight color), and the current match SHALL be scrolled into view when it becomes
+current — by navigation, by opening the find bar, or by a query that changes which match is current.
+
+#### Scenario: AllMatchesMarkedCurrentOneStandsOut
+- **GIVEN** a document with several occurrences of the query visible in the current view
+- **WHEN** the find bar is open
+- **THEN** every occurrence is marked, and the current one is visually distinguishable from the rest
+
+#### Scenario: NavigatingScrollsTheMatchIntoView
+- **GIVEN** the current match is outside the visible scroll area
+- **WHEN** the user moves to it
+- **THEN** the view scrolls so the match becomes visible
+
+### Requirement: EditModeUsesNativeSelection
+
+While the open file is being edited (the textarea buffer), the current match SHALL be indicated by
+selecting its text in the textarea and giving the textarea focus, relying on the browser's own
+scroll-into-view-on-selection behavior. Because a textarea's value carries no markup, matches other
+than the current one SHALL NOT be highlighted while editing; the match count SHALL still be
+accurate.
+
+#### Scenario: CurrentMatchIsSelectedInTheEditor
+- **GIVEN** a file open for editing with the find bar showing a current match
+- **WHEN** that match becomes current
+- **THEN** its exact text is selected in the textarea and the textarea is scrolled so the selection
+  is visible
+
+#### Scenario: OtherMatchesAreNotMarkedWhileEditing
+- **GIVEN** a file open for editing with several matches
+- **WHEN** the find bar is open
+- **THEN** only the current match is indicated (via selection); the others are not visually marked
+  on the page
+
+### Requirement: PdfWholeDocumentSearch
+
+For a PDF, the find bar SHALL search the whole document's text, not only the pages currently
+rendered. Opening the find bar on a PDF (or entering the first query) SHALL trigger the document's
+text to be read page by page for search purposes; the match count and navigation SHALL become
+usable incrementally as pages are read rather than waiting for the entire document, and SHALL
+indicate that the count may still grow while reading continues. A page that carries no text (a
+scanned image) contributes no matches from that page, and this SHALL NOT be reported as an error.
+
+#### Scenario: MatchOnAPageNotYetRendered
+- **GIVEN** a multi-page PDF with a match on a page far from the one currently shown
+- **WHEN** the user searches for that text
+- **THEN** the match is found and can be navigated to, even though that page has not been rendered
+  yet
+
+#### Scenario: PartialResultsWhileIndexingContinues
+- **GIVEN** a long PDF whose pages are still being read for search
+- **WHEN** the user is shown the match count
+- **THEN** matches found so far are navigable and the display indicates that more may still be
+  found
+
+#### Scenario: ScannedPageContributesNoMatches
+- **GIVEN** a PDF page with no extractable text
+- **WHEN** the document is searched
+- **THEN** no match is reported from that page, and no error is shown for it
+
+### Requirement: PdfMatchHighlightOnPage
+
+Navigating to a PDF match SHALL move the view to the page it is on and highlight it at its exact
+position on the page, the way a native PDF reader's find does — using the same text-layer
+positions the viewer already places over the rendered page for text selection. If the target page
+is not yet rendered when the match becomes current, the viewer SHALL render it first and then
+highlight the match.
+
+#### Scenario: NavigatingToADistantMatchJumpsPages
+- **GIVEN** the current PDF page has no match and the next match is several pages away
+- **WHEN** the user moves to the next match
+- **THEN** the view moves to the page containing that match, which is rendered, and the match is
+  highlighted at its position on the page
+
+#### Scenario: HighlightFollowsSubsequentMatchesOnTheSamePage
+- **GIVEN** a page with more than one match
+- **WHEN** the user steps between matches on that same page
+- **THEN** the highlighted position moves between them without leaving the page

--- a/openspec/changes/add-viewer-find-in-page/tasks.md
+++ b/openspec/changes/add-viewer-find-in-page/tasks.md
@@ -1,0 +1,141 @@
+## 1. Shared highlight utility
+
+- [x] 1.1 Implement a container-scoped text-match utility (`ui/src/util/findInPage.ts` or similar):
+      given a container element and a case-insensitive query, walk its text nodes, wrap each match
+      in a `<mark>` element, and return the ordered match elements plus a cleanup function that
+      restores the original text nodes. Verify with a unit test covering: matches spanning two
+      adjacent text nodes, no matches, an empty query, and cleanup fully reverting the DOM.
+- [x] 1.2 Add a match-count cap (e.g. a few thousand) with a "500+ matches"-style label when hit.
+      Verify with a unit test feeding a pathological single-character query against a large body of
+      text.
+- [x] 1.3 Add a small styling pass (current match vs. other matches) usable from both the file
+      viewer and the PDF viewer's text layer. Verify visually via `npm run bench` (see repo's
+      running-app rule) with a code file containing several occurrences of a word.
+      — CSS in `web/src/index.css` (`.find-match`/`.find-match-current`, plus the PDF-specific
+      transparent-text override); verified live (see 6.2) rather than via `npm run bench`,
+      since this feature lives in the main viewer, not the embed widget bench targets.
+
+## 2. Find bar component
+
+- [x] 2.1 Build a `FindBar` component: query input, live "i/n" count (or "searching…" state), next
+      and previous controls, close control. Verify with a component test asserting the count text
+      and that next/prev call the provided callbacks.
+- [x] 2.2 Wire Enter / Shift+Enter inside the query input to next/previous, and Escape to close.
+      Verify with a keyboard-driven component test.
+
+## 3. FileViewer integration (text, code, Markdown)
+
+- [x] 3.1 Add find-bar open/closed state to `FileViewer`; capture Ctrl+F/Cmd+F at the document
+      level while the viewer is mounted (mirroring the existing Escape listener), calling
+      `preventDefault` only when the current view is searchable per the
+      `FindNotOfferedOutsideSupportedViews` scenario (not image, not git-diff, not split). Verify
+      with a component test that Ctrl+F opens the bar on a text file and does nothing on an image
+      file.
+- [x] 3.2 Make Escape close the find bar (and clear highlights) before it closes the viewer; a
+      second Escape closes the viewer as today. Verify with a component test for both the
+      `EscapeClosesTheFindBarFirst` and `EscapeThenClosesTheViewer` scenarios.
+- [x] 3.3 Apply the shared highlight utility (task 1) to the currently displayed container: the
+      `CodeHighlight` `<pre>` in source mode, the `ReactMarkdown` output in rendered mode. Re-run it
+      whenever the query or the displayed content changes. Verify with a component test for the
+      `SwitchingModeReEvaluatesTheQuery` scenario.
+- [x] 3.4 Scroll the current match into view on every change of current match (open, next, prev,
+      query edit). Verify with a component test asserting `scrollIntoView` (or equivalent) is
+      called on the current match's element.
+- [x] 3.5 Edit-mode handling: while the textarea is active, select the current match's exact range
+      via `setSelectionRange` and focus the textarea instead of inserting marks; keep the match
+      count accurate against the live buffer. Verify with a component test for
+      `CurrentMatchIsSelectedInTheEditor` and `SearchTracksEditsInProgress`.
+      — Focus moves to the textarea just long enough to trigger the browser's
+      scroll-into-view-on-selection, then bounces back to the find field so
+      Enter/Shift+Enter keep stepping through matches (see FileViewer.tsx's
+      `selectEditMatch`); the spec's letter ("selecting its text... giving the
+      textarea focus... scrolled into view") is satisfied without leaving
+      keyboard navigation stranded in the textarea.
+- [x] 3.6 Reset find-bar state (query, matches) when the open file path changes. Verify with a
+      component test opening file A with an active query, then switching to file B.
+      — `FileViewer` is remounted per path by its caller (`key={state.openFile.path}`
+      in App.tsx, pre-existing — the same mechanism an edit draft already relies
+      on never surviving a file switch), so find state resets for the same
+      reason; verified by mounting/unmounting rather than re-rendering in place.
+
+## 4. PDF text index and search
+
+- [x] 4.1 Add a per-document text index to `PdfViewer`: for each page, fetch `getTextContent()`
+      lazily (starting from the currently open page, expanding outward), yielding between pages so
+      indexing does not block the main thread; invalidate the index when `path` or `revision`
+      changes. Verify with a unit test (page proxy fakes) asserting incremental population and
+      cancellation on document change.
+      — Implemented as standalone, React-free logic in `ui/src/util/pdfFindIndex.ts`
+      (`indexPdfText`/`pageReadOrder`), unit-tested directly; wiring it into `PdfViewer`'s
+      lifecycle (starting it, invalidating it on path/revision change) is done in task 5.1.
+- [x] 4.2 Implement search over the index: case-insensitive substring match per page, producing an
+      ordered list of `{ page, matchIndexOnPage }`. Verify with a unit test against a fake
+      multi-page index, including the `ScannedPageContributesNoMatches` case (a page with empty
+      text).
+      — `searchPdfIndex` in the same module.
+- [x] 4.3 Expose match count and an "indexing in progress" flag so the find bar can show partial
+      results per the `PartialResultsWhileIndexingContinues` scenario. Verify with a unit test that
+      the count grows as indexing proceeds and a "still searching" flag clears when it finishes.
+      — Covered at the pure-logic level (`indexPdfText`'s incremental `onPage`/`onDone`
+      callbacks, tested above); the `PdfViewer` component wiring that turns this into the
+      find bar's live count/"searching…" state is done in task 5.1.
+
+## 5. PDF find-bar integration and highlighting
+
+- [x] 5.1 Wire `PdfViewer` to accept the shared `FindBar` (via `FileViewer`, matching task 3.1's
+      Ctrl+F capture) and to expose current-match navigation that calls the existing `goTo` to bring
+      the match's page into the render window. Verify with a component test for
+      `NavigatingToADistantMatchJumpsPages`.
+      — `PdfViewer` is now `forwardRef`, exposing `{findNext, findPrevious}`; `FileViewer`
+      holds the ref and forwards `findQuery`/`onFindStateChange`. Along the way, found and
+      fixed a latent concurrency issue in the mocked pdf.js module runner (two pages'
+      concurrent `import("pdfjs-dist")` could race to the unmocked real build) by
+      memoizing the dynamic import (`loadPdfjs`) — a real fix, not a test-only workaround,
+      since production code shouldn't call `import()` separately per page either.
+- [x] 5.2 Once the target page's text layer has rendered (`drawTextLayer` resolved), apply the
+      shared highlight utility (task 1) to that page's text-layer container for the current match,
+      matching the same query occurrence found by the index. Verify with a component test that
+      renders a page, then asserts a `<mark>` appears in its text layer once rendering settles.
+- [x] 5.3 Handle stepping between multiple matches on the same already-rendered page without a page
+      change. Verify with a component test for `HighlightFollowsSubsequentMatchesOnTheSamePage`.
+- [x] 5.4 Clear PDF highlighting and index state when the document changes (`path`/`revision`) or
+      the find bar closes. Verify with a component test switching PDFs with an active query.
+      — Closing the find bar clears it via the same path as everything else: `FileViewer`
+      passes PdfViewer `findQuery=""` whenever `findOpen` is false (`effectiveFindQuery`),
+      so PdfViewer's own effects tear the highlight down exactly as an empty query would.
+
+## 6. Cross-cutting verification
+
+- [x] 6.1 Enumerate every `#### Scenario:` in `openspec/changes/add-viewer-find-in-page/specs/`
+      (`rg '^#### Scenario:' openspec/changes/add-viewer-find-in-page/specs/`) and build the
+      scenario-to-test matrix required by this project's spec-coverage rule; fix any scenario left
+      `uncovered` or `partial`.
+      — Matrix in `scenario-coverage.md` (this change's directory): 20/20 scenarios `covered`.
+      Closing the gaps found while building it (git-diff/split were untested for
+      `FindNotOfferedOutsideSupportedViews`; `OtherMatchesAreNotMarkedWhileEditing` and
+      `PartialResultsWhileIndexingContinues` had no component-level test) added 4 tests.
+- [x] 6.2 Exercise the feature in the running app per this project's UI-testing rule: run the
+      server and web dev servers directly (this feature is in the main viewer, not an embed-bench
+      target), open a code file and a PDF, drive Ctrl+F, next/prev, and Escape-twice, and confirm
+      the DOM/session state matches what was driven (not just a screenshot).
+      — This caught a real bug component tests missed: `CodeHighlight` wasn't memoized, so any
+      unrelated re-render of the viewer made React reset its `<pre>`'s real DOM (React resets a
+      `dangerouslySetInnerHTML` element on every render of the component that owns it, not only
+      when the HTML string changes), silently wiping the find marks a moment after they were
+      applied. An earlier attempt at fixing this via a `MutationObserver` (to reapply marks after
+      the async syntax-highlighting swap) made things worse: the browser split its own mutation
+      batch across two observer callbacks, so the observer caught its own edits as if they were
+      external ones and looped hard enough to hang and crash the tab once. The actual fix wraps
+      `CodeHighlight` in `React.memo` (see its own comment) so it only re-renders — and only ever
+      touches its DOM — when `code`/`path`/`onRendered` genuinely change; `onRendered` (a stable
+      callback) then drives re-highlighting through a plain effect dependency, no DOM observation
+      needed. Verified live afterward: Ctrl+F on a 40-match file, Next/Previous stepping the count
+      and the current mark correctly, Escape closing the find bar before the viewer. Also
+      exercised PDF search (`pdf-text.pdf`): the whole-document index correctly found "Revenue" on
+      a page outside the initial render window. Separately noticed, and confirmed via `git stash`
+      against the unmodified base branch, that this dev environment's PDF text *layer* (the
+      pre-existing selectable-text overlay, unrelated to this change) does not populate — so the
+      on-page highlight-box rendering itself could not be visually confirmed live in this
+      environment; that code path is covered by `PdfViewer.test.tsx`'s mocked-text-layer tests
+      instead.
+- [x] 6.3 Run `openspec validate --strict` for this change and fix any reported issues.

--- a/ui/src/components/CodeHighlight.tsx
+++ b/ui/src/components/CodeHighlight.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 import type { HLJSApi } from "highlight.js";
 
 let hljsPromise: Promise<HLJSApi> | null = null;
@@ -97,11 +97,38 @@ function languageHint(path: string): string | undefined {
   return EXTENSION_HINTS[base.slice(dot + 1).toLowerCase()];
 }
 
-/** Syntax-highlighted code, falling back to plain text until highlight.js has loaded. */
-export function CodeHighlight({ code, path }: { code: string; path: string }) {
+/**
+ * Syntax-highlighted code, falling back to plain text until highlight.js has loaded.
+ *
+ * Memoized: an unmemoized component re-renders whenever its parent does, and
+ * React resets a `dangerouslySetInnerHTML` element's actual DOM on every one
+ * of those re-renders — not only when the HTML string itself changes. A
+ * caller that marks up this component's rendered text directly (find-in-page)
+ * would otherwise see its marks silently wiped by a parent update that has
+ * nothing to do with this file's content (e.g. an unrelated bit of viewer
+ * state changing). Skipping the re-render when `code`/`path`/`onRendered`
+ * haven't changed is what makes `onRendered` a trustworthy "content actually
+ * changed" signal rather than a "something, somewhere, re-rendered" one.
+ */
+export const CodeHighlight = memo(function CodeHighlight({
+  code,
+  path,
+  onRendered,
+}: {
+  code: string;
+  path: string;
+  /** Called once the real highlighted markup replaces the plain-text fallback
+   * (or, more generally, whenever the rendered HTML changes). A caller that
+   * marks up this component's own DOM output (find-in-page) needs to know
+   * when that swap happens, since it silently replaces whatever was there —
+   * fallback text, or a previous highlight's markup — with new nodes. */
+  onRendered?: () => void;
+}) {
   const [html, setHtml] = useState<string | null>(null);
   const codeRef = useRef(code);
   codeRef.current = code;
+  const onRenderedRef = useRef(onRendered);
+  onRenderedRef.current = onRendered;
 
   useEffect(() => {
     let cancelled = false;
@@ -114,6 +141,7 @@ export function CodeHighlight({ code, path }: { code: string; path: string }) {
           ? hljs.highlight(codeRef.current, { language: hint })
           : hljs.highlightAuto(codeRef.current);
       setHtml(result.value);
+      onRenderedRef.current?.();
     });
     return () => {
       cancelled = true;
@@ -130,4 +158,4 @@ export function CodeHighlight({ code, path }: { code: string; path: string }) {
       dangerouslySetInnerHTML={{ __html: html }}
     />
   );
-}
+});

--- a/ui/src/components/FileViewer.find.test.tsx
+++ b/ui/src/components/FileViewer.find.test.tsx
@@ -180,8 +180,12 @@ describe("FileViewer find-in-page", () => {
 
       fireEvent.click(screen.getByRole("button", { name: /source/ }));
 
-      await waitFor(() => expect(screen.getByText("1/2")).toBeInTheDocument());
-      expect(document.querySelectorAll("mark.find-match")).toHaveLength(2);
+      // The count label reads "1/2" both before and after the switch (same
+      // query, same match count in this fixture) — waiting on it alone could
+      // pass without the source view ever actually being re-marked. Wait on
+      // the marks themselves instead.
+      await waitFor(() => expect(document.querySelectorAll("mark.find-match")).toHaveLength(2));
+      expect(screen.getByText("1/2")).toBeInTheDocument();
     });
 
     it("shows no matches, not an error, for a query the file does not contain", async () => {

--- a/ui/src/components/FileViewer.find.test.tsx
+++ b/ui/src/components/FileViewer.find.test.tsx
@@ -40,7 +40,7 @@ function setup(overrides: Partial<Props> = {}) {
     file: loadedFile(),
     isStreaming: false,
     gitDiff: null as GitDiffState | null,
-    gitAvailable: false,
+    inRepository: false,
     ...handlers,
     ...overrides,
   };
@@ -186,6 +186,27 @@ describe("FileViewer find-in-page", () => {
       // the marks themselves instead.
       await waitFor(() => expect(document.querySelectorAll("mark.find-match")).toHaveLength(2));
       expect(screen.getByText("1/2")).toBeInTheDocument();
+    });
+
+    it("keeps the reader's place when the content is re-rendered under an active search", async () => {
+      // Re-marking the same query against re-rendered content must not send
+      // the reader back to the first match. A view switch is the deterministic
+      // way to trigger that re-mark; syntax highlighting arriving late reaches
+      // the same code path, and did — CI caught someone stepped to match 3
+      // being dropped back to match 1 the moment highlight.js finished loading.
+      setup({ file: loadedFile({ path: "notes.md", content: "fox fox fox" }) });
+      ctrlF();
+      typeQuery("fox");
+      await waitFor(() => expect(screen.getByText("1/3")).toBeInTheDocument());
+      fireEvent.click(screen.getByLabelText("Next match"));
+      fireEvent.click(screen.getByLabelText("Next match"));
+      expect(screen.getByText("3/3")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: /source/ }));
+
+      await waitFor(() => expect(document.querySelectorAll("mark.find-match")).toHaveLength(3));
+      expect(screen.getByText("3/3")).toBeInTheDocument();
+      expect(document.querySelectorAll("mark.find-match-current")).toHaveLength(1);
     });
 
     it("shows no matches, not an error, for a query the file does not contain", async () => {

--- a/ui/src/components/FileViewer.find.test.tsx
+++ b/ui/src/components/FileViewer.find.test.tsx
@@ -188,12 +188,7 @@ describe("FileViewer find-in-page", () => {
       expect(screen.getByText("1/2")).toBeInTheDocument();
     });
 
-    it("keeps the reader's place when the content is re-rendered under an active search", async () => {
-      // Re-marking the same query against re-rendered content must not send
-      // the reader back to the first match. A view switch is the deterministic
-      // way to trigger that re-mark; syntax highlighting arriving late reaches
-      // the same code path, and did — CI caught someone stepped to match 3
-      // being dropped back to match 1 the moment highlight.js finished loading.
+    it("keeps the reader's place when switching view with a search active", async () => {
       setup({ file: loadedFile({ path: "notes.md", content: "fox fox fox" }) });
       ctrlF();
       typeQuery("fox");
@@ -204,9 +199,16 @@ describe("FileViewer find-in-page", () => {
 
       fireEvent.click(screen.getByRole("button", { name: /source/ }));
 
-      await waitFor(() => expect(document.querySelectorAll("mark.find-match")).toHaveLength(3));
-      expect(screen.getByText("3/3")).toBeInTheDocument();
-      expect(document.querySelectorAll("mark.find-match-current")).toHaveLength(1);
+      // One waitFor over the whole settled state: the source view mounts its
+      // own highlighter, which re-marks again when it finishes loading, so
+      // asserting between those two passes is asserting on a moment rather
+      // than on an outcome. FileViewer.findRerender.test.tsx drives that
+      // second pass deliberately instead of racing it.
+      await waitFor(() => {
+        expect(document.querySelectorAll("mark.find-match")).toHaveLength(3);
+        expect(document.querySelectorAll("mark.find-match-current")).toHaveLength(1);
+        expect(screen.getByText("3/3")).toBeInTheDocument();
+      });
     });
 
     it("shows no matches, not an error, for a query the file does not contain", async () => {

--- a/ui/src/components/FileViewer.find.test.tsx
+++ b/ui/src/components/FileViewer.find.test.tsx
@@ -1,0 +1,322 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { forwardRef, useImperativeHandle } from "react";
+import { FileViewer } from "./FileViewer";
+import type { GitDiffState, OpenFile } from "../useAgent";
+import type { PdfFindState, PdfViewerHandle } from "./PdfViewer";
+
+const pdfFindNext = vi.fn();
+const pdfFindPrevious = vi.fn();
+let lastOnFindStateChange: ((state: PdfFindState) => void) | undefined;
+
+vi.mock("./PdfViewer", () => ({
+  default: forwardRef<PdfViewerHandle, { path: string; onFindStateChange?: (state: PdfFindState) => void }>(
+    function FakePdfViewer({ path, onFindStateChange }, ref) {
+      lastOnFindStateChange = onFindStateChange;
+      useImperativeHandle(ref, () => ({ findNext: pdfFindNext, findPrevious: pdfFindPrevious }), []);
+      return <div data-testid="pdf-viewer" data-path={path} />;
+    },
+  ),
+}));
+
+function loadedFile(overrides: Partial<Extract<OpenFile, { status: "loaded" }>> = {}): OpenFile {
+  return { status: "loaded", path: "src/main.ts", content: "const a = 1;\n", size: 13, mtimeMs: 1000, ...overrides };
+}
+
+type Props = React.ComponentProps<typeof FileViewer>;
+
+function setup(overrides: Partial<Props> = {}) {
+  const handlers = {
+    onDirtyChange: vi.fn(),
+    onFetchGitDiff: vi.fn(),
+    onClearGitDiff: vi.fn(),
+    onOpenGitHistory: vi.fn(),
+    onClose: vi.fn(),
+    onReload: vi.fn(),
+    onSave: vi.fn(),
+    onImageLoad: vi.fn(),
+  };
+  const props: Props = {
+    file: loadedFile(),
+    isStreaming: false,
+    gitDiff: null as GitDiffState | null,
+    gitAvailable: false,
+    ...handlers,
+    ...overrides,
+  };
+  const view = render(<FileViewer {...props} />);
+  const rerenderWith = (next: Partial<Props>) => view.rerender(<FileViewer {...props} {...next} />);
+  return { ...handlers, ...view, rerenderWith };
+}
+
+const ctrlF = () => fireEvent.keyDown(document, { key: "f", ctrlKey: true });
+const escape = () => fireEvent.keyDown(document, { key: "Escape" });
+const findInput = () => screen.getByLabelText("Find") as HTMLInputElement;
+const typeQuery = (text: string) => fireEvent.change(findInput(), { target: { value: text } });
+// `getByRole("textbox")` is ambiguous once the find input (also role
+// "textbox") is on screen alongside the edit-mode textarea.
+const editTextarea = () => document.querySelector("textarea") as HTMLTextAreaElement;
+
+describe("FileViewer find-in-page", () => {
+  beforeEach(() => {
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    Element.prototype.scrollIntoView = vi.fn();
+    lastOnFindStateChange = undefined;
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("opening and closing", () => {
+    it("opens the find bar with Ctrl+F on a text file", () => {
+      setup();
+      expect(screen.queryByRole("search", { name: "Find in file" })).toBeNull();
+
+      ctrlF();
+
+      expect(screen.getByRole("search", { name: "Find in file" })).toBeInTheDocument();
+    });
+
+    it("does nothing on an image file", () => {
+      setup({ file: { status: "error", path: "photo.png", message: "Binary file — preview not supported" } });
+
+      ctrlF();
+
+      expect(screen.queryByRole("search", { name: "Find in file" })).toBeNull();
+    });
+
+    it("does nothing while showing a git diff", () => {
+      setup({ gitState: "modified", initialShowGitDiff: true });
+
+      ctrlF();
+
+      expect(screen.queryByRole("search", { name: "Find in file" })).toBeNull();
+    });
+
+    it("does nothing in the side-by-side split view", () => {
+      // jsdom ships no matchMedia, and the mode asks it whether there is room
+      // for two panes — see FileViewer.split.test.tsx for the same stub.
+      window.matchMedia = ((query: string) => ({
+        matches: true,
+        media: query,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+      })) as unknown as typeof window.matchMedia;
+      setup({ file: loadedFile({ path: "notes.md", content: "# Title\nfox" }) });
+      fireEvent.click(screen.getByRole("button", { name: /split/ }));
+      expect(screen.getByTestId("file-split")).toBeInTheDocument();
+
+      ctrlF();
+
+      expect(screen.queryByRole("search", { name: "Find in file" })).toBeNull();
+    });
+
+    it("closes the find bar first on Escape, leaving the viewer open", () => {
+      const onClose = vi.fn();
+      setup({ onClose });
+      ctrlF();
+      expect(screen.getByRole("search", { name: "Find in file" })).toBeInTheDocument();
+
+      escape();
+
+      expect(screen.queryByRole("search", { name: "Find in file" })).toBeNull();
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it("closes the viewer on a second Escape once the find bar is already closed", () => {
+      const onClose = vi.fn();
+      setup({ onClose });
+      ctrlF();
+      escape(); // closes the find bar
+
+      escape(); // now closes the viewer
+
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it("reopens with the previous query preselected", () => {
+      setup();
+      ctrlF();
+      typeQuery("outpost");
+      escape();
+
+      ctrlF();
+
+      expect(findInput().value).toBe("outpost");
+    });
+  });
+
+  describe("dom-mode search (source and rendered views)", () => {
+    it("marks every match and distinguishes the current one", async () => {
+      setup({ file: loadedFile({ content: "const fox = 1;\nconst fox2 = fox;\n" }) });
+      ctrlF();
+
+      typeQuery("fox");
+
+      await waitFor(() => expect(screen.getByText("1/3")).toBeInTheDocument());
+      const marks = document.querySelectorAll("mark.find-match");
+      expect(marks).toHaveLength(3);
+      expect(document.querySelectorAll("mark.find-match-current")).toHaveLength(1);
+    });
+
+    it("scrolls the current match into view when navigating", async () => {
+      setup({ file: loadedFile({ content: "fox fox fox" }) });
+      ctrlF();
+      typeQuery("fox");
+      await waitFor(() => expect(screen.getByText("1/3")).toBeInTheDocument());
+      (Element.prototype.scrollIntoView as ReturnType<typeof vi.fn>).mockClear();
+
+      fireEvent.click(screen.getByLabelText("Next match"));
+
+      await waitFor(() => expect(screen.getByText("2/3")).toBeInTheDocument());
+      expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+    });
+
+    it("re-evaluates the query when switching from rendered to source view", async () => {
+      setup({ file: loadedFile({ path: "notes.md", content: "The fox jumps over the fox." }) });
+      ctrlF();
+      typeQuery("fox");
+      await waitFor(() => expect(screen.getByText("1/2")).toBeInTheDocument());
+
+      fireEvent.click(screen.getByRole("button", { name: /source/ }));
+
+      await waitFor(() => expect(screen.getByText("1/2")).toBeInTheDocument());
+      expect(document.querySelectorAll("mark.find-match")).toHaveLength(2);
+    });
+
+    it("shows no matches, not an error, for a query the file does not contain", async () => {
+      setup({ file: loadedFile({ content: "nothing interesting here" }) });
+      ctrlF();
+
+      typeQuery("xyzzy");
+
+      await waitFor(() => expect(screen.getByText("0/0")).toBeInTheDocument());
+    });
+  });
+
+  describe("edit-mode search", () => {
+    it("selects the current match's exact text in the textarea", async () => {
+      setup({ file: loadedFile({ content: "one fox two fox" }), writableRoot: undefined });
+      fireEvent.click(screen.getByRole("button", { name: "✎ edit" }));
+      ctrlF();
+
+      typeQuery("fox");
+
+      await waitFor(() => expect(screen.getByText("1/2")).toBeInTheDocument());
+      const textarea = editTextarea();
+      expect(textarea.value.slice(textarea.selectionStart ?? -1, textarea.selectionEnd ?? -1)).toBe("fox");
+      expect(textarea.selectionStart).toBe(4);
+      expect(textarea.selectionEnd).toBe(7);
+      // Focus bounces back to the find field once the selection (and its
+      // native scroll-into-view) is made, so Enter/Shift+Enter keep stepping
+      // through matches without the reader having to reclick the find box.
+      expect(findInput()).toHaveFocus();
+    });
+
+    it("does not mark the other matches while editing — a textarea's value carries no markup", async () => {
+      setup({ file: loadedFile({ content: "one fox two fox" }), writableRoot: undefined });
+      fireEvent.click(screen.getByRole("button", { name: "✎ edit" }));
+      ctrlF();
+
+      typeQuery("fox");
+
+      await waitFor(() => expect(screen.getByText("1/2")).toBeInTheDocument());
+      expect(document.querySelectorAll("mark")).toHaveLength(0);
+    });
+
+    it("updates the match count as the buffer is edited, without moving the selection", async () => {
+      setup({ file: loadedFile({ content: "one fox two fox" }), writableRoot: undefined });
+      fireEvent.click(screen.getByRole("button", { name: "✎ edit" }));
+      ctrlF();
+      typeQuery("fox");
+      await waitFor(() => expect(screen.getByText("1/2")).toBeInTheDocument());
+
+      const textarea = editTextarea();
+      findInput().focus(); // simulate focus having returned to the find field
+      fireEvent.change(textarea, { target: { value: "one fox two fox three fox" } });
+
+      await waitFor(() => expect(screen.getByText("1/3")).toBeInTheDocument());
+      // Typing in the document must not steal focus back to the textarea.
+      expect(findInput()).toHaveFocus();
+    });
+
+    it("moves to the next match with Enter and wraps around", async () => {
+      setup({ file: loadedFile({ content: "one fox two fox" }), writableRoot: undefined });
+      fireEvent.click(screen.getByRole("button", { name: "✎ edit" }));
+      ctrlF();
+      typeQuery("fox");
+      await waitFor(() => expect(screen.getByText("1/2")).toBeInTheDocument());
+
+      fireEvent.keyDown(findInput(), { key: "Enter" });
+      await waitFor(() => expect(screen.getByText("2/2")).toBeInTheDocument());
+      expect(editTextarea().selectionStart).toBe(12);
+
+      fireEvent.keyDown(findInput(), { key: "Enter" });
+      await waitFor(() => expect(screen.getByText("1/2")).toBeInTheDocument());
+      expect(editTextarea().selectionStart).toBe(4);
+    });
+  });
+
+  describe("pdf mode", () => {
+    function pdfFile(path = "docs/report.pdf"): OpenFile {
+      return { status: "error", path, message: "Binary file — preview not supported" };
+    }
+
+    it("forwards the query to PdfViewer only while find is open", async () => {
+      setup({ file: pdfFile() });
+      await screen.findByTestId("pdf-viewer");
+
+      ctrlF();
+      typeQuery("fox");
+      expect(screen.getByTestId("pdf-viewer")).toBeInTheDocument();
+
+      escape(); // closes the find bar
+      // The effective query passed down clears; nothing to assert on the fake
+      // beyond it not crashing — PdfViewer's own tests cover its find logic.
+    });
+
+    it("delegates next/previous to the PdfViewer handle", async () => {
+      setup({ file: pdfFile() });
+      await screen.findByTestId("pdf-viewer");
+      ctrlF();
+      // Next/previous are disabled at 0 matches — give PdfViewer something to report.
+      lastOnFindStateChange?.({ matchCount: 2, currentIndex: 0, searching: false });
+      await waitFor(() => expect(screen.getByText("1/2")).toBeInTheDocument());
+
+      fireEvent.click(screen.getByLabelText("Next match"));
+      fireEvent.click(screen.getByLabelText("Previous match"));
+
+      expect(pdfFindNext).toHaveBeenCalledTimes(1);
+      expect(pdfFindPrevious).toHaveBeenCalledTimes(1);
+    });
+
+    it("shows the match count PdfViewer reports", async () => {
+      setup({ file: pdfFile() });
+      await screen.findByTestId("pdf-viewer");
+      ctrlF();
+
+      lastOnFindStateChange?.({ matchCount: 4, currentIndex: 1, searching: false });
+
+      await waitFor(() => expect(screen.getByText("2/4")).toBeInTheDocument());
+    });
+  });
+
+  describe("resets on file change", () => {
+    // App.tsx mounts FileViewer with `key={state.openFile.path}` specifically
+    // so a switch to another file is a remount, not a prop update — the same
+    // reason an edit draft can never survive it. Find state relies on that
+    // same remount, so this reproduces it explicitly rather than assuming it.
+    it("clears the query and matches when the open file is a new mount", async () => {
+      const { unmount } = setup({ file: loadedFile({ path: "a.ts", content: "fox fox" }) });
+      ctrlF();
+      typeQuery("fox");
+      await waitFor(() => expect(screen.getByText("1/2")).toBeInTheDocument());
+      unmount();
+
+      setup({ file: loadedFile({ path: "b.ts", content: "nothing here" }) });
+
+      expect(screen.queryByRole("search", { name: "Find in file" })).toBeNull();
+      expect(screen.queryByText("1/2")).toBeNull();
+    });
+  });
+});

--- a/ui/src/components/FileViewer.findRerender.test.tsx
+++ b/ui/src/components/FileViewer.findRerender.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { FileViewer } from "./FileViewer";
+import type { GitDiffState, OpenFile } from "../useAgent";
+
+/**
+ * The real CodeHighlight renders the file as plain text, then — once
+ * highlight.js has loaded — replaces that whole `<pre>` with highlighted
+ * markup. Find-in-page marks the rendered text directly, so that swap lands
+ * underneath an active search and everything about it (when it happens,
+ * whether the reader has already navigated) is timing.
+ *
+ * This fake reproduces the two phases on demand instead of on a promise, so a
+ * test can put the swap exactly where it wants it: after the reader has
+ * stepped to a later match. On a warm machine highlight.js resolves before
+ * anyone can type, which is why this only ever failed on CI.
+ */
+let triggerHighlight: (() => void) | undefined;
+
+vi.mock("./CodeHighlight", async () => {
+  const { memo, useState } = await import("react");
+  return {
+    // Memoized, like the real one — and for the same reason: React re-applies
+    // a `dangerouslySetInnerHTML` element's DOM on every render of the
+    // component that owns it, wiping marks a caller put there. An unmemoized
+    // fake would fail this test for a reason the real component does not have.
+    CodeHighlight: memo(function FakeCodeHighlight({
+      code,
+      onRendered,
+    }: {
+      code: string;
+      path: string;
+      onRendered?: () => void;
+    }) {
+      const [highlighted, setHighlighted] = useState(false);
+      triggerHighlight = () => {
+        setHighlighted(true);
+        onRendered?.();
+      };
+      if (!highlighted) return <pre className="whitespace-pre-wrap">{code}</pre>;
+      // The real component swaps to dangerouslySetInnerHTML, which replaces
+      // the element's whole DOM — including marks applied to the plain phase.
+      return <pre className="hljs" dangerouslySetInnerHTML={{ __html: code.replace(/[<>&]/g, "") }} />;
+    }),
+  };
+});
+
+vi.mock("./PdfViewer", () => ({ default: () => <div data-testid="pdf-viewer" /> }));
+
+function loadedFile(overrides: Partial<Extract<OpenFile, { status: "loaded" }>> = {}): OpenFile {
+  return { status: "loaded", path: "src/main.ts", content: "fox fox fox", size: 11, mtimeMs: 1000, ...overrides };
+}
+
+type Props = React.ComponentProps<typeof FileViewer>;
+
+function setup(overrides: Partial<Props> = {}) {
+  const props: Props = {
+    file: loadedFile(),
+    isStreaming: false,
+    gitDiff: null as GitDiffState | null,
+    inRepository: false,
+    onDirtyChange: vi.fn(),
+    onFetchGitDiff: vi.fn(),
+    onClearGitDiff: vi.fn(),
+    onOpenGitHistory: vi.fn(),
+    onClose: vi.fn(),
+    onReload: vi.fn(),
+    onSave: vi.fn(),
+    onImageLoad: vi.fn(),
+    ...overrides,
+  };
+  return render(<FileViewer {...props} />);
+}
+
+const ctrlF = () => fireEvent.keyDown(document, { key: "f", ctrlKey: true });
+const findInput = () => screen.getByLabelText("Find") as HTMLInputElement;
+
+describe("find-in-page when the content is re-rendered underneath it", () => {
+  beforeEach(() => {
+    triggerHighlight = undefined;
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the reader on the match they navigated to", async () => {
+    setup();
+    ctrlF();
+    fireEvent.change(findInput(), { target: { value: "fox" } });
+    await waitFor(() => expect(screen.getByText("1/3")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByLabelText("Next match"));
+    fireEvent.click(screen.getByLabelText("Next match"));
+    expect(screen.getByText("3/3")).toBeInTheDocument();
+
+    // Syntax highlighting lands, replacing the text the marks were applied to.
+    act(() => triggerHighlight?.());
+
+    await waitFor(() => {
+      expect(document.querySelectorAll("mark.find-match")).toHaveLength(3);
+      expect(document.querySelectorAll("mark.find-match-current")).toHaveLength(1);
+    });
+    expect(screen.getByText("3/3")).toBeInTheDocument();
+  });
+
+  it("still answers the next click after the swap", async () => {
+    setup();
+    ctrlF();
+    fireEvent.change(findInput(), { target: { value: "fox" } });
+    await waitFor(() => expect(screen.getByText("1/3")).toBeInTheDocument());
+
+    act(() => triggerHighlight?.());
+    await waitFor(() => expect(document.querySelectorAll("mark.find-match")).toHaveLength(3));
+
+    fireEvent.click(screen.getByLabelText("Next match"));
+
+    await waitFor(() => expect(screen.getByText("2/3")).toBeInTheDocument());
+    expect(document.querySelectorAll("mark.find-match-current")).toHaveLength(1);
+  });
+});

--- a/ui/src/components/FileViewer.tsx
+++ b/ui/src/components/FileViewer.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import rehypeKatex from "rehype-katex";
 import remarkGfm from "remark-gfm";
@@ -16,6 +16,9 @@ import { ViewerErrorBoundary } from "./ViewerErrorBoundary";
 import { readStructuredExchangeFile } from "../presentations/structuredExchange";
 import type { ValidatedStructuredExchange } from "@pi-outpost/shared/structured-exchange";
 import { StructuredExchangeDocument } from "../presentations/StructuredExchangeView";
+import { FindBar } from "./FindBar";
+import { findMatchesInText, highlightMatches, type DomMatch } from "../util/findInPage";
+import type { PdfFindState, PdfViewerHandle } from "./PdfViewer";
 
 // pdf.js is over a megabyte: a session that never opens a PDF must not load it.
 const PdfViewer = lazy(() => import("./PdfViewer"));
@@ -305,6 +308,226 @@ export function FileViewer({
    * behaved differently from the test that only exercised the first.
    */
 
+  // --- find-in-page ----------------------------------------------------------
+  /**
+   * What Ctrl+F searches, for the file as currently displayed.
+   *
+   * The split and git-diff views show two things (or a diff) at once and are
+   * not offered find in this version — a file with neither text nor a PDF's
+   * bytes yet (still loading, or an image) has nothing to search either.
+   */
+  type FindMode = "pdf" | "edit" | "dom" | "none";
+  const findMode: FindMode =
+    showGitDiff || splitting
+      ? "none"
+      : pdf
+        ? "pdf"
+        : edit !== null
+          ? "edit"
+          : loaded !== null && !image
+            ? "dom"
+            : "none";
+
+  const [findOpen, setFindOpen] = useState(false);
+  const [findQuery, setFindQuery] = useState("");
+  // Shared position pointer for dom/edit mode (pdf mode tracks its own, inside
+  // PdfViewer, since only it knows which page a match lives on).
+  const [findCurrent, setFindCurrent] = useState(0);
+  const findInputRef = useRef<HTMLInputElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const pdfViewerRef = useRef<PdfViewerHandle>(null);
+  const [pdfFindState, setPdfFindState] = useState<PdfFindState>({ matchCount: 0, currentIndex: -1, searching: false });
+  const [domMatches, setDomMatches] = useState<DomMatch[]>([]);
+  const [domTruncated, setDomTruncated] = useState(false);
+  const domHighlightRef = useRef<ReturnType<typeof highlightMatches> | null>(null);
+  // The imperative source of truth for which elements exist right now — kept
+  // separate from the `domMatches` state (which exists to drive the count
+  // display) because a React effect reacting to that state can run against a
+  // stale, already-discarded snapshot: Strict Mode's dev-only mount → cleanup
+  // → remount cycle tears the marks down and rebuilds them without an
+  // intervening render, so an effect keyed on the *first* build's array
+  // toggles a class on elements already unwrapped back to plain text —
+  // invisible, because they are no longer attached to the document. Found by
+  // driving Ctrl+F in the running app: the count updated on every "next" click
+  // but the highlight never moved, because it was never landing on live DOM.
+  const domMatchesRef = useRef<DomMatch[]>([]);
+
+  /** Marks `index` current among whatever `domMatchesRef` holds *right now*,
+   * scrolling it into view. Called directly at the moment marks are (re)built
+   * or the current index changes — not from an effect watching a snapshot. */
+  function markCurrentDomMatch(index: number) {
+    for (const [i, match] of domMatchesRef.current.entries()) {
+      for (const mark of match.marks) {
+        if (mark.isConnected) mark.classList.toggle("find-match-current", i === index);
+      }
+    }
+    const marks = domMatchesRef.current[index]?.marks;
+    if (marks?.[0]?.isConnected) marks[0].scrollIntoView({ block: "center" });
+  }
+
+  // The query search/highlighting actually run against — "" while the bar is
+  // closed, even though `findQuery` is kept so reopening restores it (rather
+  // than leaving a stale highlight, or a stale PDF match, sitting on screen
+  // after the bar that showed it has closed).
+  const effectiveFindQuery = findOpen ? findQuery : "";
+  const editMatches = useMemo(
+    () => (findMode === "edit" ? findMatchesInText(editedText, effectiveFindQuery) : []),
+    [findMode, editedText, effectiveFindQuery],
+  );
+
+  // A view that stops being searchable (switching to split, to a diff, or to
+  // an image) closes its own find bar rather than leaving one open over
+  // nothing to search.
+  useEffect(() => {
+    if (findOpen && findMode === "none") setFindOpen(false);
+  }, [findOpen, findMode]);
+
+  // Bumped by CodeHighlight's `onRendered` once its async syntax highlighting
+  // actually lands, replacing whatever was in its `<pre>` (the plain-text
+  // fallback, or a previous highlight's marks) with new DOM. That swap must
+  // re-run the effect below, or a highlight applied to the fallback vanishes
+  // the moment the real markup arrives. `onRendered` only means anything as
+  // an "actually changed" signal because CodeHighlight is memoized (see its
+  // own comment) — without that, this effect would need to reapply the
+  // highlight after *any* unrelated re-render of the viewer, since React
+  // resets a `dangerouslySetInnerHTML` element's real DOM on every render of
+  // the component that owns it, not only when the HTML string changes.
+  const [codeRenderTick, setCodeRenderTick] = useState(0);
+  const bumpCodeRenderTick = useCallback(() => setCodeRenderTick((tick) => tick + 1), []);
+
+  /**
+   * Marks every occurrence in whatever is currently mounted at `contentRef` —
+   * the rendered Markdown or the highlighted source, never both, since they
+   * are mutually exclusive views.
+   *
+   * Re-applied whenever the query changes, the view mode changes, or
+   * `codeRenderTick` says the mounted content was just replaced out from
+   * under it. Deliberately *not* driven by a `MutationObserver` on
+   * `contentRef`: this effect's own `highlightMatches`/`clear()` calls mutate
+   * that same container, and no amount of disconnecting or ignore-flagging
+   * around those calls proved reliable — a live run still produced a
+   * self-sustaining apply → mutate → observe → apply loop that hung the tab
+   * (the browser is free to split one synchronous batch of mutations across
+   * more than one callback invocation, and only some of the ways of guarding
+   * against that were tried before this was rewritten to not need it at
+   * all). Depending on an explicit, React-owned signal instead — a counter
+   * only `onRendered` increments — means this effect only ever reacts to a
+   * change *it did not cause itself*, which a DOM observer watching a
+   * container this same effect writes to cannot promise.
+   */
+  useEffect(() => {
+    function clear() {
+      domHighlightRef.current?.clear();
+      domHighlightRef.current = null;
+      domMatchesRef.current = [];
+      setDomMatches([]);
+      setDomTruncated(false);
+    }
+    const container = contentRef.current;
+    if (findMode !== "dom" || effectiveFindQuery === "" || container === null) {
+      clear();
+      return;
+    }
+
+    domHighlightRef.current?.clear();
+    const result = highlightMatches(container, effectiveFindQuery);
+    domHighlightRef.current = result;
+    domMatchesRef.current = result.matches;
+    setDomMatches(result.matches);
+    setDomTruncated(result.truncated);
+    setFindCurrent(0);
+    markCurrentDomMatch(0);
+
+    return clear;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `mode`/`showRaw`
+    // decide which element is mounted at contentRef; `codeRenderTick` is the
+    // signal that its content was just replaced (see above) — everything
+    // else about what changed inside it is irrelevant to this effect.
+  }, [findMode, effectiveFindQuery, mode, showRaw, codeRenderTick]);
+
+  /** Indicates the match by selection, per the edit-mode requirement — a
+   * textarea's value carries no markup, so this is the only match actually
+   * shown; the count above it stays accurate regardless. Focus moves to the
+   * textarea just long enough for the browser to scroll the selection into
+   * view, then back to the find field so Enter/Shift+Enter keep working. */
+  function selectEditMatch(matches: { start: number; end: number }[], index: number) {
+    const match = matches[index];
+    const textarea = textareaRef.current;
+    if (match === undefined || textarea === null) return;
+    textarea.focus();
+    textarea.setSelectionRange(match.start, match.end);
+    findInputRef.current?.focus();
+  }
+
+  // Jumps to (and selects) the first match when the query changes — but not
+  // on every keystroke typed into the document itself: editMatches recomputes
+  // for those too, and refocusing the textarea on each one would fight typing.
+  useEffect(() => {
+    if (findMode !== "edit" || !findOpen) return;
+    const matches = findMatchesInText(editedText, effectiveFindQuery);
+    setFindCurrent(0);
+    if (matches.length > 0) selectEditMatch(matches, 0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- reruns on the
+    // query (or entering edit mode with one already set), not on the buffer.
+  }, [effectiveFindQuery, findMode, findOpen]);
+
+  function openFind() {
+    setFindOpen(true);
+  }
+
+  function closeFind() {
+    setFindOpen(false);
+  }
+
+  function findNext() {
+    if (findMode === "pdf") {
+      pdfViewerRef.current?.findNext();
+    } else if (findMode === "edit") {
+      if (editMatches.length === 0) return;
+      const next = (findCurrent + 1) % editMatches.length;
+      setFindCurrent(next);
+      selectEditMatch(editMatches, next);
+    } else {
+      if (domMatches.length === 0) return;
+      const next = (findCurrent + 1) % domMatches.length;
+      setFindCurrent(next);
+      markCurrentDomMatch(next);
+    }
+  }
+
+  function findPrevious() {
+    if (findMode === "pdf") {
+      pdfViewerRef.current?.findPrevious();
+    } else if (findMode === "edit") {
+      if (editMatches.length === 0) return;
+      const next = (findCurrent - 1 + editMatches.length) % editMatches.length;
+      setFindCurrent(next);
+      selectEditMatch(editMatches, next);
+    } else {
+      if (domMatches.length === 0) return;
+      const next = (findCurrent - 1 + domMatches.length) % domMatches.length;
+      setFindCurrent(next);
+      markCurrentDomMatch(next);
+    }
+  }
+
+  const findBarState =
+    findMode === "pdf"
+      ? { matchCount: pdfFindState.matchCount, currentIndex: pdfFindState.currentIndex, truncated: false, searching: pdfFindState.searching }
+      : findMode === "edit"
+        ? {
+            matchCount: editMatches.length,
+            currentIndex: editMatches.length > 0 ? Math.min(findCurrent, editMatches.length - 1) : -1,
+            truncated: false,
+            searching: false,
+          }
+        : {
+            matchCount: domMatches.length,
+            currentIndex: domMatches.length > 0 ? Math.min(findCurrent, domMatches.length - 1) : -1,
+            truncated: domTruncated,
+            searching: false,
+          };
+
   /**
    * The editor, named once.
    *
@@ -462,7 +685,20 @@ export function FileViewer({
 
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") requestClose();
+      if (event.key === "Escape") {
+        // The find bar closes first — it, not the viewer, is what an open
+        // find bar's Escape means. A second, separate Escape (find bar
+        // already closed) reaches this branch's `else` and closes the viewer,
+        // exactly as it does without this feature.
+        if (findOpen) closeFind();
+        else requestClose();
+        return;
+      }
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "f") {
+        if (findMode === "none") return;
+        event.preventDefault();
+        openFind();
+      }
     }
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
@@ -616,6 +852,21 @@ export function FileViewer({
         </button>
       </div>
 
+      {findOpen && findMode !== "none" && (
+        <FindBar
+          inputRef={findInputRef}
+          query={findQuery}
+          onQueryChange={setFindQuery}
+          matchCount={findBarState.matchCount}
+          currentIndex={findBarState.currentIndex}
+          truncated={findBarState.truncated}
+          searching={findBarState.searching}
+          onNext={findNext}
+          onPrev={findPrevious}
+          onClose={closeFind}
+        />
+      )}
+
       {conflict && edit !== null && (
         <div className="flex items-center gap-3 border-b border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-300">
           <span className="min-w-0 flex-1">File changed on disk since you started editing.</span>
@@ -651,10 +902,13 @@ export function FileViewer({
           <ViewerErrorBoundary label="This PDF">
             <Suspense fallback={<div className="p-4 text-sm text-zinc-400 dark:text-zinc-600">loading…</div>}>
               <PdfViewer
+                ref={pdfViewerRef}
                 path={file.path}
                 serverUrl={serverUrl}
                 token={token}
                 revision={rawRevision}
+                findQuery={findMode === "pdf" ? effectiveFindQuery : ""}
+                onFindStateChange={setPdfFindState}
                 {...(onPdfLoad ? { onLoaded: onPdfLoad } : {})}
               />
             </Suspense>
@@ -679,7 +933,9 @@ export function FileViewer({
         {/* Keyed on `edit`, not `loaded`: the post-save file_changed refetch flips the file
             to "loading" for a moment and must not unmount the textarea (focus/caret loss) */}
         {edit !== null && !splitting && editor}
-        {loaded && edit === null && !splitting && !showGitDiff && markdown && !showRaw && renderedMarkdown(loaded.content)}
+        {loaded && edit === null && !splitting && !showGitDiff && markdown && !showRaw && (
+          <div ref={contentRef}>{renderedMarkdown(loaded.content)}</div>
+        )}
         {splitting && (
           <div className="flex h-full min-h-0" data-testid="file-split">
             {/* Each pane scrolls on its own: a long document must not scroll the
@@ -790,8 +1046,8 @@ export function FileViewer({
           </div>
         )}
         {loaded && edit === null && !splitting && !showGitDiff && (!markdown || showRaw) && (!diagram || showRaw) && (
-          <div className="p-4">
-            <CodeHighlight code={loaded.content} path={file.path} />
+          <div ref={contentRef} className="p-4">
+            <CodeHighlight code={loaded.content} path={file.path} onRendered={bumpCodeRenderTick} />
           </div>
         )}
       </div>

--- a/ui/src/components/FileViewer.tsx
+++ b/ui/src/components/FileViewer.tsx
@@ -351,11 +351,20 @@ export function FileViewer({
   // driving Ctrl+F in the running app: the count updated on every "next" click
   // but the highlight never moved, because it was never landing on live DOM.
   const domMatchesRef = useRef<DomMatch[]>([]);
+  /** Which match is current, alongside `domMatchesRef` and for the same reason:
+   * navigation has to act on what is true now, not on what the render that
+   * created the click handler happened to see. */
+  const currentDomMatchRef = useRef(0);
+  /** The query the marks in the DOM were built from, so a rebuild can tell
+   * "the reader typed something else" (start again at the first match) from
+   * "the content underneath was re-rendered" (stay where the reader was). */
+  const domQueryRef = useRef("");
 
   /** Marks `index` current among whatever `domMatchesRef` holds *right now*,
    * scrolling it into view. Called directly at the moment marks are (re)built
    * or the current index changes — not from an effect watching a snapshot. */
   function markCurrentDomMatch(index: number) {
+    currentDomMatchRef.current = index;
     for (const [i, match] of domMatchesRef.current.entries()) {
       for (const mark of match.marks) {
         if (mark.isConnected) mark.classList.toggle("find-match-current", i === index);
@@ -422,6 +431,11 @@ export function FileViewer({
       domMatchesRef.current = [];
       setDomMatches([]);
       setDomTruncated(false);
+      // Deliberately not resetting `currentDomMatchRef`: React runs this
+      // cleanup immediately before the effect re-runs, so zeroing it here
+      // would erase the reader's place on every re-mark before the body had a
+      // chance to keep it. A stale index is harmless — the next apply clamps
+      // it to the new match count, and a new query zeroes it explicitly.
     }
     const container = contentRef.current;
     if (findMode !== "dom" || effectiveFindQuery === "" || container === null) {
@@ -435,8 +449,17 @@ export function FileViewer({
     domMatchesRef.current = result.matches;
     setDomMatches(result.matches);
     setDomTruncated(result.truncated);
-    setFindCurrent(0);
-    markCurrentDomMatch(0);
+
+    // A different query starts again at the first match. The *same* query
+    // re-marked because the content underneath was re-rendered (syntax
+    // highlighting arriving late, a view switch) must keep the reader where
+    // they were: resetting here sent someone who had already stepped to match
+    // 4 back to match 1 the moment highlight.js finished loading.
+    const queryChanged = effectiveFindQuery !== domQueryRef.current;
+    domQueryRef.current = effectiveFindQuery;
+    const current = queryChanged ? 0 : Math.min(currentDomMatchRef.current, Math.max(result.matches.length - 1, 0));
+    setFindCurrent(current);
+    markCurrentDomMatch(current);
 
     return clear;
     // eslint-disable-next-line react-hooks/exhaustive-deps -- `mode`/`showRaw`
@@ -488,8 +511,12 @@ export function FileViewer({
       setFindCurrent(next);
       selectEditMatch(editMatches, next);
     } else {
-      if (domMatches.length === 0) return;
-      const next = (findCurrent + 1) % domMatches.length;
+      // From the refs, not the render's state: a rebuild in flight (late
+      // syntax highlighting) can leave the state this handler closed over
+      // momentarily empty, and a click answered with nothing is a click lost.
+      const total = domMatchesRef.current.length;
+      if (total === 0) return;
+      const next = (currentDomMatchRef.current + 1) % total;
       setFindCurrent(next);
       markCurrentDomMatch(next);
     }
@@ -504,8 +531,9 @@ export function FileViewer({
       setFindCurrent(next);
       selectEditMatch(editMatches, next);
     } else {
-      if (domMatches.length === 0) return;
-      const next = (findCurrent - 1 + domMatches.length) % domMatches.length;
+      const total = domMatchesRef.current.length;
+      if (total === 0) return;
+      const next = (currentDomMatchRef.current - 1 + total) % total;
       setFindCurrent(next);
       markCurrentDomMatch(next);
     }

--- a/ui/src/components/FindBar.test.tsx
+++ b/ui/src/components/FindBar.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { FindBar } from "./FindBar";
+
+function renderBar(overrides: Partial<React.ComponentProps<typeof FindBar>> = {}) {
+  const props = {
+    query: "",
+    onQueryChange: vi.fn(),
+    matchCount: 0,
+    currentIndex: -1,
+    onNext: vi.fn(),
+    onPrev: vi.fn(),
+    onClose: vi.fn(),
+    ...overrides,
+  };
+  render(<FindBar {...props} />);
+  return props;
+}
+
+describe("FindBar", () => {
+  it("focuses and selects the query field on mount", () => {
+    renderBar({ query: "outpost" });
+    const input = screen.getByLabelText("Find") as HTMLInputElement;
+    expect(input).toHaveFocus();
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe("outpost".length);
+  });
+
+  it("shows the current match out of the total", () => {
+    renderBar({ matchCount: 17, currentIndex: 2 });
+    expect(screen.getByText("3/17")).toBeInTheDocument();
+  });
+
+  it("marks the count as truncated when there may be more matches than shown", () => {
+    renderBar({ matchCount: 3000, currentIndex: 0, truncated: true });
+    expect(screen.getByText("1/3000+")).toBeInTheDocument();
+  });
+
+  it("shows a searching state instead of 0/0 while a PDF index is still building", () => {
+    renderBar({ matchCount: 0, searching: true });
+    expect(screen.getByText("searching…")).toBeInTheDocument();
+  });
+
+  it("shows 0/0 when nothing matches and nothing is in progress", () => {
+    renderBar({ matchCount: 0 });
+    expect(screen.getByText("0/0")).toBeInTheDocument();
+  });
+
+  it("calls onNext for the next control and Enter", () => {
+    const props = renderBar({ matchCount: 2 });
+    fireEvent.click(screen.getByLabelText("Next match"));
+    expect(props.onNext).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(screen.getByLabelText("Find"), { key: "Enter" });
+    expect(props.onNext).toHaveBeenCalledTimes(2);
+  });
+
+  it("calls onPrev for the previous control and Shift+Enter", () => {
+    const props = renderBar({ matchCount: 2 });
+    fireEvent.click(screen.getByLabelText("Previous match"));
+    expect(props.onPrev).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(screen.getByLabelText("Find"), { key: "Enter", shiftKey: true });
+    expect(props.onPrev).toHaveBeenCalledTimes(2);
+  });
+
+  it("disables next/previous when there are no matches", () => {
+    renderBar({ matchCount: 0 });
+    expect(screen.getByLabelText("Next match")).toBeDisabled();
+    expect(screen.getByLabelText("Previous match")).toBeDisabled();
+  });
+
+  it("closes on the close button and on Escape in the query field", () => {
+    const props = renderBar();
+    fireEvent.click(screen.getByLabelText("Close find bar"));
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(screen.getByLabelText("Find"), { key: "Escape" });
+    expect(props.onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports typed queries", () => {
+    const props = renderBar();
+    fireEvent.change(screen.getByLabelText("Find"), { target: { value: "hello" } });
+    expect(props.onQueryChange).toHaveBeenCalledWith("hello");
+  });
+});

--- a/ui/src/components/FindBar.tsx
+++ b/ui/src/components/FindBar.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useRef, type RefObject } from "react";
+
+export interface FindBarProps {
+  query: string;
+  onQueryChange: (query: string) => void;
+  /** Matches found so far — the true count while `truncated`/`searching` is still growing. */
+  matchCount: number;
+  /** More matches exist than are being marked/counted (see MAX_HIGHLIGHTED_MATCHES). */
+  truncated?: boolean;
+  /** 0-based index of the current match; meaningless (and ignored) when matchCount is 0. */
+  currentIndex: number;
+  /** A PDF's document-wide index is still being built — matches found so far are shown as partial. */
+  searching?: boolean;
+  onNext: () => void;
+  onPrev: () => void;
+  onClose: () => void;
+  /** Lets the caller refocus the query field after moving focus elsewhere to
+   * indicate a match (edit-mode's textarea selection) — falls back to an
+   * internal ref when omitted. */
+  inputRef?: RefObject<HTMLInputElement | null>;
+}
+
+/**
+ * Find-in-page bar: query, match count, next/previous, close.
+ *
+ * One component for every searchable view in the file viewer — text, code, Markdown
+ * in either mode, an in-progress edit, and a PDF — because none of them need a
+ * different UI for it, only a different source of matches.
+ */
+export function FindBar({
+  query,
+  onQueryChange,
+  matchCount,
+  truncated = false,
+  currentIndex,
+  searching = false,
+  onNext,
+  onPrev,
+  onClose,
+  inputRef: externalInputRef,
+}: FindBarProps) {
+  const ownInputRef = useRef<HTMLInputElement>(null);
+  const inputRef = externalInputRef ?? ownInputRef;
+
+  // Opening the bar (including reopening on a second Ctrl+F) always refocuses the
+  // query and selects it, so retyping replaces rather than appends.
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  const countLabel =
+    matchCount === 0 ? (searching ? "searching…" : "0/0") : `${currentIndex + 1}/${matchCount}${truncated ? "+" : ""}`;
+
+  return (
+    <div
+      role="search"
+      aria-label="Find in file"
+      className="flex items-center gap-2 border-b border-zinc-200 bg-zinc-50 px-3 py-1.5 text-xs dark:border-zinc-800 dark:bg-zinc-900"
+    >
+      <input
+        ref={inputRef}
+        type="text"
+        value={query}
+        onChange={(event) => onQueryChange(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            event.preventDefault();
+            if (event.shiftKey) onPrev();
+            else onNext();
+          } else if (event.key === "Escape") {
+            // Stopped here, not left to bubble to FileViewer's document-level
+            // listener: one Escape press must close only the find bar, not the
+            // find bar and the viewer together on the same keystroke. A second,
+            // separate Escape (find bar already closed) reaches that listener
+            // and closes the viewer, as it does without this feature.
+            event.stopPropagation();
+            onClose();
+          }
+        }}
+        placeholder="Find in file"
+        aria-label="Find"
+        className="min-w-0 flex-1 rounded border border-zinc-300 bg-white px-2 py-1 text-xs text-zinc-700 outline-none focus-visible:ring-1 focus-visible:ring-zinc-400 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-200"
+      />
+      <span className="shrink-0 tabular-nums text-zinc-500 dark:text-zinc-400">{countLabel}</span>
+      <button
+        type="button"
+        onClick={onPrev}
+        disabled={matchCount === 0}
+        aria-label="Previous match"
+        title="Previous match (Shift+Enter)"
+        className="shrink-0 rounded px-1.5 py-0.5 text-zinc-500 hover:bg-zinc-200 disabled:opacity-40 dark:text-zinc-400 dark:hover:bg-zinc-800"
+      >
+        ‹
+      </button>
+      <button
+        type="button"
+        onClick={onNext}
+        disabled={matchCount === 0}
+        aria-label="Next match"
+        title="Next match (Enter)"
+        className="shrink-0 rounded px-1.5 py-0.5 text-zinc-500 hover:bg-zinc-200 disabled:opacity-40 dark:text-zinc-400 dark:hover:bg-zinc-800"
+      >
+        ›
+      </button>
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label="Close find bar"
+        title="Close (Esc)"
+        className="shrink-0 rounded px-1.5 py-0.5 text-zinc-500 hover:bg-zinc-200 dark:text-zinc-400 dark:hover:bg-zinc-800"
+      >
+        ✕
+      </button>
+    </div>
+  );
+}

--- a/ui/src/components/PdfViewer.test.tsx
+++ b/ui/src/components/PdfViewer.test.tsx
@@ -1,18 +1,32 @@
+import { createRef } from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { PdfViewer } from "./PdfViewer";
+import { PdfViewer, type PdfViewerHandle } from "./PdfViewer";
 
 const getPage = vi.fn();
 const getDocument = vi.fn();
 const destroy = vi.fn(async () => {});
 
-const textLayerRender = vi.fn(async () => {});
+interface FakeTextLayerOptions {
+  container: HTMLElement;
+  textContentSource: unknown;
+  viewport: unknown;
+}
+const textLayerRender = vi.fn(async (_options: FakeTextLayerOptions) => {});
 
 vi.mock("pdfjs-dist", () => ({
   GlobalWorkerOptions: { workerSrc: "" },
   getDocument: (...args: unknown[]) => getDocument(...args),
   TextLayer: class {
-    render = textLayerRender;
+    options: FakeTextLayerOptions;
+    constructor(options: FakeTextLayerOptions) {
+      this.options = options;
+    }
+    // Real pdf.js renders spans of the page's own text into `container`. The
+    // mock renders nothing by default (existing tests only check that it was
+    // asked to); a find-in-page test that needs real text in the layer sets
+    // `textLayerRender`'s implementation to populate `options.container` itself.
+    render = () => textLayerRender(this.options);
   },
 }));
 
@@ -389,5 +403,218 @@ describe("PdfViewer scrolling", () => {
     fireEvent.click(screen.getByLabelText("Next page"));
     expect(await screen.findByText("Page 2 / 5")).toBeInTheDocument();
     expect(scrollIntoView).toHaveBeenCalled();
+  });
+});
+
+describe("PdfViewer find-in-page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    textLayerRender.mockImplementation(async () => {});
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    textLayerRender.mockImplementation(async () => {});
+  });
+
+  /** A page whose rendered text layer (once `textLayerRender` is told to
+   * populate it, see below) reads exactly `text` — real pdf.js text runs are
+   * split across several spans, but one text node is enough to exercise the
+   * same DOM-walking highlight utility a plain text file uses. */
+  function pageWithText(text: string) {
+    return {
+      getViewport: () => ({ width: 600, height: 800 }),
+      render: () => ({ promise: Promise.resolve(), cancel: () => {} }),
+      streamTextContent: async () => text,
+      getTextContent: async () => ({ items: [{ str: text }] }),
+    };
+  }
+
+  /** Makes the mocked text layer actually hold the page's text, so a match can
+   * be found and marked in it — the default mock renders nothing (see the
+   * shared `TextLayer` mock above). */
+  function populateTextLayers() {
+    textLayerRender.mockImplementation(async (options) => {
+      options.container.textContent = typeof options.textContentSource === "string" ? options.textContentSource : "";
+    });
+  }
+
+  function pagesByNumber(pages: Record<number, ReturnType<typeof pageWithText>>) {
+    getPage.mockImplementation(async (page: number) => pages[page] ?? pageWithText(""));
+  }
+
+  it("reports the match count and current index once the document is indexed", async () => {
+    serverReturnsPdf(2);
+    pagesByNumber({ 1: pageWithText("the quick fox"), 2: pageWithText("a fox in the box") });
+    const onFindStateChange = vi.fn();
+
+    render(<PdfViewer path="report.pdf" findQuery="fox" onFindStateChange={onFindStateChange} />);
+    await screen.findByText("Page 1 / 2");
+
+    await waitFor(() =>
+      expect(onFindStateChange).toHaveBeenCalledWith({ matchCount: 2, currentIndex: 0, searching: false }),
+    );
+  });
+
+  it("finds matches on a page that has not been read yet only once indexing reaches it", async () => {
+    serverReturnsPdf(2);
+    pagesByNumber({ 1: pageWithText("nothing here"), 2: pageWithText("a fox") });
+    const onFindStateChange = vi.fn();
+
+    render(<PdfViewer path="report.pdf" findQuery="fox" onFindStateChange={onFindStateChange} />);
+    await screen.findByText("Page 1 / 2");
+
+    await waitFor(() =>
+      expect(onFindStateChange).toHaveBeenCalledWith({ matchCount: 1, currentIndex: 0, searching: false }),
+    );
+  });
+
+  it("shows matches found so far as navigable while indexing still has pages left to read", async () => {
+    serverReturnsPdf(3);
+    pagesByNumber({ 1: pageWithText("has a fox"), 2: pageWithText("nothing"), 3: pageWithText("nothing") });
+    const onFindStateChange = vi.fn();
+
+    render(<PdfViewer path="report.pdf" findQuery="fox" onFindStateChange={onFindStateChange} />);
+    await screen.findByText("Page 1 / 3");
+
+    // The match on page 1 (read first) is reported — and navigable (a real
+    // currentIndex, not -1) — before indexing has read every page.
+    await waitFor(() =>
+      expect(onFindStateChange).toHaveBeenCalledWith({ matchCount: 1, currentIndex: 0, searching: true }),
+    );
+    // Indexing finishes without finding anything further; the count is unchanged.
+    await waitFor(() =>
+      expect(onFindStateChange).toHaveBeenCalledWith({ matchCount: 1, currentIndex: 0, searching: false }),
+    );
+  });
+
+  it("treats a page whose text cannot be read as contributing no matches, not an error", async () => {
+    serverReturnsPdf(2);
+    pagesByNumber({
+      1: { ...pageWithText(""), getTextContent: () => Promise.reject(new Error("scan, no text layer")) },
+      2: pageWithText("a fox"),
+    });
+    const onFindStateChange = vi.fn();
+
+    render(<PdfViewer path="report.pdf" findQuery="fox" onFindStateChange={onFindStateChange} />);
+    await screen.findByText("Page 1 / 2");
+
+    await waitFor(() =>
+      expect(onFindStateChange).toHaveBeenCalledWith({ matchCount: 1, currentIndex: 0, searching: false }),
+    );
+    // The page whose text failed to read still renders normally — reading text
+    // for search is independent of drawing the page.
+    expect(screen.queryByText(/could not be rendered/)).toBeNull();
+  });
+
+  it("highlights the current match at its position on the page once the text layer renders", async () => {
+    serverReturnsPdf(1);
+    pagesByNumber({ 1: pageWithText("has a fox here") });
+    populateTextLayers();
+
+    const { container } = render(<PdfViewer path="report.pdf" findQuery="fox" />);
+    await screen.findByText("Page 1 / 1");
+
+    await waitFor(() => {
+      const mark = container.querySelector(".pdf-text-layer mark.find-match-current");
+      expect(mark).not.toBeNull();
+      expect(mark?.textContent).toBe("fox");
+    });
+  });
+
+  it("jumps to a page containing the next match when it is outside the render window", async () => {
+    serverReturnsPdf(5);
+    pagesByNumber({
+      1: pageWithText("has a fox here"),
+      2: pageWithText("nothing"),
+      3: pageWithText("nothing"),
+      4: pageWithText("nothing"),
+      5: pageWithText("another fox"),
+    });
+    populateTextLayers();
+    const onFindStateChange = vi.fn();
+
+    const ref = createRef<PdfViewerHandle>();
+    const { container } = render(
+      <PdfViewer ref={ref} path="report.pdf" findQuery="fox" onFindStateChange={onFindStateChange} />,
+    );
+    await screen.findByText("Page 1 / 5");
+    // The first match (page 1) is already in view — nothing to jump to yet.
+    await waitFor(() => expect(container.querySelector(".find-match-current")).not.toBeNull());
+    // Both matches must be indexed before "next" has anywhere to go.
+    await waitFor(() =>
+      expect(onFindStateChange).toHaveBeenCalledWith({ matchCount: 2, currentIndex: 0, searching: false }),
+    );
+
+    ref.current?.findNext();
+
+    expect(await screen.findByText("Page 5 / 5")).toBeInTheDocument();
+    await waitFor(() => {
+      const mark = container.querySelector(".pdf-text-layer mark.find-match-current");
+      expect(mark?.textContent).toBe("fox");
+    });
+  });
+
+  it("moves the highlight between matches on the same page without changing page", async () => {
+    serverReturnsPdf(1);
+    pagesByNumber({ 1: pageWithText("fox fox") });
+    populateTextLayers();
+
+    const ref = createRef<PdfViewerHandle>();
+    const { container } = render(<PdfViewer ref={ref} path="report.pdf" findQuery="fox" />);
+    await screen.findByText("Page 1 / 1");
+    await waitFor(() => expect(container.querySelectorAll(".find-match").length).toBe(2));
+
+    ref.current?.findNext();
+
+    await waitFor(() => expect(container.querySelectorAll(".find-match-current")).toHaveLength(1));
+    expect(screen.getByText("Page 1 / 1")).toBeInTheDocument(); // still the same page
+    expect(getPage).not.toHaveBeenCalledWith(2);
+  });
+
+  it("wraps navigation from the last match back to the first", async () => {
+    serverReturnsPdf(1);
+    pagesByNumber({ 1: pageWithText("fox fox") });
+    populateTextLayers();
+    const onFindStateChange = vi.fn();
+
+    const ref = createRef<PdfViewerHandle>();
+    render(<PdfViewer ref={ref} path="report.pdf" findQuery="fox" onFindStateChange={onFindStateChange} />);
+    await screen.findByText("Page 1 / 1");
+    await waitFor(() => expect(onFindStateChange).toHaveBeenCalledWith({ matchCount: 2, currentIndex: 0, searching: false }));
+
+    ref.current?.findNext();
+    await waitFor(() => expect(onFindStateChange).toHaveBeenCalledWith({ matchCount: 2, currentIndex: 1, searching: false }));
+
+    ref.current?.findNext();
+    await waitFor(() => expect(onFindStateChange).toHaveBeenCalledWith({ matchCount: 2, currentIndex: 0, searching: false }));
+
+    ref.current?.findPrevious();
+    await waitFor(() => expect(onFindStateChange).toHaveBeenCalledWith({ matchCount: 2, currentIndex: 1, searching: false }));
+  });
+
+  it("clears matches and highlighting when the document changes", async () => {
+    serverReturnsPdf(1);
+    pagesByNumber({ 1: pageWithText("has a fox") });
+    populateTextLayers();
+    const onFindStateChange = vi.fn();
+
+    const { rerender } = render(
+      <PdfViewer path="a.pdf" findQuery="fox" onFindStateChange={onFindStateChange} revision={1} />,
+    );
+    await screen.findByText("Page 1 / 1");
+    await waitFor(() =>
+      expect(onFindStateChange).toHaveBeenCalledWith({ matchCount: 1, currentIndex: 0, searching: false }),
+    );
+
+    serverReturnsPdf(1);
+    pagesByNumber({ 1: pageWithText("nothing at all") });
+    onFindStateChange.mockClear();
+
+    rerender(<PdfViewer path="b.pdf" findQuery="fox" onFindStateChange={onFindStateChange} revision={1} />);
+
+    await waitFor(() =>
+      expect(onFindStateChange).toHaveBeenCalledWith({ matchCount: 0, currentIndex: -1, searching: false }),
+    );
   });
 });

--- a/ui/src/components/PdfViewer.tsx
+++ b/ui/src/components/PdfViewer.tsx
@@ -6,8 +6,10 @@
  * draws it onto a canvas with annotations disabled, so nothing inside the
  * document can navigate anywhere or run anything.
  */
-import { useCallback, useEffect, useRef, useState } from "react";
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
 import { rawFileUrl } from "../util/workspacePath";
+import { highlightMatches, type HighlightResult } from "../util/findInPage";
+import { indexPdfText, searchPdfIndex, type PdfMatch } from "../util/pdfFindIndex";
 
 /** What went wrong, in the terms a reader can act on. */
 export type PdfFailure =
@@ -28,6 +30,10 @@ interface PdfPageProxy {
   render(options: { canvas: HTMLCanvasElement; viewport: unknown; annotationMode: number }): PdfRenderTask;
   /** Feeds the selectable text layer. Absent from a page fake, hence optional. */
   streamTextContent?(): ReadableStream;
+  /** The page's text, for search — read independently of the (streamed) text layer,
+   * so a page far outside the render window can still be searched. Absent from a
+   * page fake, hence optional; a page without one contributes no matches. */
+  getTextContent?(): Promise<{ items: ReadonlyArray<{ str?: string }> }>;
 }
 
 interface PdfDocumentProxy {
@@ -46,6 +52,21 @@ interface PdfLoadingTask {
 }
 
 const ZOOM_STEPS = [0.5, 0.75, 1, 1.25, 1.5, 2, 3];
+
+/** What the find bar shows for a PDF: the document is searched as a whole (see
+ * ui/src/util/pdfFindIndex.ts), not just the pages currently rendered. */
+export interface PdfFindState {
+  matchCount: number;
+  /** -1 when there is no current match (no query, or no matches yet). */
+  currentIndex: number;
+  /** The document-wide text index is still being built; more matches may still appear. */
+  searching: boolean;
+}
+
+export interface PdfViewerHandle {
+  findNext(): void;
+  findPrevious(): void;
+}
 
 function describeSize(bytes: number): string {
   return bytes >= 1024 * 1024 ? `${Math.round(bytes / (1024 * 1024))} MB` : `${Math.round(bytes / 1024)} KB`;
@@ -86,9 +107,34 @@ async function fetchPdfBytes(serverUrl: string, path: string, token: string | nu
   return new Uint8Array(await response.arrayBuffer());
 }
 
+/**
+ * The module, loaded once and shared by every caller.
+ *
+ * Two pages can each need it at once (the render window holds several), and
+ * without this, each dynamic `import()` call raced its own module load —
+ * fine in a real browser (repeat imports of one specifier share the module
+ * job), but not always through this test suite's mocked module runner, where
+ * a second concurrent `import("pdfjs-dist")` was observed to bypass the mock
+ * and load the real, unmocked build instead. One shared promise removes the
+ * race rather than working around its symptom.
+ */
+interface PdfjsModule {
+  GlobalWorkerOptions: { workerSrc: string };
+  getDocument(options: { data: Uint8Array; useWorkerFetch: boolean; isOffscreenCanvasSupported: boolean }): unknown;
+  TextLayer: new (options: { textContentSource: unknown; container: HTMLElement; viewport: unknown }) => {
+    render(): Promise<void>;
+  };
+}
+
+let pdfjsPromise: Promise<PdfjsModule> | null = null;
+function loadPdfjs(): Promise<PdfjsModule> {
+  pdfjsPromise ??= import("pdfjs-dist") as unknown as Promise<PdfjsModule>;
+  return pdfjsPromise;
+}
+
 /** Opens the document and hands back the task that owns it, for release later. */
 async function openDocument(bytes: Uint8Array): Promise<{ doc: PdfDocumentProxy; task: PdfLoadingTask }> {
-  const pdfjs = await import("pdfjs-dist");
+  const pdfjs = await loadPdfjs();
   // Bundled beside the app, never fetched from a CDN.
   pdfjs.GlobalWorkerOptions.workerSrc = new URL("pdfjs-dist/build/pdf.worker.min.mjs", import.meta.url).toString();
   const task = pdfjs.getDocument({
@@ -121,7 +167,7 @@ async function drawTextLayer(
   if (container === null || page.streamTextContent === undefined) return;
   container.replaceChildren();
   try {
-    const pdfjs = await import("pdfjs-dist");
+    const pdfjs = await loadPdfjs();
     // The layer's spans size themselves from this variable; without it every
     // glyph collapses to zero and selection lands nowhere.
     container.style.setProperty("--total-scale-factor", String(scale));
@@ -168,6 +214,7 @@ function PdfPageSlot({
   baseSize,
   active,
   registerSlot,
+  onTextLayerReady,
 }: {
   doc: PdfDocumentProxy;
   pageNumber: number;
@@ -175,6 +222,10 @@ function PdfPageSlot({
   baseSize: { width: number; height: number };
   active: boolean;
   registerSlot: (pageNumber: number, element: HTMLDivElement | null) => void;
+  /** Reports the text layer becoming available (find-in-page can now mark it) or
+   * going away (it was drawn at a different scale, or the page left the render
+   * window and its whole subtree was unmounted). */
+  onTextLayerReady?: (pageNumber: number, container: HTMLDivElement | null) => void;
 }) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const textLayerRef = useRef<HTMLDivElement>(null);
@@ -211,7 +262,10 @@ function PdfPageSlot({
         await task.promise;
         if (cancelled) return;
         await drawTextLayer(page, viewport, textLayerRef.current, scale);
-        if (!cancelled) setFailed(false);
+        if (!cancelled) {
+          setFailed(false);
+          onTextLayerReady?.(pageNumber, textLayerRef.current);
+        }
       } catch (error) {
         // A render we cancelled ourselves is not a page that failed to draw.
         const name = error instanceof Error ? error.name : "";
@@ -222,7 +276,11 @@ function PdfPageSlot({
     return () => {
       cancelled = true;
       cancelRender(renderRef.current);
+      onTextLayerReady?.(pageNumber, null);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- onTextLayerReady is a
+    // notification, like onLoaded below: a caller passing a fresh closure each
+    // render must not retrigger this render/cancel effect.
   }, [doc, pageNumber, scale, active]);
 
   return (
@@ -249,21 +307,22 @@ function PdfPageSlot({
   );
 }
 
-export function PdfViewer({
-  path,
-  serverUrl = "",
-  token = null,
-  revision = 0,
-  onLoaded,
-}: {
-  path: string;
-  serverUrl?: string;
-  token?: string | null;
-  /** Cache-buster incremented when the file changes without changing path. */
-  revision?: number;
-  /** Called once the document opened — a PDF that never displayed is not attachable. */
-  onLoaded?: (path: string) => void;
-}) {
+export const PdfViewer = forwardRef<
+  PdfViewerHandle,
+  {
+    path: string;
+    serverUrl?: string;
+    token?: string | null;
+    /** Cache-buster incremented when the file changes without changing path. */
+    revision?: number;
+    /** Called once the document opened — a PDF that never displayed is not attachable. */
+    onLoaded?: (path: string) => void;
+    /** The active find-in-page query, or "" when find is not in use. */
+    findQuery?: string;
+    /** Reported whenever the match count, current match, or indexing progress changes. */
+    onFindStateChange?: (state: PdfFindState) => void;
+  }
+>(function PdfViewer({ path, serverUrl = "", token = null, revision = 0, onLoaded, findQuery = "", onFindStateChange }, ref) {
   const [doc, setDoc] = useState<PdfDocumentProxy | null>(null);
   const [failure, setFailure] = useState<PdfFailure | null>(null);
   const [pageNumber, setPageNumber] = useState(1);
@@ -273,6 +332,72 @@ export function PdfViewer({
   const scrollerRef = useRef<HTMLDivElement>(null);
   const slotsRef = useRef(new Map<number, HTMLDivElement>());
 
+  // --- find-in-page ---------------------------------------------------------
+  // The document-wide text index (ui/src/util/pdfFindIndex.ts): built lazily,
+  // independently of which pages are rendered, so a match far from the page
+  // currently open can still be found.
+  const [pageTexts, setPageTexts] = useState<Map<number, string>>(new Map());
+  const [indexSearching, setIndexSearching] = useState(false);
+  const [matches, setMatches] = useState<PdfMatch[]>([]);
+  const [currentMatch, setCurrentMatch] = useState(-1);
+  const indexerRef = useRef<{ cancel: () => void } | null>(null);
+  const indexStartedRef = useRef(false);
+  const prevQueryRef = useRef(findQuery);
+  // Ready text-layer containers, by page — populated by PdfPageSlot as pages
+  // render, independently of the render-window state above (that drives what's
+  // drawn; this drives what can currently be highlighted).
+  const textLayerContainersRef = useRef(new Map<number, HTMLDivElement>());
+  const activeHighlightRef = useRef<{ page: number; result: HighlightResult } | null>(null);
+  // Read inside callbacks that must not go stale between renders (see
+  // onTextLayerReady below) without forcing those callbacks to change identity.
+  const matchesRef = useRef<PdfMatch[]>([]);
+  const currentMatchRef = useRef(-1);
+  const findQueryRef = useRef(findQuery);
+  useEffect(() => {
+    matchesRef.current = matches;
+  }, [matches]);
+  useEffect(() => {
+    currentMatchRef.current = currentMatch;
+  }, [currentMatch]);
+  useEffect(() => {
+    findQueryRef.current = findQuery;
+  }, [findQuery]);
+
+  const clearHighlight = useCallback(() => {
+    activeHighlightRef.current?.result.clear();
+    activeHighlightRef.current = null;
+  }, []);
+
+  /** Marks every occurrence on `container`'s page and distinguishes the current one —
+   * the same utility, and the same "mark everything, distinguish current" behavior,
+   * that a plain text or Markdown view gets (ui/src/util/findInPage.ts). */
+  const applyHighlight = useCallback(
+    (target: PdfMatch, container: HTMLElement) => {
+      clearHighlight();
+      const result = highlightMatches(container, findQueryRef.current);
+      activeHighlightRef.current = { page: target.page, result };
+      const marks = result.matches[target.ordinalOnPage]?.marks ?? [];
+      for (const mark of marks) mark.classList.add("find-match-current");
+      marks[0]?.scrollIntoView({ block: "center" });
+    },
+    [clearHighlight],
+  );
+
+  const onTextLayerReady = useCallback(
+    (page: number, container: HTMLDivElement | null) => {
+      if (container === null) {
+        textLayerContainersRef.current.delete(page);
+        return;
+      }
+      textLayerContainersRef.current.set(page, container);
+      // If find navigation is already waiting on this page (it just came into
+      // the render window, or was redrawn at a new scale), finish the job now.
+      const target = matchesRef.current[currentMatchRef.current];
+      if (target !== undefined && target.page === page) applyHighlight(target, container);
+    },
+    [applyHighlight],
+  );
+
   useEffect(() => {
     let cancelled = false;
     let loading: PdfLoadingTask | null = null;
@@ -281,6 +406,17 @@ export function PdfViewer({
     setFailure(null);
     setPageNumber(1);
     setBaseSize(null);
+    // A new document is a new document to search: any index, match, or
+    // highlight from the previous one describes text that is no longer here.
+    indexerRef.current?.cancel();
+    indexerRef.current = null;
+    indexStartedRef.current = false;
+    setPageTexts(new Map());
+    setIndexSearching(false);
+    setMatches([]);
+    setCurrentMatch(-1);
+    clearHighlight();
+    textLayerContainersRef.current.clear();
 
     (async () => {
       try {
@@ -325,6 +461,118 @@ export function PdfViewer({
     if (element === null) slotsRef.current.delete(page);
     else slotsRef.current.set(page, element);
   }, []);
+
+  /**
+   * Starts reading the document's text for search, once — the first time a
+   * query arrives. Deliberately not torn down when `findQuery` changes (only
+   * `indexStartedRef` gates re-entry): a `useEffect` cleanup runs on every
+   * dependency change, and cancelling the indexer on each keystroke would mean
+   * it never gets past the first page or two of a document searched while
+   * someone is still typing.
+   */
+  useEffect(() => {
+    if (doc === null || findQuery === "" || indexStartedRef.current) return;
+    indexStartedRef.current = true;
+    setIndexSearching(true);
+    const document_ = doc;
+    const source = {
+      numPages: document_.numPages,
+      getPageText: async (page: number) => {
+        const proxy = await document_.getPage(page);
+        if (proxy.getTextContent === undefined) return "";
+        const content = await proxy.getTextContent();
+        return content.items.map((item) => (typeof item.str === "string" ? item.str : "")).join("");
+      },
+    };
+    indexerRef.current = indexPdfText(
+      source,
+      pageNumber,
+      (page, text) =>
+        setPageTexts((prev) => {
+          const next = new Map(prev);
+          next.set(page, text);
+          return next;
+        }),
+      () => setIndexSearching(false),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- pageNumber seeds
+    // where reading starts and is intentionally not tracked afterward;
+    // indexStartedRef already limits this to running once per document.
+  }, [doc, findQuery]);
+
+  // The indexer's lifetime is the document's, not any single render of this
+  // effect — cancelled on a new document (see the loading effect above) or on
+  // unmount, never merely because a dependency above changed.
+  useEffect(() => {
+    return () => {
+      indexerRef.current?.cancel();
+      indexerRef.current = null;
+    };
+  }, [doc]);
+
+  /**
+   * Recomputes matches whenever the index grows or the query changes. The
+   * current match resets to the first result only when the query itself
+   * changed — not when indexing merely delivered another page for the same
+   * query, which would otherwise yank the reader back to the top of the
+   * document every time a background page finishes indexing mid-navigation.
+   */
+  useEffect(() => {
+    const found = searchPdfIndex(pageTexts, doc?.numPages ?? 0, findQuery);
+    const queryChanged = findQuery !== prevQueryRef.current;
+    prevQueryRef.current = findQuery;
+    setMatches(found);
+    setCurrentMatch((prev) => {
+      if (found.length === 0) return -1;
+      if (queryChanged || prev === -1) return 0;
+      return Math.min(prev, found.length - 1);
+    });
+  }, [pageTexts, findQuery, doc]);
+
+  /**
+   * Moves to (and, once rendered, highlights) the current match. A match on a
+   * page outside the render window is brought in via `goTo`; highlighting then
+   * completes once `onTextLayerReady` reports that page's text layer drawn.
+   */
+  useEffect(() => {
+    if (currentMatch === -1 || matches.length === 0) {
+      clearHighlight();
+      return;
+    }
+    const target = matches[currentMatch];
+    if (activeHighlightRef.current !== null && activeHighlightRef.current.page !== target.page) clearHighlight();
+    if (Math.abs(target.page - pageNumber) > RENDER_WINDOW) {
+      goTo(target.page);
+      return;
+    }
+    const container = textLayerContainersRef.current.get(target.page);
+    if (container !== undefined) applyHighlight(target, container);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- goTo/applyHighlight/clearHighlight
+    // are stable; pageNumber is read only to decide whether the target page is
+    // already in the render window, not to re-run this on every scroll.
+  }, [currentMatch, matches]);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      findNext() {
+        if (matchesRef.current.length === 0) return;
+        setCurrentMatch((prev) => (prev + 1) % matchesRef.current.length);
+      },
+      findPrevious() {
+        if (matchesRef.current.length === 0) return;
+        setCurrentMatch((prev) => (prev - 1 + matchesRef.current.length) % matchesRef.current.length);
+      },
+    }),
+    [],
+  );
+
+  useEffect(() => {
+    onFindStateChange?.({ matchCount: matches.length, currentIndex: currentMatch, searching: indexSearching });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- onFindStateChange is
+    // a notification, like onLoaded above: a caller passing a fresh closure each
+    // render must not retrigger anything from this.
+  }, [matches.length, currentMatch, indexSearching]);
 
   /**
    * The page indicator follows the scroll: whichever slot crosses the middle of
@@ -443,11 +691,12 @@ export function PdfViewer({
               baseSize={baseSize}
               active={Math.abs(page - pageNumber) <= RENDER_WINDOW}
               registerSlot={registerSlot}
+              onTextLayerReady={onTextLayerReady}
             />
           ))}
       </div>
     </div>
   );
-}
+});
 
 export default PdfViewer;

--- a/ui/src/util/findInPage.test.ts
+++ b/ui/src/util/findInPage.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { findMatchesInText, highlightMatches, MAX_HIGHLIGHTED_MATCHES } from "./findInPage";
+
+describe("findMatchesInText", () => {
+  it("matches case-insensitively", () => {
+    expect(findMatchesInText("The Outpost is here", "outpost")).toEqual([{ start: 4, end: 11 }]);
+  });
+
+  it("finds every occurrence", () => {
+    expect(findMatchesInText("foo bar foo", "foo")).toEqual([
+      { start: 0, end: 3 },
+      { start: 8, end: 11 },
+    ]);
+  });
+
+  it("returns nothing for an empty query", () => {
+    expect(findMatchesInText("anything", "")).toEqual([]);
+  });
+
+  it("returns nothing when there is no match", () => {
+    expect(findMatchesInText("anything", "nope")).toEqual([]);
+  });
+
+  it("treats the query as a literal substring, not a regular expression", () => {
+    expect(findMatchesInText("a.b.c", "a.b")).toEqual([{ start: 0, end: 3 }]);
+    expect(findMatchesInText("axb", "a.b")).toEqual([]);
+  });
+});
+
+describe("highlightMatches", () => {
+  function container(html: string): HTMLElement {
+    const el = document.createElement("div");
+    el.innerHTML = html;
+    document.body.appendChild(el);
+    return el;
+  }
+
+  it("marks a match that lives entirely in one text node", () => {
+    const el = container("<p>hello world</p>");
+    const { matches, truncated } = highlightMatches(el, "world");
+
+    expect(truncated).toBe(false);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].marks).toHaveLength(1);
+    expect(matches[0].marks[0].tagName).toBe("MARK");
+    expect(matches[0].marks[0].textContent).toBe("world");
+    expect(el.textContent).toBe("hello world");
+  });
+
+  it("marks a match spanning two adjacent text nodes across an element boundary", () => {
+    // "outpost" split as "out" | "post" by a <span>, the way a syntax highlighter
+    // or a PDF text layer might break a run into separate nodes.
+    const el = container("<p>say <b>out</b>post now</p>");
+    const { matches } = highlightMatches(el, "outpost");
+
+    expect(matches).toHaveLength(1);
+    // One <mark> per underlying text node the match touches — never a single
+    // <mark> spanning the <b>, which Range.surroundContents cannot do safely.
+    expect(matches[0].marks).toHaveLength(2);
+    expect(matches[0].marks.map((mark) => mark.textContent)).toEqual(["out", "post"]);
+    expect(el.textContent).toBe("say outpost now");
+  });
+
+  it("marks several matches within the same text node", () => {
+    const el = container("<p>foo bar foo baz foo</p>");
+    const { matches } = highlightMatches(el, "foo");
+
+    expect(matches).toHaveLength(3);
+    for (const match of matches) {
+      expect(match.marks).toHaveLength(1);
+      expect(match.marks[0].textContent).toBe("foo");
+    }
+    expect(el.textContent).toBe("foo bar foo baz foo");
+  });
+
+  it("returns no matches and no marks for an empty query", () => {
+    const el = container("<p>hello world</p>");
+    const { matches, clear } = highlightMatches(el, "");
+    expect(matches).toEqual([]);
+    expect(() => clear()).not.toThrow();
+    expect(el.innerHTML).toBe("<p>hello world</p>");
+  });
+
+  it("returns no matches for a query the text does not contain", () => {
+    const el = container("<p>hello world</p>");
+    const { matches } = highlightMatches(el, "nope");
+    expect(matches).toEqual([]);
+  });
+
+  it("caps the number of marked matches and reports truncation", () => {
+    const el = container(`<p>${"a".repeat(MAX_HIGHLIGHTED_MATCHES + 50)}</p>`);
+    const { matches, truncated } = highlightMatches(el, "a");
+
+    expect(truncated).toBe(true);
+    expect(matches).toHaveLength(MAX_HIGHLIGHTED_MATCHES);
+  });
+
+  it("clear() fully reverts the DOM to its original text", () => {
+    const el = container("<p>say <b>out</b>post now, foo bar foo</p>");
+    const original = el.innerHTML;
+    const { clear } = highlightMatches(el, "foo");
+
+    expect(el.innerHTML).not.toBe(original);
+    clear();
+    expect(el.querySelectorAll("mark")).toHaveLength(0);
+    expect(el.textContent).toBe("say outpost now, foo bar foo");
+  });
+});

--- a/ui/src/util/findInPage.ts
+++ b/ui/src/util/findInPage.ts
@@ -1,0 +1,133 @@
+/**
+ * Find-in-page: locating a query in plain text, and marking it up wherever it is
+ * shown as real DOM text — rendered code, Markdown, or a PDF page's text layer.
+ *
+ * One algorithm serves all three, because none of them need to know about each
+ * other: given a container element, walk its text nodes, find the query in their
+ * concatenated text, and wrap each match in its own `<mark>` — one `<mark>` per
+ * underlying text node a match touches, rather than one spanning several, so
+ * `Range.surroundContents` never has to reason about partially-selected elements
+ * (a syntax-highlighting `<span>`, a PDF text-layer run) sitting between them.
+ */
+
+/** A generous but finite limit: unbounded matches on a pathological query (a
+ * single common character) would mean thousands of `<mark>` elements, which
+ * costs layout time for no reading benefit. The count keeps counting past it;
+ * only marking (and therefore navigation) stops. */
+export const MAX_HIGHLIGHTED_MATCHES = 3000;
+
+/** A match found in plain text, before any DOM is touched. */
+export interface TextMatch {
+  start: number;
+  end: number;
+}
+
+/** One logical match, as marked up in the DOM — one or more `<mark>` elements
+ * because a match can span more than one underlying text node. */
+export interface DomMatch {
+  marks: HTMLElement[];
+}
+
+export interface HighlightResult {
+  /** In document order. */
+  matches: DomMatch[];
+  /** True when more matches exist than were marked (see MAX_HIGHLIGHTED_MATCHES). */
+  truncated: boolean;
+  /** Restores the container's original text nodes. Idempotent. */
+  clear: () => void;
+}
+
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Every case-insensitive occurrence of `query` in `text`, plain substring — no regex features. */
+export function findMatchesInText(text: string, query: string, cap = Infinity): TextMatch[] {
+  if (query === "") return [];
+  const regex = new RegExp(escapeRegExp(query), "gi");
+  const matches: TextMatch[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(text)) !== null) {
+    matches.push({ start: match.index, end: match.index + match[0].length });
+    if (matches.length >= cap) break;
+  }
+  return matches;
+}
+
+interface NodeSpan {
+  node: Text;
+  start: number;
+  end: number;
+}
+
+/** Every non-empty text node under `container`, in document order, alongside its
+ * offset into their concatenation — the coordinate space `findMatchesInText` searches. */
+function collectTextNodes(container: HTMLElement): { nodes: NodeSpan[]; text: string } {
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+  const nodes: NodeSpan[] = [];
+  let text = "";
+  for (let node = walker.nextNode() as Text | null; node !== null; node = walker.nextNode() as Text | null) {
+    const length = node.data.length;
+    if (length === 0) continue;
+    nodes.push({ node, start: text.length, end: text.length + length });
+    text += node.data;
+  }
+  return { nodes, text };
+}
+
+/**
+ * Marks every occurrence of `query` under `container`.
+ *
+ * Matches are wrapped in reverse document order: splitting a text node for a
+ * later match only ever trims its tail, which never invalidates the offsets an
+ * earlier match (lower down the loop, further from the end) still needs to find
+ * its own place inside that same node.
+ */
+export function highlightMatches(container: HTMLElement, query: string, cap = MAX_HIGHLIGHTED_MATCHES): HighlightResult {
+  const noop: HighlightResult = { matches: [], truncated: false, clear: () => {} };
+  if (query === "") return noop;
+
+  const { nodes, text } = collectTextNodes(container);
+  if (text === "") return noop;
+
+  const found = findMatchesInText(text, query, cap + 1);
+  const truncated = found.length > cap;
+  const ranges = truncated ? found.slice(0, cap) : found;
+  if (ranges.length === 0) return { matches: [], truncated, clear: () => {} };
+
+  const matches: DomMatch[] = new Array(ranges.length);
+  for (let i = ranges.length - 1; i >= 0; i--) {
+    const { start, end } = ranges[i];
+    const marks: HTMLElement[] = [];
+    for (const span of nodes) {
+      if (span.end <= start || span.start >= end) continue;
+      const localStart = Math.max(0, start - span.start);
+      const localEnd = Math.min(span.node.data.length, end - span.start);
+      if (localStart >= localEnd) continue;
+
+      let target = span.node;
+      if (localEnd < target.data.length) target.splitText(localEnd);
+      const middle = localStart > 0 ? target.splitText(localStart) : target;
+
+      const mark = document.createElement("mark");
+      mark.className = "find-match";
+      middle.replaceWith(mark);
+      mark.appendChild(middle);
+      marks.push(mark);
+    }
+    matches[i] = { marks };
+  }
+
+  return {
+    matches,
+    truncated,
+    clear: () => {
+      for (const { marks } of matches) {
+        for (const mark of marks) {
+          mark.replaceWith(document.createTextNode(mark.textContent ?? ""));
+        }
+      }
+      container.normalize();
+    },
+  };
+}

--- a/ui/src/util/pdfFindIndex.test.ts
+++ b/ui/src/util/pdfFindIndex.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from "vitest";
+import { indexPdfText, pageReadOrder, searchPdfIndex, type PdfTextSource } from "./pdfFindIndex";
+
+describe("pageReadOrder", () => {
+  it("starts at the given page and alternates outward", () => {
+    expect(pageReadOrder(7, 4)).toEqual([4, 3, 5, 2, 6, 1, 7]);
+  });
+
+  it("clamps a start page outside the document to the nearest real page", () => {
+    expect(pageReadOrder(3, 99)).toEqual([3, 2, 1]);
+    expect(pageReadOrder(3, 0)).toEqual([1, 2, 3]);
+  });
+
+  it("handles a one-page document", () => {
+    expect(pageReadOrder(1, 1)).toEqual([1]);
+  });
+
+  it("handles an empty document", () => {
+    expect(pageReadOrder(0, 1)).toEqual([]);
+  });
+});
+
+describe("indexPdfText", () => {
+  function source(pages: Record<number, string | (() => Promise<string>)>, numPages: number): PdfTextSource {
+    return {
+      numPages,
+      getPageText: async (page) => {
+        const entry = pages[page];
+        if (typeof entry === "function") return entry();
+        if (entry === undefined) throw new Error(`no page ${page}`);
+        return entry;
+      },
+    };
+  }
+
+  it("reads pages incrementally, starting from the given page", async () => {
+    const seen: number[] = [];
+    const onDone = vi.fn();
+    indexPdfText(source({ 1: "alpha", 2: "beta", 3: "gamma" }, 3), 2, (page) => seen.push(page), onDone, () => Promise.resolve());
+
+    await vi.waitFor(() => expect(onDone).toHaveBeenCalled());
+    expect(seen).toEqual([2, 1, 3]);
+  });
+
+  it("yields between pages instead of reading the whole document synchronously", async () => {
+    const yields: number[] = [];
+    const onDone = vi.fn();
+    const seenBeforeYield: number[] = [];
+    indexPdfText(
+      source({ 1: "a", 2: "b" }, 2),
+      1,
+      (page) => seenBeforeYield.push(page),
+      onDone,
+      () => {
+        yields.push(seenBeforeYield.length);
+        return Promise.resolve();
+      },
+    );
+
+    await vi.waitFor(() => expect(onDone).toHaveBeenCalled());
+    // A yield happened after each page was reported, not all at once at the end.
+    expect(yields).toEqual([1, 2]);
+  });
+
+  it("treats a page that fails to read as contributing empty text, not an error", async () => {
+    const seen: Array<{ page: number; text: string }> = [];
+    const onDone = vi.fn();
+    indexPdfText(
+      source({ 1: "alpha", 2: () => Promise.reject(new Error("scan, no text layer")), 3: "gamma" }, 3),
+      1,
+      (page, text) => seen.push({ page, text }),
+      onDone,
+      () => Promise.resolve(),
+    );
+
+    await vi.waitFor(() => expect(onDone).toHaveBeenCalled());
+    expect(seen.find((entry) => entry.page === 2)).toEqual({ page: 2, text: "" });
+  });
+
+  it("cancel() stops further pages, including one already in flight", async () => {
+    const seen: number[] = [];
+    const onDone = vi.fn();
+    let resolvePage2: (() => void) | undefined;
+    const handle = indexPdfText(
+      source({ 1: "a", 2: () => new Promise((resolve) => (resolvePage2 = () => resolve("b"))), 3: "c" }, 3),
+      1,
+      (page) => seen.push(page),
+      onDone,
+      () => Promise.resolve(),
+    );
+
+    await vi.waitFor(() => expect(resolvePage2).toBeDefined());
+    handle.cancel();
+    resolvePage2?.();
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(seen).toEqual([1]);
+    expect(onDone).not.toHaveBeenCalled();
+  });
+});
+
+describe("searchPdfIndex", () => {
+  it("finds matches across every indexed page, in page order", () => {
+    const pageTexts = new Map([
+      [1, "the quick fox"],
+      [2, "a fox in the box"],
+    ]);
+    expect(searchPdfIndex(pageTexts, 2, "fox")).toEqual([
+      { page: 1, ordinalOnPage: 0 },
+      { page: 2, ordinalOnPage: 0 },
+    ]);
+  });
+
+  it("orders multiple matches on one page by their position", () => {
+    const pageTexts = new Map([[1, "fox fox fox"]]);
+    expect(searchPdfIndex(pageTexts, 1, "fox")).toEqual([
+      { page: 1, ordinalOnPage: 0 },
+      { page: 1, ordinalOnPage: 1 },
+      { page: 1, ordinalOnPage: 2 },
+    ]);
+  });
+
+  it("skips a page that has not been indexed yet, without treating it as searched", () => {
+    const pageTexts = new Map([[1, "fox"]]); // page 2 not indexed yet
+    expect(searchPdfIndex(pageTexts, 2, "fox")).toEqual([{ page: 1, ordinalOnPage: 0 }]);
+  });
+
+  it("reports no matches, not an error, for a page with no extractable text", () => {
+    const pageTexts = new Map([
+      [1, ""], // scanned page: indexed, empty
+      [2, "fox"],
+    ]);
+    expect(searchPdfIndex(pageTexts, 2, "fox")).toEqual([{ page: 2, ordinalOnPage: 0 }]);
+  });
+
+  it("returns nothing for an empty query", () => {
+    const pageTexts = new Map([[1, "fox"]]);
+    expect(searchPdfIndex(pageTexts, 1, "")).toEqual([]);
+  });
+});

--- a/ui/src/util/pdfFindIndex.ts
+++ b/ui/src/util/pdfFindIndex.ts
@@ -1,0 +1,95 @@
+/**
+ * Reading a PDF's text for search, page by page, independently of which pages are
+ * currently rendered — a page outside the viewer's render window has no DOM text
+ * to search (see PdfViewer.tsx), so find-in-page needs its own copy of the text.
+ */
+import { findMatchesInText } from "./findInPage";
+
+export interface PdfTextSource {
+  numPages: number;
+  /** The page's text, concatenated. A page with no extractable text (a scan)
+   * resolves to an empty string — that is not an error here. */
+  getPageText(pageNumber: number): Promise<string>;
+}
+
+/**
+ * Page numbers (1-based), starting at `startPage` and alternating outward
+ * (start, start-1, start+1, start-2, start+2, …) — the pages nearest to what the
+ * reader is already looking at are read first.
+ */
+export function pageReadOrder(numPages: number, startPage: number): number[] {
+  if (numPages <= 0) return [];
+  const start = Math.min(Math.max(Math.round(startPage), 1), numPages);
+  const order = [start];
+  let lo = start - 1;
+  let hi = start + 1;
+  while (lo >= 1 || hi <= numPages) {
+    if (lo >= 1) order.push(lo--);
+    if (hi <= numPages) order.push(hi++);
+  }
+  return order;
+}
+
+/**
+ * Reads every page's text in `pageReadOrder`, yielding control between pages so a
+ * long document does not block the main thread. A page that fails to read
+ * contributes an empty string rather than aborting the whole index.
+ *
+ * Returns a handle to cancel: once cancelled, no further `onPage`/`onDone` calls
+ * are made, even for a read already in flight when `cancel` is called.
+ */
+export function indexPdfText(
+  source: PdfTextSource,
+  startPage: number,
+  onPage: (pageNumber: number, text: string) => void,
+  onDone: () => void,
+  yieldToMainThread: () => Promise<void> = () => new Promise((resolve) => setTimeout(resolve, 0)),
+): { cancel: () => void } {
+  let cancelled = false;
+  const order = pageReadOrder(source.numPages, startPage);
+
+  void (async () => {
+    for (const page of order) {
+      if (cancelled) return;
+      let text: string;
+      try {
+        text = await source.getPageText(page);
+      } catch {
+        text = "";
+      }
+      if (cancelled) return;
+      onPage(page, text);
+      await yieldToMainThread();
+    }
+    if (!cancelled) onDone();
+  })();
+
+  return {
+    cancel: () => {
+      cancelled = true;
+    },
+  };
+}
+
+export interface PdfMatch {
+  page: number;
+  /** 0-based position of this match among the matches on its own page. */
+  ordinalOnPage: number;
+}
+
+/** Every match across every page indexed so far (`pageTexts`), in page order.
+ * A page not yet in `pageTexts` is treated as not-yet-searched, not as empty —
+ * its matches, if any, appear once it is indexed. */
+export function searchPdfIndex(pageTexts: ReadonlyMap<number, string>, numPages: number, query: string): PdfMatch[] {
+  if (query === "") return [];
+  const matches: PdfMatch[] = [];
+  for (let page = 1; page <= numPages; page++) {
+    const text = pageTexts.get(page);
+    if (text === undefined) continue;
+    const found = findMatchesInText(text, query);
+    for (let ordinalOnPage = 0; ordinalOnPage < found.length; ordinalOnPage++) {
+      matches.push({ page, ordinalOnPage });
+    }
+  }
+  return matches;
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -205,3 +205,22 @@ body,
 .pdf-text-layer ::selection {
   background: rgb(56 132 255 / 0.35);
 }
+
+/* Find-in-page marks (ui/src/util/findInPage.ts). One rule set for every
+   container it runs against — rendered code, Markdown, and a PDF's text
+   layer — because the utility itself does not know which of those it is in. */
+.find-match {
+  background-color: rgb(250 204 21 / 0.5); /* yellow-400 */
+  color: inherit;
+}
+.find-match-current {
+  background-color: rgb(249 115 22 / 0.7); /* orange-500 */
+}
+/* Inside the PDF text layer the underlying glyph is already drawn on the
+   canvas beneath; a mark's own (visible) text would draw a second copy of it
+   a few subpixels off. The highlight box is the point — keep the mark's own
+   text as invisible as the layer around it. */
+.pdf-text-layer mark.find-match,
+.pdf-text-layer mark.find-match-current {
+  color: transparent;
+}


### PR DESCRIPTION
## Why

The file viewer had no way to search within an open document. A PDF or a
text/code/Markdown file of any real length could only be searched by
scrolling, because the browser's native Ctrl+F either doesn't reach the
content (a PDF's canvas pages, an edit-mode textarea's value) or searches the
whole page including chat history and unrelated UI.

## What

- Ctrl+F / Cmd+F opens a find bar in the full-size file viewer; Escape
  closes the find bar first, a second Escape closes the viewer.
- **Text, code, Markdown** (source or rendered): every match is marked,
  the current one distinguished, scrolled into view. Shared, container-agnostic
  DOM utility (`ui/src/util/findInPage.ts`).
- **Editing**: current match selected via the textarea's native selection
  (focus briefly moves there to trigger scroll-into-view, then bounces back
  to the find field so Enter/Shift+Enter keep working).
- **PDF**: the *whole document* is searched, not just rendered pages. A lazy,
  incremental per-page text index (`ui/src/util/pdfFindIndex.ts`) reads pages
  via pdf.js's `getTextContent()`, starting at the open page and expanding
  outward. Navigating to a match brings its page into the render window and
  highlights it at its exact position, reusing the existing text layer.

## Bugs found and fixed along the way

- **PdfViewer**: two pages' concurrent `import("pdfjs-dist")` calls could
  race under the module loader used in tests (and, in principle, in
  production). Fixed by memoizing the dynamic import so every caller shares
  one promise.
- **CodeHighlight wasn't memoized**: any unrelated re-render of the file
  viewer made React reset the `<pre>`'s real DOM — a `dangerouslySetInnerHTML`
  element gets its DOM reset on every render of the component that owns it,
  not only when the HTML string actually changes — silently wiping
  find-in-page's `<mark>`s moments after they were applied. This only showed
  up driving Ctrl+F in the actual running app; component tests with mocked
  rendering never exercised it. Fixed with `React.memo`, which also makes
  `onRendered` a trustworthy "content actually changed" signal instead of a
  "something, somewhere, re-rendered" one.

Full write-up of both bugs (plus a third dead end — a `MutationObserver`
approach that self-triggered into a hang) is in
`openspec/changes/add-viewer-find-in-page/design.md` and `tasks.md`.

## Testing

- 195 tests across 10 files (`ui/src/util/findInPage.test.ts`,
  `pdfFindIndex.test.ts`, `FindBar.test.tsx`, `FileViewer.find.test.tsx`, plus
  updates to `PdfViewer.test.tsx` and the existing `FileViewer.*.test.tsx`
  suites) — all passing.
- Scenario coverage matrix: 20/20 spec scenarios `covered`
  (`openspec/changes/add-viewer-find-in-page/scenario-coverage.md`).
- Exercised live in the running app (server + web dev servers): Ctrl+F on a
  40-match code file with Next/Previous navigation, Escape-twice, and PDF
  search finding a page outside the initial render window. This is what
  caught the CodeHighlight memoization bug above.
- `openspec validate --strict`: passes.

**Known pre-existing, unrelated issue** (confirmed via `git stash` against
`main`): this dev environment's PDF text *layer* (the existing
selectable-text overlay) doesn't populate, so the on-page PDF highlight-box
rendering itself couldn't be visually re-confirmed live — that path is
covered by `PdfViewer.test.tsx`'s mocked-text-layer tests instead. Not
introduced or touched by this PR.

## Documentation impact

`README.md` — added Ctrl+F search to the file browser and PDF viewer
feature bullets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
