### PR TITLE
fix(settings): never mount two directory pickers at once

### DIFF
--- a/ui/src/components/SettingsMenu.test.tsx
+++ b/ui/src/components/SettingsMenu.test.tsx
@@ -387,6 +387,33 @@ describe("SettingsMenu", () => {
       expect(onBrowseServerPath).toHaveBeenLastCalledWith("/srv/projects");
     });
 
+  it("shows no picker at all while another one holds the listing", () => {
+    /*
+     * The invariant, not the timing.
+     *
+     * Two pickers at once is not a cosmetic overlap: everything inside one is
+     * duplicated, so "the Go button" stops naming a single thing — a browser test
+     * failed with `getByRole('button', { name: 'Go' }) resolved to 2 elements`,
+     * which a reader would have seen as a flicker of two stacked panels.
+     *
+     * The overlap itself lasted a single frame, between the render that yielded
+     * and the effect that closed the picker, and it cannot be observed from here:
+     * the test renderer flushes effects synchronously, so this assertion holds
+     * whether the decision is made during the render or one tick later. The frame
+     * is guarded in a real browser, by e2e/settings-sandbox.spec.ts. What is
+     * pinned here is the end state that both must reach.
+     */
+    const { rerenderWith } = setup({ sandbox: sandbox({ root: "/work" }) });
+    fireEvent.click(screen.getByRole("button", { name: "Settings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Browse for sandbox root" }));
+    expect(screen.getAllByRole("button", { name: "Go" })).toHaveLength(1);
+
+    // Another header control opens its own picker and takes the shared listing.
+    rerenderWith({ pickerBlocked: true });
+
+    expect(screen.queryByRole("button", { name: "Go" })).toBeNull();
+  });
+
   describe("a refused apply", () => {
     it("stays open, says why, and leaves the settings as the server still has them", () => {
       const { rerenderWith } = setup({ sandbox: sandbox({ root: "/work" }), userSkillPaths: ["/mnt/a"] });

--- a/ui/src/components/SettingsMenu.tsx
+++ b/ui/src/components/SettingsMenu.tsx
@@ -209,7 +209,17 @@ export function SettingsMenu({
     });
   }
 
-  const picker = picking !== null && (
+  /*
+   * Blocked is answered here, in the render, and not only by the effect below.
+   *
+   * An effect runs *after* the render that scheduled it, so a picker being closed
+   * because another one opened is still on the page for one frame — two pickers,
+   * two "Go" buttons, two of everything a test or a reader can address. The effect
+   * still runs, because the state has to converge: without it this picker would
+   * reappear the moment the other one closed and `pickerBlocked` went false again.
+   * What changes is that the overlap is no longer observable.
+   */
+  const picker = picking !== null && !pickerBlocked && (
     <ServerPathPicker
       label={picking === "root" ? "Choose the sandbox root" : "Choose the writable root"}
       browse={serverBrowse}

--- a/ui/src/components/WorkspaceRootControl.tsx
+++ b/ui/src/components/WorkspaceRootControl.tsx
@@ -111,7 +111,12 @@ export function WorkspaceRootControl(props: WorkspaceRootControlProps) {
         <span className="truncate font-mono">{label}</span>
         {locked ? <span className="text-zinc-400">(locked)</span> : <span aria-hidden="true">▾</span>}
       </button>
-      {picking && (
+      {/* `blocked` is answered in the render, not only by the effect above: an
+          effect runs after the render that scheduled it, so a picker yielding to
+          another one is still on the page for a frame — and two pickers mean two
+          of every control inside them. The effect stays, because the state still
+          has to converge; this only stops the overlap being observable. */}
+      {picking && !blocked && (
         <div className="absolute left-0 top-full z-20 mt-1 w-[380px] rounded-lg border border-zinc-200 bg-white p-2 shadow-xl dark:border-zinc-700 dark:bg-zinc-900">
           {applyState?.status === "error" && (
             <p role="alert" className="mb-2 text-xs text-red-600 dark:text-red-400">


### PR DESCRIPTION
CI on `main` went red with:

```
strict mode violation: getByRole('button', { name: 'Go' }) resolved to 2 elements
  e2e/settings-sandbox.spec.ts:11 › Settings keeps the agent's sandbox and external resource access in sync
```

85 of 86 browser tests passed; this was the one. It is unrelated to what shipped in #182 — `main` at `9dbda32`, which already contained all of it, passed the same suite. The commit between them only bumped version numbers.

## The defect

Both controls already knew they had to yield. `SettingsMenu` takes `pickerBlocked` and `WorkspaceRootControl` takes `blocked` — *"Another picker in the header opened: close this one rather than stack it"* — because two pickers compete for the single server-browse listing behind them.

Each did it in a `useEffect`. An effect runs **after** the render that schedules it, so for one frame both pickers were mounted. That frame is the whole bug: everything inside a picker is duplicated, so `Go`, `Use this directory` and the path field each match twice.

The condition is now answered during the render too:

```diff
-const picker = picking !== null && (
+const picker = picking !== null && !pickerBlocked && (
```

The effects stay. They are not redundant: without them the picker would spring back open the moment the other one closed and the flag went false again. What changes is that the overlap is no longer observable — by a test or by a reader.

## About the unit test

It pins the end state — blocked means no picker — and **says so rather than claiming more**. I checked it against the unfixed code and it passes there too: the test renderer flushes effects synchronously, so the intermediate frame cannot be observed from jsdom at all. Keeping it while implying it guards the race would have been worse than not having it.

The frame itself is guarded in a real browser by `e2e/settings-sandbox.spec.ts` — the test that caught this in the first place.

## Checks

- `ui` suite: 1709 passed. The one failure, `ModelBar › reports how full the context is`, is a locale-dependent assertion (`45,000` vs a French `45 000`) that fails on my machine and passes in CI; untouched here.
- Lint and typecheck clean.

Merging this should return `main` to green, after which `v0.22.0` is ready to tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbWz7Sbuq2H5QRVn6ypiUY
