### PR TITLE
fix(dialog): hold the question panel until it is answered

### DIFF
--- a/scripts/embed-bench.mts
+++ b/scripts/embed-bench.mts
@@ -299,6 +299,49 @@ const thinking = await startServer(
   { env: { ...onlyOneFakeProvider(), FAKE_PI_RPC_CONFIG: thinkingConfig } },
 );
 
+// A server whose scripted RPC child asks a question and then holds the turn until
+// it is answered — the shape a stray click outside the panel used to cancel. Send
+// any prompt to raise it.
+const questionRoot = await makeWorkspace({ "readme.md": "# question\n" });
+const questionConfig = path.join(questionRoot, "fake-rpc.json");
+await writeFile(
+  questionConfig,
+  JSON.stringify({
+    state: { sessionId: "question-1" },
+    commands_: {
+      prompt: {
+        before: [
+          {
+            type: "extension_ui_request",
+            id: "bench-question-1",
+            method: "select",
+            title: "Which branch should I cut from?\n1. main — the released line\n2. next — where the risky work lands",
+            options: ["1. main — the released line", "2. next — where the risky work lands"],
+          },
+        ],
+      },
+    },
+    // The child keeps the turn open until the answer comes back, as a real
+    // extension blocked on a dialog does.
+    dialogBlocksCommand: "prompt",
+  }),
+);
+const question = await startServer(
+  questionRoot,
+  {
+    server: { allowedOrigins: [host.url], port: HOST_PORT + 7 },
+    branding: { title: "bench question" },
+    agentRuntime: {
+      mode: "rpc",
+      executable: process.execPath,
+      args: [path.join(REPO, "server/test/fixtures/fake-pi-rpc.mjs")],
+      startupTimeoutMs: 20_000,
+    },
+    sandbox: undefined,
+  },
+  { env: { ...onlyOneFakeProvider(), FAKE_PI_RPC_CONFIG: questionConfig } },
+);
+
 // The three embed workspace-control policies, each on its own server, because the
 // policy is loaded configuration rather than a mount option: the only way to see
 // what a deployment would show is to run a server configured that way.
@@ -342,6 +385,7 @@ console.log(
 );
 console.log(`  seeded transcript           ${link(diagrams.base)}   (diagrams + table)`);
 console.log(`  tool progress bar           ${link(progress.base)}   (send any prompt, watch the tool card)`);
+console.log(`  agent question panel        ${link(question.base)}   (send any prompt; the panel holds until answered)`);
 console.log(`  model-aware thinking slider ${link(thinking.base)}   (🧠: low..xhigh, no off; switch to Plain Mini — declared off-only — and watch it settle)`);
 console.log("\n  embed workspace controls — the same widget under each policy\n");
 console.log(`  settings (the default)      ${link(plain.base)}   no header control; the root lives in Settings`);
@@ -355,6 +399,7 @@ const stop = async () => {
   stopping = true;
   await projectsMode.stop();
   await rootMode.stop();
+  await question.stop();
   await thinking.stop();
   await progress.stop();
   await diagrams.stop();

--- a/ui/src/components/ExtensionDialog.test.tsx
+++ b/ui/src/components/ExtensionDialog.test.tsx
@@ -232,8 +232,36 @@ describe("ExtensionDialog", () => {
     });
   });
 
