### PR TITLE
chore(release): v0.23.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-outpost",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "type": "module",
   "description": "A web interface for the pi coding agent: a browser chat UI you run with npx — no clone, no build.",
   "license": "MIT",

--- a/embed/package.json
+++ b/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-outpost/embed",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "type": "module",
   "description": "Mount pi-outpost as a Shadow-DOM-isolated widget inside another web app.",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "cli": {
       "name": "pi-outpost",
-      "version": "0.22.1",
+      "version": "0.23.0",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "^0.85.1",
@@ -45,7 +45,7 @@
     },
     "embed": {
       "name": "@pi-outpost/embed",
-      "version": "0.22.1",
+      "version": "0.23.0",
       "license": "MIT",
       "devDependencies": {
         "@microsoft/api-extractor": "^7.58.9",


### PR DESCRIPTION
Cuts `v0.23.0` from `main`. Three commits since `v0.22.1`.

## What is in it

**Struck-through text in Word and PDF extraction** (#190) — the headline. Text a document crosses out reached the model as ordinary text: in a `.docx` the parser read no run properties at all, and in a PDF a strike is not text but a thin filled rectangle drawn over the glyphs. Both readers now return it as `~~struck through~~`, and announce it before the content rather than after — a model asked to transcribe commits to its answer as it goes, so a note at the end arrives too late. Bold and italic come across from `.docx` too; underline deliberately does not.

**Agent resources dialog** (#192) — focus stays where the user put it instead of being pulled back to the close button on every server push, and a refused repository address stops being displayed once the field no longer holds it.

**Specs** (#191) — the strikethrough change archived, its two requirements folded into `docx-documents` and `pdf-documents`.

## The bump

`cli/package.json`, `embed/package.json` and the two matching `package-lock.json` entries, the same three files every release here touches. Nothing else in the tree carried `0.22.1`.

`node cli/dist/pi-outpost.mjs --version` on a fresh build reports `0.23.0`, which is the assertion the release workflow makes before it publishes.

## After merging

The tag is the trigger and the version claim:

```
git tag v0.23.0 && git push origin v0.23.0
```

## Documentation impact

None in this PR — a version bump. The documentation affected by what it ships was updated in #190 (`README.md`, `docs/comparison.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkwawMALSfxQJJAD2bDaAc
