### PR TITLE
test(rpc): stop bounding a passing run with a stopwatch

### DIFF
--- a/server/test/pi-rpc.test.ts
+++ b/server/test/pi-rpc.test.ts
@@ -37,8 +37,23 @@ function settings(overrides: Partial<AgentRuntimeConfig> = {}): AgentRuntimeConf
     mode: "rpc",
     executable: process.execPath,
     args: [FAKE],
-    startupTimeoutMs: 2_000,
-    commandTimeoutMs: 500,
+    /*
+     * Generous, because these bound a *failure* and nothing else.
+     *
+     * A command resolves the instant the child answers, so a longer ceiling costs
+     * a passing run nothing at all; it only decides how long a genuinely stuck
+     * command waits before it is called stuck. The old 500 ms had to cover a
+     * spawned Node process reading a record, answering it, and the answer being
+     * parsed back — comfortable on a developer's machine, and not on a CI runner
+     * with three jobs competing for two cores. It failed on Windows, which is the
+     * slowest of the three, with "the get_commands command timed out" in a test
+     * about switching sessions, which is not what that test is about.
+     *
+     * Every test that actually asserts a timeout sets its own short ceiling
+     * (`commandTimeoutMs: 40`), so none of them depends on these numbers.
+     */
+    startupTimeoutMs: 20_000,
+    commandTimeoutMs: 10_000,
     shutdownGraceMs: 100,
     ...overrides,
   };
@@ -76,10 +91,19 @@ async function startFake(config: Record<string, unknown> = {}, overrides: Partia
   }
 }
 
+/**
+ * The event, or a named failure — never a hang.
+ *
+ * Ten seconds to match `waitFor` below, which polls for the same kind of thing
+ * and was already that patient. Two seconds was the odd one out, and when a test
+ * failed for an unrelated reason this timer went on to fire afterwards, turning a
+ * clear assertion failure into "generated asynchronous activity after the test
+ * ended" and pointing the reader at the wrong deadline.
+ */
 function waitForEvent(
   runtime: AgentRuntime,
   matches: (event: RuntimeEvent) => boolean,
-  timeoutMs = 2_000,
+  timeoutMs = 10_000,
 ): Promise<RuntimeEvent> {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {


### PR DESCRIPTION
`check (windows-latest)` failed on PR #186 — a Markdown-only change — with:

```
✖ rebootstraps state and tree after switching sessions
  Error: the get_commands command timed out
      at server/src/piRpcProcess.ts:421:22
```

A test about switching sessions, failing on a stopwatch.

## The cause

The harness gave every RPC command **500 ms**. That ceiling had to cover a spawned Node process reading a record, answering it, and the answer being parsed back. Comfortable on a developer's machine; not on a CI runner with three jobs competing for two cores. Windows is the slowest of the three — 11 minutes against ubuntu's 8 — so Windows is where it broke.

The important part: **a command resolves the moment the child answers.** These ceilings cost a passing run nothing at all. All they decide is how long a genuinely stuck command waits before being called stuck. At 500 ms they bought no signal and manufactured false failures.

Now 10 s for a command, 20 s for startup — comfortably inside the runner's own 5-minute per-test timeout, so a real hang still fails with a useful message rather than by the suite giving up.

Every test that actually asserts a timeout already sets its own short ceiling (`commandTimeoutMs: 40`), so none of them depends on these defaults.

## The second change, and a correction

`waitForEvent` goes from 2 s to 10 s. Its sibling `waitFor` polls for the same kind of thing and was already at 10 s, so 2 s was simply the odd one out.

It also actively misleads. When a test fails for an unrelated reason, this timer fires *afterwards* and reports:

```
Error: Test "..." generated asynchronous activity after the test ended.
This activity created the error "timed out waiting for runtime event"
```

That is what the log showed most prominently, and I initially diagnosed this as the test helper's deadline — wrongly. The real error was underneath, in production code. Raising it removes a red herring that costs the next reader the same detour.

## Checks

`test/pi-rpc.test.ts`: **34 of 34 pass**, including the three that assert timeouts.

No production code changes — the deadline in `piRpcProcess.ts` is configurable and its default is untouched; only what the tests configure changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbWz7Sbuq2H5QRVn6ypiUY