+  describe("refusing to answer", () => {
+    it("cancels a select whose options none of fit", () => {
+      const request: DialogRequest = {
+        type: "extension_ui_request",
+        id: "refuse1",
+        method: "select",
+        title: "Pick one",
+        options: ["A", "B"],
+      };
+      render(<ExtensionDialog request={request} onRespond={mockOnRespond} />);
+      fireEvent.click(screen.getByLabelText("Refuse to answer"));
+      expect(mockOnRespond).toHaveBeenCalledWith({ id: "refuse1", cancelled: true });
+    });
+
+    it("cancels a confirm, which otherwise only offers Yes and No", () => {
+      const request: DialogRequest = {
+        type: "extension_ui_request",
+        id: "refuse2",
+        method: "confirm",
+        title: "Sure?",
+        message: "This deletes the branch.",
+      };
+      render(<ExtensionDialog request={request} onRespond={mockOnRespond} />);
+      fireEvent.click(screen.getByLabelText("Refuse to answer"));
+      expect(mockOnRespond).toHaveBeenCalledWith({ id: "refuse2", cancelled: true });
+    });
+  });
+
   describe("backdrop interaction", () => {
-    it("cancels dialog when clicking backdrop overlay", () => {
+    it("keeps the dialog up when clicking backdrop overlay", () => {
       const request: DialogRequest = {
         type: "extension_ui_request",
         id: "backdrop1",
@@ -245,7 +273,27 @@ describe("ExtensionDialog", () => {
       const overlay = container.firstChild;
       expect(overlay).toBeInTheDocument();
       if (overlay) fireEvent.click(overlay);
-      expect(mockOnRespond).toHaveBeenCalledWith({ id: "backdrop1", cancelled: true });
+      expect(mockOnRespond).not.toHaveBeenCalled();
+      // Still answerable: the question survives the stray click.
+      expect(screen.getByText("A")).toBeInTheDocument();
+      fireEvent.click(screen.getByText("A"));
+      expect(mockOnRespond).toHaveBeenCalledWith({ id: "backdrop1", value: "A" });
+    });
+
+    it("flashes the panel so a backdrop click is not silently swallowed", () => {
+      const request: DialogRequest = {
+        type: "extension_ui_request",
+        id: "backdrop2",
+        method: "select",
+        title: "Test",
+        options: ["A"],
+      };
+      const { container } = render(<ExtensionDialog request={request} onRespond={mockOnRespond} />);
+      const overlay = container.firstChild as HTMLElement;
+      const panel = overlay.firstChild as HTMLElement;
+      expect(panel.className).not.toMatch(/ring-2/);
+      fireEvent.click(overlay);
+      expect(panel.className).toMatch(/ring-2/);
     });
 
     it("does not cancel when clicking inside modal content", () => {

--- a/ui/src/components/ExtensionDialog.tsx
+++ b/ui/src/components/ExtensionDialog.tsx
@@ -80,6 +80,8 @@ export function parseMultiSelect(request: DialogRequest): { heading: string; opt
 export function ExtensionDialog({ request, onRespond }: ExtensionDialogProps) {
   const [text, setText] = useState(request.method === "editor" ? (request.prefill ?? "") : "");
   const [checked, setChecked] = useState<number[]>([]);
+  /** Set by a click on the backdrop; cleared shortly after, so the flash repeats on every try. */
+  const [nudged, setNudged] = useState(false);
   const hasTimeout = (request.method === "select" || request.method === "confirm" || request.method === "input") && request.timeout;
   const [remaining, setRemaining] = useState<number | null>(hasTimeout ? Math.ceil(hasTimeout / 1000) : null);
 
@@ -101,6 +103,12 @@ export function ExtensionDialog({ request, onRespond }: ExtensionDialogProps) {
   }
 
   useEffect(() => {
+    if (!nudged) return;
+    const timer = setTimeout(() => setNudged(false), 400);
+    return () => clearTimeout(timer);
+  }, [nudged]);
+
+  useEffect(() => {
     if (remaining === null) return;
     if (remaining <= 0) {
       onRespond({ id: request.id, cancelled: true });
@@ -111,12 +119,36 @@ export function ExtensionDialog({ request, onRespond }: ExtensionDialogProps) {
   }, [remaining, request.id, onRespond]);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" onClick={cancel}>
+    // The agent is blocked on this answer, so the backdrop does not dismiss: a
+    // stray click outside used to send `cancelled` and lose the question. It
+    // only flashes the panel to say "the answer is in here" — refusing is the
+    // ✕ in the corner, which nobody presses by accident.
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={() => setNudged(true)}
+    >
       <div
-        className={`w-full ${body ? "max-w-2xl" : "max-w-md"} rounded-xl border border-zinc-200 bg-white p-4 shadow-2xl dark:border-zinc-700 dark:bg-zinc-900`}
+        className={`w-full ${body ? "max-w-2xl" : "max-w-md"} rounded-xl border bg-white p-4 shadow-2xl transition-shadow dark:bg-zinc-900 ${
+          nudged
+            ? "border-zinc-400 ring-2 ring-zinc-400/60 dark:border-zinc-500 dark:ring-zinc-500/60"
+            : "border-zinc-200 dark:border-zinc-700"
+        }`}
         onClick={(e) => e.stopPropagation()}
       >
-        <h2 className="mb-3 text-sm font-semibold text-zinc-900 dark:text-zinc-100">{heading}</h2>
+        {/* The one deliberate refusal: none of the options fit, and the extension
+            hears "cancelled" rather than an answer nobody meant to give. */}
+        <div className="mb-3 flex items-start gap-3">
+          <h2 className="flex-1 text-sm font-semibold text-zinc-900 dark:text-zinc-100">{heading}</h2>
+          <button
+            type="button"
+            onClick={cancel}
+            aria-label="Refuse to answer"
+            title="Refuse to answer"
+            className="-mr-1 -mt-1 rounded-md px-1.5 py-0.5 text-sm leading-none text-zinc-400 hover:bg-zinc-100 hover:text-zinc-700 dark:text-zinc-500 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+          >
+            ✕
+          </button>
+        </div>
 
         {/* Option lists and previews the walker folded into the title: the host lays them out. */}
         {body && !multiSelect && (


### PR DESCRIPTION
A click on the backdrop answered the extension's question with `cancelled`, so a
stray click anywhere outside the panel silently threw away a question the agent
was blocked on. The panel now stays up until someone answers it: the backdrop
only flashes it for 400ms, which says "the answer is in here" without pretending
the click meant something.

Refusing still has to be possible — sometimes none of the options fit — so it
gets a deliberate home: a ✕ in the panel's corner, sending the same `cancelled`
that Cancel and Escape already sent. That matters most for `select` and
`confirm`, which have no Cancel button and would otherwise have had no refusal
path left at all.

## Verification

The bench grows a station for this (port 4328): a scripted RPC child that asks a
question and holds its turn until the answer arrives — the shape the bug lived
in, and the only place it could be seen. Driven there with Playwright:

- Stray clicks outside (corners, edges, a double click) leave the panel up; the
  flash class appears and clears.
- ✕ closes it and the child logs `answered:bench-question-1:cancelled` — the
  refusal reaches the extension and the turn unblocks.
- Answering an option logs `answered:bench-question-1:1. main — the released line`.
- Monkey pass: double-click on ✕ produces no second response and no page error;
  a drag started inside the panel and released on the backdrop leaves it up (the
  classic text-selection-dismisses-the-modal bug), and so does the reverse drag.

Unit tests cover the backdrop no longer answering, the flash, and ✕ cancelling
for both `select` and `confirm`. Full ui suite 1719 passed, `npm run typecheck`
and `npm run lint` clean.

## Documentation impact

None. The change is the behaviour of an extension's Custom UI dialog; no
documented flow, command, flag or configuration key describes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ks9aLfcZmYyXhpnuVNDFw9
