### PR TITLE
chore(release): v0.22.1

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-outpost",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "type": "module",
   "description": "A web interface for the pi coding agent: a browser chat UI you run with npx — no clone, no build.",
   "license": "MIT",

--- a/embed/package.json
+++ b/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-outpost/embed",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "type": "module",
   "description": "Mount pi-outpost as a Shadow-DOM-isolated widget inside another web app.",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "cli": {
       "name": "pi-outpost",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "^0.85.1",
@@ -45,7 +45,7 @@
     },
     "embed": {
       "name": "@pi-outpost/embed",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "license": "MIT",
       "devDependencies": {
         "@microsoft/api-extractor": "^7.58.9",


### PR DESCRIPTION
Version bump only: `cli` and `embed` to `0.22.1`, and the two matching workspace entries in `package-lock.json`. Four lines, the same shape as `chore(release): v0.22.0`. `npm ci --dry-run` passes, so the lock and the manifests still agree.

## What v0.22.1 contains

Since `v0.22.0` (which tags `6ff619d`), `main` has taken four commits — no new API, no new behaviour, only waits removed:

- **`b9286d3` fix(startup)** — the server no longer waits on extensions before it will serve. An extension's `session_start` handler can start a language server, index a repository or ask a question, and startup stood behind all of it, with nothing in the console but `bindExtensions has not resolved after 5s`. An extension that *asked* something was the worst case: the question was emitted before the server was listening for it, so it reached nobody and the wait never ended. The interface now comes up after five seconds and the extensions bind behind it; a question raised while binding is held and delivered to the browser that connects, which is what lets the binding finish.
- **`f420555` fix(sessions)** — a new session takes the same bound rather than paying the whole extension cost a second time, and its late-arriving skills and commands land on a narrow message instead of a snapshot that would close the file the user opened while waiting.
- **`f91f775` fix(openspec)** and **`2540e71` test(rpc)** — development-side only: the OpenSpec/OpenLore delta keeps its workspace isolation, and an RPC test no longer bounds a passing run with a stopwatch.

## Releasing

Merging this puts the bump on `main`. The tag is the publish trigger and is deliberately not part of this PR:

```
git checkout main && git pull
git tag v0.22.1 && git push origin v0.22.1
```

That builds the executables (macOS arm64, Linux x64, Windows x64), re-runs the suite and the browser e2e, publishes `pi-outpost` and `@pi-outpost/embed` to the **`latest`** channel (`scripts/release-channel.mjs 0.22.1` → `latest`; npm currently holds `0.22.0` for both), and attaches the executables to the GitHub Release.

## Documentation impact

None. The diff is three version fields; no user flow, CLI flag, configuration key, environment variable, API or documented command changes with it, and no document names a version number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UFBu5USwvVJSCxUKqjfUTt

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFBu5USwvVJSCxUKqjfUTt)_