### PR TITLE
fix(startup): stop the server waiting on extensions that bind slowly

### DIFF
--- a/server/src/agentRuntime.ts
+++ b/server/src/agentRuntime.ts
@@ -125,6 +125,14 @@ export type RuntimeEvent =
   | { type: "compaction_end"; errorMessage?: string }
   /** The runtime replaced its session object and has finished re-binding to it. */
   | { type: "session_replaced" }
+  /**
+   * Extensions finished binding after startup had stopped waiting for them.
+   *
+   * Only emitted on that late path: a `session_start` handler can contribute
+   * skills, prompt templates and commands, so a client holding the snapshot taken
+   * during the wait is holding one from before they existed.
+   */
+  | { type: "extensions_bound"; elapsedMs: number }
   /** An extension asked the user something; the answer comes back via `answerExtensionUI`. */
   | { type: "extension_ui_request"; request: ExtensionUIRequest }
   /** Something went wrong but the runtime is still usable (an extension threw, a command failed). */

--- a/server/src/embeddedRuntime.ts
+++ b/server/src/embeddedRuntime.ts
@@ -45,27 +45,87 @@ export interface EmbeddedRuntimeOptions {
   onModelFallback?: (message: string) => void;
 }
 
-/** Milliseconds before we say out loud that `bindExtensions` has not settled. */
+/**
+ * How long a caller waits on `bindExtensions` before it stops holding everything
+ * else behind it.
+ *
+ * Startup treats it as a grace period — past it the interface comes up and the
+ * binding finishes behind it. A rebind, which happens with clients already
+ * watching, keeps waiting and only says out loud that it is still going.
+ */
 const BIND_STALL_MS = 5000;
+
+/** Total build time past which startup says where the time went, rather than only being slow. */
+const SLOW_BUILD_MS = 2000;
+
+/** How many events are held for a subscriber that has not arrived yet. */
+const MAX_BUFFERED_EVENTS = 100;
+
+/** One decimal is the resolution anyone acts on here. */
+function seconds(ms: number): string {
+  return `${(ms / 1000).toFixed(1)}s`;
+}
 
 export async function createEmbeddedRuntime(options: EmbeddedRuntimeOptions): Promise<AgentRuntime> {
   // AgentSessionRuntime keeps the factory it is constructed with for every later
   // new/resume/fork. Keep that factory indirect so a Settings update can replace
   // the sandboxed toolset before starting the replacement session.
   let currentFactory = options.factory;
+  const sessionStartedAt = Date.now();
   const runtime = await createAgentSessionRuntime((factoryOptions) => currentFactory(factoryOptions), {
     cwd: options.cwd,
     agentDir: options.agentDir,
     sessionManager: options.sessionManager,
   });
+  const loadMs = Date.now() - sessionStartedAt;
   if (runtime.modelFallbackMessage) options.onModelFallback?.(runtime.modelFallbackMessage);
   const embedded = new EmbeddedRuntime(runtime, options.agentDir, (factory) => {
     const previous = currentFactory;
     currentFactory = factory;
     return previous;
   });
-  await embedded.bind();
+  const bindStartedAt = Date.now();
+  await embedded.bind({ graceMs: BIND_STALL_MS });
+  const bindMs = Date.now() - bindStartedAt;
+  // A slow start was previously indistinguishable from a wedged one, and the two
+  // halves fail for unrelated reasons: loading is the SDK compiling and evaluating
+  // every extension, binding is those extensions' own `session_start` handlers —
+  // a language server starting, a repository being indexed, a question nobody can
+  // answer yet. Only the second can be served around, so name both.
+  if (loadMs + bindMs >= SLOW_BUILD_MS) {
+    console.warn(
+      `[pi] agent runtime built in ${seconds(loadMs + bindMs)} — session and extension load ${seconds(loadMs)}, extension bind ${seconds(bindMs)}`,
+    );
+  }
   return embedded;
+}
+
+/**
+ * Whether `work` settles within `ms`.
+ *
+ * A rejection inside the window is re-thrown, because that is the caller's failure
+ * to handle exactly as if it had awaited directly. A rejection *after* the window
+ * belongs to whoever kept the original promise: this must not leave a second,
+ * unobserved promise rejecting on its own, so the race observes an outcome rather
+ * than reproducing it.
+ */
+async function settlesWithin(work: Promise<unknown>, ms: number): Promise<boolean> {
+  const observed = work.then(
+    () => true as const,
+    (error: unknown) => ({ error }),
+  );
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  // Not unref'd: the timer is the only thing holding this wait together, and it is
+  // always cleared below — an unref'd one lets a process with nothing else running
+  // resolve its loop out from under the await.
+  const timedOut = new Promise<false>((resolve) => {
+    timer = setTimeout(() => resolve(false), ms);
+  });
+  const outcome = await Promise.race([observed, timedOut]);
+  if (timer) clearTimeout(timer);
+  if (outcome === false) return false;
+  if (outcome !== true) throw outcome.error;
+  return true;
 }
 
 type SdkRuntime = Awaited<ReturnType<typeof createAgentSessionRuntime>>;
@@ -81,6 +141,20 @@ export class EmbeddedRuntime implements AgentRuntime {
   private readonly listeners = new Set<(event: RuntimeEvent) => void>();
   private readonly bridge = new ExtensionUiBridge((request) => this.emit({ type: "extension_ui_request", request }));
   private unsubscribe: () => void = () => {};
+  /**
+   * Events emitted before anything subscribed.
+   *
+   * Binding starts inside `createEmbeddedRuntime`, before the server holds the
+   * runtime it subscribes to — so an extension that asks a question from its
+   * `session_start` handler emitted into an empty listener set and the dialog was
+   * dropped. Its handler then waited on an answer nobody could be shown how to
+   * give, and the whole startup stood behind that wait. Held here instead and
+   * replayed to the first subscriber, which is the same moment any event arriving
+   * a millisecond later would reach.
+   */
+  private readonly buffered: RuntimeEvent[] = [];
+  /** Whether the replay has happened; after it, an empty listener set means nobody is listening. */
+  private replayed = false;
 
   constructor(
     private readonly runtime: SdkRuntime,
@@ -93,11 +167,22 @@ export class EmbeddedRuntime implements AgentRuntime {
   }
 
   private emit(event: RuntimeEvent): void {
+    if (!this.replayed) {
+      // Bounded: the buffer exists for a dialog and the handful of notifications
+      // around it. A binding that emits more than this before anyone is listening
+      // is not a stream anyone is going to read back.
+      if (this.buffered.length < MAX_BUFFERED_EVENTS) this.buffered.push(event);
+      return;
+    }
     for (const listener of this.listeners) listener(event);
   }
 
   subscribe(listener: (event: RuntimeEvent) => void): () => void {
     this.listeners.add(listener);
+    if (!this.replayed) {
+      this.replayed = true;
+      for (const event of this.buffered.splice(0)) listener(event);
+    }
     return () => this.listeners.delete(listener);
   }
 
@@ -241,10 +326,47 @@ export class EmbeddedRuntime implements AgentRuntime {
 
   // --- binding -------------------------------------------------------------
 
-  /** Event subscriptions attach to one AgentSession — rebind after replacement. */
-  async bind(): Promise<void> {
+  /**
+   * Event subscriptions attach to one AgentSession — rebind after replacement.
+   *
+   * `graceMs` bounds how long the caller waits for the extensions themselves.
+   * `bindExtensions` runs every extension's `session_start` handler, and there is
+   * no bound on what one of those may do: start a language server, index a
+   * repository, ask the user something. pi's own interactive mode renders and
+   * subscribes before it awaits that call (`rebindCurrentSession({
+   * renderBeforeBind: true })`); the server awaited it before it would serve at
+   * all, so each of those seconds was a browser reconnecting against a socket
+   * answering 1013 "starting up", with nothing in the log but the stall warning.
+   *
+   * Without a grace — a rebind, where clients are already watching — the wait is
+   * kept and only reported, because there the session being replaced is the thing
+   * the client is waiting for.
+   */
+  async bind(options?: { graceMs?: number }): Promise<void> {
     this.unsubscribe = this.session.subscribe((event: any) => this.translate(event));
-    await this.bindExtensions();
+    const startedAt = Date.now();
+    const binding = this.bindExtensions();
+    if (options?.graceMs === undefined) {
+      const stallWarning = setTimeout(() => {
+        console.warn(`[pi] bindExtensions has not resolved after ${seconds(BIND_STALL_MS)} — extensions may be unavailable this session`);
+      }, BIND_STALL_MS);
+      try {
+        await binding;
+      } finally {
+        clearTimeout(stallWarning);
+      }
+      return;
+    }
+    if (await settlesWithin(binding, options.graceMs)) return;
+    console.warn(
+      `[pi] extensions have not bound after ${seconds(options.graceMs)} — serving the interface without them; they attach when they finish`,
+    );
+    void binding.then(
+      () => this.emit({ type: "extensions_bound", elapsedMs: Date.now() - startedAt }),
+      // Not fatal the way a failure inside the grace is: the session is already
+      // serving, so this is reported and the runtime keeps the tools it has.
+      (error: unknown) => this.emit({ type: "error", message: `[extensions] ${error instanceof Error ? error.message : String(error)}` }),
+    );
   }
 
   private translate(event: any): void {
@@ -307,32 +429,29 @@ export class EmbeddedRuntime implements AgentRuntime {
     }
   }
 
-  /** (Re)bind the extension runtime — UI bridge, mode, error reporting — to the current session. */
+  /**
+   * (Re)bind the extension runtime — UI bridge, mode, error reporting — to the
+   * current session.
+   *
+   * This has been observed never to settle: an extension whose `session_start`
+   * handler asks a question waits for an answer, and until a client is listening
+   * there is nobody to ask. Whether the caller waits for it is `bind()`'s decision.
+   */
   private async bindExtensions(): Promise<void> {
-    // `bindExtensions()` has been observed never to settle in some process contexts
-    // (spawned under `concurrently` / Start-Process, where stdout isn't a TTY).
-    // This warning surfaces that case instead of hanging silently.
-    const stallWarning = setTimeout(() => {
-      console.warn("[pi] bindExtensions has not resolved after 5s — extensions may be unavailable this session");
-    }, BIND_STALL_MS);
-    try {
-      await this.session.bindExtensions({
-        // Cast: structurally satisfies ExtensionUIContext (verified against the SDK's
-        // own RPC-mode implementation); see the `theme` getter for the one gap.
-        uiContext: this.bridge.createContext() as any,
-        mode: "rpc",
-        shutdownHandler: () => {
-          // Unlike pi's one-shot RPC subprocess, this server is long-lived and shared
-          // across tabs/sessions — an extension asking to "shut down" shouldn't kill it.
-          console.warn("[pi] extension requested shutdown — ignored (pi-outpost is a persistent server)");
-        },
-        onError: (err) => {
-          this.emit({ type: "error", message: `[extension ${err.extensionPath}] ${err.error}` });
-        },
-      });
-    } finally {
-      clearTimeout(stallWarning);
-    }
+    await this.session.bindExtensions({
+      // Cast: structurally satisfies ExtensionUIContext (verified against the SDK's
+      // own RPC-mode implementation); see the `theme` getter for the one gap.
+      uiContext: this.bridge.createContext() as any,
+      mode: "rpc",
+      shutdownHandler: () => {
+        // Unlike pi's one-shot RPC subprocess, this server is long-lived and shared
+        // across tabs/sessions — an extension asking to "shut down" shouldn't kill it.
+        console.warn("[pi] extension requested shutdown — ignored (pi-outpost is a persistent server)");
+      },
+      onError: (err) => {
+        this.emit({ type: "error", message: `[extension ${err.extensionPath}] ${err.error}` });
+      },
+    });
   }
 
   /** After a session replacement, `runtime.session` is a new object — rewire everything to it. */

--- a/server/src/embeddedRuntime.ts
+++ b/server/src/embeddedRuntime.ts
@@ -46,12 +46,11 @@ export interface EmbeddedRuntimeOptions {
 }
 
 /**
- * How long a caller waits on `bindExtensions` before it stops holding everything
- * else behind it.
+ * How long a caller waits on `bindExtensions` before it stops holding the session
+ * it has behind the extensions it does not have yet.
  *
- * Startup treats it as a grace period — past it the interface comes up and the
- * binding finishes behind it. A rebind, which happens with clients already
- * watching, keeps waiting and only says out loud that it is still going.
+ * Past it, startup serves the interface and a `/new` hands over its session; the
+ * binding finishes behind either, and says so when it lands.
  */
 const BIND_STALL_MS = 5000;
 
@@ -85,7 +84,7 @@ export async function createEmbeddedRuntime(options: EmbeddedRuntimeOptions): Pr
     return previous;
   });
   const bindStartedAt = Date.now();
-  await embedded.bind({ graceMs: BIND_STALL_MS });
+  await embedded.bind();
   const bindMs = Date.now() - bindStartedAt;
   // A slow start was previously indistinguishable from a wedged one, and the two
   // halves fail for unrelated reasons: loading is the SDK compiling and evaluating
@@ -338,34 +337,36 @@ export class EmbeddedRuntime implements AgentRuntime {
    * all, so each of those seconds was a browser reconnecting against a socket
    * answering 1013 "starting up", with nothing in the log but the stall warning.
    *
-   * Without a grace — a rebind, where clients are already watching — the wait is
-   * kept and only reported, because there the session being replaced is the thing
-   * the client is waiting for.
+   * The same bound covers a session replacement, where the identical wait sat
+   * between `/new` and a usable session. The session object exists either way
+   * before its extensions have finished starting up, and it is the session the
+   * caller is waiting for: the tools were registered when the extensions loaded,
+   * and what binding adds — contributed skills, a `session_start` handler's own
+   * work — arrives afterwards through `extensions_bound`.
    */
   async bind(options?: { graceMs?: number }): Promise<void> {
     this.unsubscribe = this.session.subscribe((event: any) => this.translate(event));
+    const bound = this.session;
     const startedAt = Date.now();
     const binding = this.bindExtensions();
-    if (options?.graceMs === undefined) {
-      const stallWarning = setTimeout(() => {
-        console.warn(`[pi] bindExtensions has not resolved after ${seconds(BIND_STALL_MS)} — extensions may be unavailable this session`);
-      }, BIND_STALL_MS);
-      try {
-        await binding;
-      } finally {
-        clearTimeout(stallWarning);
-      }
-      return;
-    }
-    if (await settlesWithin(binding, options.graceMs)) return;
+    if (await settlesWithin(binding, options?.graceMs ?? BIND_STALL_MS)) return;
     console.warn(
-      `[pi] extensions have not bound after ${seconds(options.graceMs)} — serving the interface without them; they attach when they finish`,
+      `[pi] extensions have not bound after ${seconds(options?.graceMs ?? BIND_STALL_MS)} — the session is usable now; they attach when they finish`,
     );
     void binding.then(
-      () => this.emit({ type: "extensions_bound", elapsedMs: Date.now() - startedAt }),
-      // Not fatal the way a failure inside the grace is: the session is already
-      // serving, so this is reported and the runtime keeps the tools it has.
-      (error: unknown) => this.emit({ type: "error", message: `[extensions] ${error instanceof Error ? error.message : String(error)}` }),
+      () => {
+        // A binding left behind by a session that has since been replaced has
+        // nothing to announce: its skills went with it, and the snapshot the
+        // announcement refreshes describes the session that took its place.
+        if (this.session !== bound) return;
+        this.emit({ type: "extensions_bound", elapsedMs: Date.now() - startedAt });
+      },
+      (error: unknown) => {
+        // Not fatal the way a failure inside the grace is: the session is already
+        // serving, so this is reported and the runtime keeps the tools it has.
+        if (this.session !== bound) return;
+        this.emit({ type: "error", message: `[extensions] ${error instanceof Error ? error.message : String(error)}` });
+      },
     );
   }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1797,17 +1797,6 @@ async function announceFileChange(workspace: Workspace, args: unknown): Promise<
  * session emits through this too, and a closure over the boot workspace would send
  * its stream to the wrong audience — or to nobody.
  */
-/**
- * Projects whose snapshot grew while a turn was streaming, and which owe their
- * clients one once it ends.
- *
- * A snapshot lands on a client as a state replacement, so one sent between two
- * deltas discards the reply being streamed into. Late-bound extensions are the
- * only thing that can move the snapshot mid-turn, and they are worth showing, so
- * the update waits for the turn rather than being dropped.
- */
-const snapshotOwedAfterTurn = new Set<string>();
-
 function onRuntimeEvent(workspace: Workspace, event: RuntimeEvent): void {
   switch (event.type) {
     case "agent_start":
@@ -1831,10 +1820,6 @@ function onRuntimeEvent(workspace: Workspace, event: RuntimeEvent): void {
       // The turn is persisted now: hand the client the entries so the bubbles it
       // echoed optimistically become editable (edit_prompt targets an entry id).
       broadcast(workspace, { type: "user_entries", entries: branchUserEntries(workspace) });
-      // Nothing is streaming into now, so a snapshot held back for that reason can go.
-      if (snapshotOwedAfterTurn.delete(workspace.root)) {
-        broadcast(workspace, { type: "session_replaced", ...snapshot(workspace) });
-      }
       broadcast(workspace, { type: "tree", roots: buildTree(workspace) });
       // Off the prompt path on purpose: a slow title must never delay a reply
       void maybeNameSession(workspace);
@@ -2011,18 +1996,23 @@ function onRuntimeEvent(workspace: Workspace, event: RuntimeEvent): void {
       }
       break;
     case "extensions_bound": {
+      const state = workspace.agent.snapshot();
       // The startup banner named the skills that existed when it printed. Say what
-      // the wait was, and name them again only when the binding actually added some.
+      // the wait cost, and name them again only when the binding actually added some.
       console.log(`[pi] extensions bound after ${(event.elapsedMs / 1000).toFixed(1)}s`);
-      const skills = workspace.agent
-        .snapshot()
-        .commands.filter((command) => command.source === "skill")
-        .map((command) => command.name);
+      const skills = state.commands.filter((command) => command.source === "skill").map((command) => command.name);
       if (skills.length > 0) console.log(`[pi] skills: ${skills.join(", ")}`);
       // Renderers can come from an extension that only registered them now.
       refreshExtensionRender(workspace);
-      if (workspace.agent.snapshot().isStreaming) snapshotOwedAfterTurn.add(workspace.root);
-      else broadcast(workspace, { type: "session_replaced", ...snapshot(workspace) });
+      // Commands and tools only. A snapshot would be the easy way to say "things
+      // changed" and the wrong one: clients treat it as a session change and close
+      // the file the user opened while waiting.
+      broadcast(workspace, { type: "extensions_bound", commands: state.commands, ...(state.tools ? { tools: state.tools } : {}) });
+      // Skills an extension contributed are inventory too, and the panel showing
+      // them has its own message. Nothing else here waits on it.
+      void refreshResourceInventory(workspace)
+        .then((inventory) => broadcast(workspace, { type: "agent_resource_inventory", inventory }))
+        .catch(reportError);
       break;
     }
     case "extension_ui_request":

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1797,6 +1797,17 @@ async function announceFileChange(workspace: Workspace, args: unknown): Promise<
  * session emits through this too, and a closure over the boot workspace would send
  * its stream to the wrong audience — or to nobody.
  */
+/**
+ * Projects whose snapshot grew while a turn was streaming, and which owe their
+ * clients one once it ends.
+ *
+ * A snapshot lands on a client as a state replacement, so one sent between two
+ * deltas discards the reply being streamed into. Late-bound extensions are the
+ * only thing that can move the snapshot mid-turn, and they are worth showing, so
+ * the update waits for the turn rather than being dropped.
+ */
+const snapshotOwedAfterTurn = new Set<string>();
+
 function onRuntimeEvent(workspace: Workspace, event: RuntimeEvent): void {
   switch (event.type) {
     case "agent_start":
@@ -1820,6 +1831,10 @@ function onRuntimeEvent(workspace: Workspace, event: RuntimeEvent): void {
       // The turn is persisted now: hand the client the entries so the bubbles it
       // echoed optimistically become editable (edit_prompt targets an entry id).
       broadcast(workspace, { type: "user_entries", entries: branchUserEntries(workspace) });
+      // Nothing is streaming into now, so a snapshot held back for that reason can go.
+      if (snapshotOwedAfterTurn.delete(workspace.root)) {
+        broadcast(workspace, { type: "session_replaced", ...snapshot(workspace) });
+      }
       broadcast(workspace, { type: "tree", roots: buildTree(workspace) });
       // Off the prompt path on purpose: a slow title must never delay a reply
       void maybeNameSession(workspace);
@@ -1995,6 +2010,21 @@ function onRuntimeEvent(workspace: Workspace, event: RuntimeEvent): void {
           .then(() => queueWorkPlanSessionSync(workspace));
       }
       break;
+    case "extensions_bound": {
+      // The startup banner named the skills that existed when it printed. Say what
+      // the wait was, and name them again only when the binding actually added some.
+      console.log(`[pi] extensions bound after ${(event.elapsedMs / 1000).toFixed(1)}s`);
+      const skills = workspace.agent
+        .snapshot()
+        .commands.filter((command) => command.source === "skill")
+        .map((command) => command.name);
+      if (skills.length > 0) console.log(`[pi] skills: ${skills.join(", ")}`);
+      // Renderers can come from an extension that only registered them now.
+      refreshExtensionRender(workspace);
+      if (workspace.agent.snapshot().isStreaming) snapshotOwedAfterTurn.add(workspace.root);
+      else broadcast(workspace, { type: "session_replaced", ...snapshot(workspace) });
+      break;
+    }
     case "extension_ui_request":
       // Only the four dialog methods block a turn. notify, setStatus, setWidget,
       // setTitle and set_editor_text are one-way — badging those would report a
@@ -2032,7 +2062,6 @@ function onRuntimeEvent(workspace: Workspace, event: RuntimeEvent): void {
   }
 }
 
-workspace.agent.subscribe((event) => onRuntimeEvent(workspace, event));
 refreshExtensionRender(workspace);
 
 // --- Client message handling -----------------------------------------------------
@@ -4268,6 +4297,20 @@ if (!credentialStatus(workspace).usableModel) {
       : `[pi] no credentials in ${AGENT_DIR} — open the UI to set one up, or run "pi-outpost login --provider <name>" (provider environment variables work too)`,
   );
 }
+
+/**
+ * Start listening to the boot project's runtime — last, and deliberately.
+ *
+ * Extensions bind before this file finishes evaluating, and one of them may have
+ * asked a question or contributed a skill on the way. The runtime holds those
+ * events until something subscribes and then replays them, which runs
+ * `onRuntimeEvent` for real — and that handler reaches module state declared
+ * further down this file. Subscribing where the events *start* rather than where
+ * the module is *whole* is how a startup dialog crashed the server on
+ * `Cannot access 'starting' before initialization`. Everything above is defined by
+ * here, so a replayed event and a live one take exactly the same path.
+ */
+workspace.agent.subscribe((event) => onRuntimeEvent(workspace, event));
 
 
 /**

--- a/server/test/embeddedRuntime.test.ts
+++ b/server/test/embeddedRuntime.test.ts
@@ -114,6 +114,37 @@ describe("EmbeddedRuntime startup binding", () => {
     assert.equal(asked.request.title, "Reload openlore?");
   });
 
+  it("says nothing for a binding whose session has since been replaced", async () => {
+    let release: () => void = () => {};
+    const first = {
+      subscribe: () => () => {},
+      bindExtensions: async () => {
+        await new Promise<void>((resolve) => (release = resolve));
+      },
+    };
+    const second = { subscribe: () => () => {}, bindExtensions: async () => {} };
+    let session: unknown = first;
+    const runtime = new EmbeddedRuntime({ get session() { return session; } } as never, "/nowhere");
+    const warnings = captureWarnings();
+    try {
+      await runtime.bind({ graceMs: 10 });
+    } finally {
+      warnings.restore();
+    }
+
+    const events: RuntimeEvent[] = [];
+    runtime.subscribe((event) => events.push(event));
+    // What a `/new` does while the previous session's extensions are still binding.
+    session = second;
+    release();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.equal(
+      events.some((event) => event.type === "extensions_bound"),
+      false,
+      "the announcement would refresh the snapshot of a session that never waited for it",
+    );
+  });
+
   it("keeps a binding failure inside the grace fatal, and a later one merely reported", async () => {
     const immediate = {
       subscribe: () => () => {},

--- a/server/test/embeddedRuntime.test.ts
+++ b/server/test/embeddedRuntime.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import type { CreateAgentSessionRuntimeFactory } from "@earendil-works/pi-coding-agent";
+import type { RuntimeEvent } from "../src/agentRuntime.ts";
 import { EmbeddedRuntime } from "../src/embeddedRuntime.ts";
 
 describe("EmbeddedRuntime tool rebuilding", () => {
@@ -40,5 +41,108 @@ describe("EmbeddedRuntime tool rebuilding", () => {
 
     await runtime.rebuildTools();
     assert.deepEqual(factoriesUsed, [newFactory, newFactory], "the next session still uses the replacement factory");
+  });
+});
+
+/** Poll rather than count ticks: the binding settles through promise callbacks, not a fixed number of them. */
+async function waitFor(condition: () => boolean, what: string): Promise<void> {
+  const deadline = Date.now() + 2000;
+  while (!condition()) {
+    if (Date.now() > deadline) throw new Error(`timed out waiting for ${what}`);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+/** Collects the warnings the runtime prints, so a test can read them instead of the operator. */
+function captureWarnings(): { lines: string[]; restore: () => void } {
+  const lines: string[] = [];
+  const original = console.warn;
+  console.warn = (...args: unknown[]) => {
+    lines.push(args.map(String).join(" "));
+  };
+  return { lines, restore: () => (console.warn = original) };
+}
+
+describe("EmbeddedRuntime startup binding", () => {
+  it("stops waiting on extensions that outlive the grace, and reports them when they land", async () => {
+    let release: () => void = () => {};
+    const session = {
+      subscribe: () => () => {},
+      bindExtensions: async () => {
+        await new Promise<void>((resolve) => (release = resolve));
+      },
+    };
+    const runtime = new EmbeddedRuntime({ get session() { return session; } } as never, "/nowhere");
+    const warnings = captureWarnings();
+    try {
+      await runtime.bind({ graceMs: 10 });
+    } finally {
+      warnings.restore();
+    }
+    assert.match(warnings.lines.join("\n"), /extensions have not bound/, "the operator is told the interface came up without them");
+
+    const events: RuntimeEvent[] = [];
+    runtime.subscribe((event) => events.push(event));
+    release();
+    await waitFor(() => events.some((event) => event.type === "extensions_bound"), "the late binding to be announced");
+    const bound = events.find((event) => event.type === "extensions_bound");
+    assert.ok(bound && bound.type === "extensions_bound" && bound.elapsedMs >= 0, "the announcement carries how long it took");
+  });
+
+  it("replays a dialog raised before anything subscribed", async () => {
+    const session = {
+      subscribe: () => () => {},
+      bindExtensions: async (bindings: { uiContext: { confirm: (title: string, message: string) => Promise<boolean> } }) => {
+        // What a `session_start` handler does when it wants an answer: the promise
+        // stays pending until a client sends one back.
+        await bindings.uiContext.confirm("Reload openlore?", "The index is stale");
+      },
+    };
+    const runtime = new EmbeddedRuntime({ get session() { return session; } } as never, "/nowhere");
+    const warnings = captureWarnings();
+    try {
+      await runtime.bind({ graceMs: 10 });
+    } finally {
+      warnings.restore();
+    }
+
+    const events: RuntimeEvent[] = [];
+    runtime.subscribe((event) => events.push(event));
+    const asked = events.find((event) => event.type === "extension_ui_request");
+    assert.ok(asked && asked.type === "extension_ui_request", "the question survived having no audience");
+    assert.equal(asked.request.method, "confirm");
+    assert.equal(asked.request.title, "Reload openlore?");
+  });
+
+  it("keeps a binding failure inside the grace fatal, and a later one merely reported", async () => {
+    const immediate = {
+      subscribe: () => () => {},
+      bindExtensions: async () => {
+        throw new Error("extension bind failed");
+      },
+    };
+    const fatal = new EmbeddedRuntime({ get session() { return immediate; } } as never, "/nowhere");
+    await assert.rejects(fatal.bind({ graceMs: 50 }), /extension bind failed/, "a fast failure still stops startup");
+
+    let fail: (error: Error) => void = () => {};
+    const late = {
+      subscribe: () => () => {},
+      bindExtensions: async () => {
+        await new Promise<void>((_resolve, reject) => (fail = reject));
+      },
+    };
+    const runtime = new EmbeddedRuntime({ get session() { return late; } } as never, "/nowhere");
+    const warnings = captureWarnings();
+    try {
+      await runtime.bind({ graceMs: 10 });
+    } finally {
+      warnings.restore();
+    }
+    const events: RuntimeEvent[] = [];
+    runtime.subscribe((event) => events.push(event));
+    fail(new Error("openlore never answered"));
+    await waitFor(() => events.some((event) => event.type === "error"), "the late failure to be reported");
+    const reported = events.find((event) => event.type === "error");
+    assert.match(reported && reported.type === "error" ? reported.message : "", /openlore never answered/);
   });
 });

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -723,6 +723,16 @@ export type ServerMessage =
    * live extension dialogs, notifications, statuses and widgets the server still holds.
    */
   | { type: "credentials_changed"; models: ModelChoice[]; model: string; credentials: CredentialStatus }
+  /**
+   * Extensions finished binding after the session was already in use — their
+   * `session_start` handlers ran late, and the commands and skills they contribute
+   * exist only now.
+   *
+   * Narrow for the same reason `credentials_changed` is: the session is the one the
+   * user is already in. A snapshot here would close the file they opened while
+   * waiting, drop their file tree and diff, and wipe live extension dialogs.
+   */
+  | { type: "extensions_bound"; commands: CommandInfo[]; tools?: { name: string; active: boolean }[] }
   | { type: "thinking_changed"; level: string }
   | { type: "user"; text: string; images?: WireImage[] }
   /**

--- a/ui/src/useAgent.test.ts
+++ b/ui/src/useAgent.test.ts
@@ -1526,6 +1526,46 @@ describe("extension UI", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Late-binding extensions
+// ---------------------------------------------------------------------------
+describe("extensions_bound", () => {
+  it("adopts the commands and tools that arrived late", async () => {
+    const result = await connected([], { commands: [{ name: "skill:one", source: "skill" }] });
+
+    act(() =>
+      mockWs!.receive({
+        type: "extensions_bound",
+        commands: [
+          { name: "skill:one", source: "skill" },
+          { name: "skill:two", source: "skill" },
+        ],
+        tools: [{ name: "lens_diagnostics", active: true }],
+      }),
+    );
+
+    await waitFor(() => expect(result.current.state.commands).toHaveLength(2));
+    expect(result.current.state.tools).toEqual([{ name: "lens_diagnostics", active: true }]);
+  });
+
+  it("keeps the file the user opened while waiting", async () => {
+    // The reason this message exists rather than a snapshot: binding can land long
+    // after the session became usable, and the user has been using it.
+    const result = await connected();
+
+    act(() => result.current.readFile("notes.md"));
+    const requestId = (JSON.parse(mockWs!.sent[mockWs!.sent.length - 1]) as { requestId: string }).requestId;
+    act(() => mockWs!.receive({ type: "file_content", requestId, path: "notes.md", content: "hi", size: 2, mtimeMs: 1 }));
+    await waitFor(() => expect(result.current.state.openFile?.status).toBe("loaded"));
+
+    act(() => mockWs!.receive({ type: "extensions_bound", commands: [{ name: "skill:late", source: "skill" }] }));
+
+    await waitFor(() => expect(result.current.state.commands).toHaveLength(1));
+    expect(result.current.state.openFile?.path).toBe("notes.md");
+    expect(result.current.state.tools).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Credentials
 // ---------------------------------------------------------------------------
 describe("credentials_changed", () => {

--- a/ui/src/useAgent.ts
+++ b/ui/src/useAgent.ts
@@ -873,6 +873,12 @@ function reduce(state: AgentState, action: Action): AgentState {
         // case sends an error *and* this message — clearing them would eat it
       };
     }
+    case "extensions_bound":
+      // Extensions that bound after the session was already in use. Their commands
+      // and tools exist now; everything else — the transcript, the open file, a
+      // dialog one of them raised while binding — is untouched on purpose, which is
+      // why this is not a snapshot.
+      return { ...state, commands: message.commands, tools: message.tools ?? state.tools };
     case "thinking_changed":
       return { ...state, thinkingLevel: message.level };
     case "work_plan_changed":


### PR DESCRIPTION
The console said all there was to say: `[pi] bindExtensions has not resolved
after 5s`, and then a long nothing. Everything between `listen` and that
silence is a browser reconnecting against a socket that answers 1013
"starting up" — the interface cannot come up until the runtime is built, and
the runtime was not built until every extension's `session_start` handler had
returned. A handler may start a language server, index a repository, or ask
the user a question; none of that is bounded, and one case never ends at all.

An extension that asks something from `session_start` did the worst of it.
The dialog goes out as a runtime event, and binding runs inside
`createEmbeddedRuntime` — before the server holds the runtime to subscribe
to. The request was emitted into an empty listener set and dropped, so the
handler waited on an answer nobody could be shown how to give, and startup
waited behind it. Reproduced with an extension whose `session_start` calls
`ctx.ui.confirm`: on main the server never finishes starting.

Three changes, one shape:

- Startup waits up to 5s for the binding, then serves the interface and lets
  it finish behind it. This is what pi's own interactive mode does — it
  renders and subscribes before awaiting the same call. A binding that lands
  late announces itself, so a client holding a snapshot from during the wait
  gets the skills and commands the extensions contributed; mid-turn that
  update waits for the turn rather than replacing the reply being streamed.
- Events emitted before anything subscribed are held and replayed to the
  first subscriber, so a question raised at `session_start` reaches the tab
  that connects and can be answered — which is what lets the binding finish.
- The boot workspace subscribes at the end of startup rather than the middle.
  A replayed event runs the same handlers a live one runs, and those reach
  module state declared further down the file: subscribing where the events
  start rather than where the module is whole crashed the server on
  `Cannot access 'starting' before initialization`.

A slow start also now says where the time went — loading extensions and
binding them fail for unrelated reasons, and only the second can be served
around.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UFBu5USwvVJSCxUKqjfUTt