### PR TITLE
fix(dev): stop the dev server hanging when started via npm run dev

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "node": ">=24"
   },
   "scripts": {
-    "dev": "tsx watch src/index.ts --config ../pi-outpost.config.dev.json",
+    "dev": "node --watch --import tsx src/index.ts --config ../pi-outpost.config.dev.json",
     "start": "tsx src/index.ts",
     "typecheck": "tsc --noEmit",
     "build": "tsc --noEmit",


### PR DESCRIPTION
`npm run dev` never brought the server up. Vite retried its `/ws` proxy against 3141 indefinitely while the server process sat at 0.2s CPU — never binding, never printing even its first `[config]` line.

## Cause

`tsx watch` runs the server as a grandchild, and that grandchild deadlocks in the ESM loader thread under `concurrently` on Node 26. Isolated by elimination, each run checked for the `127.0.0.1:3141/` bind line:

| Invocation | Result |
|---|---|
| `tsx watch` alone | binds |
| `npm run dev --workspace server` | binds |
| `concurrently` + `tsx watch` | **hangs** |
| `concurrently` + `tsx` (no watch) | binds |
| `concurrently` + `node --import tsx` | binds |
| `concurrently` + `node --watch --import tsx` | binds |

Deterministic — 3 of 3 on `npm run dev`. That is why it only ever broke through the top-level script: starting the server on its own removes the one layer that triggers it, so the failure looked like a stale process or a port conflict rather than a script bug.

## Fix

Use Node's native watcher and keep `tsx` purely as the TS loader, which drops the spawner that deadlocks while preserving reload. `engines` already requires `node >=24`, so `--watch` is available to everyone who can run this package.

```diff
-"dev": "tsx watch src/index.ts --config ../pi-outpost.config.dev.json",
+"dev": "node --watch --import tsx src/index.ts --config ../pi-outpost.config.dev.json",
```

## Verification

Exercised on the real `npm run dev`, not just the isolated script:

- server reaches `[server] http://127.0.0.1:3141/`
- touching `server/src/index.ts` logs `Restarting 'src/index.ts …'` and re-binds, so watch still works
- app driven in the browser: `/health` through the vite proxy returns 200, the proxied WebSocket opens, and the UI renders live server data (file tree, branch, session list, model roster) — that data only arrives over the WS
- console clean across two page loads

Two error shapes remain in the dev log and are both expected: `ECONNREFUSED` for the first few seconds is vite proxying before the server has finished booting (the agent runtime enumerates tools and skills at startup), and it stops on bind. `ECONNABORTED` is the browser hanging up mid-write during a full reload — reproduced on demand by reloading the page.

## Documentation impact

None. The command is still `npm run dev` with no change to flags, config keys, or environment variables. The only other `tsx watch` reference in the repo is inside an archived openspec task record, which is a historical account and should not be rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfsKtYK2zMH3M3D8M2qDL5
