### PR TITLE
chore(release): v0.22.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-outpost",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "type": "module",
   "description": "A web interface for the pi coding agent: a browser chat UI you run with npx — no clone, no build.",
   "license": "MIT",

--- a/embed/package.json
+++ b/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-outpost/embed",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "type": "module",
   "description": "Mount pi-outpost as a Shadow-DOM-isolated widget inside another web app.",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "cli": {
       "name": "pi-outpost",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "^0.85.1",
@@ -45,7 +45,7 @@
     },
     "embed": {
       "name": "@pi-outpost/embed",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "MIT",
       "devDependencies": {
         "@microsoft/api-extractor": "^7.58.9",


### PR DESCRIPTION
Bumps `cli` and `embed` to **0.22.0**. Nothing else — the three files the previous release commits touched.

Tagging `v0.22.0` after this merges triggers the release workflow, which builds the per-platform executables, checks each one reports the version being released, and publishes.

## What ships since v0.21.0

**Word export from the file viewer** (#182). Any text file open in the viewer downloads as a real `.docx`. Markdown becomes Word's own structure — heading styles, nested and ordered lists, tables with a marked header row, hyperlinks, verbatim code. LaTeX becomes **native Word equations** rather than pictures of them: an equation drawn as an image cannot sit on the text baseline, so `$x_i$` mid-sentence would ride high with its subscript hanging below the line. Mermaid diagrams travel as vectors with a raster behind them. Verified in real Word (opens with the repair dialog suppressed; four equation objects; shape type 17, the vector) and in LibreOffice 26.8.

**Windows: no more console flashing** (#182). Child processes spawned without `windowsHide` open a console window each. Repository questions are asked on every workspace switch and tree listing, and the agent is spawned per session, so the machine flashed a black rectangle at its user all day. `startupFailure.ts` already passed the flag; the git runner, the pi RPC process, the bash probe and the test harness now do too.

**Sandbox** (#181): the agent's tools are kept acting inside the root, on pi 0.85.1.

**Dev server** (d5605b0): no longer hangs when started through `npm run dev`.

## Not in this PR

- `docs/comparison.md` still reads "Measured on **2026-09-04**, against **pi-outpost 0.21.0** and the **pi SDK 0.84.4**". I have left it alone deliberately: the version there is part of a measurement claim, and bumping the number without re-running the comparison would assert a measurement that never happened. The SDK line is already stale (#181 moved to 0.85.1), so that document wants a real refresh rather than a find-and-replace.
- Four completed OpenSpec changes are still unarchived — `add-docx-export`, `add-doctor-command`, `add-integrated-terminal`, `add-viewer-find-in-page`. Archiving folds their delta specs into the main specs, which is worth doing so `openspec/specs/` describes what actually ships, but it is its own change and does not belong in a version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbWz7Sbuq2H5QRVn6ypiUY
