### PR TITLE
fix(openspec): stop the openlore delta dropping workspace isolation

### DIFF
--- a/openspec/changes/integrate-openlore-per-workspace/specs/multi-project-workspaces/spec.md
+++ b/openspec/changes/integrate-openlore-per-workspace/specs/multi-project-workspaces/spec.md
@@ -2,7 +2,15 @@
 
 ### Requirement: IsolateWorkspacesFromEachOther
 
-Each workspace SHALL own its agent session, sandbox, browser and writable roots, git state, file watcher, toolset, session manager, work plan and code-intelligence runtime. A server message produced by one workspace SHALL reach only the clients subscribed to that workspace. A tool call in one workspace SHALL be confined to that workspace's sandbox.
+Each workspace SHALL own its agent session, sandbox, browser and writable roots, its set of
+git repositories, file watcher, toolset, session manager, work plan, Outcome source state and
+code-intelligence runtime. A server message
+produced by one workspace SHALL reach only the clients subscribed to that workspace. A tool
+call in one workspace SHALL be confined to that workspace's sandbox. A git command served
+for one workspace SHALL run only against a repository in that workspace's own set, whichever
+repositories another open workspace holds. An Outcome request SHALL be composed only from the
+current session and repositories of the workspace to which the requesting client is bound; its
+updates and navigation targets SHALL NOT expose or act on another workspace's state.
 
 A workspace's code-intelligence runtime SHALL analyse that workspace's working tree and no other, and SHALL share no index, cache or mutable analysis state with another workspace — including a workspace open on another git worktree of the same repository.
 
@@ -16,6 +24,23 @@ A workspace's code-intelligence runtime SHALL analyse that workspace's working t
 - **WHEN** an agent tool in A tries to read a file under B's root
 - **THEN** the tool call fails, unless that path is within A's own sandbox
 
+#### Scenario: RepositoriesArePerWorkspace
+- **GIVEN** workspace A and workspace B, each holding repositories under its own root
+- **WHEN** a git request is served for a client subscribed to A
+- **THEN** it is answered from A's repository set only, and none of B's repositories is consulted
+
+#### Scenario: OutcomeIsPerWorkspace
+- **GIVEN** workspace A and workspace B have different Work Plans, evidence, and changed files
+- **WHEN** a client subscribed to A requests or refreshes Outcome
+- **THEN** the response contains only A's current-session plan, evidence, and repository results
+- **AND** no Outcome content from B reaches that client
+
+#### Scenario: Workspace switch rejects stale Outcome
+- **GIVEN** an Outcome request for workspace A is still in flight
+- **WHEN** the client switches to workspace B before the response arrives
+- **THEN** A's response is not rendered in B's Outcome view
+- **AND** navigation offered in B remains confined to B
+
 #### Scenario: CodeIntelligenceIsPerWorkspace
 - **GIVEN** workspace A and workspace B open on two git worktrees of one repository
 - **WHEN** each builds or updates its code-intelligence index
@@ -23,7 +48,7 @@ A workspace's code-intelligence runtime SHALL analyse that workspace's working t
 
 ### Requirement: RetireIdleWorkspaces
 
-A workspace with no client subscribed and no turn running MAY be stopped after a configured period of inactivity, releasing its watcher, session and code-intelligence runtime. A workspace SHALL NOT be stopped while a turn is running, however long it has run, and a stopped workspace SHALL be rebuilt transparently when it is next opened — its code intelligence included, started or resumed as part of that rebuild.
+A workspace with no client subscribed and no turn running MAY be stopped after a configured period of inactivity, releasing its watcher, session and code-intelligence runtime. A workspace SHALL NOT be stopped while a turn is running or while its authoritative Work Plan makes it ready for review, however long it has been unattended, and a stopped workspace SHALL be rebuilt transparently when it is next opened — its code intelligence included, started or resumed as part of that rebuild.
 
 Releasing or suspending one workspace's code-intelligence resources SHALL leave every other workspace's running.
 
@@ -31,6 +56,11 @@ Releasing or suspending one workspace's code-intelligence resources SHALL leave 
 - **GIVEN** a workspace with no client subscribed whose agent has been streaming past the inactivity period
 - **WHEN** the retirement sweep runs
 - **THEN** the workspace is left running
+
+#### Scenario: ReviewReadyWorkspacesAreNeverRetired
+- **GIVEN** an unattended workspace whose authoritative Work Plan makes it ready for review
+- **WHEN** the retirement sweep runs
+- **THEN** the workspace is left available and remains reported as ready for review
 
 #### Scenario: ReopeningARetiredWorkspace
 - **GIVEN** a workspace stopped after inactivity


### PR DESCRIPTION
`integrate-openlore-per-workspace` is an unstarted change whose delta for `multi-project-workspaces` was written against an older version of that spec. A `MODIFIED` requirement **replaces the whole block**, so archiving it as it stood would have deleted behaviour nobody proposed deleting — silently, since the deletion looks like a normal spec update in the diff.

## What the validator caught

Four scenarios that exist in the main spec and were missing from the `MODIFIED` blocks:

- `RepositoriesArePerWorkspace`
- `OutcomeIsPerWorkspace`
- `Workspace switch rejects stale Outcome`
- `ReviewReadyWorkspacesAreNeverRetired`

## What it could not catch

The validator compares scenarios, not prose — and the prose had drifted further.

**`IsolateWorkspacesFromEachOther`** had lost:
- `its set of git repositories`, softened to `git state`
- `Outcome source state` from the list of what a workspace owns
- the sentence confining a git command to its own workspace's repositories
- the sentence composing an Outcome request only from the requesting client's workspace

**`RetireIdleWorkspaces`** had lost the clause forbidding retirement *"while its authoritative Work Plan makes it ready for review"* — which is the very requirement its missing scenario exists to check. Scenario and prose would have gone together, leaving nothing to notice the loss.

## What this does

Rebuilds both blocks as **the current requirement plus what this change actually proposes**: a per-workspace code-intelligence runtime that shares no index or cache with another workspace (including one on another worktree of the same repository), is released when a workspace is retired, resumed when it is reopened, and leaves other workspaces' runtimes untouched.

No behaviour is proposed here that was not already proposed; nothing is removed that the change did not set out to remove.

## Validation

`openspec validate --all --strict` → **47 passed, 0 failed**. That was 46/1 before this.

This is planning-artifact only — no source, no tests, no runtime effect. The change itself remains unstarted, and is now safe to pick up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbWz7Sbuq2H5QRVn6ypiUY
