### PR TITLE
feat(resources): manage Git skill collections skill by skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,8 @@ a fresh agent session immediately.
 | Write and bash permissions | The same switches as `sandbox.allowWrite` / `sandbox.allowBash` |
 | Agent resources | **Manage agent resources** opens one repository-first view for skills and extensions |
 | Local folders | **Add local folder…** stores skill roots under `userSkillPaths` and extension roots under `userExtensionPaths` |
-| Git repositories | **Add Git repository…** asks for the repository address and an editable local clone folder, previews recognized roots, then activates only the selected ones |
+| Git repositories | **Add Git repository…** asks for the repository address and an editable local clone folder, then lists its skills grouped by folder, **all off**: turn skills on one by one or with **All on** / **All off**, then **Save**; later changes take effect with **Apply**. Extension roots are selected as before |
+| Removing a repository | **Remove repository** unregisters it as a whole and, for a clone pi-outpost manages, deletes it from disk after a confirmation. Files you pointed it at elsewhere are kept |
 
 Two lists, deliberately: what the **configuration file** declares (`skillPaths`,
 `extensionPaths`) belongs to the deployment, and the interface can neither rewrite nor
@@ -411,6 +412,7 @@ in [`pi-outpost.config.example.json`](pi-outpost.config.example.json).
 | `extensionLock` | Forbid adding or removing extension paths from Settings |
 | `noSkills` / `skillPaths` | Disable skill discovery, or name skill files and directories. `skillPaths` loads even under `noSkills`. Disabling matters for real isolation: skills otherwise also load from `~/.agents/skills` and from `.agents/skills` walked up from `cwd`, neither of which `agentDir` scopes |
 | `userSkillPaths` | Skill directories added from Settings, loaded after `skillPaths` |
+| `userSkillCollections` | Git repositories added as skill collections: `[{ "path", "managed", "enabledSkills": ["folder/skill", …] }]`. Only the listed skill directories load, after `userSkillPaths`. Written by the server |
 | `noPromptTemplates` / `promptPaths` | Same for prompt templates (`agentDir` and the project's `cwd/.pi/prompts`) |
 | `allowedModels` | Restrict the model switcher to these `{ "provider", "id" }` pairs. Without it, every built-in model whose provider has auth is listed — often more variants than a deployment actually serves |
 | `thinkingLevels` | Declare what thinking levels a model accepts, for one the runtime cannot describe. See [Thinking levels](#thinking-levels) |

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -327,12 +327,30 @@ Paths are resolved against the configuration file's directory, and are automatic
 made readable to the agent even when they sit outside the sandbox root.
 
 Open **Settings → Manage agent resources** to add either a local folder or a Git
-repository. A local folder writes to `userSkillPaths` or `userExtensionPaths`. For Git,
-enter the clone address and confirm or edit the suggested local folder, then select the
-recognized skill and extension roots from the metadata-only preview. Managed suggestions
-live under `<user config dir>/resource-repositories/`; removing a resource path later never
-deletes that clone. Recognized layouts are a root `SKILL.md`, `skills/`,
-`.agents/skills/`, `extensions/`, `.pi/extensions/`, and `.agents/extensions/`.
+repository. A local folder writes to `userSkillPaths` or `userExtensionPaths`, and loads
+everything in it. For Git, enter the clone address and confirm or edit the suggested local
+folder. Managed suggestions live under `<user config dir>/resource-repositories/`.
+
+A Git repository is added as a **skill collection**: the preview lists every `SKILL.md` in
+it, grouped by the folders the repository keeps them in, and **every skill starts off**.
+Turn on the ones you want — one switch per skill, **All on** / **All off** for the whole
+repository or for one folder — then **Save** to add the repository. Later changes in the
+repository's pane are staged and take effect with **Apply**; either way the session is
+replaced once with exactly those skills. Nothing from the repository is loaded until a skill is turned on, and a skill
+that arrives later through an update stays off. The skills that are on are listed at the top
+of the repository, each with **Turn off**; **Search skills** and **Only on** narrow a large
+collection, and the repository list shows how many are on. A repository is named after its
+`origin`, not after the local folder it was cloned into. Copies of the same skill in different
+folders are listed as the repository ships them. The selection is stored under
+`userSkillCollections`. Extension roots (`extensions/`, `.pi/extensions/`,
+`.agents/extensions/`) are still selected as roots. A repository added before collections
+existed keeps loading everything under its skill roots.
+
+**Remove repository** unregisters a repository as a whole — its skills, extensions and
+selection — after a confirmation. For a clone pi-outpost made, or one inside the managed
+folder, it also **deletes the clone from disk**, local changes included; that cannot be
+undone. A repository you pointed at elsewhere is unregistered and its files are kept. A
+repository that supplies a path from the configuration file cannot be removed here.
 
 Both flows rebuild the session at once — no server restart — and never alter paths declared
 by the deployment. Extension folders warn that they execute code; an extension-bearing or

--- a/e2e/settings-extensions.spec.ts
+++ b/e2e/settings-extensions.spec.ts
@@ -221,7 +221,8 @@ test("repository states stay correlated through rapid actions and changing inven
   await dialog.getByRole("button", { name: /Locally edited/ }).click();
   await expect(dialog.getByText("Uncommitted files are present.")).toBeVisible();
   await expect(dialog.getByText(/external terminal/)).toBeVisible();
-  await expect(dialog.getByRole("button", { name: "Update repository" })).toBeDisabled();
+  // Nothing to apply, so nothing is offered: no update action at all, not a dead one.
+  await expect(dialog.getByRole("button", { name: "Update repository" })).toHaveCount(0);
   await expect.poll(() => requests.update).toBe(1);
   await expect(dialog.getByText("Repository updated and runtimes reloaded.")).toHaveCount(0);
   await dialog.getByRole("button", { name: /Shared skills/ }).click();
@@ -236,7 +237,7 @@ test("repository states stay correlated through rapid actions and changing inven
 
   await dialog.getByRole("button", { name: /In use/ }).click();
   await expect(dialog.getByText("Workspace busy", { exact: true }).last()).toBeVisible();
-  await expect(dialog.getByRole("button", { name: "Update repository" })).toBeDisabled();
+  await expect(dialog.getByRole("button", { name: "Update repository" })).toHaveCount(0);
 
   await dialog.getByRole("button", { name: /Stale assessment/ }).click();
   await dialog.getByRole("button", { name: "Update repository" }).click();

--- a/openspec/changes/manage-skill-collections/.openspec.yaml
+++ b/openspec/changes/manage-skill-collections/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-11

--- a/openspec/changes/manage-skill-collections/design.md
+++ b/openspec/changes/manage-skill-collections/design.md
@@ -1,0 +1,195 @@
+## Context
+
+See proposal.md — Why. The relevant current state:
+
+- Enrollment (`ResourceRepositoryService.cloneAndPreview` → `confirmPreview` in
+  `server/src/resourceRepositories.ts`, `handleEnrollAgentResourceRepository` in
+  `server/src/index.ts`) persists **roots**: `discoverResourceRoots` offers the repository root
+  (only when `SKILL.md` sits directly there), `skills/` and `.agents/skills`, and a confirmed root is
+  appended to `userSkillPaths`. For `claude-skills-collection` that is `skills/` alone — 348 skills
+  in one switch — while its 34 category folders are never offered.
+- Every explicit skill path reaches the runtime through one function, `allSkillPaths(config)`
+  (`server/src/config.ts`), whose callers are the embedded loader's `additionalSkillPaths`
+  (`index.ts` ~981), RPC `--skill` arguments (`rpcResourceArgs.ts`), and the sandbox's read-only
+  resource roots (`index.ts` 1170 and 2325).
+- The inventory is built from what the **runtime loaded** plus declared roots
+  (`normalizeResources`, `buildInventory`), grouped by enclosing Git worktree. A skill that is not
+  loaded is invisible to it.
+- Settings changes go through `handleUpdateConfig`, which persists (`persistEditableSettings`,
+  atomic, validated through `loadConfig`), replaces the session, and rolls everything back when the
+  replacement is refused. On a runtime without `rebuildTools` (RPC) it refuses the change outright.
+- Repository updates reserve every affected workspace (`affectedResourceWorkspaces` +
+  `reserveAffected` in `handleUpdateAgentResourceRepository`) so no turn or session change can
+  interleave with a Git mutation.
+- pi 0.85.1: `loadSkillsFromDir` treats a directory containing `SKILL.md` as one skill root and does
+  not recurse further, so a skill's own directory loads exactly that skill. `parseFrontmatter` is
+  exported. Pi keeps the first skill it meets under a name and reports the rest as collisions.
+  Pi settings accept `!pattern` / `-path` exclusions, and `DefaultResourceLoader` has a
+  `skillsOverride` hook.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A collection repository costs nothing in the prompt until the user turns skills on.
+- One source of truth for which skill paths a session receives, shared by both runtimes and the
+  sandbox, so a skill that is on is also readable and a skill that is off is neither loaded nor
+  granted.
+- Removal deletes a managed clone and never anything else.
+
+**Non-Goals:**
+- Per-skill control for Add local folder, for configuration-file skill paths, or for repositories
+  enrolled before this change (they keep root semantics; no migration).
+- Per-extension enablement. Extensions keep root-based enrollment.
+- Selective enablement on the RPC runtime — it already refuses runtime-settings changes.
+- Reading repository manifests (`skills.json`, `marketplace.json`, bundles) for grouping.
+- Deduplicating skills across folders.
+
+## Decisions
+
+### 1. An allowlist of enabled skill directories, persisted per repository
+
+New configuration key, written only by the interface:
+
+```json
+"userSkillCollections": [
+  { "path": "/abs/worktree", "managed": true, "enabledSkills": ["dev-skills/react-component-builder"] }
+]
+```
+
+`enabledSkills` holds POSIX paths relative to the worktree, one per skill directory. `managed`
+records that pi-outpost's clone operation created the folder (a reused existing clone is not
+`managed` unless it lies inside managed storage — see 6).
+
+*Alternatives.* **pi exclusions** (`-path`, `!pattern` in a skills array): default-off would need an
+exclusion per skill, and a skill added by an update would load by default — the opposite of the
+requirement. **`skillsOverride`**: embedded-only, filters by name after everything was loaded and
+parsed, and a name is not a stable identity across two copies of the same skill. **Enabled
+directories appended to `userSkillPaths`**: loses which repository a path belongs to, so removal,
+grouping and "all off" would have to be reconstructed from path prefixes, and it would mix root
+semantics with skill semantics in one key. A separate key keeps old registrations untouched, which
+is what "only new repositories" requires.
+
+### 2. `allSkillPaths` is the single feed
+
+`allSkillPaths(config)` returns `[...skillPaths, ...userSkillPaths, ...enabledCollectionSkillDirs]`,
+where the last part resolves each enabled entry against its worktree and keeps it only when the
+directory still exists inside the worktree and contains `SKILL.md`. Because every consumer already
+calls this function, the embedded loader, RPC arguments and sandbox read-only roots all follow
+without further wiring. Collections come last, so a configuration-file or user skill keeps winning
+a name collision, as it does today.
+
+Passing each skill's **directory** (not its `SKILL.md`) matches pi's own discovery rule — a
+directory with `SKILL.md` is one skill, no recursion — and makes the read-only sandbox exception
+cover the skill's supporting files.
+
+### 3. Catalogue: a bounded walk parsed by pi's own frontmatter parser
+
+`discoverSkillCatalogue(worktree)` walks the canonical worktree with `readdir` + `lstat`: no
+symlinks, skip `.git` and `node_modules`, stop descending into a directory once it holds `SKILL.md`
+(pi's rule), depth ≤ 8, at most 2,000 skills, at most 16 KiB read per `SKILL.md`. Frontmatter is
+parsed with pi's exported `parseFrontmatter`, so the name shown is the name the runtime will use.
+Group = POSIX path of the skill directory's parent relative to the worktree; `""` is displayed as
+the repository name. Reaching a bound sets `catalogueBound: { kind, limit }` on the result.
+
+The walk is cheap enough (≈700 directories for the example) to rerun on every inventory build and
+on every selection change; no cache, so an external change to the worktree is seen on the next
+rebuild.
+
+*Alternative.* Reusing `loadSkillsFromDir` on the worktree root: unbounded, follows pi's own rules
+for root `.md` files, and returns skills without the folder structure we need to group by.
+
+### 4. Inventory carries collection state
+
+`AgentResourceRepository` gains:
+
+```ts
+collection?: {
+  groups: Array<{ path: string; label: string }>;
+  skills: Array<{
+    relativePath: string; name: string; description?: string; group: string;
+    state: "off" | "on-loaded" | "on-not-loaded" | "on-missing"; reason?: string;
+  }>;
+  bound?: { kind: "depth" | "count"; limit: number };
+};
+removal: { allowed: boolean; deletesFiles: boolean; path: string; reason?: string };
+```
+
+A declared collection creates its repository group even when nothing is loaded (it is added to
+`normalizeResources`' declared entries the way an unrepresented root is today). State is computed by
+joining the fresh catalogue, the persisted `enabledSkills`, and the runtime's reported resources by
+canonical skill directory. An enabled entry missing from the catalogue is `on-missing`; an enabled
+entry the runtime did not report is `on-not-loaded`, with the collision or rejection message when
+the runtime's diagnostics carry one.
+
+### 5. Protocol
+
+- `AgentResourceRepositoryPreview` gains `skills` (catalogue entries, all off) and `bound`; the
+  preview fingerprint covers the catalogue as well as the roots.
+- `enroll_agent_resource_repository` gains `enabledSkills: string[]`. `skillRoots` remains for
+  re-enrolling a worktree already registered through roots.
+- New `set_agent_resource_skills { repositoryId, enabledSkills, requestId }` — the complete set that
+  should be on for one repository. Sending a full set makes the request idempotent and serves
+  per-skill, per-group and repository-wide changes with one message.
+- New `remove_agent_resource_repository { repositoryId, requestId }`, answered by
+  `agent_resource_removed { requestId, result, inventory }` with
+  `result.status: "removed" | "removed-files-kept" | "removed-delete-failed"` and the path.
+- Errors keep using `agent_resource_error`.
+
+### 6. Selection and removal ride on `handleUpdateConfig`
+
+`EditableSettings` and `handleUpdateConfig` gain `userSkillCollections`. Selection changes and
+removals call it, so persistence, validation-by-`loadConfig`, session replacement, rollback on a
+refused replacement, and the RPC refusal are all inherited instead of re-implemented. The server
+validates a requested set by rebuilding the catalogue and refusing any entry not in it.
+
+The affected-workspace reservation used by updates is extracted from
+`handleUpdateAgentResourceRepository` into a helper and reused, so a selection change or removal is
+refused while a consumer is streaming or replacing its session, and nothing can start in between.
+
+Removal order: reserve → unregister (collection entry, user skill roots and user extension roots
+inside the worktree) through `handleUpdateConfig` → on handoff, delete → rebuild inventory. The clone
+is deleted only when all of these hold at that moment: its canonical path equals the registered
+worktree and is Git's `--show-toplevel` for it; it is `managed: true` **or** lies inside
+`managedRoot`; it is neither a filesystem root nor `managedRoot` itself. Deletion uses `fs.rm`
+recursively, which unlinks symbolic links rather than following them. Deletion runs under the
+repository mutex (`repositoryLocks`) so it cannot interleave with a refresh or update.
+
+*Alternative.* Delete first, then unregister: a live session would briefly point at vanished files,
+and a refused replacement could not be rolled back — the files would be gone.
+
+### 7. The dialog stages changes and applies them together
+
+Each apply replaces the session. Applying on every switch click would replace it once per click,
+and a click landing during the previous replacement would be refused as busy. The dialog therefore
+keeps a pending set per repository id, shows the pending count with **Apply** and **Discard**, and
+sends one `set_agent_resource_skills` with the complete resulting set. **All on / All off** (repository)
+and the per-group pair only edit the pending set. A new inventory for the same repository rebases the
+pending set on the supplied state instead of dropping it; a vanished repository id drops it. The
+preview uses the same component with everything off, and its confirmation sends the pending set as
+`enabledSkills`.
+
+## Risks / Trade-offs
+
+- [Deleting the wrong directory] → deletion needs a registered worktree, canonical equality with
+  Git's top level, and managed ownership; refuses roots and `managedRoot`; symlinks are unlinked,
+  not followed. Tests cover a symlink out of the clone, a clone outside managed storage, and a
+  forged repository id.
+- [Windows: Git's read-only object files make `fs.rm` fail with EPERM] → clear the read-only
+  attribute and retry on EPERM/EACCES; a remaining failure is reported as `removed-delete-failed`
+  with the path. Checked on the Windows CI runner.
+- [All on for a 700-skill repository makes a very large prompt] → it is the user's explicit choice;
+  the repository shows how many skills are on so the size is visible before applying.
+- [Name collisions between copies of the same skill] → pi keeps the first; the other is
+  `on-not-loaded` with the collision reason, so the user sees why rather than guessing.
+- [Catalogue walk on every rebuild] → bounded by depth and count; worst case is ~2,000 small reads
+  capped at 16 KiB each.
+- [A legacy root-enrolled repository and a collection on the same worktree] → re-enrolling a
+  root-registered worktree stays in root mode, so one worktree is never both.
+
+## Migration Plan
+
+No migration: existing `userSkillPaths` entries keep loading everything. The new key is additive and
+is only written once a collection is enrolled. A downgrade to a version that ignores the key leaves
+collection skills unloaded, their clones on disk, and the rest of the configuration working
+(confirmed by loading a configuration carrying the key through the previous `loadConfig`).
+Rollback is removing the key.

--- a/openspec/changes/manage-skill-collections/proposal.md
+++ b/openspec/changes/manage-skill-collections/proposal.md
@@ -1,0 +1,75 @@
+## Why
+
+A Git repository that carries a large collection of skills cannot be managed through the Agent
+resources dialog. Enrolling one activates a whole skill root at once — for
+`khalilbenaz/claude-skills-collection` that is 348 skills pushed into every system prompt — and the
+only thing the dialog can take back is that root. The collection's own organisation (34 category
+folders) is never shown, because discovery offers only the repository root, `skills/` and
+`.agents/skills`. A collection is useful when a reader can keep the ten skills they want out of
+hundreds; today it is all or nothing, and getting rid of it leaves the clone on disk.
+
+## What Changes
+
+- **Skills of a newly enrolled Git repository are off by default.** Enrolling registers the
+  repository and its catalogue of skills; nothing from it loads until the user turns a skill on.
+  Each skill can be turned on or off individually.
+- **Bulk switches.** The selected repository offers **All on** and **All off**; each folder group
+  inside it offers the same pair for its own skills.
+- **Skills are grouped the way the repository lays them out.** The catalogue lists every `SKILL.md`
+  in the repository (bounded walk), grouped by the folder that contains the skill, named by its
+  path from the repository root. No repository-specific manifest (`skills.json`,
+  `marketplace.json`) is consulted. Duplicates are shown as the repository ships them; nothing is
+  deduplicated.
+- **Only what is turned on is loaded.** The runtime receives each enabled skill's directory as an
+  individual skill path, in place of the whole root. A skill that appears later through a
+  repository update stays off until the user turns it on.
+- **Remove repository.** One action unregisters every path and every enabled skill of a repository
+  and deletes its clone from disk, after an explicit confirmation. **BREAKING** against the current
+  rule that removing a repository's last path "SHALL NOT delete the managed clone". Files are
+  deleted only for a clone pi-outpost manages; a repository the user pointed at elsewhere is
+  unregistered and its files are kept, and the dialog says so.
+- **Existing registrations are unchanged.** Repositories already enrolled through skill roots keep
+  loading everything under those roots; there is no migration. Add local folder is unchanged.
+  Extensions keep today's root-based enrollment.
+
+## Capabilities
+
+### New Capabilities
+
+None — this extends the existing resource-management capability.
+
+### Modified Capabilities
+
+- `agent-resource-management`: enrollment of a Git repository registers a skill catalogue with
+  every skill off instead of activating skill roots; adds per-skill enablement with repository-level
+  and folder-level bulk switches, folder-tree grouping, and whole-repository removal that deletes a
+  managed clone.
+- `components`: `AgentResourceManager` renders a collection repository's skills grouped by folder
+  with per-skill switches, **All on** / **All off** at repository and folder level, staged changes
+  applied together, and a **Remove repository** action behind an irreversible-action confirmation.
+- `persistent-runtime-settings`: the enabled-skill selection of each collection is persisted under
+  its own key, survives a restart, and — like any changed skill path — replaces the session when it
+  changes.
+
+## Impact
+
+- `server/src/resourceRepositories.ts` — skill catalogue discovery (bounded walk of every
+  `SKILL.md`, frontmatter name and description), collection-aware preview and confirmation,
+  repository removal with confined deletion.
+- `server/src/config.ts` — new persisted key for collections and their enabled skills;
+  `allSkillPaths` gains the enabled skill directories, which carries them to the embedded loader,
+  to RPC `--skill` arguments and to the sandbox's read-only resource exceptions through the
+  existing call sites.
+- `server/src/index.ts` — new client messages (set enabled skills, remove repository), reuse of the
+  affected-workspace reservation used by updates, session replacement and rollback through
+  `handleUpdateConfig`.
+- `shared/src/protocol.ts` — preview carries a skill catalogue; inventory repositories carry
+  collection state (skills, groups, enabled, loaded, removable, managed); two new client messages.
+- `ui/src/components/AgentResourceManager.tsx`, `ui/src/useAgent.ts`, `ui/src/App.tsx` — grouped
+  catalogue, switches, bulk actions, staged apply, remove confirmation.
+- Tests: `server/test/resourceRepositories.test.ts`, `server/test/agentResourcesWire.test.mjs`,
+  `server/test/settings-persistence.test.mjs`, `ui/src/components/AgentResourceManager.test.tsx`;
+  a running-app check on the bench.
+- Runtime: selective enablement works on the embedded runtime; the RPC runtime already refuses
+  runtime-settings changes and keeps doing so.
+- Docs: `docs/how-to.md` and the README's resources section describe enrollment and removal.

--- a/openspec/changes/manage-skill-collections/scenario-coverage.md
+++ b/openspec/changes/manage-skill-collections/scenario-coverage.md
@@ -1,0 +1,99 @@
+# Scenario coverage — manage-skill-collections
+
+Every `#### Scenario:` this change's deltas declare, matched to the assertion that would fail if the
+contract broke. Sixty-eight scenarios: thirty-nine in `agent-resource-management` (twenty-seven
+added, twelve carried by the modified `Repository enrollment`), twenty-four in `components` (thirteen
+added, eleven carried by the modified `AgentResourceManager`), five added in
+`persistent-runtime-settings`.
+
+Enumerated with `rg '^#### Scenario:' openspec/changes/manage-skill-collections/specs/`.
+
+The server scenarios are asserted at the boundary the spec names: a booted server over its real
+socket, reading back what the replacement session loaded (its reported resources), what reached the
+configuration file, and what is on disk. The one seam is deletion failure, which no portable fixture
+can force — `useResourceRemover` makes `rm` fail on demand and the test asserts what the service then
+reports. Dialog scenarios are asserted on the rendered component; the running-app walkthrough is
+recorded under tasks 8.3 and 8.4.
+
+## agent-resource-management
+
+| Scenario | Coverage | Assertion evidence |
+|---|---|---|
+| Category folders become groups | covered | `server/test/skillCatalogue.test.ts` — “category folders become groups” builds a fixture shaped like claude-skills-collection (category folders plus prefixed `skills/` copies) and asserts every skill with its folder group, path and frontmatter name. |
+| Duplicates are listed as shipped | covered | `server/test/skillCatalogue.test.ts` — “duplicates are listed as shipped” asserts both copies of one skill are listed, each in its own group, even under one name. |
+| No manifest decides the grouping | covered | `server/test/skillCatalogue.test.ts` — “a manifest has no effect on the grouping” ships a skills.json manifest whose category differs and asserts the groups are exactly the folders. |
+| Cataloguing runs no repository code | covered | `server/test/skillCatalogue.test.ts` — “cataloguing runs no repository code” plants an extension and a skill helper that write a marker when imported and asserts the marker never appears. |
+| A symlinked skill is not followed | covered | `server/test/skillCatalogue.test.ts` — “a symlinked skill contributes nothing, inside or outside the worktree” asserts only the real directory is listed. |
+| A catalogue that reaches its bound says so | covered | `server/test/skillCatalogue.test.ts` — the count-bound and depth-bound tests assert the result names the bound and its limit. |
+| A newly enrolled collection loads nothing | covered | `server/test/collectionEnrollmentWire.test.mjs` — “a collection enrolled with nothing on loads none of its skills” asserts the catalogue is previewed, no skill from the clone is loaded, and the collection is persisted with an empty selection. |
+| Turning one skill on loads that skill alone | covered | `server/test/collectionSelectionWire.test.mjs` — “one skill, all on, one group, all off…” first step asserts the replacement session loads `rust` and nothing else from the repository; `server/test/skillCollectionsWire.test.mjs` asserts the off skill is not loaded at boot. |
+| All on and all off for the repository | covered | `server/test/collectionSelectionWire.test.mjs` — the same test asserts every catalogued skill is loaded after the full set, and none after the empty set, with the persisted selection read back. |
+| All on for one folder group | covered | `server/test/collectionSelectionWire.test.mjs` — the same test applies the `dev-skills` set and asserts exactly `react` and `rust` are loaded. |
+| A selection outside the catalogue is refused | covered | `server/test/collectionSelectionWire.test.mjs` — “a selection outside the catalogue, a path leaving the repository, or an unknown id is refused” asserts each refusal, an unchanged persisted selection, and no session replacement. |
+| A refused replacement keeps the previous selection | covered | `server/test/collectionSelectionWire.test.mjs` — “a vetoed replacement keeps the previous selection” uses a real vetoing extension and asserts the persisted selection and the retained session's loaded skills are unchanged. |
+| A busy workspace blocks a selection change | covered | `server/test/collectionSelectionWire.test.mjs` — “a busy workspace loading the collection blocks a selection change, naming it” streams a turn in another project and asserts the refusal names it and nothing is persisted. |
+| A skill added by an update stays off | covered | `server/test/collectionSelectionWire.test.mjs` — “an update adds a skill that stays off…” fast-forwards a new skill in and asserts it is `off` while the enabled one stays `on-loaded`. |
+| A skill that is on but gone is reported missing | covered | `server/test/collectionSelectionWire.test.mjs` — the same test deletes the enabled skill upstream and asserts it is `on-missing` and not loaded; `server/test/collectionInventory.test.ts` — “each state…” asserts the missing state and its reason. |
+| A skill that is on but not loaded says so | covered | `server/test/collectionInventory.test.ts` — “two enabled copies under one name: the one not loaded names the winner” asserts `on-not-loaded` with a reason naming the loaded copy's path. |
+| A root-enrolled repository keeps loading everything | covered | `server/test/skillCollections.test.ts` — “collections come after the configured and user paths” asserts a user skill root is still handed to the runtime whole; `server/test/collectionEnrollmentWire.test.mjs` — “a worktree already registered through a skill root is previewed in root mode” asserts it keeps root enrollment. |
+| Removing a managed collection deletes its clone | covered | `server/test/collectionRemovalWire.test.mjs` — “removing a collection pi-outpost cloned unregisters it and deletes the clone” asserts `removed`, the folder gone from disk, the persisted entry gone, and nothing from it loaded. |
+| A repository outside managed storage keeps its files | covered | `server/test/collectionRemovalWire.test.mjs` — “removing a repository pi-outpost does not manage keeps its files and says so” asserts `removed-files-kept` with the path and reason, the files present, and the entry unregistered. |
+| A configuration-file path blocks removal | covered | `server/test/collectionRemovalWire.test.mjs` — “a repository supplying a configuration-file path is refused…” asserts the refusal, the clone present and the entry kept; `server/test/collectionInventory.test.ts` asserts `removal.allowed` is false with the reason. |
+| Removal is refused while a consumer is busy | covered | `server/test/collectionRemovalWire.test.mjs` — “removal is refused while a workspace loading the repository is busy” asserts the refusal names the busy project and nothing is unregistered or deleted. |
+| A refused replacement keeps the repository | covered | `server/test/collectionRemovalWire.test.mjs` — “a vetoed replacement keeps the repository registered and its files on disk” asserts the persisted entry and the clone are both intact. |
+| Deletion never leaves the worktree | covered | `server/test/cloneDeletion.test.ts` — “a symbolic link out of the clone is unlinked, its target untouched” and “a folder reached through a link is kept” assert nothing outside the canonical clone is removed. |
+| A failed deletion is reported as partial | covered | `server/test/cloneDeletion.test.ts` — “a deletion that fails is reported with its reason, not as done” forces `rm` to fail and asserts `failed: true`, the reason, and the files still present; `ui/src/components/AgentResourceManager.test.tsx` — “shows what removal did after the repository has left the list” asserts the partial result is shown as an alert naming the path. |
+| An unknown repository is refused | covered | `server/test/collectionRemovalWire.test.mjs` — the configured-path test also sends an unissued id and asserts the refusal with the clone untouched. |
+| A repository is named after its origin | covered | `server/test/collectionInventory.test.ts` — “a repository is named after its origin, not the folder it was cloned into” clones into a hash-suffixed folder, sets a credential-bearing origin, and asserts the name and that no credential reaches the inventory; `server/test/collectionEnrollment.test.ts` — “a preview names the repository after its origin, not its clone folder”. |
+| A repository without an origin keeps its folder name | covered | `server/test/collectionInventory.test.ts` — “a repository without an origin keeps its folder name”. |
+| Add a local skill folder | covered | `ui/src/components/AgentResourceManager.test.tsx` — “adds a local skill folder once through the picker” asserts the chosen directory is added exactly once. |
+| Add a local extension folder | covered | `ui/src/components/AgentResourceManager.test.tsx` — “requires an executable warning and respects extension lock for local folders” asserts the warning gates the apply and the lock disables it. |
+| Activated external resources remain readable | covered | `server/test/sandboxSettingsWire.test.mjs` — the ReadConfiguredResourceOutsideRoot cases read an outside skill and extension with the agent's real `read` tool; `server/test/skillCollectionsWire.test.mjs` does the same for an enabled collection skill and asserts a skill that is off is denied. |
+| Refused replacement rolls enrollment back | covered | `server/test/sandboxSettingsWire.test.mjs` — “an extension veto rolls back the sandbox…”; `server/test/collectionSelectionWire.test.mjs` and `server/test/collectionRemovalWire.test.mjs` — the vetoed-replacement tests assert the persisted collections and the retained session are unchanged. |
+| Add a repository containing skills and extensions | covered | `server/test/agentResourcesWire.test.mjs` — “repository enrollment is composed for the requesting socket workspace only” enrolls a collection skill with an extension root and asserts one mixed group with both; `server/test/collectionEnrollmentWire.test.mjs` — “a collection enrolled with one skill on loads exactly that skill”. |
+| Enrollment does not execute extensions during preview | covered | `server/test/resourceRepositories.test.ts` — “previews recognized roots without executing extension modules” asserts the side-effect marker never appears. |
+| Extension lock permits skill-only enrollment | covered | `server/test/agentResourcesWire.test.mjs` — “extension lock filters a mixed preview while allowing skill-only enrollment” asserts the extension root is locked and the enabled skill alone is enrolled. |
+| Clone address is required and confined | covered | `server/test/resourceRepositories.test.ts` — “reuses the same-origin clone and refuses occupied or unsafe destinations before cloning” asserts every unsafe destination is refused and existing content kept. |
+| Clone has no recognizable resources | covered | `server/test/resourceRepositories.test.ts` — “reports a resource-empty clone without registering paths…” asserts the refusal for a clone with neither skills nor extension roots. |
+| Re-add the same repository address | covered | `server/test/resourceRepositories.test.ts` — the reuse test asserts the same checkout is reused; `server/test/agentResourcesWire.test.mjs` re-clones the same address and asserts one repository. |
+| Re-enroll an existing repository | covered | `server/test/collectionEnrollmentWire.test.mjs` — “re-enrolling a collection adds skills and keeps those already on” asserts one persisted entry holding both skills and one repository group. |
+| Enroll with nothing turned on | covered | `server/test/collectionEnrollment.test.ts` — “an empty selection is a valid enrollment”; `server/test/collectionEnrollmentWire.test.mjs` asserts the enrolled repository loads nothing. |
+
+## components
+
+| Scenario | Coverage | Assertion evidence |
+|---|---|---|
+| Open repository-first resource manager | covered | `ui/src/components/AgentResourceManager.test.tsx` — “opens a repository-first split inventory…” asserts grouped repositories, counts and details. |
+| Settings delegates resource changes to the dialog | covered | `ui/src/components/SettingsMenu.test.tsx` — the resource-management entry-point tests assert one “Manage agent resources” button opens the dialog. |
+| Add repository previews roots before applying | covered | `ui/src/components/AgentResourceManager.test.tsx` — “previews a collection with every skill off and adds it with nothing on” asserts every switch off and no enrollment until confirmed; “suggests an editable clone folder and previews before enrollment” covers the roots preview. |
+| Git repository form suggests but does not fix the destination | covered | `ui/src/components/AgentResourceManager.test.tsx` — the clone test adopts and edits the suggestion; the parent-picker test keeps the custom leaf. |
+| Add local folder remains available | covered | `ui/src/components/AgentResourceManager.test.tsx` — the local skill and extension tests drive both picker flows. |
+| Search and attention filters preserve repository context | covered | `ui/src/components/AgentResourceManager.test.tsx` — “filters by kind and attention while preserving a matching repository context” asserts kind-filtered counts and resources. |
+| Dirty repository directs resolution outside the app | covered | `ui/src/components/AgentResourceManager.test.tsx` — “directs dirty repositories to external resolution without mutation controls”. |
+| Update is offered only when there is one | covered | `ui/src/components/AgentResourceManager.test.tsx` — “offers Update repository only once an update is available” asserts no Update action while unchecked or current, an enabled one when updateable, and a disabled “Updating…” while it runs; the dirty-repository test asserts none is shown there either. |
+| Extension confirmation precedes update callback | covered | `ui/src/components/AgentResourceManager.test.tsx` — “confirms revision-specific executable changes before invoking update”. |
+| Selection changes during an operation | covered | `ui/src/components/AgentResourceManager.test.tsx` — “keeps an in-flight result keyed to its repository…”. |
+| A selected repository the server no longer knows | covered | `ui/src/components/AgentResourceManager.test.tsx` — the same test removes the selected repository and asserts the fallback. |
+| Provenance-unavailable resources stay visible | covered | `ui/src/components/AgentResourceManager.test.tsx` — the repository-first test asserts the unavailable group stays listed. |
+| Collection skills are grouped by folder with switches | covered | `ui/src/components/AgentResourceManager.test.tsx` — “lists a collection's skills by folder, with a switch each and an on-count per group” asserts group on-counts and switch states. |
+| Skill states are distinguished | covered | `ui/src/components/AgentResourceManager.test.tsx` — “renders each state distinctly…” asserts Loaded, Not loaded with its reason, Missing with its reason, and nothing for off. |
+| All on and all off stage the whole repository | covered | `ui/src/components/AgentResourceManager.test.tsx` — “stages the whole repository with All on and All off, without calling back” asserts every switch, the pending count, and no callback. |
+| Folder-level all on stages one group only | covered | `ui/src/components/AgentResourceManager.test.tsx` — “stages one folder group with its own All on” asserts the other groups are unchanged. |
+| Apply reports the whole pending selection once | covered | `ui/src/components/AgentResourceManager.test.tsx` — “applies the complete resulting selection once…” asserts one callback with the repository id and the complete set. |
+| Discard restores the supplied state | covered | `ui/src/components/AgentResourceManager.test.tsx` — “discards pending changes back to the supplied state” asserts the switches and no callback. |
+| A pending selection stays with its repository | covered | `ui/src/components/AgentResourceManager.test.tsx` — “keeps a pending selection with its own repository across a switch and back”, plus the tests that keep it across an unrelated inventory and drop it for a vanished repository. |
+| The skills that are on can be found | covered | `ui/src/components/AgentResourceManager.test.tsx` — “opens the folder holding a skill that is on in a large collection, and filters to the skills that are on” asserts the skill listed under “Skills that are on” with its folder, the repository list reading “1 on · 60”, that folder open and the others folded, the filter listing that skill alone, and Turn off staging it off. |
+| Search narrows a collection's skills | covered | `ui/src/components/AgentResourceManager.test.tsx` — “narrows the skills by search, and a folder's All on then acts on its matches only” asserts the matches, a folder bulk action confined to them, and the empty result. |
+| Remove repository requires confirmation | covered | `ui/src/components/AgentResourceManager.test.tsx` — “confirms before removing, names the path, and does nothing on cancel”. |
+| Removing an unmanaged repository says the files stay | covered | `ui/src/components/AgentResourceManager.test.tsx` — “says the files stay when pi-outpost does not manage the repository”. |
+| A configuration-file repository cannot be removed here | covered | `ui/src/components/AgentResourceManager.test.tsx` — “offers no removal for a configuration-file repository, and says why”. |
+
+## persistent-runtime-settings
+
+| Scenario | Coverage | Assertion evidence |
+|---|---|---|
+| Restart preserves a collection selection | covered | `server/test/skillCollections.test.ts` — “a persisted selection is what the next load returns” reads the written file back through `loadConfig`; `server/test/skillCollectionsWire.test.mjs` boots a server from such a file and asserts only the enabled skill is loaded. |
+| A selection change leaves configuration-file paths intact | covered | `server/test/skillCollections.test.ts` — “writing a collection leaves the configuration file's skill paths as written”. |
+| A newly enabled collection skill is visible after apply | covered | `server/test/collectionSelectionWire.test.mjs` — “one skill, all on, one group, all off…” asserts the replacement session reports the newly enabled skill as loaded. |
+| A failed write keeps the live selection | covered | `server/test/collectionSelectionWire.test.mjs` — “a selection that cannot be persisted keeps the live one” removes the configuration file, then asserts the refusal, no session replacement, and the live session still loading the old selection. |
+| Removal clears the persisted selection | covered | `server/test/collectionRemovalWire.test.mjs` — the managed-removal test asserts `userSkillCollections` is empty on disk afterwards. |

--- a/openspec/changes/manage-skill-collections/specs/agent-resource-management/spec.md
+++ b/openspec/changes/manage-skill-collections/specs/agent-resource-management/spec.md
@@ -1,0 +1,287 @@
+## ADDED Requirements
+
+### Requirement: Skill collection catalogue
+
+When a Git repository is enrolled through **Add Git repository**, the system SHALL build a catalogue
+of the skills that repository carries: every directory in the worktree that contains a `SKILL.md`,
+wherever it sits, rather than only the repository root, `skills/` and `.agents/skills`. Each entry
+SHALL report the skill's name as its frontmatter declares it (its directory name when none is
+declared), its description when declared, its path relative to the repository root, and the folder
+group it belongs to.
+
+Skills SHALL be grouped by the folder that contains the skill's directory, and each group SHALL be
+named by that folder's path relative to the repository root; a skill whose directory sits at the
+repository root belongs to a group named after the repository. The grouping SHALL come from the
+repository's own folder tree alone: the system SHALL NOT read a repository-specific index,
+manifest or marketplace file to decide it. Skills SHALL be listed as the repository lays them out:
+two directories carrying the same or equivalent skill under different names SHALL both appear, each
+in its own group, and neither SHALL be merged into or hidden behind the other.
+
+Building the catalogue SHALL NOT import or execute any code from the repository, SHALL stay inside
+the canonical worktree, SHALL NOT follow symbolic links, and SHALL skip `.git` and `node_modules`.
+It SHALL be bounded in directory depth, in the number of skills listed and in the bytes read from
+each `SKILL.md`; a repository that exceeds a bound SHALL be reported as such, naming the bound,
+rather than presented as if the listed skills were all it contains.
+
+#### Scenario: Category folders become groups
+- **GIVEN** a repository whose skills live under `dev-skills/<skill>/SKILL.md`, `agent-skills/<skill>/SKILL.md` and `skills/<prefixed-skill>/SKILL.md`
+- **WHEN** the repository is enrolled
+- **THEN** the catalogue lists every one of those skills, grouped under `dev-skills`, `agent-skills` and `skills`
+
+#### Scenario: Duplicates are listed as shipped
+- **GIVEN** a repository carrying the same skill as `agent-skills/a2a-protocol-guide` and as `skills/agent-a2a-protocol-guide`
+- **WHEN** its catalogue is built
+- **THEN** both entries appear, each in its own group under its own name
+
+#### Scenario: No manifest decides the grouping
+- **GIVEN** a repository shipping an index or marketplace file whose categories differ from its folders
+- **WHEN** its catalogue is built
+- **THEN** the groups follow the folders and the file has no effect on them
+
+#### Scenario: Cataloguing runs no repository code
+- **WHEN** a repository whose extension module has an observable top-level side effect is catalogued
+- **THEN** that side effect does not occur
+
+#### Scenario: A symlinked skill is not followed
+- **GIVEN** a directory in the repository that is a symbolic link to a folder containing `SKILL.md`, inside or outside the worktree
+- **WHEN** the catalogue is built
+- **THEN** that link contributes no entry
+
+#### Scenario: A catalogue that reaches its bound says so
+- **GIVEN** a repository carrying more skills than the catalogue bound
+- **WHEN** its catalogue is built
+- **THEN** the result states that the bound was reached and names it
+
+### Requirement: Selective skill enablement
+
+Every skill in the catalogue of a repository enrolled through **Add Git repository** SHALL be off
+when the repository is enrolled. The system SHALL let the user turn each skill on or off
+individually, turn every skill of the repository on or off at once, and turn every skill of one
+folder group on or off at once. Only skills that are on SHALL be loaded into the agent session; a
+skill that is off SHALL NOT appear in the agent's skills or system prompt.
+
+The selection SHALL be addressed by the repository's server-issued identifier and SHALL be
+validated against a freshly built catalogue of that repository: a skill path the catalogue does
+not contain, a path outside the worktree, or an identifier the server does not know SHALL be
+refused without changing anything. A change of selection SHALL take effect through a session
+replacement with the same rollback guarantees as an enrollment: a replacement refused before
+handoff leaves the previous selection persisted and the previous session active, and the client is
+told it failed. The change SHALL be refused while any started workspace loading that repository is
+streaming a turn or replacing its session, and on a runtime that cannot rebuild its resources.
+
+A skill that first appears in the repository after enrollment — through an update or an external
+change to the worktree — SHALL be off until the user turns it on. A skill that is on but whose
+directory no longer exists or no longer contains `SKILL.md` SHALL NOT be passed to the runtime, and
+the inventory SHALL show it as missing rather than as loaded. A skill that is on but that the
+runtime did not load — a name another skill already claimed, frontmatter the runtime rejects —
+SHALL be shown as on and not loaded, with the reason when the runtime reports one.
+
+Repositories enrolled before this requirement, through skill roots, SHALL keep loading every skill
+under those roots; this requirement does not change them.
+
+#### Scenario: A newly enrolled collection loads nothing
+- **WHEN** a repository carrying skills is enrolled through Add Git repository without turning any skill on
+- **THEN** the repository and its catalogue appear in the inventory
+- **AND** none of its skills is loaded into the agent session
+
+#### Scenario: Turning one skill on loads that skill alone
+- **GIVEN** an enrolled collection with every skill off
+- **WHEN** the user turns on one skill and the change is applied
+- **THEN** the replacement session loads that skill and no other skill from the repository
+
+#### Scenario: All on and all off for the repository
+- **GIVEN** an enrolled collection
+- **WHEN** the user turns every skill of the repository on, then every skill off
+- **THEN** after the first change every catalogued skill is loaded, and after the second none is
+
+#### Scenario: All on for one folder group
+- **GIVEN** an enrolled collection with skills in the groups `dev-skills` and `agent-skills`, all off
+- **WHEN** the user turns on every skill of `dev-skills`
+- **THEN** every skill of `dev-skills` is loaded and no skill of `agent-skills` is
+
+#### Scenario: A selection outside the catalogue is refused
+- **WHEN** a client sends a selection naming a path the repository's catalogue does not contain, a path outside the worktree, or an unknown repository identifier
+- **THEN** the request is refused, nothing is persisted, and the session is not replaced
+
+#### Scenario: A refused replacement keeps the previous selection
+- **GIVEN** a selection change that requires replacing the session
+- **WHEN** replacement is refused before the new session takes over
+- **THEN** the previous selection stays persisted and the previous session stays active
+- **AND** the client receives a failure
+
+#### Scenario: A busy workspace blocks a selection change
+- **WHEN** a started workspace loading the repository is streaming a turn or replacing its session
+- **THEN** the selection change is refused, naming the busy workspace, and nothing changes
+
+#### Scenario: A skill added by an update stays off
+- **GIVEN** an enrolled collection with some skills on
+- **WHEN** a repository update adds a new skill directory
+- **THEN** the new skill appears in the catalogue as off and is not loaded
+- **AND** the skills that were on stay on
+
+#### Scenario: A skill that is on but gone is reported missing
+- **GIVEN** a skill that is on
+- **WHEN** its directory is removed from the worktree and the resources are rebuilt
+- **THEN** the runtime is not given its path and the inventory shows it as missing
+
+#### Scenario: A skill that is on but not loaded says so
+- **GIVEN** two skills that are on and declare the same name
+- **WHEN** the session loads its skills
+- **THEN** the skill the runtime did not load is shown as on and not loaded
+
+#### Scenario: A root-enrolled repository keeps loading everything
+- **GIVEN** a repository enrolled before this change through a skill root
+- **WHEN** the server starts with this change
+- **THEN** every skill under that root is still loaded and no selection is imposed on it
+
+### Requirement: Whole-repository removal
+
+The system SHALL let the user remove an enrolled repository as a whole, addressed by its
+server-issued identifier. Removal SHALL unregister every user skill root, user extension root and
+skill selection belonging to that repository, and SHALL then delete the repository's clone from
+disk when pi-outpost manages that clone — it created the clone, or the clone lies inside
+pi-outpost-managed resource storage. A repository the user pointed at outside managed storage
+SHALL be unregistered and its files SHALL be kept, and the result SHALL say that they were kept and
+where.
+
+Removal SHALL be refused, with nothing unregistered or deleted, when the repository supplies a path
+declared in the configuration file, when its identifier is unknown, when any started workspace
+loading it is streaming a turn or replacing its session, and on a runtime that cannot rebuild its
+resources. Deletion SHALL be confined to the repository's canonical worktree: it SHALL NOT follow a
+symbolic link out of it, SHALL NOT delete a filesystem root, the managed-storage folder itself, or a
+path that is not the top-level folder of the enrolled repository.
+
+Unregistering SHALL take effect through a session replacement with the enrollment rollback
+guarantees, and the clone SHALL be deleted only after the replacement session has taken over, so no
+session still loads resources from files being deleted. A replacement refused before handoff SHALL
+leave the registration and the files as they were. A deletion that fails after unregistering SHALL
+be reported as such — the repository is no longer loaded, its files remain at a named path — and
+MUST NOT be reported as a complete removal.
+
+#### Scenario: Removing a managed collection deletes its clone
+- **GIVEN** a repository cloned by pi-outpost into managed storage, with some skills on
+- **WHEN** the user removes the repository
+- **THEN** none of its skills or extensions is loaded, no settings entry refers to it, and its clone no longer exists on disk
+
+#### Scenario: A repository outside managed storage keeps its files
+- **GIVEN** a repository enrolled from a folder outside managed storage that pi-outpost did not create
+- **WHEN** the user removes the repository
+- **THEN** it is unregistered and no longer loaded
+- **AND** its files are left in place and the result says so, naming the path
+
+#### Scenario: A configuration-file path blocks removal
+- **GIVEN** a repository that supplies a skill or extension path declared in the configuration file
+- **WHEN** the user asks to remove it
+- **THEN** the removal is refused and nothing is unregistered or deleted
+
+#### Scenario: Removal is refused while a consumer is busy
+- **WHEN** a started workspace loading the repository is streaming a turn or replacing its session
+- **THEN** the removal is refused, naming the busy workspace, and nothing is unregistered or deleted
+
+#### Scenario: A refused replacement keeps the repository
+- **WHEN** the session replacement that unregistering requires is refused before handoff
+- **THEN** the repository stays registered, its files stay on disk, and the client receives a failure
+
+#### Scenario: Deletion never leaves the worktree
+- **GIVEN** a managed clone containing a symbolic link to a directory outside it
+- **WHEN** the repository is removed
+- **THEN** the linked directory and its contents are untouched
+
+#### Scenario: A failed deletion is reported as partial
+- **GIVEN** a managed clone whose files cannot all be deleted
+- **WHEN** the repository is removed
+- **THEN** the result states that the repository is no longer loaded and that files remain at the named path
+
+#### Scenario: An unknown repository is refused
+- **WHEN** a client asks to remove an identifier the server does not know
+- **THEN** the request is refused and no file is deleted
+
+### Requirement: Repository display name
+
+The system SHALL name a repository, in its preview and its inventory group, after the repository
+its `origin` remote points to — the last segment of that address without a `.git` suffix, query or
+fragment — rather than after the local folder it was cloned into. A worktree without an `origin`
+SHALL be named after its folder. The name SHALL NOT carry credentials from the address.
+
+#### Scenario: A repository is named after its origin
+- **GIVEN** a clone of `https://github.com/khalilbenaz/claude-skills-collection.git` in a local folder named `resources-3f9a1c2b7e`
+- **WHEN** it is previewed and enrolled
+- **THEN** the preview and the inventory name it `claude-skills-collection`
+
+#### Scenario: A repository without an origin keeps its folder name
+- **GIVEN** a worktree with no `origin` remote
+- **WHEN** it is inventoried
+- **THEN** it is named after its folder
+
+## MODIFIED Requirements
+
+### Requirement: Repository enrollment
+
+The Agent resources dialog SHALL expose two distinct enrollment operations. **Add local folder** SHALL let the user select an existing server-side directory and identify it as a skill or extension root, preserving the existing user-path behavior whether or not that folder belongs to Git. **Add Git repository** SHALL require both a repository address and a local server-side clone folder. The interface SHALL suggest a collision-resistant folder under pi-outpost-managed resource storage and SHALL let the user replace it or choose its parent with the server-directory picker.
+
+The server SHALL accept only a non-empty repository address in a supported HTTPS, SSH, Git, file, or SCP-like Git form, SHALL pass it to Git as data rather than as an option or shell input, and SHALL redact embedded credentials from errors returned to clients. It SHALL resolve the requested clone folder through a canonical existing parent, refuse a filesystem root, an invalid basename, symlink ambiguity, or an occupied destination that is not the same origin, and SHALL NOT overwrite or empty existing content. Re-adding the same address and folder SHALL reuse its existing clone after verifying its origin rather than creating a duplicate. Clone operations SHALL disable repository hooks, decline recursive submodule initialization, and report a failed clone without registering resource paths.
+
+After a clone, and before changing runtime settings, the system SHALL inspect that worktree without importing or executing extension code and SHALL present a preview of the repository's skill catalogue, as described under Skill collection catalogue, and of the extension roots it can register. The user SHALL explicitly select which extension roots to activate; every skill in the catalogue SHALL start off, and the preview SHALL let the user turn skills on before confirming. Confirming with no skill turned on and no extension root selected SHALL still enroll the repository and its catalogue, loading nothing from it.
+
+Confirmed skill selections SHALL be persisted as that repository's collection selection, and confirmed extension roots SHALL be persisted using the existing user extension-path setting. Existing deployment-configured paths SHALL remain unchanged. Extension roots SHALL require the same executable-code warning as any other extension-path addition, and `extensionLock` SHALL prevent selecting or confirming extension roots while still permitting skill-only enrollment.
+
+After an activated root or selection is persisted, the replacement session SHALL be created from the same effective sandbox and resource configuration that produced the rebuilt inventory. Every configured skill root, enabled collection skill, prompt root, extension directory, and extension script SHALL remain a read-only sandbox exception even when it is outside `sandbox.root`; those exceptions MUST NOT widen write access. The system SHALL acknowledge the activation only after the replacement session has taken over with that configuration.
+
+If session replacement is refused before handoff to the new session, the system SHALL restore the previous persisted settings, workspace resources, runtime factory, and file-browser boundary, SHALL keep the prior session active, and SHALL report failure instead of acknowledging the activation. This pre-handoff rollback is distinct from a Git update whose worktree has already advanced: the latter retains its explicit partial-failure semantics under Affected runtime reload.
+
+A preview SHALL be bound to the repository revision, catalogue and root set it observed, SHALL expire, and SHALL be usable once: a confirmation arriving after expiry, after a second use, or after the observed catalogue or roots changed SHALL be refused and SHALL require a fresh preview. A cloned worktree with neither a catalogued skill nor a recognizable extension root, or a selected skill or root that changes before confirmation, SHALL be refused without changing settings. Re-enrolling a canonical worktree already represented as a collection SHALL merge newly confirmed extension roots and skills into its existing group without duplicating paths, selections or repositories, and SHALL leave skills already on as they were. Re-enrolling a canonical worktree already represented through user skill roots SHALL keep those roots and their load-everything behaviour. Removing a repository is governed by Whole-repository removal.
+
+#### Scenario: Add a local skill folder
+- **WHEN** the user selects Add local folder, chooses an existing directory, and identifies it as a skill root
+- **THEN** that directory is persisted once in the user skill paths and rebuilt into the active runtime
+
+#### Scenario: Add a local extension folder
+- **WHEN** the user selects Add local folder and chooses to add an extension root
+- **THEN** the executable-code warning is shown before the directory is persisted
+- **AND** an extension-locked deployment refuses the addition
+
+#### Scenario: Activated external resources remain readable
+- **GIVEN** a skill or extension root, or an enabled collection skill, is outside the current sandbox root
+- **WHEN** the user activates it through Add local folder or a Git repository preview or selection
+- **THEN** the replacement session discovers or loads the resource
+- **AND** its read, list, search, and find tools can access that configured location without granting write access there
+
+#### Scenario: Refused replacement rolls enrollment back
+- **GIVEN** activating a resource root or selection requires replacing the current session
+- **WHEN** an extension or lifecycle hook refuses replacement before the new session takes over
+- **THEN** the persisted settings, workspace resources, runtime tool factory, file-browser boundary, and active session remain as they were before the request
+- **AND** the client receives a failure rather than a successful settings acknowledgement
+
+#### Scenario: Add a repository containing skills and extensions
+- **WHEN** the user selects a Git worktree containing catalogued skills and recognizable extension roots, turns on some skills and confirms the extension roots from the preview
+- **THEN** the skill selection and the user extension paths are persisted and the rebuilt inventory shows one mixed repository group
+- **AND** only the skills turned on are loaded
+
+#### Scenario: Enrollment does not execute extensions during preview
+- **WHEN** the selected repository contains an extension whose module has an observable top-level side effect
+- **THEN** previewing the repository does not trigger that side effect
+
+#### Scenario: Extension lock permits skill-only enrollment
+- **WHEN** extension paths are locked and the selected repository contains both catalogued skills and extension roots
+- **THEN** the preview permits confirming the skill selection but disables extension roots with the lock reason
+
+#### Scenario: Clone address is required and confined
+- **WHEN** the repository address is invalid or the local folder is a filesystem root, has no canonical parent, uses an invalid final segment, or is occupied by different content
+- **THEN** enrollment is refused before Git starts and no existing content is overwritten
+- **AND** neither value is interpreted through a shell
+
+#### Scenario: Clone has no recognizable resources
+- **WHEN** a repository is cloned successfully but contains neither a catalogued skill nor a recognizable extension root
+- **THEN** no runtime path or selection is registered and the dialog explains that the clone has nothing it can activate
+
+#### Scenario: Re-add the same repository address
+- **WHEN** the user submits an address and local folder already holding a clone with the same canonical origin
+- **THEN** the server verifies and reuses that clone and presents a fresh resource preview without creating a second clone
+
+#### Scenario: Re-enroll an existing repository
+- **WHEN** a selected worktree is already represented as a collection and the user confirms a newly discovered extension root or turns on another skill
+- **THEN** the path or skill is added once to the existing repository group, skills already on stay on, and no duplicate repository is created
+
+#### Scenario: Enroll with nothing turned on
+- **WHEN** the user confirms a collection preview without turning any skill on and without selecting an extension root
+- **THEN** the repository is enrolled with its catalogue and nothing from it is loaded

--- a/openspec/changes/manage-skill-collections/specs/components/spec.md
+++ b/openspec/changes/manage-skill-collections/specs/components/spec.md
@@ -1,0 +1,146 @@
+## MODIFIED Requirements
+
+### Requirement: AgentResourceManager
+
+The component layer SHALL expose a dedicated Agent resources dialog from Settings as the single interactive surface for adding and removing user skill and extension roots, for turning collection skills on and off, and for removing repositories. Settings SHALL retain the loaded and configured resource summary but SHALL open this dialog instead of presenting separate add-directory controls. The dialog SHALL present separate **Add local folder…** and **Add Git repository…** buttons. The dialog SHALL otherwise use a repository-first split layout: a searchable and filterable repository list with an attention summary on the left, and the selected repository's status, actions, skills, and extensions on the right. Non-Git and provenance-unavailable resources SHALL be reachable as non-updateable groups.
+
+For a repository enrolled as a collection, the detail pane SHALL list the repository's catalogued skills grouped by the folder groups the inventory supplies, each skill with an on/off switch showing its supplied state — on and loaded, on and not loaded with its reason, on and missing, or off. The pane SHALL offer **All on** and **All off** for the whole repository, and the same pair for each folder group. Each folder group SHALL show how many of its skills are on and SHALL be collapsible. Switch and bulk actions SHALL stage a pending selection that the dialog shows as pending, together with the number of changes, until the user applies it — reporting it in one callback — or discards it. The pending selection SHALL belong to the repository it was made for: it MUST NOT be applied to, or displayed under, another repository, and a new inventory for the same repository SHALL NOT silently drop it. The collection preview shown before enrollment SHALL use the same grouped catalogue with every skill off.
+
+The pane SHALL let the user find skills in a large collection: the skills that are on SHALL be listed together above the folder groups, each with its folder, its state and a way to turn it off, and the repository list SHALL show how many of a collection's skills are on; folder groups holding a skill that is on SHALL open by default while the others stay folded, a filter SHALL narrow the list to the skills that are on, and a search SHALL narrow it to skills whose name, folder path or description matches. While a filter or search is active, each folder SHALL show only its matching skills, and its **All on** / **All off** SHALL act on those skills alone.
+
+The detail pane SHALL offer **Remove repository** for a repository whose resources are all user-registered. Requesting it SHALL first show a confirmation that names the repository and the path whose files will be deleted, or states that the files will be kept when the repository is not managed by pi-outpost, and says that the deletion cannot be undone; the removal callback SHALL be invoked only after that explicit confirmation. A repository that supplies a configuration-file path SHALL offer no removal action and SHALL say why.
+
+Repository identities are server-issued and do not outlive the server that issued them. The dialog SHALL treat an identity it can no longer resolve — after a reconnect, a restart, or an inventory that no longer contains it — as a stale selection, and SHALL fall back to a visible group rather than showing an empty detail pane or an operation aimed at nothing.
+
+The component SHALL render only supplied inventory and operation state and SHALL report repository selection/enrollment, resource-root removal, skill selection, repository removal, refresh, update, confirmation, selection, search, and filtering requests through callbacks. It SHALL disable or withhold update actions when the supplied state is blocked, explain how local changes can be resolved externally, and require a separate explicit confirmation step for repositories marked as containing extensions. Results from an earlier selection or operation MUST NOT be presented as belonging to a newly selected repository.
+
+#### Scenario: Open repository-first resource manager
+- **GIVEN** Settings is supplied with resource repository and inventory state
+- **WHEN** the user opens Agent resources
+- **THEN** a split dialog lists repository groups and shows the selected group's status, skills, and extensions
+
+#### Scenario: Settings delegates resource changes to the dialog
+- **GIVEN** Settings is supplied with loaded resources and user resource paths
+- **WHEN** the user asks to manage agent resources
+- **THEN** it opens the Agent resources dialog
+- **AND** Settings itself offers no separate add-directory or remove-path controls
+
+#### Scenario: Add repository previews roots before applying
+- **GIVEN** the Agent resources dialog is open
+- **WHEN** the user selects Add Git repository and submits a repository address and local clone folder
+- **THEN** the dialog presents the grouped skill catalogue with every skill off, and the discovered extension roots for selection
+- **AND** does not request a settings change until the user confirms the preview
+
+#### Scenario: Git repository form suggests but does not fix the destination
+- **GIVEN** the user has entered a repository address
+- **WHEN** the Add Git repository form derives its local folder
+- **THEN** it suggests a collision-resistant path under managed resource storage
+- **AND** the user can edit that path or select its parent with the server-directory picker before cloning
+
+#### Scenario: Add local folder remains available
+- **GIVEN** the Agent resources dialog is open
+- **WHEN** the user selects Add local folder
+- **THEN** the dialog opens the server-directory picker and lets the user choose whether the folder contains skills or extensions
+
+#### Scenario: Search and attention filters preserve repository context
+- **GIVEN** the dialog contains several repositories with different resource kinds and states, including a repository that supplies both skills and extensions
+- **WHEN** the user searches or filters by resource kind or attention state
+- **THEN** only groups containing a match remain and the detail pane either retains a matching selection or selects a visible group
+- **AND** each visible group and its detail pane contain only resources matching the active resource-kind filter, while search and attention filters determine group visibility
+- **AND** each visible group count reflects that kind-filtered resource subset rather than the repository's unfiltered total
+
+#### Scenario: Dirty repository directs resolution outside the app
+- **GIVEN** the selected repository is reported as dirty
+- **WHEN** its details are displayed
+- **THEN** no update action is enabled and the dialog exposes its path and guidance to review local changes externally
+- **AND** it offers no commit, stash, discard, rebase, or merge control
+
+#### Scenario: Update is offered only when there is one
+- **GIVEN** a selected repository that has not been checked, is up to date, or cannot be fast-forwarded
+- **WHEN** its details are displayed
+- **THEN** Check is offered and no Update repository action is shown
+- **AND** once the repository is reported as updateable, Update repository is shown, and it stays visible, disabled, while the update runs
+
+#### Scenario: Extension confirmation precedes update callback
+- **GIVEN** an updateable selected repository is marked as supplying extensions
+- **WHEN** the user requests an update
+- **THEN** the dialog first explains the executable-code risk
+- **AND** invokes the update callback only after explicit confirmation
+
+#### Scenario: Selection changes during an operation
+- **GIVEN** a check or update is pending for one repository
+- **WHEN** the user selects another repository before it completes
+- **THEN** the pending state and result remain correlated with the original repository and are not rendered as the new repository's result
+
+#### Scenario: A selected repository the server no longer knows
+- **GIVEN** a repository is selected in the dialog
+- **WHEN** a new inventory arrives without that repository, as after a server restart
+- **THEN** the dialog selects a visible group and offers no action for the identity that is gone
+
+#### Scenario: Provenance-unavailable resources stay visible
+- **GIVEN** inventory entries cannot be attributed to a Git repository
+- **WHEN** the Agent resources dialog opens
+- **THEN** those entries appear in an explicitly non-updateable group with the supplied reason
+
+#### Scenario: Collection skills are grouped by folder with switches
+- **GIVEN** a collection repository whose inventory supplies skills in the folder groups `dev-skills` and `agent-skills`
+- **WHEN** the repository is selected
+- **THEN** its skills appear under those two groups, each with a switch showing whether it is on, and each group shows how many of its skills are on
+
+#### Scenario: Skill states are distinguished
+- **GIVEN** a collection whose inventory supplies skills that are on and loaded, on and not loaded with a reason, on and missing, and off
+- **WHEN** the repository is selected
+- **THEN** each of those four states is rendered distinctly, with the supplied reason for the one not loaded
+
+#### Scenario: All on and all off stage the whole repository
+- **GIVEN** a selected collection with some skills on
+- **WHEN** the user presses All on, then All off
+- **THEN** after each press every skill of the repository shows as pending in that state
+- **AND** no selection callback is invoked until the user applies
+
+#### Scenario: Folder-level all on stages one group only
+- **GIVEN** a selected collection with skills in two folder groups, all off
+- **WHEN** the user presses All on for one group
+- **THEN** only that group's skills show as pending on, and the other group is unchanged
+
+#### Scenario: Apply reports the whole pending selection once
+- **GIVEN** pending switch changes across several groups of one repository
+- **WHEN** the user applies them
+- **THEN** the selection callback is invoked once with that repository's identity and the complete resulting set of skills that are on
+
+#### Scenario: Discard restores the supplied state
+- **GIVEN** pending switch changes
+- **WHEN** the user discards them
+- **THEN** every switch shows the state the inventory supplies and no callback is invoked
+
+#### Scenario: A pending selection stays with its repository
+- **GIVEN** pending switch changes for one repository
+- **WHEN** the user selects another repository and comes back
+- **THEN** the other repository shows no pending change, and the first repository still shows its own
+
+#### Scenario: The skills that are on can be found
+- **GIVEN** a collection of several hundred skills with one skill on
+- **WHEN** the repository is selected
+- **THEN** that skill is listed above the folders with its folder and a way to turn it off, and the repository list says one skill is on
+- **AND** the folder holding it is open while the other folders are folded, and the filter for skills that are on lists that skill alone
+
+#### Scenario: Search narrows a collection's skills
+- **GIVEN** a selected collection
+- **WHEN** the user searches for part of a skill's name or folder
+- **THEN** only matching skills are listed, each in its folder, and a folder's All on turns on only its matching skills
+
+#### Scenario: Remove repository requires confirmation
+- **GIVEN** a selected repository whose resources are all user-registered and whose clone pi-outpost manages
+- **WHEN** the user requests Remove repository
+- **THEN** a confirmation names the repository and the path whose files will be deleted and states that this cannot be undone
+- **AND** the removal callback is invoked only after the user confirms, and not at all if they cancel
+
+#### Scenario: Removing an unmanaged repository says the files stay
+- **GIVEN** a selected repository that pi-outpost does not manage
+- **WHEN** the user requests Remove repository
+- **THEN** the confirmation states that the repository will be unregistered and its files kept
+
+#### Scenario: A configuration-file repository cannot be removed here
+- **GIVEN** a selected repository that supplies a path declared in the configuration file
+- **WHEN** its details are displayed
+- **THEN** no Remove repository action is offered and the dialog says why

--- a/openspec/changes/manage-skill-collections/specs/persistent-runtime-settings/spec.md
+++ b/openspec/changes/manage-skill-collections/specs/persistent-runtime-settings/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Persist collection skill selections
+
+The system SHALL persist, for each repository enrolled as a skill collection, the repository and
+the set of its skills that are on, under a key of its own, apart from the configuration file's
+skill paths and from the user skill paths. A restart SHALL load the same skills that were on
+before it, and no others from that repository. Persisting a selection SHALL NOT rewrite or remove a
+skill path declared in the configuration file.
+
+A changed selection SHALL be treated like a changed skill path: it SHALL be persisted and SHALL
+replace the agent session, and a persistence failure SHALL keep the live configuration unchanged.
+Removing a repository SHALL remove its selection from the persisted settings.
+
+#### Scenario: Restart preserves a collection selection
+- **GIVEN** a collection with two skills on
+- **WHEN** the server restarts
+- **THEN** those two skills are loaded and no other skill from that repository is
+
+#### Scenario: A selection change leaves configuration-file paths intact
+- **GIVEN** the configuration file declares a skill path
+- **WHEN** the user changes a collection selection and applies it
+- **THEN** the persisted configuration still declares that skill path unchanged
+
+#### Scenario: A newly enabled collection skill is visible after apply
+- **WHEN** the user turns a collection skill on and the change is applied
+- **THEN** the replacement session lists that skill
+
+#### Scenario: A failed write keeps the live selection
+- **WHEN** persisting a changed selection fails
+- **THEN** the live configuration and the active session keep the previous selection and the client is told the change failed
+
+#### Scenario: Removal clears the persisted selection
+- **WHEN** a collection repository is removed
+- **THEN** the persisted settings no longer name that repository or any of its skills

--- a/openspec/changes/manage-skill-collections/tasks.md
+++ b/openspec/changes/manage-skill-collections/tasks.md
@@ -1,0 +1,77 @@
+## 1. Configuration and the runtime feed
+
+- [x] 1.1 Add `userSkillCollections` (`{ path, managed, enabledSkills }[]`) to `AppConfig`, `loadConfig` validation (absolute resolution, POSIX relative entries, no `..`, no duplicates) and `EditableSettings`/`persistEditableSettings` under its own key; verify with `server/test/skillCollections.test.ts` cases (written, then read back through `loadConfig` as the next boot would) for a round-trip restart and for a configuration-file `skillPaths` entry surviving a collection write
+- [x] 1.2 Extend `allSkillPaths` to append each enabled collection skill directory that still exists inside its worktree and contains `SKILL.md`, after `skillPaths` and `userSkillPaths`; verify with a config unit test (order, missing directory dropped, path escaping the worktree dropped) and an `rpc-resource-args.test.ts` case showing one `--skill` per enabled directory
+- [x] 1.3 Prove the sandbox read-only roots follow: an enabled skill outside `sandbox.root` is readable and not writable by the session's tools, a disabled one is not readable; verify in `server/test/skillCollectionsWire.test.mjs` (booted server, the agent's own read tool)
+- [x] 1.4 Confirm a configuration carrying `userSkillCollections` still loads through the previous release's `loadConfig` (downgrade path) and record the result in the PR
+
+## 2. Skill catalogue
+
+- [x] 2.1 Implement `discoverSkillCatalogue(worktree)` in `server/src/resourceRepositories.ts`: `readdir`/`lstat` walk, no symlinks, skip `.git`/`node_modules`, stop at a directory holding `SKILL.md`, depth ≤ 8, ≤ 2,000 skills, ≤ 16 KiB read per file, frontmatter via pi's `parseFrontmatter`, group = parent path relative to the worktree; verify with `skillCatalogue.test.ts` on a fixture shaped like claude-skills-collection (category folders + prefixed `skills/` copies, a root `SKILL.md`, a manifest whose categories differ from the folders)
+- [x] 2.2 Cover the catalogue's refusals and bounds: symlinked skill directory inside and outside the worktree contributes nothing, count and depth bounds are reported with their limit, duplicates are both listed, a repository with a top-level-side-effect extension triggers nothing; verify each as its own test in `skillCatalogue.test.ts`
+
+## 3. Enrollment
+
+- [x] 3.1 Extend `AgentResourceRepositoryPreview` with `skills` and `bound`, include the catalogue in the preview fingerprint, and accept a clone with catalogued skills but no skill root; verify that a changed catalogue between preview and confirmation is refused and that a clone with neither skills nor extension roots is still refused
+- [x] 3.2 Record `managed: true` when `cloneAndPreview` created the folder (not when it reused an existing clone), and accept `enabledSkills` in `enroll_agent_resource_repository`: validate against the fresh catalogue, persist the collection entry through `handleUpdateConfig`, allow an empty selection; verify in `collectionEnrollmentWire.test.mjs` (and `collectionEnrollment.test.ts` for refusals and the managed flag) that enrolling with nothing on loads no collection skill and enrolling with one on loads exactly that one
+- [x] 3.3 Re-enrollment: a worktree already registered as a collection merges new extension roots and skills and keeps skills already on; a worktree already registered through user skill roots stays in root mode; verify both in `collectionEnrollmentWire.test.mjs`
+
+## 4. Inventory
+
+- [x] 4.1 Add a declared collection's worktree to the inventory even when nothing from it is loaded, and attach `collection` (groups, skills with `off`/`on-loaded`/`on-not-loaded`/`on-missing`, reason, bound) by joining catalogue, persisted selection and runtime resources; verify with `collectionInventory.test.ts` cases for each state, including a name collision between two enabled copies
+- [x] 4.2 Attach `removal` (`allowed`, `deletesFiles`, `path`, `reason`) to every repository: refused with a reason when any of its paths is configuration-file declared, `deletesFiles` only for managed clones; verify with `collectionInventory.test.ts` cases for a managed clone, an unmanaged clone, managed storage, a configured path, and a vanished folder
+
+## 5. Selection and removal on the server
+
+- [x] 5.1 Extract the affected-workspace reservation from `handleUpdateAgentResourceRepository` into a helper without changing update behaviour; verify the existing update tests still pass unchanged
+- [x] 5.2 Add `set_agent_resource_skills` (protocol, message allowlist, handler): known id only, full set validated against a fresh catalogue, reservation, `handleUpdateConfig`; verify in `collectionSelectionWire.test.mjs`: one skill on loads it alone, all on / all off, per-group set, outside-catalogue path / `..` path / unknown id refused with nothing persisted, busy workspace refused naming it, refused replacement keeps the previous selection, RPC runtime refused
+- [x] 5.3 Prove update semantics: after a fast-forward that adds a skill directory, the new skill is `off` and previously enabled skills stay on; after one that deletes an enabled skill, it is `on-missing` and not passed to the runtime; verify in `collectionSelectionWire.test.mjs` with a local upstream
+- [x] 5.4 Add `remove_agent_resource_repository` → `agent_resource_removed`: reserve, unregister collection entry and every user skill/extension root inside the worktree through `handleUpdateConfig`, then under the repository mutex delete only when canonical path = registered worktree = Git top level, managed (flag or inside `managedRoot`), not a filesystem root and not `managedRoot`; verify in `collectionRemovalWire.test.mjs`: managed clone deleted, unmanaged clone kept with `removed-files-kept`, configured path refused, unknown id refused, busy refused, refused replacement leaves registration and files
+- [ ] 5.5 Make deletion safe and honest across platforms: symlink out of the clone leaves its target untouched; on EPERM/EACCES clear read-only attributes and retry; a remaining failure yields `removed-delete-failed` with the path; verify in `cloneDeletion.test.ts` including a read-only directory and a forced failure, and watch the Windows CI job pass
+
+## 6. Agent resources dialog
+
+- [x] 6.1 Render a collection's skills grouped by folder with collapsible groups, per-group on-count, and a switch per skill showing the four states with reasons; verify in `AgentResourceManager.test.tsx`
+- [x] 6.2 Add repository-level **All on** / **All off** and per-group all on / all off that edit a per-repository pending set, with pending count, **Apply** (one callback with the complete set) and **Discard**; keep the pending set per repository id, rebase it on a new inventory for the same id, drop it for a vanished id; verify each behaviour as its own test, including switching repositories and back
+- [x] 6.3 Use the same grouped catalogue, all off, in the Add Git repository preview and send its pending set as `enabledSkills`; verify a test that confirms with nothing on and one with two skills on
+- [x] 6.4 Add **Remove repository** with an irreversible-action confirmation naming the path (or saying files are kept when unmanaged), no action and a reason for configured repositories, and callback only after confirm; verify confirm, cancel, unmanaged and configured cases
+- [x] 6.5 Wire the new messages through `ui/src/useAgent.ts` and `ui/src/App.tsx` (operation state correlated by request id and repository id, results never shown under another repository); verify in `useAgent.test.ts`
+
+## 7. Documentation
+
+- [x] 7.1 Update `docs/how-to.md` and the README resources section: collections start with every skill off, per-skill and bulk switches, Apply, and that Remove repository deletes a managed clone from disk; check the links and commands they cite
+
+## 8. Verification
+
+- [x] 8.1 Write `openspec/changes/manage-skill-collections/scenario-coverage.md` mapping every scenario (`rg '^#### Scenario:' openspec/changes/manage-skill-collections`) to a test whose assertion would fail if the contract broke; run `npm run check:scenarios`
+- [x] 8.2 Run `npm run lint`, the server and UI suites, and `openspec validate manage-skill-collections --strict`; all pass
+- [x] 8.3 Rebuild `web`, `@pi-outpost/embed` and `build:e2e-host`, run `npm run bench`, and with Playwright enroll claude-skills-collection: check the groups in the DOM, turn on two skills and read the session's skill list, All on / All off, then Remove repository and confirm the clone is gone from disk
+- [x] 8.4 Monkey pass on the bench: double-click Apply, toggle while an apply is in flight, switch repositories with pending changes, remove a repository while a turn is streaming, delete the clone on disk under the running app then open the dialog, rapid All on / All off; report what broke and fix what is in scope
+
+## Notes from the running-app passes (8.3, 8.4)
+
+- Enrolling the real claude-skills-collection: 696 skills in 35 folder groups, all off; two turned on,
+  both reported Loaded; the config file held exactly those two; Remove repository deleted the clone.
+- Found and fixed there, neither caught by the suites at the time: the snapshot of the session
+  replacement a resource operation causes reset every pending operation, so the answer (removal
+  banner, enrollment result, apply error) was dropped — `applySnapshot` now clears them only on
+  `hello` and `workspace_switched`, with a `useAgent.test.ts` regression test. And the Work Plan
+  session sync was queued only after the inventory refresh, so a replacement awaiting it could run
+  ahead of the inherited plan — slower inventory builds exposed it in `work-plan-server.test.mjs`;
+  `queueWorkPlanSessionSync` now takes the refresh as a dependency inside its chain.
+- Monkey pass: pending changes stayed with their repository across switches; ten rounds of
+  All on / All off left a consistent state; a double-clicked Apply applied once; switches are
+  disabled while an apply is in flight; a double-clicked Remove opened one confirmation.
+- Left open: after a clone is deleted under the running app, Refresh all marks the repository
+  Unavailable but its skill list stays the last inventory's until the next rebuild. Removing it
+  still works and says so. Removal during a streaming turn is not drivable on the offline bench;
+  `collectionRemovalWire.test.mjs` covers that refusal.
+- User review after 8.4 found what the scripted passes had not: a skill turned on could not be found
+  among 696 (large collections opened folded, the only open folder held 348 rows), and the repository
+  was named after its local clone folder. Fixed: repositories are named after their `origin`; the
+  skills that are on are listed above the folders with Turn off; Search skills and Only on narrow the
+  list; the repository list reads "N on · total"; descriptions clamp to two lines (the embedded build
+  had no `line-clamp` utility). Re-checked on the bench from what the screen shows, with screenshots.
+- Still worth a look: copies of one skill in two folders (`skills/writing-changelog-writer`,
+  `writing-skills/changelog-writer`) look identical, and nothing warns that turning both on loads it
+  twice — left as the repository ships them, per the no-dedupe decision.

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -398,6 +398,14 @@ export interface AppConfig {
    */
   userSkillPaths: string[];
   /**
+   * Git repositories enrolled as skill collections through the Agent resources
+   * dialog. Unlike a skill path, a collection loads nothing by itself: only the
+   * skill directories named in `enabledSkills` reach the session. Held under its
+   * own key so the root-enrolled repositories in `userSkillPaths` keep loading
+   * everything, and so a repository can be removed as one entry.
+   */
+  userSkillCollections: SkillCollection[];
+  /**
    * Skip auto-discovering prompt templates entirely (both agentDir and the
    * project's cwd/.pi/prompts). Like noSkills, cwd doubles as both the
    * agent's working directory and a resource-discovery root, so pointing
@@ -635,6 +643,42 @@ export function optionalStringArray(raw: Record<string, unknown>, key: string): 
   return value as string[];
 }
 
+/**
+ * `userSkillCollections`: written by the interface, but a file is a file and a
+ * hand edit must fail loudly rather than load a skill from outside its worktree.
+ * Entries naming the same repository merge — the set of skills that are on is
+ * what matters, not how many times it was written.
+ */
+export function optionalSkillCollections(
+  raw: Record<string, unknown>,
+  resolve: (p: string) => string,
+): SkillCollection[] {
+  const value = raw.userSkillCollections;
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) fail(`"userSkillCollections" must be an array`);
+  const merged = new Map<string, SkillCollection>();
+  value.forEach((entry, index) => {
+    const label = `userSkillCollections[${index}]`;
+    const item = asObject(entry, label);
+    const where = optionalString(item, "path", `${label}.path`);
+    if (!where) fail(`"${label}.path" is required`);
+    const root = resolve(where);
+    const enabled = optionalStringArray(item, "enabledSkills") ?? [];
+    for (const relative of enabled) {
+      if (!collectionSkillDir(root, relative)) {
+        fail(`"${label}.enabledSkills" entry "${relative}" must be a relative path inside the repository`);
+      }
+    }
+    const previous = merged.get(root);
+    merged.set(root, {
+      path: root,
+      managed: optionalBoolean(item, "managed", false) || (previous?.managed ?? false),
+      enabledSkills: [...new Set([...(previous?.enabledSkills ?? []), ...enabled])],
+    });
+  });
+  return [...merged.values()];
+}
+
 export function optionalModelList(
   raw: Record<string, unknown>,
   key: string,
@@ -746,6 +790,7 @@ export function loadConfig(
     noSkills: false,
     skillPaths: [],
     userSkillPaths: [],
+    userSkillCollections: [],
     noPromptTemplates: false,
     promptPaths: [],
     appendSystemPrompt: [],
@@ -827,6 +872,7 @@ export function loadConfig(
       readExceptions: [
         ...(optionalStringArray(raw, "skillPaths") ?? []).map(resolve),
         ...(optionalStringArray(raw, "userSkillPaths") ?? []).map(resolve),
+        ...enabledCollectionSkillDirs(optionalSkillCollections(raw, resolve)),
         ...(optionalStringArray(raw, "promptPaths") ?? []).map(resolve),
         ...(optionalStringArray(raw, "extensionPaths") ?? []).map(resolve),
         ...(optionalStringArray(raw, "userExtensionPaths") ?? []).map(resolve),
@@ -928,6 +974,7 @@ export function loadConfig(
   config.noSkills = optionalBoolean(raw, "noSkills", false);
   config.skillPaths = (optionalStringArray(raw, "skillPaths") ?? []).map(resolve);
   config.userSkillPaths = (optionalStringArray(raw, "userSkillPaths") ?? []).map(resolve);
+  config.userSkillCollections = optionalSkillCollections(raw, resolve);
   config.noPromptTemplates = optionalBoolean(raw, "noPromptTemplates", false);
   config.promptPaths = (optionalStringArray(raw, "promptPaths") ?? []).map(resolve);
   config.allowedModels = optionalModelList(raw, "allowedModels");
@@ -1236,6 +1283,8 @@ export interface EditableSettings {
    * The operator's `skillPaths` are never written here and never removed.
    */
   userSkillPaths?: string[];
+  /** Skill collections and their enabled skills. Absent leaves them untouched. */
+  userSkillCollections?: SkillCollection[];
   /**
    * Extension paths the interface manages (absolute). Absent leaves them untouched.
    * The operator's `extensionPaths` are never written here and never removed.
@@ -1252,7 +1301,62 @@ export interface EditableSettings {
  * against a directory someone added from the interface.
  */
 export function allSkillPaths(config: AppConfig): string[] {
-  return [...config.skillPaths, ...config.userSkillPaths];
+  return [...config.skillPaths, ...config.userSkillPaths, ...enabledCollectionSkillDirs(config.userSkillCollections ?? [])];
+}
+
+/**
+ * A repository enrolled as a skill collection, and which of its skills are on.
+ * `enabledSkills` are POSIX paths relative to `path`, one per skill directory.
+ * `managed` records that pi-outpost's own clone created the folder, which is
+ * what allows removing the repository to delete it.
+ */
+export interface SkillCollection {
+  path: string;
+  managed: boolean;
+  enabledSkills: string[];
+}
+
+/** Resolve one enabled entry to its directory, or undefined when it cannot be inside `root`. */
+export function collectionSkillDir(root: string, relative: string): string | undefined {
+  if (!relative || relative.includes("\\") || path.posix.isAbsolute(relative)) return undefined;
+  const segments = relative.split("/");
+  if (segments.some((segment) => segment === "" || segment === "." || segment === "..")) return undefined;
+  return path.join(root, ...segments);
+}
+
+/**
+ * The skill directories the session should load from collections: each enabled
+ * entry that still resolves inside its worktree — symlinks included, so a link
+ * cannot smuggle an outside directory in — and still holds a `SKILL.md`. A skill
+ * that vanished in an update is dropped here rather than handed to the loader.
+ *
+ * Last in `allSkillPaths` on purpose: the loader keeps the first skill under a
+ * name, so the configuration file's and the user's own paths keep winning.
+ */
+export function enabledCollectionSkillDirs(collections: readonly SkillCollection[]): string[] {
+  const dirs: string[] = [];
+  for (const collection of collections) {
+    let root: string;
+    try {
+      root = fs.realpathSync(collection.path);
+    } catch {
+      continue;
+    }
+    for (const relative of collection.enabledSkills) {
+      const dir = collectionSkillDir(root, relative);
+      if (!dir) continue;
+      try {
+        const canonical = fs.realpathSync(dir);
+        const rel = path.relative(root, canonical);
+        if (rel === "" || rel.startsWith("..") || path.isAbsolute(rel)) continue;
+        if (!fs.statSync(path.join(canonical, "SKILL.md")).isFile()) continue;
+        dirs.push(canonical);
+      } catch {
+        // Gone or unreadable: not loaded, reported as missing by the inventory.
+      }
+    }
+  }
+  return [...new Set(dirs)];
 }
 
 /**
@@ -1333,6 +1437,13 @@ export function persistEditableSettings(
   // Written under its own key: `skillPaths` belongs to whoever wrote the file, and
   // an apply must never be able to drop one of theirs.
   if (update.userSkillPaths) raw.userSkillPaths = update.userSkillPaths.map((p) => path.resolve(p));
+  if (update.userSkillCollections) {
+    raw.userSkillCollections = update.userSkillCollections.map((collection) => ({
+      path: path.resolve(collection.path),
+      managed: collection.managed,
+      enabledSkills: [...new Set(collection.enabledSkills)],
+    }));
+  }
   // Same reasoning one kind over: `extensionPaths` and `extensionLock` belong to
   // whoever wrote the file, and neither is read or rewritten here. Only the keys
   // named in this function are touched; everything else survives the write as it was.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -24,6 +24,7 @@ import {
 import {
   type AgentResourceInventory,
   type AgentResourceReloadResult,
+  AgentResourceRemovalResult,
   type AgentResourceUpdateResult,
   type ClientMessage,
   type ContextUsage,
@@ -86,6 +87,8 @@ import {
   loadConfig,
   NoConfigError,
   persistEditableSettings,
+  collectionSkillDir,
+  type SkillCollection,
 } from "./config.ts";
 import {
   carriesIndexHtml,
@@ -157,7 +160,7 @@ import { composeAppendSystemPrompt } from "./systemPrompt.ts";
 import { createPdfExtractToolDefinition } from "./pdfTool.ts";
 import { Workspace, shouldRetireWorkspace, type WorkspaceOptions, type WorkspaceSettings } from "./workspace.ts";
 import { WorkspaceRegistry } from "./workspaceRegistry.ts";
-import { ResourceRepositoryService } from "./resourceRepositories.ts";
+import { discoverSkillCatalogue, ResourceRepositoryService } from "./resourceRepositories.ts";
 import { deriveWorkspaceActivity, workspaceActivityNeedsAttention } from "./workspaceActivity.ts";
 import { isWithin, realResolve } from "./sandbox.ts";
 import {
@@ -1198,6 +1201,7 @@ function resourceInventoryInput(target: Workspace) {
     userSkillPaths: config.userSkillPaths,
     configuredExtensionPaths: config.extensionPaths,
     userExtensionPaths: config.userExtensionPaths,
+    userSkillCollections: config.userSkillCollections,
     extensionLock: config.extensionLock === true,
   };
 }
@@ -1362,9 +1366,17 @@ function publishWorkPlanTools(workspace: Workspace, plan: WorkPlan | null): void
   workspace.agent.setToolPublished(WORK_PLAN_EXTENDED_TOOL, plan !== null);
 }
 
-function queueWorkPlanSessionSync(workspace: Workspace): Promise<void> {
+/**
+ * `after` is work the snapshot must reflect — the resource inventory — and is
+ * awaited inside the chain rather than before calling this: `workPlanSync` has to
+ * cover the whole replacement from the moment the event arrives. Chained only
+ * after the inventory, a replacement awaiting `workPlanSync` in the meantime saw
+ * the previous, settled promise and went on before the inherited plan loaded.
+ */
+function queueWorkPlanSessionSync(workspace: Workspace, after?: Promise<unknown>): Promise<void> {
   const sessionFile = workspace.agent.snapshot().sessionFile;
   workspace.workPlanSync = workspace.workPlanSync.catch(() => {}).then(async () => {
+    if (after) await after.catch(() => {});
     const inheritanceSource = workspace.workPlanInheritanceSource;
     const inherited =
       inheritanceSource !== undefined && !sameSessionFile(inheritanceSource, sessionFile);
@@ -1982,17 +1994,14 @@ function onRuntimeEvent(workspace: Workspace, event: RuntimeEvent): void {
         // The updater awaits this exact refresh. Running a second inventory scan
         // here and in the request handler doubled every fetch and made the second
         // workspace race the first session replacement on slower CI hosts.
-        const sync = refreshResourceInventory(workspace, updatedRepositoryPath)
-          .then(async (inventory) => {
-            await queueWorkPlanSessionSync(workspace);
-            return inventory;
-          });
+        const refreshed = refreshResourceInventory(workspace, updatedRepositoryPath);
+        const sync = queueWorkPlanSessionSync(workspace, refreshed).then(() => refreshed);
         resourceReloadSyncs.set(workspace.root, sync);
         void sync.catch(reportError);
       } else {
-        void refreshResourceInventory(workspace)
-          .catch(reportError)
-          .then(() => queueWorkPlanSessionSync(workspace));
+        const refreshed = refreshResourceInventory(workspace);
+        void refreshed.catch(reportError);
+        void queueWorkPlanSessionSync(workspace, refreshed);
       }
       break;
     case "extensions_bound": {
@@ -2191,6 +2200,7 @@ async function handleUpdateConfig(
   update: {
     sandbox?: { root: string; allowWrite: boolean; allowBash: boolean; writableRoot?: string };
     userSkillPaths?: string[];
+    userSkillCollections?: SkillCollection[];
     userExtensionPaths?: string[];
   },
   resourceRequestId?: string,
@@ -2265,11 +2275,33 @@ async function handleUpdateConfig(
     refuse(`Could not use resource folder: ${error instanceof Error ? error.message : String(error)}`);
     return undefined;
   }
+  // A collection whose clone vanished outside the app is kept as written: refusing
+  // it would make every later collection change — its own removal included —
+  // impossible. The loader already skips skills that no longer exist.
+  let mergedCollections: SkillCollection[] | undefined;
+  if (update.userSkillCollections) {
+    try {
+      mergedCollections = await Promise.all(update.userSkillCollections.map(async (collection) => {
+        const resolved = resolve(collection.path);
+        const root = await fs.realpath(resolved).catch(() => resolved);
+        const stats = await fs.stat(root).catch(() => undefined);
+        if (stats && !stats.isDirectory()) throw new Error(`${collection.path} is not a directory`);
+        const enabled = [...new Set(collection.enabledSkills)];
+        const outside = enabled.find((relative) => !collectionSkillDir(root, relative));
+        if (outside !== undefined) throw new Error(`${outside} is not a skill path inside ${collection.path}`);
+        return { path: root, managed: collection.managed === true, enabledSkills: enabled };
+      }));
+    } catch (error) {
+      refuse(`Could not use skill collection: ${error instanceof Error ? error.message : String(error)}`);
+      return undefined;
+    }
+  }
 
   const persisted: EditableSettings = {
     ...(mergedSandbox ? { sandbox: mergedSandbox } : {}),
     ...(mergedSkillPaths ? { userSkillPaths: mergedSkillPaths } : {}),
     ...(mergedExtensionPaths ? { userExtensionPaths: mergedExtensionPaths } : {}),
+    ...(mergedCollections ? { userSkillCollections: mergedCollections } : {}),
   };
   // Keep an exact rollback projection. Extensions can veto the mandatory fresh
   // session; accepting the disk/browser half while retaining the old agent would
@@ -2287,12 +2319,14 @@ async function handleUpdateConfig(
       : {}),
     ...(mergedSkillPaths ? { userSkillPaths: [...config.userSkillPaths] } : {}),
     ...(mergedExtensionPaths ? { userExtensionPaths: [...config.userExtensionPaths] } : {}),
+    ...(mergedCollections ? { userSkillCollections: cloneCollections(config.userSkillCollections) } : {}),
   };
   const previousSandbox = current
     ? { ...current, readExceptions: [...current.readExceptions] }
     : undefined;
   const previousSkillPaths = [...config.userSkillPaths];
   const previousExtensionPaths = [...config.userExtensionPaths];
+  const previousCollections = cloneCollections(config.userSkillCollections);
   try {
     persistEditableSettings(config, persisted);
   } catch (error) {
@@ -2307,6 +2341,7 @@ async function handleUpdateConfig(
   try {
     if (mergedSkillPaths) config.userSkillPaths = mergedSkillPaths;
     if (mergedExtensionPaths) config.userExtensionPaths = mergedExtensionPaths;
+    if (mergedCollections) config.userSkillCollections = mergedCollections;
     if (mergedSandbox) {
       config.sandbox = {
         root: mergedSandbox.root,
@@ -2345,6 +2380,7 @@ async function handleUpdateConfig(
       // fail-safe and a restart will build both sides from the on-disk settings.
       config.userSkillPaths = previousSkillPaths;
       config.userExtensionPaths = previousExtensionPaths;
+      config.userSkillCollections = previousCollections;
       config.sandbox = previousSandbox;
       await workspace.rebuildResources({
         cwd: workspace.settings.cwd,
@@ -3505,7 +3541,12 @@ async function handleCloneAgentResourceRepository(
   requestId: string,
 ): Promise<void> {
   try {
-    const preview = await resourceService(workspace).cloneAndPreview(repositoryUrl, destinationPath, config.extensionLock === true);
+    const preview = await resourceService(workspace).cloneAndPreview(
+      repositoryUrl,
+      destinationPath,
+      config.extensionLock === true,
+      config.userSkillPaths,
+    );
     send(socket, { type: "agent_resource_preview", requestId, preview });
   } catch (error) {
     sendAgentResourceError(socket, requestId, error);
@@ -3518,6 +3559,7 @@ async function handleEnrollAgentResourceRepository(
   previewToken: string,
   skillRoots: string[],
   extensionRoots: string[],
+  enabledSkills: string[],
   requestId: string,
 ): Promise<void> {
   try {
@@ -3526,23 +3568,54 @@ async function handleEnrollAgentResourceRepository(
       skillRoots,
       extensionRoots,
       config.extensionLock === true,
+      enabledSkills,
     );
     const unique = (values: string[]) => [...new Set(values)];
+    const extensionUpdate = confirmed.extensionRoots.length > 0
+      ? { userExtensionPaths: unique([...config.userExtensionPaths, ...confirmed.extensionRoots]) }
+      : {};
     const inventory = await handleUpdateConfig(
       workspace,
       socket,
-      {
-        userSkillPaths: unique([...config.userSkillPaths, ...confirmed.skillRoots]),
-        ...(confirmed.extensionRoots.length > 0
-          ? { userExtensionPaths: unique([...config.userExtensionPaths, ...confirmed.extensionRoots]) }
-          : {}),
-      },
+      confirmed.mode === "collection"
+        ? {
+            userSkillCollections: withCollection(config.userSkillCollections, {
+              path: confirmed.repositoryPath,
+              managed: confirmed.managed,
+              enabledSkills: confirmed.enabledSkills,
+            }),
+            ...extensionUpdate,
+          }
+        : { userSkillPaths: unique([...config.userSkillPaths, ...confirmed.skillRoots]), ...extensionUpdate },
       requestId,
     );
     if (inventory) send(socket, { type: "agent_resource_enrolled", requestId, inventory });
   } catch (error) {
     sendAgentResourceError(socket, requestId, error);
   }
+}
+
+function cloneCollections(collections: readonly SkillCollection[]): SkillCollection[] {
+  return collections.map((collection) => ({ ...collection, enabledSkills: [...collection.enabledSkills] }));
+}
+
+/**
+ * Merge an enrollment into the collections: re-enrolling a repository adds the
+ * newly chosen skills to those already on — it never turns one off — and a
+ * repository once known to be pi-outpost's clone stays so.
+ */
+function withCollection(collections: readonly SkillCollection[], entry: SkillCollection): SkillCollection[] {
+  const existing = collections.find((candidate) => path.resolve(candidate.path) === path.resolve(entry.path));
+  if (!existing) return [...collections, entry];
+  return collections.map((candidate) =>
+    candidate === existing
+      ? {
+          path: existing.path,
+          managed: existing.managed || entry.managed,
+          enabledSkills: [...new Set([...existing.enabledSkills, ...entry.enabledSkills])],
+        }
+      : candidate,
+  );
 }
 
 async function handleRefreshAgentResourceRepositories(
@@ -3567,6 +3640,164 @@ function affectedResourceWorkspaces(repositoryPath: string): Workspace[] {
   return [...roots].map((root) => workspaces.get(root)).filter((target): target is Workspace => target !== undefined);
 }
 
+/**
+ * Why a change to a repository's resources must wait: the first of its consumers
+ * that is starting, replacing its session, or streaming a turn. Workspaces already
+ * reserved by the caller are its own and do not count.
+ */
+function busyResourceConsumer(targets: readonly Workspace[], reserved: ReadonlySet<Workspace> = new Set()): string | undefined {
+  const busy = targets.find(
+    (target) => !reserved.has(target) && (starting.has(target.root) || target.replacingSession || (target.started && target.isBusy())),
+  );
+  return busy ? `${path.basename(busy.root)} is busy; wait for its current turn to finish` : undefined;
+}
+
+async function canonicalOrResolved(value: string): Promise<string> {
+  return fs.realpath(value).catch(() => path.resolve(value));
+}
+
+/**
+ * Turn a collection's skills on or off: `enabledSkills` is the complete set that
+ * should be on. Checked against a catalogue built now — not the one the dialog
+ * was shown — and applied through the settings path, so persistence, the session
+ * replacement and its rollback are the same as for any skill path.
+ */
+async function handleSetAgentResourceSkills(
+  workspace: Workspace,
+  socket: WebSocket,
+  repositoryId: string,
+  enabledSkills: string[],
+  requestId: string,
+): Promise<void> {
+  try {
+    const repositoryPath = resourceService(workspace).repositoryPath(repositoryId);
+    if (!repositoryPath) throw new Error("Unknown resource repository");
+    let collection: SkillCollection | undefined;
+    for (const candidate of config.userSkillCollections) {
+      if ((await canonicalOrResolved(candidate.path)) === repositoryPath) collection = candidate;
+    }
+    if (!collection) throw new Error("This repository is not a skill collection");
+    const catalogued = new Set((await discoverSkillCatalogue(repositoryPath)).skills.map((entry) => entry.relativePath));
+    const chosen = [...new Set(enabledSkills)];
+    const stranger = chosen.find((relative) => !catalogued.has(relative));
+    if (stranger !== undefined) throw new Error(`The selected skill ${stranger} is not in this repository`);
+    const busy = busyResourceConsumer([...new Set([workspace, ...affectedResourceWorkspaces(repositoryPath)])]);
+    if (busy) throw new Error(busy);
+    const inventory = await handleUpdateConfig(
+      workspace,
+      socket,
+      {
+        userSkillCollections: config.userSkillCollections.map((candidate) =>
+          candidate === collection ? { ...candidate, enabledSkills: chosen } : candidate,
+        ),
+      },
+      requestId,
+    );
+    if (inventory) send(socket, { type: "agent_resource_skills_applied", requestId, repositoryId, inventory });
+  } catch (error) {
+    sendAgentResourceError(socket, requestId, error);
+  }
+}
+
+/**
+ * Remove a repository as a whole: unregister every path and selection inside it,
+ * then — only once no session loads from it any more — delete a clone pi-outpost
+ * manages. Unregistering goes through the settings path and its rollback; if that
+ * is refused nothing is deleted. Other projects loading the repository are held
+ * and rebuilt first, because the requester's replacement alone would leave them
+ * reading files that are about to disappear.
+ */
+async function handleRemoveAgentResourceRepository(
+  workspace: Workspace,
+  socket: WebSocket,
+  repositoryId: string,
+  requestId: string,
+): Promise<void> {
+  const service = resourceService(workspace);
+  const known = service.repositoryRemoval(repositoryId);
+  if (!known) {
+    sendAgentResourceError(socket, requestId, new Error("Unknown resource repository"));
+    return;
+  }
+  const { path: root, removal } = known;
+  if (!removal.allowed) {
+    sendAgentResourceError(socket, requestId, new Error(removal.reason ?? "This repository cannot be removed here"));
+    return;
+  }
+  const others = affectedResourceWorkspaces(root).filter((target) => target !== workspace);
+  const busy = busyResourceConsumer([workspace, ...others]);
+  if (busy) {
+    sendAgentResourceError(socket, requestId, new Error(busy));
+    return;
+  }
+  const reserved = new Set<Workspace>();
+  for (const target of others) {
+    target.replacingSession = true;
+    reserved.add(target);
+  }
+  try {
+    const inside = async (value: string) => {
+      const canonical = await canonicalOrResolved(value);
+      return canonical === root || isWithin(root, canonical);
+    };
+    const keep = async (values: readonly string[]) => {
+      const kept: string[] = [];
+      for (const value of values) if (!(await inside(value))) kept.push(value);
+      return kept;
+    };
+    const collections: SkillCollection[] = [];
+    for (const collection of config.userSkillCollections) {
+      if ((await canonicalOrResolved(collection.path)) !== root) collections.push(collection);
+    }
+    const skillPaths = await keep(config.userSkillPaths);
+    const extensionPaths = await keep(config.userExtensionPaths);
+    const inventory = await handleUpdateConfig(
+      workspace,
+      socket,
+      {
+        userSkillCollections: collections,
+        userSkillPaths: skillPaths,
+        ...(extensionPaths.length !== config.userExtensionPaths.length ? { userExtensionPaths: extensionPaths } : {}),
+      },
+      requestId,
+    );
+    // Refused or failed: handleUpdateConfig has reported it and restored the
+    // previous settings, so the repository is still registered and untouched.
+    if (!inventory) return;
+
+    let stillLoading: string | undefined;
+    for (const target of others) {
+      if (!target.started) continue;
+      const rebuild = target.agent.rebuildTools;
+      try {
+        const reload = rebuild ? await rebuild.call(target.agent) : { cancelled: true };
+        if (reload.cancelled) stillLoading ??= target.root;
+        else broadcast(target, { type: "agent_resource_inventory", inventory: await refreshResourceInventory(target) });
+      } catch {
+        stillLoading ??= target.root;
+      }
+    }
+
+    let result: AgentResourceRemovalResult;
+    if (!removal.deletesFiles) {
+      result = { status: "removed-files-kept", path: root, reason: "pi-outpost does not manage this folder, so its files were kept" };
+    } else if (stillLoading) {
+      result = { status: "removed-files-kept", path: root, reason: `${path.basename(stillLoading)} still loads resources from it, so its files were kept` };
+    } else {
+      const deletion = await service.deleteManagedClone(root, removal.deletesFiles);
+      result = deletion.deleted
+        ? { status: "removed", path: root }
+        : { status: deletion.failed ? "removed-delete-failed" : "removed-files-kept", path: root, reason: deletion.reason };
+    }
+    const fresh = await refreshResourceInventory(workspace);
+    send(socket, { type: "agent_resource_removed", requestId, repositoryId, result, inventory: fresh });
+  } catch (error) {
+    sendAgentResourceError(socket, requestId, error);
+  } finally {
+    for (const target of reserved) target.replacingSession = false;
+  }
+}
+
 async function handleUpdateAgentResourceRepository(
   workspace: Workspace,
   socket: WebSocket,
@@ -3587,10 +3818,8 @@ async function handleUpdateAgentResourceRepository(
   const reserved = new Set<Workspace>();
   const reserveAffected = (): string | undefined => {
     affected = affectedResourceWorkspaces(repositoryPath);
-    const busy = affected.find(
-      (target) => !reserved.has(target) && (starting.has(target.root) || target.replacingSession || (target.started && target.isBusy())),
-    );
-    if (busy) return `${path.basename(busy.root)} is busy; wait for its current turn to finish`;
+    const busy = busyResourceConsumer(affected, reserved);
+    if (busy) return busy;
     for (const target of affected) {
       target.replacingSession = true;
       reserved.add(target);
@@ -3708,6 +3937,8 @@ const AGENT_COMMANDS = new Set<ClientMessage["type"]>([
   "update_config",
   "enroll_agent_resource_repository",
   "update_agent_resource_repository",
+  "set_agent_resource_skills",
+  "remove_agent_resource_repository",
 ]);
 
 function handleClientMessage(socket: WebSocket, raw: string): void {
@@ -4065,6 +4296,8 @@ function handleClientMessage(socket: WebSocket, raw: string): void {
         !Array.isArray(message.extensionRoots) ||
         message.skillRoots.some((value) => typeof value !== "string") ||
         message.extensionRoots.some((value) => typeof value !== "string") ||
+        (message.enabledSkills !== undefined &&
+          (!Array.isArray(message.enabledSkills) || message.enabledSkills.some((value) => typeof value !== "string"))) ||
         typeof message.requestId !== "string"
       ) return;
       handleEnrollAgentResourceRepository(
@@ -4073,8 +4306,24 @@ function handleClientMessage(socket: WebSocket, raw: string): void {
         message.previewToken,
         message.skillRoots,
         message.extensionRoots,
+        message.enabledSkills ?? [],
         message.requestId,
       ).catch((error) => sendAgentResourceError(socket, message.requestId, error));
+      break;
+    case "set_agent_resource_skills":
+      if (
+        typeof message.repositoryId !== "string" ||
+        !Array.isArray(message.enabledSkills) ||
+        message.enabledSkills.some((value) => typeof value !== "string") ||
+        typeof message.requestId !== "string"
+      ) return;
+      handleSetAgentResourceSkills(workspace, socket, message.repositoryId, message.enabledSkills, message.requestId)
+        .catch((error) => sendAgentResourceError(socket, message.requestId, error));
+      break;
+    case "remove_agent_resource_repository":
+      if (typeof message.repositoryId !== "string" || typeof message.requestId !== "string") return;
+      handleRemoveAgentResourceRepository(workspace, socket, message.repositoryId, message.requestId)
+        .catch((error) => sendAgentResourceError(socket, message.requestId, error));
       break;
     case "refresh_agent_resource_repositories":
       if (

--- a/server/src/resourceRepositories.ts
+++ b/server/src/resourceRepositories.ts
@@ -13,6 +13,9 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import type {
+  AgentCollectionSkill,
+  AgentResourceCollection,
+  AgentResourceRemoval,
   AgentResourceInfo,
   AgentResourceInventory,
   AgentResourceKind,
@@ -20,9 +23,12 @@ import type {
   AgentResourceRepositoryAssessment,
   AgentResourceRepositoryPreview,
   AgentResourceRepositoryStatus,
+  AgentSkillCatalogueBound,
+  AgentSkillCatalogueEntry,
 } from "@pi-outpost/shared";
+import { parseFrontmatter } from "@earendil-works/pi-coding-agent";
 import { currentGitExecutable } from "./git.ts";
-import { userConfigDir } from "./config.ts";
+import { type SkillCollection, userConfigDir } from "./config.ts";
 import { isWithin } from "./sandbox.ts";
 
 const execFileAsync = promisify(execFile);
@@ -66,6 +72,42 @@ type ResourceGitObserver = (event: {
 }) => void;
 let resourceGitObserver: ResourceGitObserver | undefined;
 
+/**
+ * Git marks its object files read-only, and on Windows a read-only file cannot be
+ * unlinked, so the first `rm` of a clone there fails with EPERM. Clearing the
+ * read-only bits (never following a link) and trying once more is what makes
+ * removal work on that platform; anything still failing is reported.
+ */
+async function removeTreeForcefully(target: string): Promise<void> {
+  try {
+    await fs.rm(target, { recursive: true, force: true, maxRetries: 3 });
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== "EPERM" && code !== "EACCES") throw error;
+    await makeWritable(target);
+    await fs.rm(target, { recursive: true, force: true, maxRetries: 3 });
+  }
+}
+
+async function makeWritable(target: string): Promise<void> {
+  const entry = await fs.lstat(target).catch(() => undefined);
+  if (!entry || entry.isSymbolicLink()) return;
+  if (entry.isDirectory()) {
+    await fs.chmod(target, 0o700).catch(() => undefined);
+    const children = await fs.readdir(target).catch(() => [] as string[]);
+    for (const child of children) await makeWritable(path.join(target, child));
+  } else {
+    await fs.chmod(target, 0o600).catch(() => undefined);
+  }
+}
+
+let resourceRemover: (target: string) => Promise<void> = removeTreeForcefully;
+
+/** Test seam: make deletion fail on demand, which no portable fixture can force. */
+export function useResourceRemover(remover?: (target: string) => Promise<void>): void {
+  resourceRemover = remover ?? removeTreeForcefully;
+}
+
 /** Test seam for proving command shape and concurrency without replacing Git. */
 export function useResourceGitObserver(observer?: ResourceGitObserver): void {
   resourceGitObserver = observer;
@@ -79,12 +121,25 @@ interface KnownRepository {
   resources: AgentResourceInfo[];
   containsExtensions: boolean;
   assessment: AgentResourceRepositoryAssessment;
+  collection?: AgentResourceCollection;
+  removal: AgentResourceRemoval;
 }
 
 interface PreviewRecord {
   preview: AgentResourceRepositoryPreview;
   rootsKey: string;
   expiresAt: number;
+  /** pi-outpost created this clone, or it lies in managed storage. */
+  managed: boolean;
+}
+
+export interface ConfirmedEnrollment {
+  repositoryPath: string;
+  mode: AgentResourceRepositoryPreview["mode"];
+  managed: boolean;
+  skillRoots: string[];
+  extensionRoots: string[];
+  enabledSkills: string[];
 }
 
 interface AssessmentRecord {
@@ -103,6 +158,7 @@ export interface ResourceInventoryInput {
   userSkillPaths: string[];
   configuredExtensionPaths: string[];
   userExtensionPaths: string[];
+  userSkillCollections?: readonly SkillCollection[];
   extensionLock: boolean;
 }
 
@@ -166,6 +222,24 @@ export class ResourceRepositoryService {
       byRoot.set(root, list);
     }
 
+    // A collection is a repository even when none of its skills is loaded: its
+    // catalogue is what the user turns skills on from. One whose folder vanished
+    // stays listed, so it can still be seen and removed.
+    const collectionsByRoot = new Map<string, SkillCollection>();
+    const missingCollections: SkillCollection[] = [];
+    for (const collection of input.userSkillCollections ?? []) {
+      const canonical = await canonicalExisting(collection.path);
+      const root = canonical ? await enclosingRepository(canonical) : undefined;
+      if (!root) {
+        missingCollections.push(collection);
+        continue;
+      }
+      collectionsByRoot.set(root, collection);
+      if (!byRoot.has(root)) byRoot.set(root, []);
+    }
+    const removalFor = await removalPolicy(input, await canonicalExisting(this.managedRoot));
+    const loadedSkills = resources.filter((resource) => resource.kind === "skill" && resource.path);
+
     const next = new Map<string, KnownRepository>();
     for (const [root, repoResources] of byRoot) {
       const filesystemIdentity = await repositoryFilesystemIdentity(root);
@@ -178,14 +252,35 @@ export class ResourceRepositoryService {
           : previous?.assessment.status === "locked"
             ? blockedAssessment(id, "unchecked")
             : previous?.assessment ?? blockedAssessment(id, "unchecked");
+      const collection = collectionsByRoot.get(root);
+      const name = await repositoryDisplayName(root);
       next.set(id, {
         id,
         path: root,
         filesystemIdentity,
-        name: path.basename(root) || root,
+        name,
         resources: repoResources,
         containsExtensions,
         assessment,
+        ...(collection ? { collection: await collectionView(root, name, collection, loadedSkills) } : {}),
+        removal: removalFor(root, collection),
+      });
+    }
+    for (const collection of missingCollections) {
+      const where = path.resolve(collection.path);
+      const filesystemIdentity = `missing:${where}`;
+      const id = repositoryId(where, filesystemIdentity);
+      const name = path.basename(where) || where;
+      next.set(id, {
+        id,
+        path: where,
+        filesystemIdentity,
+        name,
+        resources: [],
+        containsExtensions: false,
+        assessment: blockedAssessment(id, "unavailable", "The repository's folder no longer exists"),
+        collection: withGroups(name, collection.enabledSkills.map(missingSkill)),
+        removal: { allowed: true, deletesFiles: false, path: where },
       });
     }
     this.repositories = next;
@@ -214,22 +309,43 @@ export class ResourceRepositoryService {
     return this.buildInventory(input);
   }
 
-  async preview(selectedPath: string, extensionLock: boolean): Promise<AgentResourceRepositoryPreview> {
+  /**
+   * A worktree already registered through one of the user's skill roots keeps that
+   * load-everything enrollment ("roots"); every other repository is enrolled as a
+   * collection whose skills start off.
+   */
+  async preview(
+    selectedPath: string,
+    extensionLock: boolean,
+    options: { userSkillPaths?: readonly string[]; managed?: boolean } = {},
+  ): Promise<AgentResourceRepositoryPreview> {
     const selected = await canonicalDirectory(selectedPath);
     const root = await enclosingRepository(selected);
     if (!root) throw new ResourceRepositoryError("The selected directory is not inside a Git worktree");
-    const roots = await discoverResourceRoots(root, extensionLock);
-    if (roots.length === 0) throw new ResourceRepositoryError("No recognizable skill or extension roots were found in this repository");
+    const mode = (await enrolledThroughSkillRoots(root, options.userSkillPaths ?? [])) ? "roots" : "collection";
+    const observed = await observeRepository(root, extensionLock, mode);
+    if (observed.roots.length === 0 && observed.skills.length === 0) {
+      throw new ResourceRepositoryError("No recognizable skill or extension roots were found in this repository");
+    }
     const headRevision = (await runGit(root, ["rev-parse", "HEAD"])).trim();
     const token = randomUUID();
     const preview: AgentResourceRepositoryPreview = {
       token,
       repositoryPath: root,
-      repositoryName: path.basename(root) || root,
+      repositoryName: await repositoryDisplayName(root),
       headRevision,
-      roots,
+      mode,
+      roots: observed.roots,
+      skills: observed.skills,
+      ...(observed.bound ? { bound: observed.bound } : {}),
     };
-    this.previews.set(token, { preview, rootsKey: rootsFingerprint(roots), expiresAt: this.now() + PREVIEW_TTL_MS });
+    const managedRoot = await canonicalExisting(this.managedRoot);
+    this.previews.set(token, {
+      preview,
+      rootsKey: observed.key,
+      expiresAt: this.now() + PREVIEW_TTL_MS,
+      managed: options.managed === true || (managedRoot !== undefined && managedRoot !== root && isWithin(managedRoot, root)),
+    });
     return preview;
   }
 
@@ -243,7 +359,12 @@ export class ResourceRepositoryService {
     );
   }
 
-  async cloneAndPreview(repositoryUrl: string, destinationPath: string, extensionLock: boolean): Promise<AgentResourceRepositoryPreview> {
+  async cloneAndPreview(
+    repositoryUrl: string,
+    destinationPath: string,
+    extensionLock: boolean,
+    userSkillPaths: readonly string[] = [],
+  ): Promise<AgentResourceRepositoryPreview> {
     const address = validateRepositoryAddress(repositoryUrl);
     const identity = repositoryAddressIdentity(address);
     await fs.mkdir(this.managedRoot, { recursive: true });
@@ -288,7 +409,9 @@ export class ResourceRepositoryService {
     }
     const credentialFreeAddress = repositoryAddressWithoutCredentials(address);
     if (credentialFreeAddress !== address) await runGit(destination, ["remote", "set-url", "origin", credentialFreeAddress]);
-    const preview = await this.preview(destination, extensionLock);
+    // Only a folder this clone created is pi-outpost's to delete later; a reused
+    // existing clone may be someone's working copy (unless it sits in managed storage).
+    const preview = await this.preview(destination, extensionLock, { userSkillPaths, managed: !existing });
     preview.repositoryUrl = redactRepositoryAddress(address);
     const record = this.previews.get(preview.token);
     if (record) record.preview = preview;
@@ -300,27 +423,44 @@ export class ResourceRepositoryService {
     skillRoots: string[],
     extensionRoots: string[],
     extensionLock: boolean,
-  ): Promise<{ repositoryPath: string; skillRoots: string[]; extensionRoots: string[] }> {
+    enabledSkills: string[] = [],
+  ): Promise<ConfirmedEnrollment> {
     const record = this.previews.get(token);
     this.previews.delete(token);
     if (!record) throw new ResourceRepositoryError("This repository preview is no longer valid; preview it again");
     if (this.now() > record.expiresAt) throw new ResourceRepositoryError("This repository preview has expired; preview it again");
-    const fresh = await discoverResourceRoots(record.preview.repositoryPath, extensionLock);
-    const head = (await runGit(record.preview.repositoryPath, ["rev-parse", "HEAD"])).trim();
-    if (head !== record.preview.headRevision || rootsFingerprint(fresh) !== record.rootsKey) {
+    const { preview } = record;
+    const fresh = await observeRepository(preview.repositoryPath, extensionLock, preview.mode);
+    const head = (await runGit(preview.repositoryPath, ["rev-parse", "HEAD"])).trim();
+    if (head !== preview.headRevision || fresh.key !== record.rootsKey) {
       throw new ResourceRepositoryError("The repository changed after preview; preview it again");
     }
-    const permitted = new Map(fresh.map((root) => [`${root.kind}:${root.path}`, root]));
+    const permitted = new Map(fresh.roots.map((root) => [`${root.kind}:${root.path}`, root]));
     const select = (kind: AgentResourceKind, values: string[]) =>
       [...new Set(values)].map((value) => {
         const candidate = permitted.get(`${kind}:${value}`);
         if (!candidate || candidate.locked) throw new ResourceRepositoryError(`The selected ${kind} root is unavailable`);
         return candidate.path;
       });
+    // In a collection preview `fresh.roots` holds no skill root, so a skill root sent
+    // for one is refused here as unavailable: its skills are chosen one by one.
     const skills = select("skill", skillRoots);
     const extensions = select("extension", extensionRoots);
-    if (skills.length + extensions.length === 0) throw new ResourceRepositoryError("Select at least one resource root");
-    return { repositoryPath: record.preview.repositoryPath, skillRoots: skills, extensionRoots: extensions };
+    const base = { repositoryPath: preview.repositoryPath, managed: record.managed, extensionRoots: extensions };
+    if (preview.mode === "roots") {
+      if (enabledSkills.length > 0) {
+        throw new ResourceRepositoryError("This repository is registered through skill roots; select roots rather than individual skills");
+      }
+      if (skills.length + extensions.length === 0) throw new ResourceRepositoryError("Select at least one resource root");
+      return { ...base, mode: "roots", skillRoots: skills, enabledSkills: [] };
+    }
+    const catalogued = new Set(fresh.skills.map((entry) => entry.relativePath));
+    const chosen = [...new Set(enabledSkills)];
+    const stranger = chosen.find((relative) => !catalogued.has(relative));
+    if (stranger !== undefined) throw new ResourceRepositoryError(`The selected skill ${stranger} is not in this repository`);
+    // An empty selection is a valid enrollment: the catalogue is registered and
+    // nothing from it loads until a skill is turned on.
+    return { ...base, mode: "collection", skillRoots: [], enabledSkills: chosen };
   }
 
   async refresh(repositoryIdValue?: string, extensionLock = false): Promise<AgentResourceRepositoryAssessment[]> {
@@ -417,6 +557,46 @@ export class ResourceRepositoryService {
 
   repositoryResources(repositoryIdValue: string): AgentResourceInfo[] {
     return this.repositories.get(repositoryIdValue)?.resources ?? [];
+  }
+
+  /** Where a known repository is and what removing it may do, or undefined for an unissued id. */
+  repositoryRemoval(repositoryIdValue: string): { path: string; removal: AgentResourceRemoval } | undefined {
+    const repo = this.repositories.get(repositoryIdValue);
+    return repo ? { path: repo.path, removal: repo.removal } : undefined;
+  }
+
+  /**
+   * Delete a clone that removing its repository has already unregistered.
+   *
+   * Every condition is checked again here, under the repository's lock, rather
+   * than trusted from the inventory that offered the action: the folder must still
+   * be the canonical top level of a Git worktree, must be pi-outpost's (created by
+   * its clone, or inside managed storage), and must be neither a filesystem root
+   * nor managed storage itself. Symbolic links inside it are unlinked, never
+   * followed. A failure is returned as a reason, never thrown past the caller: the
+   * repository is already unregistered, and that must still be reported.
+   */
+  async deleteManagedClone(root: string, managed: boolean): Promise<{ deleted: true } | { deleted: false; failed: boolean; reason: string }> {
+    return this.withLock(root, async () => {
+      const kept = (reason: string) => ({ deleted: false as const, failed: false, reason });
+      const canonical = await canonicalExisting(root);
+      if (!canonical) return { deleted: true as const };
+      if (canonical !== root) return kept("The repository folder moved or became a link; its files were kept");
+      if (path.parse(canonical).root === canonical) return kept("A filesystem root is never deleted");
+      const managedRoot = await canonicalExisting(this.managedRoot);
+      if (managedRoot === canonical) return kept("Managed resource storage itself is never deleted");
+      const inManagedStorage = managedRoot !== undefined && isWithin(managedRoot, canonical);
+      if (!managed && !inManagedStorage) return kept("pi-outpost does not manage this folder; its files were kept");
+      const topLevel = await tryGit(canonical, ["rev-parse", "--show-toplevel"]);
+      const canonicalTopLevel = topLevel ? await canonicalExisting(topLevel.trim()) : undefined;
+      if (canonicalTopLevel !== canonical) return kept("The folder is no longer the top of a Git repository; its files were kept");
+      try {
+        await resourceRemover(canonical);
+        return { deleted: true as const };
+      } catch (error) {
+        return { deleted: false as const, failed: true, reason: `Could not delete every file: ${firstLine(error)}` };
+      }
+    });
   }
 
   private requireRepository(id: string): KnownRepository {
@@ -518,7 +698,95 @@ function toWireRepository(repo: KnownRepository): AgentResourceRepository {
     resourceIds: repo.resources.map((resource) => resource.id).sort(),
     containsExtensions: repo.containsExtensions,
     assessment: repo.assessment,
+    ...(repo.collection ? { collection: repo.collection } : {}),
+    removal: repo.removal,
   };
+}
+
+/**
+ * Who may remove a repository, and whether removing it deletes files. A
+ * repository supplying a configuration-file path is the operator's; one nobody
+ * added through Agent resources is not the dialog's to remove; files are deleted
+ * only for a clone pi-outpost made or keeps in its managed storage.
+ */
+async function removalPolicy(
+  input: ResourceInventoryInput,
+  managedRoot: string | undefined,
+): Promise<(root: string, collection?: SkillCollection) => AgentResourceRemoval> {
+  const canonical = async (values: readonly string[]) =>
+    (await Promise.all(values.map(canonicalExisting))).filter((value): value is string => value !== undefined);
+  const configured = await canonical([...input.configuredSkillPaths, ...input.configuredExtensionPaths]);
+  const user = await canonical([...input.userSkillPaths, ...input.userExtensionPaths]);
+  return (root, collection) => {
+    if (configured.some((entry) => isWithin(root, entry))) {
+      return { allowed: false, deletesFiles: false, path: root, reason: "This repository supplies a path from the configuration file, so it can only be removed there" };
+    }
+    if (!collection && !user.some((entry) => isWithin(root, entry))) {
+      return { allowed: false, deletesFiles: false, path: root, reason: "This repository was not added through Agent resources" };
+    }
+    const inManagedStorage = managedRoot !== undefined && managedRoot !== root && isWithin(managedRoot, root);
+    return { allowed: true, deletesFiles: collection?.managed === true || inManagedStorage, path: root };
+  };
+}
+
+/**
+ * Join a repository's catalogue, the selection that is on, and what the runtime
+ * actually loaded. A skill that is on but was not loaded says why when it can be
+ * told: another skill of the same name reached the loader first.
+ */
+async function collectionView(
+  root: string,
+  repositoryName: string,
+  collection: SkillCollection,
+  loadedSkills: readonly AgentResourceInfo[],
+): Promise<AgentResourceCollection> {
+  const catalogue = await discoverSkillCatalogue(root);
+  const enabled = new Set(collection.enabledSkills);
+  const loadedDirs = new Set(loadedSkills.map((resource) => skillDirectoryOf(resource.path!)));
+  const skills: AgentCollectionSkill[] = catalogue.skills.map((entry) => {
+    if (!enabled.has(entry.relativePath)) return { ...entry, state: "off" };
+    const dir = entry.relativePath ? path.join(root, ...entry.relativePath.split("/")) : root;
+    if (loadedDirs.has(dir)) return { ...entry, state: "on-loaded" };
+    const winner = loadedSkills.find((resource) => resource.name === entry.name);
+    return {
+      ...entry,
+      state: "on-not-loaded",
+      reason: winner
+        ? `Another skill named "${entry.name}" was loaded first, from ${winner.path}`
+        : "The session did not load this skill",
+    };
+  });
+  const catalogued = new Set(catalogue.skills.map((entry) => entry.relativePath));
+  for (const relative of collection.enabledSkills) {
+    if (!catalogued.has(relative)) skills.push(missingSkill(relative));
+  }
+  return withGroups(repositoryName, skills, catalogue.bound);
+}
+
+function missingSkill(relative: string): AgentCollectionSkill {
+  const at = relative.lastIndexOf("/");
+  return {
+    relativePath: relative,
+    name: relative.slice(at + 1) || relative,
+    group: at === -1 ? "" : relative.slice(0, at),
+    state: "on-missing",
+    reason: "This skill is no longer in the repository",
+  };
+}
+
+function withGroups(
+  repositoryName: string,
+  skills: AgentCollectionSkill[],
+  bound?: AgentResourceCollection["bound"],
+): AgentResourceCollection {
+  skills.sort((a, b) => a.group.localeCompare(b.group) || a.relativePath.localeCompare(b.relativePath));
+  const groups = [...new Set(skills.map((skill) => skill.group))].map((group) => ({ path: group, label: group || repositoryName }));
+  return { skills, groups, ...(bound ? { bound } : {}) };
+}
+
+/** The runtime reports a skill by its SKILL.md; the catalogue by its directory. */
+function skillDirectoryOf(resourcePath: string): string {
+  return path.basename(resourcePath) === "SKILL.md" ? path.dirname(resourcePath) : resourcePath;
 }
 
 function blockedAssessment(repositoryIdValue: string, status: "unchecked" | "checking"): AgentResourceRepositoryAssessment;
@@ -676,6 +944,88 @@ async function containsNamedFile(root: string, name: string, maxDepth: number): 
   return walk(root, 0);
 }
 
+export const SKILL_CATALOGUE_MAX_DEPTH = 8;
+export const SKILL_CATALOGUE_MAX_SKILLS = 2_000;
+const SKILL_CATALOGUE_MAX_BYTES = 16 * 1024;
+
+export interface SkillCatalogue {
+  skills: AgentSkillCatalogueEntry[];
+  bound?: AgentSkillCatalogueBound;
+}
+
+/**
+ * Every skill a worktree carries, found by its own folder tree.
+ *
+ * The walk follows pi's discovery rule — a directory holding `SKILL.md` is one
+ * skill and is not descended into — so each entry is exactly what the loader
+ * will build from that directory. It reads files and nothing else: no module is
+ * imported, no symlink followed, `.git` and `node_modules` are skipped. Depth,
+ * count and bytes per file are bounded, and hitting a bound is reported rather
+ * than passed off as the whole repository.
+ */
+export async function discoverSkillCatalogue(
+  worktree: string,
+  limits: { maxDepth?: number; maxSkills?: number } = {},
+): Promise<SkillCatalogue> {
+  const maxDepth = limits.maxDepth ?? SKILL_CATALOGUE_MAX_DEPTH;
+  const maxSkills = limits.maxSkills ?? SKILL_CATALOGUE_MAX_SKILLS;
+  const skills: AgentSkillCatalogueEntry[] = [];
+  let bound: AgentSkillCatalogueBound | undefined;
+  const walk = async (dir: string, depth: number): Promise<void> => {
+    if (bound?.kind === "count") return;
+    let entries;
+    try { entries = await fs.readdir(dir, { withFileTypes: true }); } catch { return; }
+    if (entries.some((entry) => entry.isFile() && entry.name === "SKILL.md")) {
+      if (skills.length >= maxSkills) {
+        bound = { kind: "count", limit: maxSkills };
+        return;
+      }
+      skills.push(await catalogueEntry(worktree, dir));
+      return;
+    }
+    const children = entries
+      .filter((entry) => entry.isDirectory() && entry.name !== ".git" && entry.name !== "node_modules")
+      .map((entry) => entry.name)
+      .sort();
+    if (children.length === 0) return;
+    if (depth >= maxDepth) {
+      bound ??= { kind: "depth", limit: maxDepth };
+      return;
+    }
+    for (const child of children) await walk(path.join(dir, child), depth + 1);
+  };
+  await walk(worktree, 0);
+  skills.sort((a, b) => a.group.localeCompare(b.group) || a.relativePath.localeCompare(b.relativePath));
+  return bound ? { skills, bound } : { skills };
+}
+
+async function catalogueEntry(worktree: string, dir: string): Promise<AgentSkillCatalogueEntry> {
+  const relativePath = path.relative(worktree, dir).split(path.sep).join("/");
+  const group = relativePath.includes("/") ? relativePath.slice(0, relativePath.lastIndexOf("/")) : "";
+  let name: string | undefined;
+  let description: string | undefined;
+  try {
+    const handle = await fs.open(path.join(dir, "SKILL.md"), "r");
+    try {
+      const buffer = Buffer.alloc(SKILL_CATALOGUE_MAX_BYTES);
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+      const { frontmatter } = parseFrontmatter<Record<string, unknown>>(buffer.subarray(0, bytesRead).toString("utf8"));
+      if (typeof frontmatter.name === "string" && frontmatter.name.trim()) name = frontmatter.name.trim();
+      if (typeof frontmatter.description === "string" && frontmatter.description.trim()) description = frontmatter.description.trim();
+    } finally {
+      await handle.close();
+    }
+  } catch {
+    // Unreadable or malformed frontmatter: still a skill directory, named by its folder.
+  }
+  return {
+    relativePath,
+    name: name ?? (path.basename(dir) || relativePath),
+    ...(description ? { description } : {}),
+    group,
+  };
+}
+
 async function containsExtension(root: string): Promise<boolean> {
   let entries;
   try { entries = await fs.readdir(root, { withFileTypes: true }); } catch { return false; }
@@ -695,8 +1045,30 @@ function dedupeRoots(roots: AgentResourceRepositoryPreview["roots"]): AgentResou
   return [...new Map(roots.map((root) => [`${root.kind}:${root.path}`, root])).values()];
 }
 
-function rootsFingerprint(roots: AgentResourceRepositoryPreview["roots"]): string {
-  return createHash("sha256").update(JSON.stringify(roots)).digest("hex");
+/**
+ * What a preview shows, and the fingerprint a confirmation must match: the roots
+ * it can register and, for a collection, the whole catalogue — a skill added or
+ * renamed between preview and confirmation invalidates the preview.
+ */
+async function observeRepository(
+  root: string,
+  extensionLock: boolean,
+  mode: AgentResourceRepositoryPreview["mode"],
+): Promise<{ roots: AgentResourceRepositoryPreview["roots"]; skills: AgentSkillCatalogueEntry[]; bound?: AgentSkillCatalogueBound; key: string }> {
+  const discovered = await discoverResourceRoots(root, extensionLock);
+  const roots = mode === "collection" ? discovered.filter((candidate) => candidate.kind === "extension") : discovered;
+  const catalogue = mode === "collection" ? await discoverSkillCatalogue(root) : { skills: [] };
+  const key = createHash("sha256").update(JSON.stringify({ mode, roots, catalogue })).digest("hex");
+  return { roots, skills: catalogue.skills, ...(catalogue.bound ? { bound: catalogue.bound } : {}), key };
+}
+
+/** Whether one of the user's skill roots lies inside this worktree. */
+async function enrolledThroughSkillRoots(root: string, userSkillPaths: readonly string[]): Promise<boolean> {
+  for (const candidate of userSkillPaths) {
+    const canonical = await canonicalExisting(candidate);
+    if (canonical && isWithin(root, canonical)) return true;
+  }
+  return false;
 }
 
 function resourceSort(a: AgentResourceInfo, b: AgentResourceInfo): number {
@@ -825,6 +1197,23 @@ function trimBoundaryHyphens(value: string): string {
   while (start < end && value[start] === "-") start += 1;
   while (end > start && value[end - 1] === "-") end -= 1;
   return start === 0 && end === value.length ? value : value.slice(start, end);
+}
+
+/**
+ * The name a repository goes by: the last segment of its `origin` address, as its
+ * owner spelled it. The folder is a local choice — a suggested clone folder carries
+ * a hash suffix, and the user may have named it anything — so it is only the
+ * fallback, for a worktree with no origin.
+ */
+async function repositoryDisplayName(root: string): Promise<string> {
+  const origin = (await tryGit(root, ["remote", "get-url", "origin"]))?.trim();
+  if (origin) {
+    const suffix = [origin.indexOf("?"), origin.indexOf("#")].filter((index) => index >= 0).sort((a, b) => a - b)[0];
+    const clean = trimTrailingAddressSeparators(suffix === undefined ? origin : origin.slice(0, suffix));
+    const tail = clean.split(/[\\/:]/).at(-1)?.replace(/\.git$/i, "");
+    if (tail) return tail;
+  }
+  return path.basename(root) || root;
 }
 
 function repositorySlug(address: string): string {

--- a/server/test/agentResourcesWire.test.mjs
+++ b/server/test/agentResourcesWire.test.mjs
@@ -92,15 +92,17 @@ test("repository enrollment is composed for the requesting socket workspace only
     requestId: "clone-alpha",
   });
   const previewMessage = await alphaClient.waitFor((message) => message.type === "agent_resource_preview" && message.requestId === "clone-alpha");
-  const skillRoot = previewMessage.preview.roots.find((candidate) => candidate.kind === "skill");
+  assert.equal(previewMessage.preview.mode, "collection");
+  assert.deepEqual(previewMessage.preview.skills.map((entry) => entry.relativePath), ["skills/review"]);
+  assert.equal(previewMessage.preview.roots.some((candidate) => candidate.kind === "skill"), false);
   const extensionRoot = previewMessage.preview.roots.find((candidate) => candidate.kind === "extension");
-  assert.ok(skillRoot);
   assert.ok(extensionRoot);
   alphaClient.send({
     type: "enroll_agent_resource_repository",
     previewToken: previewMessage.preview.token,
-    skillRoots: [skillRoot.path],
+    skillRoots: [],
     extensionRoots: [extensionRoot.path],
+    enabledSkills: ["skills/review"],
     requestId: "enroll-alpha",
   });
   const enrolled = await alphaClient.waitFor((message) => message.type === "agent_resource_enrolled" && message.requestId === "enroll-alpha");
@@ -126,7 +128,9 @@ test("repository enrollment is composed for the requesting socket workspace only
   alphaClient.send({
     type: "enroll_agent_resource_repository",
     previewToken: again.preview.token,
-    skillRoots: [again.preview.roots.find((candidate) => candidate.kind === "skill").path],
+    // Re-enrolling with no skill chosen keeps the one already on.
+    skillRoots: [],
+    enabledSkills: [],
     extensionRoots: [again.preview.roots.find((candidate) => candidate.kind === "extension").path],
     requestId: "enroll-again",
   });
@@ -150,15 +154,15 @@ test("extension lock filters a mixed preview while allowing skill-only enrollmen
     requestId: "locked-preview",
   });
   const preview = await client.waitFor((message) => message.type === "agent_resource_preview" && message.requestId === "locked-preview");
-  const skillRoot = preview.preview.roots.find((candidate) => candidate.kind === "skill");
+  assert.deepEqual(preview.preview.skills.map((entry) => entry.relativePath), ["skills/review"]);
   const extensionRoot = preview.preview.roots.find((candidate) => candidate.kind === "extension");
-  assert.ok(skillRoot);
   assert.equal(extensionRoot.locked, true);
   client.send({
     type: "enroll_agent_resource_repository",
     previewToken: preview.preview.token,
-    skillRoots: [skillRoot.path],
+    skillRoots: [],
     extensionRoots: [],
+    enabledSkills: ["skills/review"],
     requestId: "locked-enroll",
   });
   const enrolled = await client.waitFor((message) => message.type === "agent_resource_enrolled" && message.requestId === "locked-enroll");

--- a/server/test/cloneDeletion.test.ts
+++ b/server/test/cloneDeletion.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Deleting a removed repository's clone: only pi-outpost's own folder, never
+ * through a link, and honest when the deletion stops part-way.
+ */
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { access, chmod, mkdtemp, mkdir, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { after, afterEach, before, describe, test } from "node:test";
+import { useGitExecutable } from "../src/git.ts";
+import { ResourceRepositoryService, useResourceRemover } from "../src/resourceRepositories.ts";
+
+const git = execFileSync(process.platform === "win32" ? "where" : "which", ["git"], { encoding: "utf8" }).split("\n")[0].trim();
+const roots: string[] = [];
+
+function run(cwd: string, args: string[]): string {
+  return execFileSync(git, args, { cwd, encoding: "utf8" }).trim();
+}
+
+async function temp(name: string): Promise<string> {
+  const root = await realpath(await mkdtemp(path.join(tmpdir(), `pi-clone-deletion-${name}-`)));
+  roots.push(root);
+  return root;
+}
+
+/** A real repository with a commit, so Git's read-only object files are present. */
+async function clone(root: string): Promise<string> {
+  await mkdir(path.join(root, "skills", "one"), { recursive: true });
+  run(root, ["init", "-q", "--initial-branch=main"]);
+  run(root, ["config", "user.email", "test@example.com"]);
+  run(root, ["config", "user.name", "Deletion Test"]);
+  run(root, ["config", "commit.gpgsign", "false"]);
+  await writeFile(path.join(root, "skills", "one", "SKILL.md"), "---\nname: one\ndescription: One.\n---\n");
+  run(root, ["add", "."]);
+  run(root, ["commit", "-q", "-m", "one"]);
+  return root;
+}
+
+const exists = (target: string) => access(target).then(() => true, () => false);
+
+before(() => useGitExecutable(git));
+afterEach(() => useResourceRemover());
+after(async () => {
+  for (const root of roots) {
+    await chmod(root, 0o700).catch(() => undefined);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+describe("managed clone deletion", () => {
+  test("a managed clone with Git's read-only objects is deleted", async () => {
+    const base = await temp("objects");
+    const repo = await clone(path.join(base, "collection"));
+    const result = await new ResourceRepositoryService(path.join(base, "managed")).deleteManagedClone(repo, true);
+    assert.deepEqual(result, { deleted: true });
+    assert.equal(await exists(repo), false);
+  });
+
+  test("a read-only directory inside the clone does not stop the deletion", { skip: process.platform === "win32" }, async () => {
+    const base = await temp("readonly");
+    const repo = await clone(path.join(base, "collection"));
+    const locked = path.join(repo, "locked");
+    await mkdir(locked);
+    await writeFile(path.join(locked, "file.txt"), "cannot unlink me until the directory is writable\n");
+    await chmod(locked, 0o555);
+    const result = await new ResourceRepositoryService(path.join(base, "managed")).deleteManagedClone(repo, true);
+    assert.deepEqual(result, { deleted: true });
+    assert.equal(await exists(repo), false);
+  });
+
+  // openlore: scenario=DeletionNeverLeavesTheWorktree spec=agent-resource-management
+  test("a symbolic link out of the clone is unlinked, its target untouched", async () => {
+    const base = await temp("symlink");
+    const outside = path.join(base, "outside");
+    await mkdir(outside);
+    await writeFile(path.join(outside, "precious.txt"), "keep\n");
+    const repo = await clone(path.join(base, "collection"));
+    await symlink(outside, path.join(repo, "escape"), "dir");
+    const result = await new ResourceRepositoryService(path.join(base, "managed")).deleteManagedClone(repo, true);
+    assert.deepEqual(result, { deleted: true });
+    assert.equal(await exists(repo), false);
+    assert.equal(await exists(path.join(outside, "precious.txt")), true);
+  });
+
+  // openlore: scenario=AFailedDeletionIsReportedAsPartial spec=agent-resource-management
+  test("a deletion that fails is reported with its reason, not as done", async () => {
+    const base = await temp("failure");
+    const repo = await clone(path.join(base, "collection"));
+    useResourceRemover(async () => {
+      const error = new Error("EBUSY: resource busy or locked") as NodeJS.ErrnoException;
+      error.code = "EBUSY";
+      throw error;
+    });
+    const result = await new ResourceRepositoryService(path.join(base, "managed")).deleteManagedClone(repo, true);
+    assert.equal(result.deleted, false);
+    assert.equal((result as { failed: boolean }).failed, true, "a deletion that stopped part-way is a failure, not a refusal");
+    assert.match((result as { reason: string }).reason, /Could not delete every file: EBUSY/);
+    assert.equal(await exists(repo), true);
+  });
+
+  test("a folder pi-outpost does not manage is kept", async () => {
+    const base = await temp("unmanaged");
+    const repo = await clone(path.join(base, "theirs"));
+    const result = await new ResourceRepositoryService(path.join(base, "managed")).deleteManagedClone(repo, false);
+    assert.equal(result.deleted, false);
+    assert.equal((result as { failed: boolean }).failed, false, "a refusal keeps the files on purpose");
+    assert.match((result as { reason: string }).reason, /does not manage/);
+    assert.equal(await exists(repo), true);
+  });
+
+  test("inside managed storage is pi-outpost's even without the flag", async () => {
+    const base = await temp("storage");
+    const managedRoot = path.join(base, "managed");
+    const repo = await clone(path.join(managedRoot, "clone"));
+    assert.deepEqual(await new ResourceRepositoryService(managedRoot).deleteManagedClone(repo, false), { deleted: true });
+  });
+
+  test("managed storage itself, a subfolder, and a folder that is not a repository are kept", async () => {
+    const base = await temp("refusals");
+    const managedRoot = path.join(base, "managed");
+    await clone(managedRoot);
+    const service = new ResourceRepositoryService(managedRoot);
+    assert.match(((await service.deleteManagedClone(managedRoot, true)) as { reason: string }).reason, /Managed resource storage itself/);
+    assert.match(((await service.deleteManagedClone(path.join(managedRoot, "skills"), true)) as { reason: string }).reason, /no longer the top of a Git repository/);
+    const plain = path.join(base, "plain");
+    await mkdir(plain);
+    assert.match(((await service.deleteManagedClone(plain, true)) as { reason: string }).reason, /no longer the top of a Git repository/);
+    assert.equal(await exists(path.join(managedRoot, "skills", "one", "SKILL.md")), true);
+    assert.equal(await exists(plain), true);
+  });
+
+  test("a folder reached through a link is kept", async () => {
+    const base = await temp("linked-root");
+    const repo = await clone(path.join(base, "real"));
+    const link = path.join(base, "link");
+    await symlink(repo, link, "dir");
+    const result = await new ResourceRepositoryService(path.join(base, "managed")).deleteManagedClone(link, true);
+    assert.equal(result.deleted, false);
+    assert.equal(await exists(repo), true);
+  });
+});

--- a/server/test/collectionEnrollment.test.ts
+++ b/server/test/collectionEnrollment.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Enrolling a repository as a skill collection: preview, confirmation, and what
+ * the confirmation hands back to be persisted.
+ */
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, mkdir, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { after, before, describe, test } from "node:test";
+import { useGitExecutable } from "../src/git.ts";
+import { ResourceRepositoryService } from "../src/resourceRepositories.ts";
+
+const git = execFileSync(process.platform === "win32" ? "where" : "which", ["git"], { encoding: "utf8" }).split("\n")[0].trim();
+const roots: string[] = [];
+
+function run(cwd: string, args: string[]): string {
+  return execFileSync(git, args, { cwd, encoding: "utf8" }).trim();
+}
+
+async function temp(name: string): Promise<string> {
+  const root = await realpath(await mkdtemp(path.join(tmpdir(), `pi-collection-${name}-`)));
+  roots.push(root);
+  return root;
+}
+
+async function skill(root: string, relative: string): Promise<void> {
+  const dir = path.join(root, ...relative.split("/"));
+  await mkdir(dir, { recursive: true });
+  await writeFile(path.join(dir, "SKILL.md"), `---\nname: ${path.basename(relative)}\ndescription: test skill\n---\n`);
+}
+
+async function repository(name: string, skills: string[]): Promise<string> {
+  const root = await temp(name);
+  run(root, ["init", "-q", "--initial-branch=main"]);
+  run(root, ["config", "user.email", "test@example.com"]);
+  run(root, ["config", "user.name", "Collection Test"]);
+  run(root, ["config", "commit.gpgsign", "false"]);
+  for (const relative of skills) await skill(root, relative);
+  run(root, ["add", "."]);
+  run(root, ["commit", "-q", "-m", "skills"]);
+  return root;
+}
+
+async function bareRemote(name: string, skills: string[]): Promise<{ base: string; address: string }> {
+  const seed = await repository(`${name}-seed`, skills);
+  const base = await temp(name);
+  const remote = path.join(base, "remote.git");
+  await mkdir(remote);
+  run(remote, ["init", "-q", "--bare", "--initial-branch=main"]);
+  run(seed, ["remote", "add", "origin", remote]);
+  run(seed, ["push", "-q", "-u", "origin", "main"]);
+  return { base, address: pathToFileURL(remote).toString() };
+}
+
+before(() => useGitExecutable(git));
+after(async () => Promise.all(roots.map((root) => rm(root, { recursive: true, force: true }))));
+
+describe("collection enrollment", () => {
+  test("a catalogue change between preview and confirmation is refused", async () => {
+    const root = await repository("catalogue-change", ["group/one"]);
+    const service = new ResourceRepositoryService();
+    const preview = await service.preview(root, false);
+    await skill(root, "group/two");
+    await assert.rejects(() => service.confirmPreview(preview.token, [], [], false, ["group/one"]), /changed after preview/);
+  });
+
+  test("a collection preview offers no skill root, and refuses one sent anyway", async () => {
+    const root = await repository("no-root", ["skills/one"]);
+    const service = new ResourceRepositoryService();
+    const preview = await service.preview(root, false);
+    assert.equal(preview.mode, "collection");
+    assert.deepEqual(preview.roots, []);
+    await assert.rejects(
+      () => service.confirmPreview(preview.token, [path.join(root, "skills")], [], false),
+      /selected skill root is unavailable/,
+    );
+  });
+
+  test("a skill the catalogue does not contain is refused", async () => {
+    const root = await repository("stranger", ["group/one"]);
+    const service = new ResourceRepositoryService();
+    for (const stranger of ["group/none", "../escape", "group"]) {
+      const preview = await service.preview(root, false);
+      await assert.rejects(
+        () => service.confirmPreview(preview.token, [], [], false, [stranger]),
+        /not in this repository/,
+        `refuses ${stranger}`,
+      );
+    }
+  });
+
+  // openlore: scenario=EnrollWithNothingTurnedOn spec=agent-resource-management
+  test("an empty selection is a valid enrollment", async () => {
+    const root = await repository("empty-selection", ["group/one", "group/two"]);
+    const service = new ResourceRepositoryService();
+    const preview = await service.preview(root, false);
+    assert.deepEqual(preview.skills.map((entry) => entry.relativePath), ["group/one", "group/two"]);
+    const confirmed = await service.confirmPreview(preview.token, [], [], false, []);
+    assert.equal(confirmed.mode, "collection");
+    assert.deepEqual(confirmed.enabledSkills, []);
+    assert.deepEqual(confirmed.skillRoots, []);
+    assert.equal(confirmed.repositoryPath, root);
+  });
+
+  test("a selection is deduplicated and kept to the catalogue", async () => {
+    const root = await repository("selection", ["a/one", "b/two"]);
+    const service = new ResourceRepositoryService();
+    const preview = await service.preview(root, false);
+    const confirmed = await service.confirmPreview(preview.token, [], [], false, ["b/two", "b/two", "a/one"]);
+    assert.deepEqual(confirmed.enabledSkills, ["b/two", "a/one"]);
+  });
+
+  // openlore: scenario=ARootEnrolledRepositoryKeepsLoadingEverything spec=agent-resource-management
+  test("a worktree registered through a skill root keeps root enrollment", async () => {
+    const root = await repository("legacy", ["skills/one"]);
+    const service = new ResourceRepositoryService();
+    const preview = await service.preview(root, false, { userSkillPaths: [path.join(root, "skills")] });
+    assert.equal(preview.mode, "roots");
+    assert.deepEqual(preview.skills, []);
+    const skillRoot = preview.roots.find((entry) => entry.kind === "skill")!.path;
+    await assert.rejects(
+      () => service.confirmPreview(preview.token, [skillRoot], [], false, ["skills/one"]),
+      /registered through skill roots/,
+    );
+    const again = await service.preview(root, false, { userSkillPaths: [path.join(root, "skills")] });
+    const confirmed = await service.confirmPreview(again.token, [skillRoot], [], false);
+    assert.equal(confirmed.mode, "roots");
+    assert.deepEqual(confirmed.skillRoots, [skillRoot]);
+  });
+
+  test("a preview names the repository after its origin, not its clone folder", async () => {
+    const { base, address } = await bareRemote("preview-name", ["skills/one"]);
+    const service = new ResourceRepositoryService(path.join(base, "managed"));
+    const preview = await service.cloneAndPreview(address, path.join(base, "resources-3f9a1c2b7e"), false);
+    assert.equal(preview.repositoryName, "remote", "the bare remote is remote.git");
+  });
+
+  test("a clone this service created is managed; a reused clone outside managed storage is not", async () => {
+    const { base, address } = await bareRemote("managed", ["skills/one"]);
+    const service = new ResourceRepositoryService(path.join(base, "managed"));
+
+    const created = await service.cloneAndPreview(address, path.join(base, "fresh"), false);
+    assert.equal((await service.confirmPreview(created.token, [], [], false)).managed, true);
+
+    const reused = path.join(base, "someone-elses");
+    run(base, ["clone", "-q", path.join(base, "remote.git"), reused]);
+    const existing = await service.cloneAndPreview(address, reused, false);
+    assert.equal((await service.confirmPreview(existing.token, [], [], false)).managed, false);
+
+    const inManaged = path.join(base, "managed", "already-here");
+    run(base, ["clone", "-q", path.join(base, "remote.git"), inManaged]);
+    const stored = await service.cloneAndPreview(address, inManaged, false);
+    assert.equal((await service.confirmPreview(stored.token, [], [], false)).managed, true, "managed storage is pi-outpost's");
+  });
+});

--- a/server/test/collectionEnrollmentWire.test.mjs
+++ b/server/test/collectionEnrollmentWire.test.mjs
@@ -6,7 +6,7 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { mkdir, readFile, realpath, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import test from "node:test";
 import { connect, makeWorkspace, startServer } from "./harness.mjs";
 
@@ -116,7 +116,9 @@ test("a worktree already registered through a skill root is previewed in root mo
   const root = await realpath(await makeWorkspace());
   const address = await collectionRemote(root);
   const checkout = path.join(root, "legacy-checkout");
-  run(root, ["clone", "-q", new URL(address).pathname, checkout]);
+  // fileURLToPath, not URL.pathname: on Windows the pathname is "/D:/…", which Git
+  // records as a different origin than the one the server derives from the URL.
+  run(root, ["clone", "-q", fileURLToPath(address), checkout]);
   const { client } = await boot(t, root, { userSkillPaths: [path.join(checkout, "skills")] });
   const preview = await previewClone(client, address, checkout, "legacy");
   assert.equal(preview.mode, "roots");

--- a/server/test/collectionEnrollmentWire.test.mjs
+++ b/server/test/collectionEnrollmentWire.test.mjs
@@ -1,0 +1,125 @@
+/**
+ * Collection enrollment over the real socket: what the server persists and what
+ * the replacement session loads after an Add Git repository confirmation.
+ */
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdir, readFile, realpath, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import test from "node:test";
+import { connect, makeWorkspace, startServer } from "./harness.mjs";
+
+const git = execFileSync(process.platform === "win32" ? "where" : "which", ["git"], { encoding: "utf8" }).split("\n")[0].trim();
+
+function run(cwd, args) {
+  return execFileSync(git, args, { cwd, encoding: "utf8" }).trim();
+}
+
+async function collectionRemote(root) {
+  const remote = path.join(root, "collection-origin.git");
+  const seed = path.join(root, "collection-seed");
+  await mkdir(remote);
+  run(remote, ["init", "-q", "--bare", "--initial-branch=main"]);
+  await mkdir(seed);
+  run(seed, ["init", "-q", "--initial-branch=main"]);
+  run(seed, ["config", "user.email", "test@example.com"]);
+  run(seed, ["config", "user.name", "Collection Wire Test"]);
+  run(seed, ["config", "commit.gpgsign", "false"]);
+  for (const [relative, name] of [["skills/review", "review"], ["tools/lint", "lint"]]) {
+    await mkdir(path.join(seed, ...relative.split("/")), { recursive: true });
+    await writeFile(path.join(seed, ...relative.split("/"), "SKILL.md"), `---\nname: ${name}\ndescription: ${name} skill.\n---\n`);
+  }
+  run(seed, ["add", "."]);
+  run(seed, ["commit", "-q", "-m", "initial"]);
+  run(seed, ["remote", "add", "origin", remote]);
+  run(seed, ["push", "-q", "-u", "origin", "main"]);
+  return pathToFileURL(remote).toString();
+}
+
+async function boot(t, root, options = {}) {
+  const server = await startServer(root, options);
+  t.after(() => server.stop());
+  const client = connect(server.wsUrl());
+  t.after(() => client.close());
+  await client.waitFor("hello", 180_000);
+  return { server, client };
+}
+
+async function previewClone(client, address, destination, requestId) {
+  client.send({ type: "clone_agent_resource_repository", repositoryUrl: address, destinationPath: destination, requestId });
+  const answer = await client.waitFor(
+    (message) => (message.type === "agent_resource_preview" || message.type === "agent_resource_error") && message.requestId === requestId,
+    180_000,
+  );
+  assert.equal(answer.type, "agent_resource_preview", answer.message);
+  return answer.preview;
+}
+
+async function enroll(client, preview, enabledSkills, requestId) {
+  client.send({ type: "enroll_agent_resource_repository", previewToken: preview.token, skillRoots: [], extensionRoots: [], enabledSkills, requestId });
+  const answer = await client.waitFor(
+    (message) => (message.type === "agent_resource_enrolled" || message.type === "agent_resource_error") && message.requestId === requestId,
+    180_000,
+  );
+  assert.equal(answer.type, "agent_resource_enrolled", answer.message);
+  return answer.inventory;
+}
+
+const loadedSkillsUnder = (inventory, root) =>
+  inventory.resources.filter((resource) => resource.kind === "skill" && resource.path?.startsWith(root + path.sep)).map((resource) => resource.name).sort();
+
+// openlore: scenario=ANewlyEnrolledCollectionLoadsNothing spec=agent-resource-management
+test("a collection enrolled with nothing on loads none of its skills", async (t) => {
+  const root = await realpath(await makeWorkspace());
+  const address = await collectionRemote(root);
+  const { server, client } = await boot(t, root);
+  const destination = path.join(root, "collection");
+  const preview = await previewClone(client, address, destination, "preview-empty");
+  assert.equal(preview.mode, "collection");
+  assert.deepEqual(preview.skills.map((entry) => entry.relativePath), ["skills/review", "tools/lint"]);
+
+  const inventory = await enroll(client, preview, [], "enroll-empty");
+  assert.deepEqual(loadedSkillsUnder(inventory, destination), []);
+  const persisted = JSON.parse(await readFile(server.configFile, "utf8"));
+  assert.deepEqual(persisted.userSkillCollections, [{ path: destination, managed: true, enabledSkills: [] }]);
+  assert.equal(persisted.userSkillPaths, undefined, "no skill root is registered for a collection");
+});
+
+// openlore: scenario=AddARepositoryContainingSkillsAndExtensions spec=agent-resource-management
+test("a collection enrolled with one skill on loads exactly that skill", async (t) => {
+  const root = await realpath(await makeWorkspace());
+  const address = await collectionRemote(root);
+  const { client } = await boot(t, root);
+  const destination = path.join(root, "collection");
+  const preview = await previewClone(client, address, destination, "preview-one");
+  const inventory = await enroll(client, preview, ["tools/lint"], "enroll-one");
+  assert.deepEqual(loadedSkillsUnder(inventory, destination), ["lint"]);
+});
+
+// openlore: scenario=ReEnrollAnExistingRepository spec=agent-resource-management
+test("re-enrolling a collection adds skills and keeps those already on", async (t) => {
+  const root = await realpath(await makeWorkspace());
+  const address = await collectionRemote(root);
+  const { server, client } = await boot(t, root);
+  const destination = path.join(root, "collection");
+  await enroll(client, await previewClone(client, address, destination, "p1"), ["skills/review"], "e1");
+  const inventory = await enroll(client, await previewClone(client, address, destination, "p2"), ["tools/lint"], "e2");
+  assert.deepEqual(loadedSkillsUnder(inventory, destination), ["lint", "review"]);
+  const persisted = JSON.parse(await readFile(server.configFile, "utf8"));
+  assert.equal(persisted.userSkillCollections.length, 1, "one repository, not two");
+  assert.deepEqual(persisted.userSkillCollections[0].enabledSkills, ["skills/review", "tools/lint"]);
+  assert.equal(inventory.repositories.filter((repository) => repository.path === destination).length, 1);
+});
+
+test("a worktree already registered through a skill root is previewed in root mode", async (t) => {
+  const root = await realpath(await makeWorkspace());
+  const address = await collectionRemote(root);
+  const checkout = path.join(root, "legacy-checkout");
+  run(root, ["clone", "-q", new URL(address).pathname, checkout]);
+  const { client } = await boot(t, root, { userSkillPaths: [path.join(checkout, "skills")] });
+  const preview = await previewClone(client, address, checkout, "legacy");
+  assert.equal(preview.mode, "roots");
+  assert.ok(preview.roots.some((entry) => entry.kind === "skill"));
+  assert.deepEqual(preview.skills, []);
+});

--- a/server/test/collectionInventory.test.ts
+++ b/server/test/collectionInventory.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Collections in the inventory: every catalogued skill with its state, and what
+ * removing the repository would be allowed to do.
+ */
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, mkdir, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { after, before, describe, test } from "node:test";
+import type { AgentResourceInfo } from "@pi-outpost/shared";
+import type { SkillCollection } from "../src/config.ts";
+import { useGitExecutable } from "../src/git.ts";
+import { ResourceRepositoryService } from "../src/resourceRepositories.ts";
+
+const git = execFileSync(process.platform === "win32" ? "where" : "which", ["git"], { encoding: "utf8" }).split("\n")[0].trim();
+const roots: string[] = [];
+
+function run(cwd: string, args: string[]): string {
+  return execFileSync(git, args, { cwd, encoding: "utf8" }).trim();
+}
+
+async function temp(name: string): Promise<string> {
+  const root = await realpath(await mkdtemp(path.join(tmpdir(), `pi-collection-inventory-${name}-`)));
+  roots.push(root);
+  return root;
+}
+
+async function repository(root: string, skills: Array<[string, string]>): Promise<string> {
+  await mkdir(root, { recursive: true });
+  run(root, ["init", "-q", "--initial-branch=main"]);
+  run(root, ["config", "user.email", "test@example.com"]);
+  run(root, ["config", "user.name", "Inventory Test"]);
+  run(root, ["config", "commit.gpgsign", "false"]);
+  for (const [relative, name] of skills) {
+    const dir = path.join(root, ...relative.split("/"));
+    await mkdir(dir, { recursive: true });
+    await writeFile(path.join(dir, "SKILL.md"), `---\nname: ${name}\ndescription: test\n---\n`);
+  }
+  run(root, ["add", "."]);
+  run(root, ["commit", "-q", "-m", "skills"]);
+  return root;
+}
+
+/** What the runtime reports for a loaded skill: its SKILL.md. */
+function loaded(dir: string, name: string): AgentResourceInfo {
+  const file = path.join(dir, "SKILL.md");
+  return { id: `skill:${file}`, kind: "skill", name, origin: "runtime", path: file };
+}
+
+function input(
+  resources: AgentResourceInfo[],
+  userSkillCollections: SkillCollection[],
+  extra: Partial<{ configuredSkillPaths: string[]; userSkillPaths: string[] }> = {},
+) {
+  return {
+    resources,
+    capabilities: { skills: "available" as const, extensions: "available" as const },
+    configuredSkillPaths: extra.configuredSkillPaths ?? [],
+    userSkillPaths: extra.userSkillPaths ?? [],
+    configuredExtensionPaths: [],
+    userExtensionPaths: [],
+    userSkillCollections,
+    extensionLock: false,
+  };
+}
+
+before(() => useGitExecutable(git));
+after(async () => Promise.all(roots.map((root) => rm(root, { recursive: true, force: true }))));
+
+describe("collection inventory", () => {
+  test("a collection with nothing loaded is listed with every skill off", async () => {
+    const base = await temp("off");
+    const repo = await repository(path.join(base, "collection"), [["dev-skills/react", "react"], ["agent-skills/a2a", "a2a"]]);
+    const inventory = await new ResourceRepositoryService(path.join(base, "managed")).buildInventory(
+      input([], [{ path: repo, managed: false, enabledSkills: [] }]),
+    );
+    const listed = inventory.repositories.find((candidate) => candidate.path === repo);
+    assert.ok(listed, "the repository is in the inventory although nothing from it is loaded");
+    assert.deepEqual(listed.resourceIds, []);
+    assert.deepEqual(listed.collection?.groups, [
+      { path: "agent-skills", label: "agent-skills" },
+      { path: "dev-skills", label: "dev-skills" },
+    ]);
+    assert.deepEqual(listed.collection?.skills.map((skill) => [skill.relativePath, skill.state]), [
+      ["agent-skills/a2a", "off"],
+      ["dev-skills/react", "off"],
+    ]);
+  });
+
+  // openlore: scenario=ASkillThatIsOnButGoneIsReportedMissing spec=agent-resource-management
+  test("each state: on and loaded, on and not loaded, on and missing, off", async () => {
+    const base = await temp("states");
+    const repo = await repository(path.join(base, "collection"), [["g/loaded", "loaded"], ["g/skipped", "skipped"], ["g/off", "off"]]);
+    const inventory = await new ResourceRepositoryService(path.join(base, "managed")).buildInventory(
+      input([loaded(path.join(repo, "g", "loaded"), "loaded")], [
+        { path: repo, managed: false, enabledSkills: ["g/loaded", "g/skipped", "g/vanished"] },
+      ]),
+    );
+    const skills = inventory.repositories.find((candidate) => candidate.path === repo)!.collection!.skills;
+    assert.deepEqual(skills.map((skill) => [skill.relativePath, skill.state]), [
+      ["g/loaded", "on-loaded"],
+      ["g/off", "off"],
+      ["g/skipped", "on-not-loaded"],
+      ["g/vanished", "on-missing"],
+    ]);
+    assert.equal(skills.find((skill) => skill.state === "on-not-loaded")?.reason, "The session did not load this skill");
+    assert.match(skills.find((skill) => skill.state === "on-missing")?.reason ?? "", /no longer in the repository/);
+  });
+
+  // openlore: scenario=ASkillThatIsOnButNotLoadedSaysSo spec=agent-resource-management
+  test("two enabled copies under one name: the one not loaded names the winner", async () => {
+    const base = await temp("collision");
+    const repo = await repository(path.join(base, "collection"), [["agent-skills/a2a", "a2a"], ["skills/agent-a2a", "a2a"]]);
+    const first = path.join(repo, "agent-skills", "a2a");
+    const inventory = await new ResourceRepositoryService(path.join(base, "managed")).buildInventory(
+      input([loaded(first, "a2a")], [{ path: repo, managed: false, enabledSkills: ["agent-skills/a2a", "skills/agent-a2a"] }]),
+    );
+    const skills = inventory.repositories.find((candidate) => candidate.path === repo)!.collection!.skills;
+    assert.equal(skills.find((skill) => skill.relativePath === "agent-skills/a2a")?.state, "on-loaded");
+    const loser = skills.find((skill) => skill.relativePath === "skills/agent-a2a")!;
+    assert.equal(loser.state, "on-not-loaded");
+    assert.match(loser.reason ?? "", /Another skill named "a2a" was loaded first/);
+    assert.ok(loser.reason?.includes(path.join(first, "SKILL.md")));
+  });
+
+  test("a skill at the repository root is grouped under the repository's name", async () => {
+    const base = await temp("root-group");
+    const repo = await repository(path.join(base, "solo-skill"), [[".", "solo"]]);
+    const inventory = await new ResourceRepositoryService(path.join(base, "managed")).buildInventory(
+      input([], [{ path: repo, managed: false, enabledSkills: [] }]),
+    );
+    assert.deepEqual(inventory.repositories.find((candidate) => candidate.path === repo)!.collection!.groups, [
+      { path: "", label: "solo-skill" },
+    ]);
+  });
+
+  test("removal: a managed collection deletes its files, an unmanaged one keeps them", async () => {
+    const base = await temp("removal");
+    const managedRepo = await repository(path.join(base, "managed-clone"), [["g/one", "one"]]);
+    const theirs = await repository(path.join(base, "theirs"), [["g/two", "two"]]);
+    const inventory = await new ResourceRepositoryService(path.join(base, "managed")).buildInventory(
+      input([], [
+        { path: managedRepo, managed: true, enabledSkills: [] },
+        { path: theirs, managed: false, enabledSkills: [] },
+      ]),
+    );
+    assert.deepEqual(inventory.repositories.find((candidate) => candidate.path === managedRepo)?.removal, {
+      allowed: true,
+      deletesFiles: true,
+      path: managedRepo,
+    });
+    assert.deepEqual(inventory.repositories.find((candidate) => candidate.path === theirs)?.removal, {
+      allowed: true,
+      deletesFiles: false,
+      path: theirs,
+    });
+  });
+
+  test("removal: a clone inside managed storage is managed even when enrolled by root", async () => {
+    const base = await temp("managed-storage");
+    const managedRoot = path.join(base, "managed");
+    const repo = await repository(path.join(managedRoot, "legacy"), [["skills/one", "one"]]);
+    const inventory = await new ResourceRepositoryService(managedRoot).buildInventory(
+      input([loaded(path.join(repo, "skills", "one"), "one")], [], { userSkillPaths: [path.join(repo, "skills")] }),
+    );
+    const removal = inventory.repositories.find((candidate) => candidate.path === repo)?.removal;
+    assert.deepEqual(removal, { allowed: true, deletesFiles: true, path: repo });
+  });
+
+  // openlore: scenario=AConfigurationFilePathBlocksRemoval spec=agent-resource-management
+  test("removal: a repository supplying a configuration-file path is not removable", async () => {
+    const base = await temp("configured");
+    const repo = await repository(path.join(base, "operator"), [["skills/one", "one"]]);
+    const inventory = await new ResourceRepositoryService(path.join(base, "managed")).buildInventory(
+      input([loaded(path.join(repo, "skills", "one"), "one")], [{ path: repo, managed: true, enabledSkills: [] }], {
+        configuredSkillPaths: [path.join(repo, "skills")],
+      }),
+    );
+    const removal = inventory.repositories.find((candidate) => candidate.path === repo)?.removal;
+    assert.equal(removal?.allowed, false);
+    assert.equal(removal?.deletesFiles, false);
+    assert.match(removal?.reason ?? "", /configuration file/);
+  });
+
+  test("removal: a repository nobody added through Agent resources is not removable", async () => {
+    const base = await temp("runtime-only");
+    const repo = await repository(path.join(base, "discovered"), [["skills/one", "one"]]);
+    const inventory = await new ResourceRepositoryService(path.join(base, "managed")).buildInventory(
+      input([loaded(path.join(repo, "skills", "one"), "one")], []),
+    );
+    const removal = inventory.repositories.find((candidate) => candidate.path === repo)?.removal;
+    assert.equal(removal?.allowed, false);
+    assert.match(removal?.reason ?? "", /not added through Agent resources/);
+  });
+
+  // openlore: scenario=ARepositoryIsNamedAfterItsOrigin spec=agent-resource-management
+  test("a repository is named after its origin, not the folder it was cloned into", async () => {
+    const base = await temp("origin-name");
+    const repo = await repository(path.join(base, "resources-3f9a1c2b7e"), [["g/one", "one"]]);
+    run(repo, ["remote", "add", "origin", "https://user:secret@github.com/khalilbenaz/claude-skills-collection.git?ref=main"]);
+    const inventory = await new ResourceRepositoryService(path.join(base, "managed")).buildInventory(
+      input([], [{ path: repo, managed: true, enabledSkills: [] }]),
+    );
+    const listed = inventory.repositories.find((candidate) => candidate.path === repo)!;
+    assert.equal(listed.name, "claude-skills-collection");
+    assert.ok(!JSON.stringify(listed).includes("secret"), "no credential reaches the inventory");
+  });
+
+  // openlore: scenario=ARepositoryWithoutAnOriginKeepsItsFolderName spec=agent-resource-management
+  test("a repository without an origin keeps its folder name", async () => {
+    const base = await temp("no-origin");
+    const repo = await repository(path.join(base, "plain-folder"), [["g/one", "one"]]);
+    const inventory = await new ResourceRepositoryService(path.join(base, "managed")).buildInventory(
+      input([], [{ path: repo, managed: false, enabledSkills: [] }]),
+    );
+    assert.equal(inventory.repositories.find((candidate) => candidate.path === repo)?.name, "plain-folder");
+  });
+
+  test("a collection whose folder vanished stays listed, unavailable and removable", async () => {
+    const base = await temp("vanished");
+    const gone = path.join(base, "gone");
+    const inventory = await new ResourceRepositoryService(path.join(base, "managed")).buildInventory(
+      input([], [{ path: gone, managed: true, enabledSkills: ["g/one"] }]),
+    );
+    const listed = inventory.repositories.find((candidate) => candidate.path === gone);
+    assert.ok(listed);
+    assert.equal(listed.assessment.status, "unavailable");
+    assert.deepEqual(listed.removal, { allowed: true, deletesFiles: false, path: gone });
+    assert.deepEqual(listed.collection?.skills.map((skill) => [skill.relativePath, skill.state]), [["g/one", "on-missing"]]);
+  });
+});

--- a/server/test/collectionRemovalWire.test.mjs
+++ b/server/test/collectionRemovalWire.test.mjs
@@ -1,0 +1,168 @@
+/**
+ * Removing a repository as a whole over the real socket: what is unregistered,
+ * what is deleted from disk, and what is left alone when removal is refused.
+ */
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { access, mkdir, readFile, realpath, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import test from "node:test";
+import { connect, makeWorkspace, startServer } from "./harness.mjs";
+import { startScriptedServer } from "./multiProjectHarness.mjs";
+
+const git = execFileSync(process.platform === "win32" ? "where" : "which", ["git"], { encoding: "utf8" }).split("\n")[0].trim();
+const VETO = fileURLToPath(new URL("./fixtures/veto-session-switch.mjs", import.meta.url));
+
+function run(cwd, args) {
+  return execFileSync(git, args, { cwd, encoding: "utf8" }).trim();
+}
+
+async function remote(root) {
+  const bare = path.join(root, "origin.git");
+  const seed = path.join(root, "seed");
+  await mkdir(bare);
+  run(bare, ["init", "-q", "--bare", "--initial-branch=main"]);
+  await mkdir(path.join(seed, "skills", "review"), { recursive: true });
+  run(seed, ["init", "-q", "--initial-branch=main"]);
+  run(seed, ["config", "user.email", "test@example.com"]);
+  run(seed, ["config", "user.name", "Removal Test"]);
+  run(seed, ["config", "commit.gpgsign", "false"]);
+  await writeFile(path.join(seed, "skills", "review", "SKILL.md"), "---\nname: review\ndescription: Review.\n---\n");
+  run(seed, ["add", "."]);
+  run(seed, ["commit", "-q", "-m", "initial"]);
+  run(seed, ["remote", "add", "origin", bare]);
+  run(seed, ["push", "-q", "-u", "origin", "main"]);
+  return bare;
+}
+
+async function inventoryOf(client, hello) {
+  if (hello.agentResources) return hello.agentResources;
+  return (await client.waitFor((message) => message.type === "agent_resource_inventory", 180_000)).inventory;
+}
+
+async function removeRepository(client, repositoryId, requestId) {
+  client.send({ type: "remove_agent_resource_repository", repositoryId, requestId });
+  return client.waitFor(
+    (message) => (message.type === "agent_resource_removed" || message.type === "agent_resource_error") && message.requestId === requestId,
+    180_000,
+  );
+}
+
+const exists = (target) => access(target).then(() => true, () => false);
+const persisted = async (server) => JSON.parse(await readFile(server.configFile, "utf8"));
+
+async function boot(t, root, config, scripted) {
+  const server = scripted ? await startScriptedServer(root, scripted.others, scripted.script, config) : await startServer(root, config);
+  t.after(() => server.stop());
+  const client = connect(server.wsUrl());
+  t.after(() => client.close());
+  const hello = await client.waitFor("hello", 180_000);
+  return { server, client, hello };
+}
+
+// openlore: scenario=RemovingAManagedCollectionDeletesItsClone spec=agent-resource-management
+// openlore: scenario=RemovalClearsThePersistedSelection spec=persistent-runtime-settings
+test("removing a collection pi-outpost cloned unregisters it and deletes the clone", async (t) => {
+  const root = await realpath(await makeWorkspace());
+  const bare = await remote(root);
+  const { server, client } = await boot(t, root, {});
+  const destination = path.join(root, "managed-collection");
+  client.send({ type: "clone_agent_resource_repository", repositoryUrl: pathToFileURL(bare).toString(), destinationPath: destination, requestId: "clone" });
+  const preview = await client.waitFor((message) => message.type === "agent_resource_preview" && message.requestId === "clone", 180_000);
+  client.send({ type: "enroll_agent_resource_repository", previewToken: preview.preview.token, skillRoots: [], extensionRoots: [], enabledSkills: ["skills/review"], requestId: "enroll" });
+  const enrolled = await client.waitFor((message) => message.type === "agent_resource_enrolled" && message.requestId === "enroll", 180_000);
+  const repository = enrolled.inventory.repositories.find((candidate) => candidate.path === destination);
+  assert.deepEqual(repository.removal, { allowed: true, deletesFiles: true, path: destination });
+
+  const answer = await removeRepository(client, repository.id, "remove");
+  assert.equal(answer.type, "agent_resource_removed", answer.message);
+  assert.deepEqual(answer.result, { status: "removed", path: destination });
+  assert.equal(await exists(destination), false, "the clone is gone from disk");
+  assert.deepEqual((await persisted(server)).userSkillCollections, []);
+  assert.equal(answer.inventory.repositories.some((candidate) => candidate.path === destination), false);
+  assert.equal(answer.inventory.resources.some((resource) => resource.path?.startsWith(destination + path.sep)), false, "nothing from it is loaded");
+});
+
+// openlore: scenario=ARepositoryOutsideManagedStorageKeepsItsFiles spec=agent-resource-management
+test("removing a repository pi-outpost does not manage keeps its files and says so", async (t) => {
+  const root = await realpath(await makeWorkspace());
+  const bare = await remote(root);
+  const checkout = path.join(root, "their-checkout");
+  run(root, ["clone", "-q", bare, checkout]);
+  const { server, client, hello } = await boot(t, root, { userSkillCollections: [{ path: checkout, managed: false, enabledSkills: ["skills/review"] }] });
+  const repository = (await inventoryOf(client, hello)).repositories.find((candidate) => candidate.path === checkout);
+  assert.equal(repository.removal.deletesFiles, false);
+  const answer = await removeRepository(client, repository.id, "remove");
+  assert.equal(answer.type, "agent_resource_removed", answer.message);
+  assert.equal(answer.result.status, "removed-files-kept");
+  assert.equal(answer.result.path, checkout);
+  assert.match(answer.result.reason, /does not manage/);
+  assert.equal(await exists(path.join(checkout, "skills", "review", "SKILL.md")), true);
+  assert.deepEqual((await persisted(server)).userSkillCollections, []);
+});
+
+// openlore: scenario=AConfigurationFilePathBlocksRemoval spec=agent-resource-management
+test("a repository supplying a configuration-file path is refused, and an unknown id too", async (t) => {
+  const root = await realpath(await makeWorkspace());
+  const bare = await remote(root);
+  const checkout = path.join(root, "operator-checkout");
+  run(root, ["clone", "-q", bare, checkout]);
+  const { server, client, hello } = await boot(t, root, {
+    skillPaths: [path.join(checkout, "skills")],
+    userSkillCollections: [{ path: checkout, managed: true, enabledSkills: [] }],
+  });
+  const repository = (await inventoryOf(client, hello)).repositories.find((candidate) => candidate.path === checkout);
+  const refused = await removeRepository(client, repository.id, "configured");
+  assert.equal(refused.type, "agent_resource_error");
+  assert.match(refused.message, /configuration file/);
+  const unknown = await removeRepository(client, "resource-repo:not-issued", "unknown");
+  assert.equal(unknown.type, "agent_resource_error");
+  assert.match(unknown.message, /unknown resource repository/i);
+  assert.equal(await exists(checkout), true);
+  assert.equal((await persisted(server)).userSkillCollections.length, 1, "nothing was unregistered");
+});
+
+// openlore: scenario=ARefusedReplacementKeepsTheRepository spec=agent-resource-management
+test("a vetoed replacement keeps the repository registered and its files on disk", async (t) => {
+  const root = await realpath(await makeWorkspace());
+  const bare = await remote(root);
+  const checkout = path.join(root, "vetoed-checkout");
+  run(root, ["clone", "-q", bare, checkout]);
+  const { server, client, hello } = await boot(t, root, {
+    extensionPaths: [VETO],
+    userSkillCollections: [{ path: checkout, managed: true, enabledSkills: ["skills/review"] }],
+  });
+  const repository = (await inventoryOf(client, hello)).repositories.find((candidate) => candidate.path === checkout);
+  const answer = await removeRepository(client, repository.id, "vetoed");
+  assert.equal(answer.type, "agent_resource_error");
+  assert.match(answer.message, /cancelled by an extension/i);
+  assert.equal(await exists(path.join(checkout, "skills", "review", "SKILL.md")), true);
+  assert.deepEqual((await persisted(server)).userSkillCollections, [{ path: checkout, managed: true, enabledSkills: ["skills/review"] }]);
+});
+
+// openlore: scenario=RemovalIsRefusedWhileAConsumerIsBusy spec=agent-resource-management
+test("removal is refused while a workspace loading the repository is busy", async (t) => {
+  const root = await realpath(await makeWorkspace());
+  const beta = await realpath(await makeWorkspace());
+  const bare = await remote(root);
+  const checkout = path.join(root, "busy-checkout");
+  run(root, ["clone", "-q", bare, checkout]);
+  const { server, client, hello } = await boot(t, root, { userSkillCollections: [{ path: checkout, managed: true, enabledSkills: [] }] }, {
+    others: [beta],
+    script: { state: { sessionId: "busy-removal", isStreaming: false }, commands_: { prompt: { after: [{ type: "agent_start" }] } } },
+  });
+  const worker = connect(server.wsUrl());
+  t.after(() => worker.close());
+  await worker.waitFor("hello");
+  worker.send({ type: "switch_workspace", root: beta });
+  await worker.waitFor((message) => message.type === "workspace_switched" && message.workspace.root === beta);
+  worker.send({ type: "prompt", text: "stay busy" });
+  await worker.waitFor((message) => message.type === "agent_start" || message.type === "streaming");
+  const repository = (await inventoryOf(client, hello)).repositories.find((candidate) => candidate.path === checkout);
+  const answer = await removeRepository(client, repository.id, "busy");
+  assert.equal(answer.type, "agent_resource_error");
+  assert.match(answer.message, new RegExp(`${path.basename(beta)} is busy`));
+  assert.equal(await exists(checkout), true);
+  assert.equal((await persisted(server)).userSkillCollections.length, 1);
+});

--- a/server/test/collectionSelectionWire.test.mjs
+++ b/server/test/collectionSelectionWire.test.mjs
@@ -1,0 +1,244 @@
+/**
+ * Turning collection skills on and off over the real socket.
+ *
+ * Each assertion reads what the replacement session loaded (the inventory's
+ * loaded resources) and what reached the configuration file, never only the
+ * acknowledgement.
+ */
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdir, readFile, realpath, rm, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import { connect, makeWorkspace, startServer } from "./harness.mjs";
+import { startScriptedServer } from "./multiProjectHarness.mjs";
+
+const git = execFileSync(process.platform === "win32" ? "where" : "which", ["git"], { encoding: "utf8" }).split("\n")[0].trim();
+const VETO = fileURLToPath(new URL("./fixtures/veto-session-switch.mjs", import.meta.url));
+
+function run(cwd, args) {
+  return execFileSync(git, args, { cwd, encoding: "utf8" }).trim();
+}
+
+const SKILLS = [["dev-skills/react", "react"], ["dev-skills/rust", "rust"], ["agent-skills/a2a", "a2a"]];
+
+async function writeSkill(root, relative, name) {
+  await mkdir(path.join(root, ...relative.split("/")), { recursive: true });
+  await writeFile(path.join(root, ...relative.split("/"), "SKILL.md"), `---\nname: ${name}\ndescription: ${name} skill.\n---\n`);
+}
+
+/** A bare remote, its seed, and a checkout of it registered as a collection. */
+async function collectionCheckout(root) {
+  const remote = path.join(root, "origin.git");
+  const seed = path.join(root, "seed");
+  const checkout = path.join(root, "collection");
+  await mkdir(remote);
+  run(remote, ["init", "-q", "--bare", "--initial-branch=main"]);
+  await mkdir(seed);
+  run(seed, ["init", "-q", "--initial-branch=main"]);
+  run(seed, ["config", "user.email", "test@example.com"]);
+  run(seed, ["config", "user.name", "Selection Test"]);
+  run(seed, ["config", "commit.gpgsign", "false"]);
+  for (const [relative, name] of SKILLS) await writeSkill(seed, relative, name);
+  run(seed, ["add", "."]);
+  run(seed, ["commit", "-q", "-m", "initial"]);
+  run(seed, ["remote", "add", "origin", remote]);
+  run(seed, ["push", "-q", "-u", "origin", "main"]);
+  run(root, ["clone", "-q", remote, checkout]);
+  return { seed, checkout };
+}
+
+async function inventoryOf(client, hello) {
+  if (hello.agentResources) return hello.agentResources;
+  return (await client.waitFor((message) => message.type === "agent_resource_inventory", 180_000)).inventory;
+}
+
+async function setSkills(client, repositoryId, enabledSkills, requestId) {
+  client.send({ type: "set_agent_resource_skills", repositoryId, enabledSkills, requestId });
+  return client.waitFor(
+    (message) => (message.type === "agent_resource_skills_applied" || message.type === "agent_resource_error") && message.requestId === requestId,
+    180_000,
+  );
+}
+
+const loadedUnder = (inventory, root) =>
+  inventory.resources.filter((resource) => resource.kind === "skill" && resource.path?.startsWith(root + path.sep)).map((resource) => resource.name).sort();
+
+const persistedSelection = async (server) =>
+  JSON.parse(await readFile(server.configFile, "utf8")).userSkillCollections?.[0]?.enabledSkills;
+
+async function bootWithCollection(t, enabledSkills = [], extra = {}) {
+  const root = await realpath(await makeWorkspace());
+  const { seed, checkout } = await collectionCheckout(root);
+  const server = await startServer(root, { userSkillCollections: [{ path: checkout, managed: false, enabledSkills }], ...extra });
+  t.after(() => server.stop());
+  const client = connect(server.wsUrl());
+  t.after(() => client.close());
+  const hello = await client.waitFor("hello", 180_000);
+  const repository = (await inventoryOf(client, hello)).repositories.find((candidate) => candidate.path === checkout);
+  assert.ok(repository, "the collection is in the inventory");
+  return { root, seed, checkout, server, client, repository };
+}
+
+// openlore: scenario=TurningOneSkillOnLoadsThatSkillAlone spec=agent-resource-management
+// openlore: scenario=AllOnAndAllOffForTheRepository spec=agent-resource-management
+// openlore: scenario=AllOnForOneFolderGroup spec=agent-resource-management
+test("one skill, all on, one group, all off: the session loads exactly what is on", async (t) => {
+  const { checkout, server, client, repository } = await bootWithCollection(t);
+
+  const one = await setSkills(client, repository.id, ["dev-skills/rust"], "one");
+  assert.equal(one.type, "agent_resource_skills_applied", one.message);
+  assert.deepEqual(loadedUnder(one.inventory, checkout), ["rust"]);
+  assert.deepEqual(await persistedSelection(server), ["dev-skills/rust"]);
+  const state = (inventory) => Object.fromEntries(
+    inventory.repositories.find((candidate) => candidate.id === repository.id).collection.skills.map((skill) => [skill.relativePath, skill.state]),
+  );
+  assert.deepEqual(state(one.inventory), { "agent-skills/a2a": "off", "dev-skills/react": "off", "dev-skills/rust": "on-loaded" });
+
+  const all = await setSkills(client, repository.id, SKILLS.map(([relative]) => relative), "all-on");
+  assert.deepEqual(loadedUnder(all.inventory, checkout), ["a2a", "react", "rust"]);
+
+  const group = await setSkills(client, repository.id, ["dev-skills/react", "dev-skills/rust"], "group");
+  assert.deepEqual(loadedUnder(group.inventory, checkout), ["react", "rust"], "only the dev-skills group");
+
+  const none = await setSkills(client, repository.id, [], "all-off");
+  assert.deepEqual(loadedUnder(none.inventory, checkout), []);
+  assert.deepEqual(await persistedSelection(server), []);
+});
+
+// openlore: scenario=ASelectionOutsideTheCatalogueIsRefused spec=agent-resource-management
+test("a selection outside the catalogue, a path leaving the repository, or an unknown id is refused", async (t) => {
+  const { server, client, repository } = await bootWithCollection(t, ["dev-skills/react"]);
+  for (const [enabled, id, requestId, pattern] of [
+    [["dev-skills/none"], repository.id, "stranger", /not in this repository/],
+    [["../escape"], repository.id, "escape", /not in this repository/],
+    [["dev-skills/react"], "resource-repo:not-issued", "unknown", /unknown resource repository/i],
+  ]) {
+    const answer = await setSkills(client, id, enabled, requestId);
+    assert.equal(answer.type, "agent_resource_error", `${requestId} is refused`);
+    assert.match(answer.message, pattern);
+  }
+  assert.deepEqual(await persistedSelection(server), ["dev-skills/react"], "nothing was persisted");
+  assert.equal(client.received.some((message) => message.type === "session_replaced"), false, "the session was not replaced");
+});
+
+// openlore: scenario=ARefusedReplacementKeepsThePreviousSelection spec=agent-resource-management
+test("a vetoed replacement keeps the previous selection", async (t) => {
+  const { checkout, server, client, repository } = await bootWithCollection(t, ["dev-skills/react"], { extensionPaths: [VETO] });
+  const answer = await setSkills(client, repository.id, ["agent-skills/a2a"], "vetoed");
+  assert.equal(answer.type, "agent_resource_error");
+  assert.match(answer.message, /cancelled by an extension/i);
+  assert.deepEqual(await persistedSelection(server), ["dev-skills/react"]);
+  client.send({ type: "refresh_agent_resource_repositories", repositoryId: repository.id, requestId: "after-veto" });
+  await client.waitFor((message) => message.type === "agent_resource_assessments" && message.requestId === "after-veto");
+  const observer = connect(server.wsUrl());
+  t.after(() => observer.close());
+  const hello = await observer.waitFor("hello", 180_000);
+  assert.deepEqual(loadedUnder(await inventoryOf(observer, hello), checkout), ["react"], "the retained session still loads the old selection");
+});
+
+// openlore: scenario=ABusyWorkspaceBlocksASelectionChange spec=agent-resource-management
+test("a busy workspace loading the collection blocks a selection change, naming it", async (t) => {
+  const root = await realpath(await makeWorkspace());
+  const beta = await realpath(await makeWorkspace());
+  const { checkout } = await collectionCheckout(root);
+  const server = await startScriptedServer(root, [beta], {
+    state: { sessionId: "busy-collection", isStreaming: false },
+    commands_: { prompt: { after: [{ type: "agent_start" }] } },
+  }, { userSkillCollections: [{ path: checkout, managed: false, enabledSkills: ["dev-skills/react"] }] });
+  t.after(() => server.stop());
+  const alpha = connect(server.wsUrl());
+  const worker = connect(server.wsUrl());
+  t.after(() => { alpha.close(); worker.close(); });
+  const hello = await alpha.waitFor("hello");
+  await worker.waitFor("hello");
+  worker.send({ type: "switch_workspace", root: beta });
+  await worker.waitFor((message) => message.type === "workspace_switched" && message.workspace.root === beta);
+  worker.send({ type: "prompt", text: "stay busy" });
+  await worker.waitFor((message) => message.type === "agent_start" || message.type === "streaming");
+  const repository = (await inventoryOf(alpha, hello)).repositories.find((candidate) => candidate.path === checkout);
+  const answer = await setSkills(alpha, repository.id, [], "busy");
+  assert.equal(answer.type, "agent_resource_error");
+  assert.match(answer.message, new RegExp(`${path.basename(beta)} is busy`));
+  assert.deepEqual(JSON.parse(await readFile(server.configFile, "utf8")).userSkillCollections[0].enabledSkills, ["dev-skills/react"]);
+});
+
+test("the RPC runtime refuses a selection change", async (t) => {
+  const root = await realpath(await makeWorkspace());
+  const { checkout } = await collectionCheckout(root);
+  const server = await startScriptedServer(root, [], { state: { sessionId: "rpc-collection", isStreaming: false } }, {
+    userSkillCollections: [{ path: checkout, managed: false, enabledSkills: [] }],
+  });
+  t.after(() => server.stop());
+  const client = connect(server.wsUrl());
+  t.after(() => client.close());
+  const hello = await client.waitFor("hello");
+  const repository = (await inventoryOf(client, hello)).repositories.find((candidate) => candidate.path === checkout);
+  const answer = await setSkills(client, repository.id, ["dev-skills/react"], "rpc");
+  assert.equal(answer.type, "agent_resource_error");
+  assert.match(answer.message, /runtime/i);
+  assert.deepEqual(JSON.parse(await readFile(server.configFile, "utf8")).userSkillCollections[0].enabledSkills, []);
+});
+
+async function updateCollection(client, repositoryId, requestId) {
+  client.send({ type: "refresh_agent_resource_repositories", repositoryId, requestId: `${requestId}-assess` });
+  const checked = await client.waitFor((message) => message.type === "agent_resource_assessments" && message.requestId === `${requestId}-assess`, 180_000);
+  const assessment = checked.assessments.find((candidate) => candidate.repositoryId === repositoryId);
+  assert.equal(assessment.status, "updateable", assessment.reason);
+  client.send({
+    type: "update_agent_resource_repository",
+    repositoryId,
+    assessmentToken: assessment.token,
+    localRevision: assessment.localRevision,
+    upstreamRevision: assessment.upstreamRevision,
+    requestId,
+  });
+  const result = await client.waitFor((message) => message.type === "agent_resource_update_result" && message.requestId === requestId, 180_000);
+  assert.equal(result.result.status, "updated", result.result.reason);
+  return result.inventory;
+}
+
+// openlore: scenario=ASkillAddedByAnUpdateStaysOff spec=agent-resource-management
+// openlore: scenario=ASkillThatIsOnButGoneIsReportedMissing spec=agent-resource-management
+test("an update adds a skill that stays off, and one deleting an enabled skill leaves it missing", async (t) => {
+  const { seed, checkout, client, repository } = await bootWithCollection(t, ["dev-skills/react"]);
+
+  await writeSkill(seed, "dev-skills/zig", "zig");
+  run(seed, ["add", "."]);
+  run(seed, ["commit", "-q", "-m", "add zig"]);
+  run(seed, ["push", "-q"]);
+  const added = await updateCollection(client, repository.id, "add");
+  const skillsAfterAdd = added.repositories.find((candidate) => candidate.id === repository.id).collection.skills;
+  assert.equal(skillsAfterAdd.find((skill) => skill.relativePath === "dev-skills/zig").state, "off");
+  assert.equal(skillsAfterAdd.find((skill) => skill.relativePath === "dev-skills/react").state, "on-loaded");
+  assert.deepEqual(loadedUnder(added, checkout), ["react"]);
+
+  await rm(path.join(seed, "dev-skills", "react"), { recursive: true });
+  run(seed, ["add", "-A"]);
+  run(seed, ["commit", "-q", "-m", "drop react"]);
+  run(seed, ["push", "-q"]);
+  const dropped = await updateCollection(client, repository.id, "drop");
+  const skillsAfterDrop = dropped.repositories.find((candidate) => candidate.id === repository.id).collection.skills;
+  assert.equal(skillsAfterDrop.find((skill) => skill.relativePath === "dev-skills/react").state, "on-missing");
+  assert.deepEqual(loadedUnder(dropped, checkout), [], "the vanished skill is not handed to the runtime");
+});
+
+// openlore: scenario=AFailedWriteKeepsTheLiveSelection spec=persistent-runtime-settings
+test("a selection that cannot be persisted keeps the live one", async (t) => {
+  const { checkout, server, client, repository } = await bootWithCollection(t, ["dev-skills/react"]);
+  // Removing the configuration file makes the persistence transaction fail before
+  // it can write a replacement, on every platform.
+  await unlink(server.configFile);
+  const answer = await setSkills(client, repository.id, ["agent-skills/a2a"], "unwritable");
+  assert.equal(answer.type, "agent_resource_error");
+  assert.match(answer.message, /cannot read|could not save/i);
+  assert.equal(client.received.some((message) => message.type === "session_replaced"), false, "the session was not replaced");
+  const observer = connect(server.wsUrl());
+  t.after(() => observer.close());
+  const hello = await observer.waitFor("hello", 180_000);
+  const live = await inventoryOf(observer, hello);
+  assert.deepEqual(loadedUnder(live, checkout), ["react"], "the session still loads the selection it had");
+  const skills = live.repositories.find((candidate) => candidate.id === repository.id).collection.skills;
+  assert.equal(skills.find((skill) => skill.relativePath === "agent-skills/a2a").state, "off");
+});

--- a/server/test/resourceRepositories.test.ts
+++ b/server/test/resourceRepositories.test.ts
@@ -94,7 +94,11 @@ describe("resource repository enrollment", () => {
     assert.match(path.basename(suggested), /^remote-[a-f0-9]{10}$/);
     const preview = await service.cloneAndPreview(address, destination, false);
     assert.equal(await realpath(preview.repositoryPath), await realpath(destination));
-    assert.deepEqual(new Set(preview.roots.map((entry) => entry.kind)), new Set(["skill", "extension"]));
+    // A repository enrolled from now on is a collection: its skills are listed one
+    // by one, and only extension roots are offered as roots.
+    assert.equal(preview.mode, "collection");
+    assert.deepEqual(preview.roots.map((entry) => entry.kind), ["extension"]);
+    assert.deepEqual(preview.skills.map((entry) => entry.relativePath), ["skills/review"]);
     assert.equal(run(destination, ["submodule", "status"]), "");
   });
 
@@ -200,7 +204,7 @@ describe("resource repository enrollment", () => {
       destination,
       false,
     );
-    assert.ok(preview.roots.some((entry) => entry.kind === "skill"));
+    assert.deepEqual(preview.skills.map((entry) => entry.relativePath), ["skills/safe"]);
     await assert.rejects(access(path.join(destination, "extensions", "vendor", "extension.ts")));
   });
 
@@ -221,8 +225,8 @@ describe("resource repository enrollment", () => {
     const preview = await service.preview(root, false);
     assert.deepEqual(preview.roots.map((entry) => [entry.kind, path.relative(root, entry.path)]), [
       ["extension", "extensions"],
-      ["skill", "skills"],
     ]);
+    assert.deepEqual(preview.skills.map((entry) => entry.relativePath), ["skills/ship"]);
     await assert.rejects(access(marker));
   });
 
@@ -256,9 +260,9 @@ describe("resource repository enrollment", () => {
     const service = new ResourceRepositoryService();
     const preview = await service.preview(root, true);
     assert.equal(preview.roots.find((entry) => entry.kind === "extension")?.locked, true);
-    const skillPath = preview.roots.find((entry) => entry.kind === "skill")!.path;
-    const selected = await service.confirmPreview(preview.token, [skillPath], [], true);
-    assert.deepEqual(selected.skillRoots, [skillPath]);
+    const selected = await service.confirmPreview(preview.token, [], [], true, ["skills/one"]);
+    assert.deepEqual(selected.enabledSkills, ["skills/one"]);
+    assert.deepEqual(selected.skillRoots, []);
     assert.deepEqual(selected.extensionRoots, []);
   });
 
@@ -272,8 +276,8 @@ describe("resource repository enrollment", () => {
     const service = new ResourceRepositoryService(path.join(root, "managed"), () => now);
     const expired = await service.preview(root, false);
     now += 11 * 60_000;
-    await assert.rejects(() => service.confirmPreview(expired.token, [expired.roots[0].path], [], false), /expired/);
-    await assert.rejects(() => service.confirmPreview(expired.token, [expired.roots[0].path], [], false), /no longer valid/);
+    await assert.rejects(() => service.confirmPreview(expired.token, [], [], false, ["skills/one"]), /expired/);
+    await assert.rejects(() => service.confirmPreview(expired.token, [], [], false, ["skills/one"]), /no longer valid/);
   });
 
   test("refuses non-repositories and stale candidate sets", async () => {
@@ -289,8 +293,8 @@ describe("resource repository enrollment", () => {
     const preview = await service.preview(root, false);
     await mkdir(path.join(root, "extensions"));
     await writeFile(path.join(root, "extensions", "later.ts"), "export default () => {};\n");
-    await assert.rejects(() => service.confirmPreview(preview.token, [preview.roots[0].path], [], false), /changed after preview/);
-    await assert.rejects(() => service.confirmPreview(preview.token, [preview.roots[0].path], [], false), /no longer valid/);
+    await assert.rejects(() => service.confirmPreview(preview.token, [], [], false, ["skills/one"]), /changed after preview/);
+    await assert.rejects(() => service.confirmPreview(preview.token, [], [], false, ["skills/one"]), /no longer valid/);
   });
 });
 

--- a/server/test/skillCatalogue.test.ts
+++ b/server/test/skillCatalogue.test.ts
@@ -1,0 +1,171 @@
+/**
+ * The skill catalogue: what a repository carries, found by its own folder tree.
+ *
+ * The fixture is shaped like khalilbenaz/claude-skills-collection — category
+ * folders, the same skills again as prefixed copies under `skills/`, and a
+ * manifest whose categories do not match the folders.
+ */
+import assert from "node:assert/strict";
+import { access, mkdtemp, mkdir, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { after, describe, test } from "node:test";
+import { discoverSkillCatalogue } from "../src/resourceRepositories.ts";
+
+const roots: string[] = [];
+after(async () => Promise.all(roots.map((root) => rm(root, { recursive: true, force: true }))));
+
+async function temp(): Promise<string> {
+  const root = await realpath(await mkdtemp(path.join(tmpdir(), "pi-skill-catalogue-")));
+  roots.push(root);
+  return root;
+}
+
+async function skill(root: string, relative: string, frontmatter = `name: ${path.basename(relative)}\ndescription: ${path.basename(relative)} skill`): Promise<string> {
+  const dir = path.join(root, ...relative.split("/"));
+  await mkdir(dir, { recursive: true });
+  await writeFile(path.join(dir, "SKILL.md"), `---\n${frontmatter}\n---\n\n# Body\n`);
+  return dir;
+}
+
+async function collection(): Promise<string> {
+  const root = await temp();
+  await skill(root, "dev-skills/react-guide");
+  await skill(root, "dev-skills/rust-guide");
+  await skill(root, "agent-skills/a2a-protocol-guide");
+  await skill(root, "skills/dev-react-guide");
+  await skill(root, "skills/agent-a2a-protocol-guide");
+  await writeFile(
+    path.join(root, "skills.json"),
+    JSON.stringify({ categories: [{ key: "everything", label: "All in one" }] }),
+  );
+  await mkdir(path.join(root, "docs"), { recursive: true });
+  await writeFile(path.join(root, "docs", "README.md"), "# Not a skill\n");
+  return root;
+}
+
+describe("skill catalogue", () => {
+  // openlore: scenario=CategoryFoldersBecomeGroups spec=agent-resource-management
+  test("category folders become groups", async () => {
+    const root = await collection();
+    const { skills, bound } = await discoverSkillCatalogue(root);
+    assert.equal(bound, undefined);
+    assert.deepEqual(
+      skills.map((entry) => [entry.group, entry.relativePath, entry.name]),
+      [
+        ["agent-skills", "agent-skills/a2a-protocol-guide", "a2a-protocol-guide"],
+        ["dev-skills", "dev-skills/react-guide", "react-guide"],
+        ["dev-skills", "dev-skills/rust-guide", "rust-guide"],
+        ["skills", "skills/agent-a2a-protocol-guide", "agent-a2a-protocol-guide"],
+        ["skills", "skills/dev-react-guide", "dev-react-guide"],
+      ],
+    );
+    assert.equal(skills[0].description, "a2a-protocol-guide skill");
+  });
+
+  // openlore: scenario=DuplicatesAreListedAsShipped spec=agent-resource-management
+  test("duplicates are listed as shipped", async () => {
+    const root = await temp();
+    const body = "name: a2a\ndescription: Same skill twice";
+    await skill(root, "agent-skills/a2a-protocol-guide", body);
+    await skill(root, "skills/agent-a2a-protocol-guide", body);
+    const { skills } = await discoverSkillCatalogue(root);
+    assert.deepEqual(skills.map((entry) => entry.relativePath), ["agent-skills/a2a-protocol-guide", "skills/agent-a2a-protocol-guide"]);
+    assert.deepEqual(skills.map((entry) => entry.name), ["a2a", "a2a"], "both kept, even under one name");
+  });
+
+  // openlore: scenario=NoManifestDecidesTheGrouping spec=agent-resource-management
+  test("a manifest has no effect on the grouping", async () => {
+    const root = await collection();
+    const { skills } = await discoverSkillCatalogue(root);
+    assert.deepEqual([...new Set(skills.map((entry) => entry.group))], ["agent-skills", "dev-skills", "skills"]);
+    assert.ok(!skills.some((entry) => entry.group === "everything"));
+  });
+
+  test("a skill at the repository root is one skill, grouped under the root", async () => {
+    const root = await temp();
+    await skill(root, ".", "name: root-skill\ndescription: At the top");
+    await skill(root, "nested/ignored");
+    const { skills } = await discoverSkillCatalogue(root);
+    assert.deepEqual(skills.map((entry) => [entry.group, entry.relativePath, entry.name]), [["", "", "root-skill"]]);
+  });
+
+  test("a directory holding SKILL.md is not descended into", async () => {
+    const root = await temp();
+    await skill(root, "outer");
+    await skill(root, "outer/inner");
+    const { skills } = await discoverSkillCatalogue(root);
+    assert.deepEqual(skills.map((entry) => entry.relativePath), ["outer"]);
+  });
+
+  test("missing frontmatter names the skill by its folder", async () => {
+    const root = await temp();
+    const dir = path.join(root, "g", "plain");
+    await mkdir(dir, { recursive: true });
+    await writeFile(path.join(dir, "SKILL.md"), "# Plain skill without frontmatter\n");
+    const { skills } = await discoverSkillCatalogue(root);
+    assert.deepEqual(skills, [{ relativePath: "g/plain", name: "plain", group: "g" }]);
+  });
+
+  test("a large SKILL.md is read only up to the byte bound", async () => {
+    const root = await temp();
+    const dir = path.join(root, "g", "big");
+    await mkdir(dir, { recursive: true });
+    await writeFile(path.join(dir, "SKILL.md"), `---\nname: big\ndescription: Large body\n---\n${"x".repeat(2 * 1024 * 1024)}\n`);
+    const { skills } = await discoverSkillCatalogue(root);
+    assert.deepEqual(skills, [{ relativePath: "g/big", name: "big", description: "Large body", group: "g" }]);
+  });
+
+  // openlore: scenario=ASymlinkedSkillIsNotFollowed spec=agent-resource-management
+  test("a symlinked skill contributes nothing, inside or outside the worktree", async () => {
+    const root = await temp();
+    const outside = await temp();
+    const real = await skill(root, "real/one");
+    await skill(outside, "secret");
+    await mkdir(path.join(root, "links"), { recursive: true });
+    await symlink(real, path.join(root, "links", "inside"), "dir");
+    await symlink(path.join(outside, "secret"), path.join(root, "links", "outside"), "dir");
+    const { skills } = await discoverSkillCatalogue(root);
+    assert.deepEqual(skills.map((entry) => entry.relativePath), ["real/one"]);
+  });
+
+  test(".git and node_modules are skipped", async () => {
+    const root = await temp();
+    await skill(root, ".git/hooks-skill");
+    await skill(root, "node_modules/pkg/skill");
+    await skill(root, "kept/one");
+    const { skills } = await discoverSkillCatalogue(root);
+    assert.deepEqual(skills.map((entry) => entry.relativePath), ["kept/one"]);
+  });
+
+  // openlore: scenario=ACatalogueThatReachesItsBoundSaysSo spec=agent-resource-management
+  test("a catalogue that reaches its count bound says so", async () => {
+    const root = await collection();
+    const { skills, bound } = await discoverSkillCatalogue(root, { maxSkills: 3 });
+    assert.equal(skills.length, 3);
+    assert.deepEqual(bound, { kind: "count", limit: 3 });
+  });
+
+  test("a catalogue that reaches its depth bound says so", async () => {
+    const root = await temp();
+    await skill(root, "a/shallow");
+    await skill(root, "a/b/c/deep");
+    const { skills, bound } = await discoverSkillCatalogue(root, { maxDepth: 2 });
+    assert.deepEqual(skills.map((entry) => entry.relativePath), ["a/shallow"]);
+    assert.deepEqual(bound, { kind: "depth", limit: 2 });
+  });
+
+  // openlore: scenario=CataloguingRunsNoRepositoryCode spec=agent-resource-management
+  test("cataloguing runs no repository code", async () => {
+    const root = await collection();
+    const marker = path.join(root, "side-effect-ran");
+    await mkdir(path.join(root, "extensions"), { recursive: true });
+    await writeFile(
+      path.join(root, "extensions", "loud.ts"),
+      `import { writeFileSync } from "node:fs";\nwriteFileSync(${JSON.stringify(marker)}, "ran");\nexport default () => {};\n`,
+    );
+    await writeFile(path.join(root, "dev-skills", "react-guide", "helper.mjs"), `import { writeFileSync } from "node:fs";\nwriteFileSync(${JSON.stringify(marker)}, "ran");\n`);
+    await discoverSkillCatalogue(root);
+    await assert.rejects(access(marker), "no module from the repository was imported");
+  });
+});

--- a/server/test/skillCollections.test.ts
+++ b/server/test/skillCollections.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Skill collections in the configuration: what is persisted, what the next boot
+ * loads, and which directories reach the runtime.
+ *
+ * Read back through `loadConfig` for the same reason as config-persist.test.ts:
+ * the property is "the next boot loads what the user chose", not "a key exists".
+ */
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, test } from "node:test";
+import type { AppConfig } from "../src/config.ts";
+import { allSkillPaths, enabledCollectionSkillDirs, loadConfig, persistEditableSettings } from "../src/config.ts";
+import { rpcResourceArgs } from "../src/rpcResourceArgs.ts";
+
+async function workspace(config: Record<string, unknown> = {}): Promise<{ dir: string; file: string }> {
+  const dir = realpathSync(await mkdtemp(path.join(tmpdir(), "pi-outpost-collections-")));
+  const file = path.join(dir, "pi-outpost.config.json");
+  await writeFile(file, `${JSON.stringify({ cwd: dir, ...config }, null, 2)}\n`);
+  return { dir, file };
+}
+
+const load = (dir: string, file: string) => loadConfig(dir, { config: file }, {}, { quiet: true });
+
+async function skill(root: string, relative: string, name = path.basename(relative)): Promise<string> {
+  const dir = path.join(root, ...relative.split("/"));
+  await mkdir(dir, { recursive: true });
+  await writeFile(path.join(dir, "SKILL.md"), `---\nname: ${name}\ndescription: ${name} for tests.\n---\n`);
+  return dir;
+}
+
+describe("skill collections in the configuration", () => {
+  test("a persisted selection is what the next load returns", async () => {
+    const { dir, file } = await workspace();
+    try {
+      const repo = path.join(dir, "collection");
+      await skill(repo, "dev-skills/react");
+      await skill(repo, "agent-skills/a2a");
+      persistEditableSettings(load(dir, file), {
+        userSkillCollections: [{ path: repo, managed: true, enabledSkills: ["dev-skills/react", "dev-skills/react"] }],
+      }, {});
+      const after = load(dir, file);
+      assert.deepEqual(after.userSkillCollections, [{ path: repo, managed: true, enabledSkills: ["dev-skills/react"] }]);
+      assert.deepEqual(allSkillPaths(after), [path.join(repo, "dev-skills", "react")], "only the skill that is on");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("writing a collection leaves the configuration file's skill paths as written", async () => {
+    const { dir, file } = await workspace({ skillPaths: ["./deployment-skills"] });
+    try {
+      await mkdir(path.join(dir, "deployment-skills"), { recursive: true });
+      const repo = path.join(dir, "collection");
+      await skill(repo, "a/one");
+      persistEditableSettings(load(dir, file), { userSkillCollections: [{ path: repo, managed: false, enabledSkills: ["a/one"] }] }, {});
+      const raw = JSON.parse(await readFile(file, "utf8")) as Record<string, unknown>;
+      assert.deepEqual(raw.skillPaths, ["./deployment-skills"]);
+      assert.equal(raw.userSkillPaths, undefined, "the user's root list is not invented");
+      const after = load(dir, file);
+      assert.deepEqual(after.skillPaths, [path.join(dir, "deployment-skills")]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("collections come after the configured and user paths", async () => {
+    const { dir, file } = await workspace({ skillPaths: ["./deployment"], userSkillPaths: ["./mine"] });
+    try {
+      await mkdir(path.join(dir, "deployment"), { recursive: true });
+      await mkdir(path.join(dir, "mine"), { recursive: true });
+      const repo = path.join(dir, "collection");
+      await skill(repo, "x/on");
+      persistEditableSettings(load(dir, file), { userSkillCollections: [{ path: repo, managed: false, enabledSkills: ["x/on"] }] }, {});
+      assert.deepEqual(allSkillPaths(load(dir, file)), [
+        path.join(dir, "deployment"),
+        path.join(dir, "mine"),
+        path.join(repo, "x", "on"),
+      ]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("an enabled skill that is gone, or has no SKILL.md, is not handed on", async () => {
+    const { dir } = await workspace();
+    try {
+      const repo = path.join(dir, "collection");
+      await skill(repo, "kept");
+      await mkdir(path.join(repo, "empty"), { recursive: true });
+      assert.deepEqual(
+        enabledCollectionSkillDirs([{ path: repo, managed: false, enabledSkills: ["kept", "vanished", "empty"] }]),
+        [path.join(repo, "kept")],
+      );
+      assert.deepEqual(enabledCollectionSkillDirs([{ path: path.join(dir, "no-repo"), managed: false, enabledSkills: ["kept"] }]), []);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a symlink cannot carry an outside skill into a collection", async () => {
+    const { dir } = await workspace();
+    try {
+      const repo = path.join(dir, "collection");
+      await mkdir(repo, { recursive: true });
+      const outside = await skill(dir, "outside/secret");
+      await symlink(outside, path.join(repo, "linked"), "dir");
+      assert.deepEqual(enabledCollectionSkillDirs([{ path: repo, managed: false, enabledSkills: ["linked"] }]), []);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a hand-written entry that leaves the repository refuses to load", async () => {
+    for (const bad of ["../escape", "/abs/path", "a/../../b", "a\\b", ""]) {
+      const { dir, file } = await workspace({ userSkillCollections: [{ path: "./collection", enabledSkills: [bad] }] });
+      try {
+        assert.throws(() => load(dir, file), /must be a relative path inside the repository/, `rejects ${JSON.stringify(bad)}`);
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  test("entries naming one repository merge", async () => {
+    const { dir, file } = await workspace({
+      userSkillCollections: [
+        { path: "./collection", enabledSkills: ["a"] },
+        { path: "./collection", managed: true, enabledSkills: ["b", "a"] },
+      ],
+    });
+    try {
+      assert.deepEqual(load(dir, file).userSkillCollections, [
+        { path: path.join(dir, "collection"), managed: true, enabledSkills: ["a", "b"] },
+      ]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("the sandbox may read an enabled collection skill outside its root", async () => {
+    const { dir, file } = await workspace();
+    try {
+      const project = path.join(dir, "project");
+      await mkdir(project, { recursive: true });
+      const repo = path.join(dir, "collection");
+      await skill(repo, "on");
+      await skill(repo, "off");
+      await writeFile(file, `${JSON.stringify({
+        cwd: project,
+        sandbox: { root: project },
+        userSkillCollections: [{ path: repo, enabledSkills: ["on"] }],
+      })}\n`);
+      const exceptions = load(dir, file).sandbox!.readExceptions;
+      assert.ok(exceptions.includes(path.join(repo, "on")));
+      assert.ok(!exceptions.includes(path.join(repo, "off")));
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("the RPC child receives one --skill per enabled skill", async () => {
+    const { dir } = await workspace();
+    try {
+      const repo = path.join(dir, "collection");
+      await skill(repo, "g/one");
+      await skill(repo, "g/two");
+      await skill(repo, "g/off");
+      const args = rpcResourceArgs(
+        {
+          noExtensions: false, extensionPaths: [], userExtensionPaths: [], extensionScripts: [],
+          noSkills: false, skillPaths: [], userSkillPaths: [], noPromptTemplates: false, promptPaths: [], offline: false,
+          userSkillCollections: [{ path: repo, managed: false, enabledSkills: ["g/one", "g/two"] }],
+        } as unknown as AppConfig,
+        { bundledSkills: [], appendSystemPrompt: [] },
+      );
+      assert.deepEqual(args, ["--skill", path.join(repo, "g", "one"), "--skill", path.join(repo, "g", "two")]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/server/test/skillCollectionsWire.test.mjs
+++ b/server/test/skillCollectionsWire.test.mjs
@@ -1,0 +1,83 @@
+/**
+ * Collection skills at the real boundary: a server booted from a configuration
+ * that enrolls a collection, its embedded agent, and that agent's own read tool.
+ *
+ * The configuration-level tests prove the path lists; these prove the session
+ * that the lists produce — the skill that is on is loaded and readable although
+ * it lies outside the sandbox, and the skill that is off is neither.
+ */
+import assert from "node:assert/strict";
+import { mkdir, readFile, realpath, writeFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { connect, makeWorkspace, startServer } from "./harness.mjs";
+
+const PROVIDER = fileURLToPath(new URL("./fixtures/sandbox-settings-provider.mjs", import.meta.url));
+
+async function waitForFile(file, timeoutMs = 30_000) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const value = await readFile(file, "utf8").catch(() => undefined);
+    if (value !== undefined) return value;
+    if (Date.now() > deadline) throw new Error("the agent never returned its read result");
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+}
+
+async function collectionProject() {
+  const project = await realpath(await makeWorkspace());
+  const sandboxRoot = path.join(project, "workspace");
+  const repo = path.join(project, "resources", "collection");
+  await mkdir(sandboxRoot);
+  for (const [relative, body] of [["group/on-skill", "ON_SKILL_BODY"], ["group/off-skill", "OFF_SKILL_BODY"]]) {
+    const dir = path.join(repo, ...relative.split("/"));
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      path.join(dir, "SKILL.md"),
+      `---\nname: ${path.basename(relative)}\ndescription: A collection skill for tests\n---\n\n${body}\n`,
+    );
+  }
+  return { project, sandboxRoot, repo };
+}
+
+async function bootAndRead(t, { project, sandboxRoot, repo }, readPath) {
+  const log = path.join(project, "collection-read.json");
+  const server = await startServer(
+    project,
+    {
+      sandbox: { root: sandboxRoot, allowWrite: false, allowBash: false },
+      extensionPaths: [PROVIDER],
+      allowedModels: [{ provider: "sandbox-settings-test", id: "sandbox-settings-test" }],
+      userSkillCollections: [{ path: repo, managed: false, enabledSkills: ["group/on-skill"] }],
+    },
+    { env: { SANDBOX_SETTINGS_LOG: log, SANDBOX_SETTINGS_READ_PATH: readPath } },
+  );
+  t.after(() => server.stop());
+  const client = connect(server.wsUrl());
+  t.after(() => client.close());
+  const hello = await client.waitFor("hello", 30_000);
+  client.send({ type: "set_model", provider: "sandbox-settings-test", id: "sandbox-settings-test" });
+  await client.waitFor("model_changed");
+  client.send({ type: "prompt", text: "Read the matching skill before answering." });
+  return { hello, toolResult: await waitForFile(log) };
+}
+
+const skillNames = (hello) => (hello.commands ?? []).filter((c) => c.source === "skill").map((c) => c.name);
+
+// openlore: scenario=TurningOneSkillOnLoadsThatSkillAlone spec=agent-resource-management
+test("an enabled collection skill outside the sandbox is loaded and readable", async (t) => {
+  const setup = await collectionProject();
+  const { hello, toolResult } = await bootAndRead(t, setup, path.join(setup.repo, "group", "on-skill", "SKILL.md"));
+  assert.ok(skillNames(hello).includes("skill:on-skill"), `on-skill is loaded: ${JSON.stringify(skillNames(hello))}`);
+  assert.ok(!skillNames(hello).includes("skill:off-skill"), "off-skill is not loaded");
+  assert.match(toolResult, /ON_SKILL_BODY/, "the agent's read tool reaches the enabled skill");
+  assert.doesNotMatch(toolResult, /Access denied|outside the sandbox/);
+});
+
+test("a collection skill that is off is not readable outside the sandbox", async (t) => {
+  const setup = await collectionProject();
+  const { toolResult } = await bootAndRead(t, setup, path.join(setup.repo, "group", "off-skill", "SKILL.md"));
+  assert.doesNotMatch(toolResult, /OFF_SKILL_BODY/, "a skill that is off grants no read access");
+  assert.match(toolResult, /Access denied|outside the sandbox/i);
+});

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -235,6 +235,33 @@ export type AgentResourceRepositoryAssessment = AgentResourceRepositoryAssessmen
     | { status: Exclude<AgentResourceRepositoryStatus, "unchecked" | "checking" | "updateable" | "current">; reason: string }
   );
 
+/**
+ * A collection skill as the user sees it: off, or on — and when on, whether the
+ * session actually loaded it, and why not when it did not.
+ */
+export type AgentCollectionSkillState = "off" | "on-loaded" | "on-not-loaded" | "on-missing";
+
+export interface AgentCollectionSkill extends AgentSkillCatalogueEntry {
+  state: AgentCollectionSkillState;
+  reason?: string;
+}
+
+export interface AgentResourceCollection {
+  skills: AgentCollectionSkill[];
+  /** Folder groups in display order; `label` is the repository name for the root group. */
+  groups: Array<{ path: string; label: string }>;
+  bound?: AgentSkillCatalogueBound;
+}
+
+/** Whether Remove repository is offered, and what it would do to the files. */
+export interface AgentResourceRemoval {
+  allowed: boolean;
+  /** True only for a clone pi-outpost manages; otherwise the files are kept. */
+  deletesFiles: boolean;
+  path: string;
+  reason?: string;
+}
+
 export interface AgentResourceRepository {
   /** Opaque server-issued identity. Clients never send a filesystem path to update. */
   id: string;
@@ -243,6 +270,9 @@ export interface AgentResourceRepository {
   resourceIds: string[];
   containsExtensions: boolean;
   assessment: AgentResourceRepositoryAssessment;
+  /** Present for a repository enrolled as a skill collection. */
+  collection?: AgentResourceCollection;
+  removal?: AgentResourceRemoval;
 }
 
 export interface AgentResourceInventory {
@@ -252,13 +282,51 @@ export interface AgentResourceInventory {
   capabilities: { skills: "available" | "unavailable"; extensions: "available" | "unavailable" };
 }
 
+/** One skill found in a repository's own folder tree, whether or not it is loaded. */
+export interface AgentSkillCatalogueEntry {
+  /** POSIX path of the skill directory, relative to the repository root. */
+  relativePath: string;
+  /** The frontmatter name the runtime will use, or the directory name. */
+  name: string;
+  description?: string;
+  /** POSIX path of the folder holding the skill directory; "" for the repository root. */
+  group: string;
+}
+
+/** A catalogue walk stopped at one of its bounds, so the list is not the whole repository. */
+export interface AgentSkillCatalogueBound {
+  kind: "depth" | "count";
+  limit: number;
+}
+
 export interface AgentResourceRepositoryPreview {
   token: string;
   repositoryPath: string;
   repositoryName: string;
   headRevision: string;
   repositoryUrl?: string;
+  /**
+   * "collection": a repository enrolled from now on — its skills are listed one by
+   * one in `skills`, all off, and `roots` holds only extension roots.
+   * "roots": a worktree already registered through skill roots, which keeps
+   * loading everything under the roots it selects.
+   */
+  mode: "collection" | "roots";
   roots: Array<{ kind: AgentResourceKind; path: string; name: string; locked?: boolean }>;
+  skills: AgentSkillCatalogueEntry[];
+  bound?: AgentSkillCatalogueBound;
+}
+
+/**
+ * What removing a repository did. "removed": unregistered and its clone deleted.
+ * "removed-files-kept": unregistered, files left in place (not pi-outpost's, or
+ * still in use) — `reason` says which. "removed-delete-failed": unregistered, but
+ * the deletion stopped part-way; files remain at `path`.
+ */
+export interface AgentResourceRemovalResult {
+  status: "removed" | "removed-files-kept" | "removed-delete-failed";
+  path: string;
+  reason?: string;
 }
 
 export interface AgentResourceReloadResult {
@@ -877,6 +945,14 @@ export type ServerMessage =
   | { type: "agent_resource_assessments"; requestId: string; assessments: AgentResourceRepositoryAssessment[] }
   | { type: "agent_resource_inventory"; inventory: AgentResourceInventory }
   | { type: "agent_resource_update_result"; requestId: string; result: AgentResourceUpdateResult; inventory: AgentResourceInventory }
+  | { type: "agent_resource_skills_applied"; requestId: string; repositoryId: string; inventory: AgentResourceInventory }
+  | {
+      type: "agent_resource_removed";
+      requestId: string;
+      repositoryId: string;
+      result: AgentResourceRemovalResult;
+      inventory: AgentResourceInventory;
+    }
   | { type: "agent_resource_error"; requestId: string; message: string }
   /**
    * Editable runtime settings were persisted and the session rebuilt from them —
@@ -1023,8 +1099,14 @@ export type ClientMessage =
       previewToken: string;
       skillRoots: string[];
       extensionRoots: string[];
+      /** Collection previews only: the skills to turn on, as catalogue relative paths. */
+      enabledSkills?: string[];
       requestId: string;
     }
+  /** The complete set of a collection's skills that should be on; applied through a session replacement. */
+  | { type: "set_agent_resource_skills"; repositoryId: string; enabledSkills: string[]; requestId: string }
+  /** Unregister a repository as a whole, and delete its clone when pi-outpost manages it. */
+  | { type: "remove_agent_resource_repository"; repositoryId: string; requestId: string }
   /** Refresh one known repository, or every known repository when id is absent. */
   | { type: "refresh_agent_resource_repositories"; repositoryId?: string; requestId: string }
   /** Advance one known repository to the exact upstream captured by its assessment. */

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -139,6 +139,8 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
     suggestAgentResourceClonePath,
     cloneAgentResourceRepository,
     enrollAgentResourceRepository,
+    setAgentResourceSkills,
+    removeAgentResourceRepository,
     refreshAgentResourceRepositories,
     updateAgentResourceRepository,
     browseServerDirectory,
@@ -892,6 +894,8 @@ const App = forwardRef<AppHandle, AppProps>(function App({ serverUrl = "", rootE
             onSuggestAgentResourceClonePath={suggestAgentResourceClonePath}
             onCloneAgentResourceRepository={cloneAgentResourceRepository}
             onEnrollAgentResourceRepository={enrollAgentResourceRepository}
+            onSetAgentResourceSkills={setAgentResourceSkills}
+            onRemoveAgentResourceRepository={removeAgentResourceRepository}
             onRefreshAgentResourceRepositories={refreshAgentResourceRepositories}
             onUpdateAgentResourceRepository={updateAgentResourceRepository}
             onFetchGitLog={fetchGitLog}

--- a/ui/src/components/AgentResourceManager.test.tsx
+++ b/ui/src/components/AgentResourceManager.test.tsx
@@ -1,6 +1,12 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import type { AgentResourceInventory, AgentResourceRepositoryAssessment } from "@pi-outpost/shared";
+import type {
+  AgentCollectionSkill,
+  AgentResourceInventory,
+  AgentResourceRepository,
+  AgentResourceRepositoryAssessment,
+  AgentResourceRepositoryPreview,
+} from "@pi-outpost/shared";
 import type { AgentResourceOperationState } from "../useAgent";
 import { AgentResourceManager } from "./AgentResourceManager";
 
@@ -10,6 +16,8 @@ const operations = (overrides: Partial<AgentResourceOperationState> = {}): Agent
   enrollment: null,
   refresh: null,
   updates: {},
+  skills: {},
+  removals: {},
   ...overrides,
 });
 
@@ -54,6 +62,8 @@ function setup(overrides: Record<string, unknown> = {}) {
     onSuggestClonePath: vi.fn(),
     onCloneRepository: vi.fn(),
     onEnrollRepository: vi.fn(),
+    onSetSkills: vi.fn(),
+    onRemoveRepository: vi.fn(),
     onRefresh: vi.fn(),
     onUpdate: vi.fn(),
   };
@@ -152,9 +162,11 @@ describe("AgentResourceManager", () => {
       repositoryPath: "/srv/custom/resources",
       repositoryName: "resources",
       headRevision: "abc",
+      mode: "roots",
+      skills: [],
       roots: [{ kind: "skill", path: "/srv/custom/resources/skills", name: "skills" }],
     } } }) });
-    fireEvent.click(screen.getByRole("button", { name: "Activate selected resources" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
     expect(onEnrollRepository).toHaveBeenCalledWith("preview-token", ["/srv/custom/resources/skills"], []);
   });
 
@@ -164,13 +176,15 @@ describe("AgentResourceManager", () => {
       repositoryPath: "/srv/custom/resources",
       repositoryName: "resources",
       headRevision: "abc",
+      mode: "roots",
+      skills: [],
       roots: [{ kind: "extension", path: "/srv/custom/resources/extensions", name: "extensions" }],
     } } }) });
     fireEvent.click(screen.getByRole("button", { name: "Add Git repository…" }));
     expect(screen.getByText(/Extensions execute code/)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Activate selected resources" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
     fireEvent.click(screen.getByRole("checkbox", { name: /I trust the selected extension roots/ }));
-    fireEvent.click(screen.getByRole("button", { name: "Activate selected resources" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
     expect(onEnrollRepository).toHaveBeenCalledWith("preview-token", [], ["/srv/custom/resources/extensions"]);
   });
 
@@ -275,6 +289,8 @@ describe("AgentResourceManager", () => {
         repositoryPath: "/srv/resources",
         repositoryName: "resources",
         headRevision: "abc",
+        mode: "roots",
+        skills: [],
         roots: [{ kind: "skill", path: "/srv/resources/skills", name: "skills" }],
       } },
       enrollment: { requestId: "enroll", status: "error", message: "This repository preview has expired; preview it again" },
@@ -308,10 +324,23 @@ describe("AgentResourceManager", () => {
   it("directs dirty repositories to external resolution without mutation controls", () => {
     setup({ inventory: inventory("dirty") });
     expect(screen.getByText(/external terminal/)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Update repository" })).toBeDisabled();
+    expect(screen.queryByRole("button", { name: "Update repository" })).not.toBeInTheDocument();
     for (const forbidden of ["Commit", "Stash", "Discard", "Rebase", "Merge"]) {
       expect(screen.queryByRole("button", { name: forbidden })).not.toBeInTheDocument();
     }
+  });
+
+  // openlore: scenario=UpdateIsOfferedOnlyWhenThereIsOne spec=components
+  it("offers Update repository only once an update is available", () => {
+    const { rerenderWith } = setup({ inventory: inventory("unchecked") });
+    expect(screen.getByRole("button", { name: "Check" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Update repository" })).not.toBeInTheDocument();
+    rerenderWith({ inventory: inventory("current") });
+    expect(screen.queryByRole("button", { name: "Update repository" })).not.toBeInTheDocument();
+    rerenderWith({ inventory: inventory("updateable") });
+    expect(screen.getByRole("button", { name: "Update repository" })).toBeEnabled();
+    rerenderWith({ inventory: inventory("unchecked"), operations: operations({ updates: { "repo-team": { requestId: "u", status: "loading" } } }) });
+    expect(screen.getByRole("button", { name: "Updating…" })).toBeDisabled();
   });
 
   it("confirms revision-specific executable changes before invoking update", () => {
@@ -335,6 +364,8 @@ describe("AgentResourceManager", () => {
       repositoryPath: "/srv/resources",
       repositoryName: "resources",
       headRevision: "abc",
+      mode: "roots",
+      skills: [],
       roots: [
         { kind: "skill", path: "/srv/resources/skills", name: "skills" },
         { kind: "skill", path: "/srv/resources/.agents/skills", name: ".agents/skills" },
@@ -344,12 +375,12 @@ describe("AgentResourceManager", () => {
     const checkboxes = screen.getAllByRole("checkbox");
     expect(checkboxes).toHaveLength(2);
     fireEvent.click(checkboxes[1]);
-    fireEvent.click(screen.getByRole("button", { name: "Activate selected resources" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
     expect(onEnrollRepository).toHaveBeenCalledWith("preview-token", ["/srv/resources/skills"], []);
 
     // ...and unticking the last one leaves nothing to activate.
     fireEvent.click(checkboxes[0]);
-    expect(screen.getByRole("button", { name: "Activate selected resources" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
   });
 
   it("closes on Escape and on a click outside the dialog, but not on a click inside it", () => {
@@ -415,5 +446,319 @@ describe("AgentResourceManager", () => {
     rerenderWith({ inventory: { ...inventory(), repositories: [], resources: [inventory().resources[2]] } });
     expect(screen.getByText("remote-only")).toBeInTheDocument();
     expect(screen.queryByText("team-resources")).not.toBeInTheDocument();
+  });
+});
+
+const COLLECTION_SKILLS: AgentCollectionSkill[] = [
+  { relativePath: "agent-skills/a2a", name: "a2a", group: "agent-skills", state: "off" },
+  { relativePath: "dev-skills/react", name: "react", group: "dev-skills", state: "on-not-loaded", reason: "Another skill named \"react\" was loaded first, from /elsewhere/react/SKILL.md" },
+  { relativePath: "dev-skills/rust", name: "rust", group: "dev-skills", state: "on-loaded" },
+  { relativePath: "skills/agent-a2a", name: "agent-a2a", group: "skills", state: "on-missing", reason: "This skill is no longer in the repository" },
+];
+
+function collectionRepository(overrides: Partial<AgentResourceRepository> = {}, skills: AgentCollectionSkill[] = COLLECTION_SKILLS): AgentResourceRepository {
+  return {
+    id: "repo-collection",
+    name: "claude-skills-collection",
+    path: "/repos/collection",
+    resourceIds: [],
+    containsExtensions: false,
+    assessment: { repositoryId: "repo-collection", status: "unchecked" },
+    collection: {
+      skills,
+      groups: [...new Set(skills.map((skill) => skill.group))].sort().map((group) => ({ path: group, label: group })),
+    },
+    removal: { allowed: true, deletesFiles: true, path: "/repos/collection" },
+    ...overrides,
+  };
+}
+
+const collectionInventory = (repository: AgentResourceRepository = collectionRepository(), extra: AgentResourceRepository[] = []): AgentResourceInventory => ({
+  capabilities: { skills: "available", extensions: "available" },
+  resources: [
+    { id: "skill:rust", kind: "skill", name: "rust", origin: "runtime", path: "/repos/collection/dev-skills/rust/SKILL.md" },
+    ...(extra.length ? inventory().resources.slice(0, 2) : []),
+  ],
+  repositories: [repository, ...extra],
+});
+
+const teamRepository = (): AgentResourceRepository => inventory().repositories[0];
+const skillSwitch = (relativePath: string) => screen.getByRole("switch", { name: new RegExp(`\\(${relativePath}\\)`) });
+
+describe("AgentResourceManager collections", () => {
+  // openlore: scenario=CollectionSkillsAreGroupedByFolderWithSwitches spec=components
+  it("lists a collection's skills by folder, with a switch each and an on-count per group", () => {
+    setup({ inventory: collectionInventory() });
+    expect(screen.getByRole("button", { name: /claude-skills-collection/ })).toHaveTextContent("4");
+    expect(screen.getByRole("button", { name: /^dev-skills/ })).toHaveTextContent("2/2 on");
+    expect(screen.getByRole("button", { name: /^agent-skills/ })).toHaveTextContent("0/1 on");
+    expect(skillSwitch("dev-skills/rust")).toBeChecked();
+    expect(skillSwitch("agent-skills/a2a")).not.toBeChecked();
+    expect(screen.getByText(/3 of 4 on/)).toBeInTheDocument();
+  });
+
+  // openlore: scenario=SkillStatesAreDistinguished spec=components
+  it("renders each state distinctly, with the reason for the ones not loaded", () => {
+    setup({ inventory: collectionInventory() });
+    const row = (relativePath: string) => skillSwitch(relativePath).closest("label")!;
+    expect(row("dev-skills/rust")).toHaveTextContent("Loaded");
+    expect(row("dev-skills/react")).toHaveTextContent(/Not loaded — Another skill named "react" was loaded first/);
+    expect(row("skills/agent-a2a")).toHaveTextContent(/Missing — This skill is no longer in the repository/);
+    expect(row("agent-skills/a2a")).not.toHaveTextContent(/Loaded|Not loaded|Missing|Pending/);
+  });
+
+  // openlore: scenario=TheSkillsThatAreOnCanBeFound spec=components
+  it("opens the folder holding a skill that is on in a large collection, and filters to the skills that are on", () => {
+    const many: AgentCollectionSkill[] = [];
+    for (const group of ["alpha", "beta", "gamma"]) {
+      for (let index = 0; index < 20; index += 1) {
+        many.push({ relativePath: `${group}/skill-${index}`, name: `${group}-skill-${index}`, group, state: "off" });
+      }
+    }
+    many[25] = { ...many[25], state: "on-loaded" };
+    setup({ inventory: { ...collectionInventory(collectionRepository({}, many)), resources: [] } });
+    expect(screen.getByRole("button", { name: /^beta/ })).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("button", { name: /^alpha/ })).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByRole("button", { name: /^gamma/ })).toHaveAttribute("aria-expanded", "false");
+    expect(skillSwitch("beta/skill-5")).toBeChecked();
+    expect(screen.getByRole("region", { name: "Skills that are on" })).toHaveTextContent(/beta-skill-5\s*beta/);
+    expect(screen.getByRole("button", { name: /claude-skills-collection/ })).toHaveTextContent("1 on · 60");
+    fireEvent.click(screen.getByRole("button", { name: "Only on (1)" }));
+    expect(screen.queryByRole("region", { name: "Skills that are on" })).not.toBeInTheDocument();
+    expect(screen.getAllByRole("switch")).toHaveLength(1);
+    expect(skillSwitch("beta/skill-5")).toBeChecked();
+    fireEvent.click(screen.getByRole("button", { name: "Only on (1)" }));
+    fireEvent.click(screen.getByRole("button", { name: "Turn off beta-skill-5 (beta/skill-5)" }));
+    expect(skillSwitch("beta/skill-5")).not.toBeChecked();
+    expect(screen.getByText(/1 pending change\b/)).toBeInTheDocument();
+  });
+
+  // openlore: scenario=SearchNarrowsACollectionsSkills spec=components
+  it("narrows the skills by search, and a folder's All on then acts on its matches only", () => {
+    setup({ inventory: collectionInventory() });
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search skills" }), { target: { value: "rea" } });
+    expect(screen.getAllByRole("switch").map((element) => element.getAttribute("aria-label"))).toEqual(["react (dev-skills/react)"]);
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search skills" }), { target: { value: "a2a" } });
+    expect(screen.getAllByRole("switch")).toHaveLength(2);
+    fireEvent.click(screen.getByRole("button", { name: "All off in skills" }));
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search skills" }), { target: { value: "" } });
+    expect(skillSwitch("skills/agent-a2a")).not.toBeChecked();
+    expect(skillSwitch("dev-skills/rust")).toBeChecked();
+    expect(skillSwitch("dev-skills/react")).toBeChecked();
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search skills" }), { target: { value: "no such skill" } });
+    expect(screen.getByText("No skill matches.")).toBeInTheDocument();
+  });
+
+  it("folds and unfolds a folder group", () => {
+    setup({ inventory: collectionInventory() });
+    const group = screen.getByRole("button", { name: /^dev-skills/ });
+    expect(group).toHaveAttribute("aria-expanded", "true");
+    fireEvent.click(group);
+    expect(group).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("switch", { name: /\(dev-skills\/rust\)/ })).not.toBeInTheDocument();
+    fireEvent.click(group);
+    expect(skillSwitch("dev-skills/rust")).toBeInTheDocument();
+  });
+
+  it("keeps a collection with nothing loaded in the list", () => {
+    const allOff = COLLECTION_SKILLS.map((skill) => ({ ...skill, state: "off" as const, reason: undefined }));
+    setup({ inventory: { ...collectionInventory(collectionRepository({}, allOff)), resources: [] } });
+    expect(screen.getByRole("button", { name: /claude-skills-collection/ })).toHaveTextContent("4");
+    expect(screen.getByText(/0 of 4 on/)).toBeInTheDocument();
+  });
+
+  // openlore: scenario=AllOnAndAllOffStageTheWholeRepository spec=components
+  it("stages the whole repository with All on and All off, without calling back", () => {
+    const { onSetSkills } = setup({ inventory: collectionInventory() });
+    fireEvent.click(screen.getByRole("button", { name: "All on" }));
+    for (const skill of COLLECTION_SKILLS) expect(skillSwitch(skill.relativePath)).toBeChecked();
+    expect(skillSwitch("agent-skills/a2a").closest("label")).toHaveTextContent("Pending: on");
+    expect(screen.getByText(/1 pending change\b/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "All off" }));
+    for (const skill of COLLECTION_SKILLS) expect(skillSwitch(skill.relativePath)).not.toBeChecked();
+    expect(screen.getByText(/3 pending changes/)).toBeInTheDocument();
+    expect(onSetSkills).not.toHaveBeenCalled();
+  });
+
+  // openlore: scenario=FolderLevelAllOnStagesOneGroupOnly spec=components
+  it("stages one folder group with its own All on", () => {
+    setup({ inventory: collectionInventory() });
+    fireEvent.click(screen.getByRole("button", { name: "All off in dev-skills" }));
+    expect(skillSwitch("dev-skills/react")).not.toBeChecked();
+    expect(skillSwitch("dev-skills/rust")).not.toBeChecked();
+    fireEvent.click(screen.getByRole("button", { name: "All on in agent-skills" }));
+    expect(skillSwitch("agent-skills/a2a")).toBeChecked();
+    expect(skillSwitch("skills/agent-a2a")).toBeChecked();
+    expect(skillSwitch("dev-skills/rust")).not.toBeChecked();
+  });
+
+  // openlore: scenario=ApplyReportsTheWholePendingSelectionOnce spec=components
+  it("applies the complete resulting selection once, letting go of skills that are gone", () => {
+    const { onSetSkills } = setup({ inventory: collectionInventory() });
+    fireEvent.click(skillSwitch("agent-skills/a2a"));
+    fireEvent.click(skillSwitch("dev-skills/rust"));
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    expect(onSetSkills).toHaveBeenCalledTimes(1);
+    expect(onSetSkills.mock.calls[0][0]).toBe("repo-collection");
+    expect([...onSetSkills.mock.calls[0][1]].sort()).toEqual(["agent-skills/a2a", "dev-skills/react"]);
+  });
+
+  // openlore: scenario=DiscardRestoresTheSuppliedState spec=components
+  it("discards pending changes back to the supplied state", () => {
+    const { onSetSkills } = setup({ inventory: collectionInventory() });
+    fireEvent.click(skillSwitch("agent-skills/a2a"));
+    fireEvent.click(screen.getByRole("button", { name: "Discard" }));
+    expect(skillSwitch("agent-skills/a2a")).not.toBeChecked();
+    expect(screen.queryByText(/pending change/)).not.toBeInTheDocument();
+    expect(onSetSkills).not.toHaveBeenCalled();
+  });
+
+  // openlore: scenario=APendingSelectionStaysWithItsRepository spec=components
+  it("keeps a pending selection with its own repository across a switch and back", () => {
+    setup({ inventory: collectionInventory(collectionRepository(), [teamRepository()]) });
+    fireEvent.click(screen.getByRole("button", { name: /claude-skills-collection/ }));
+    fireEvent.click(skillSwitch("agent-skills/a2a"));
+    expect(screen.getByText(/1 pending change\b/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /team-resources/ }));
+    expect(screen.queryByText(/pending change/)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /claude-skills-collection/ }));
+    expect(screen.getByText(/1 pending change\b/)).toBeInTheDocument();
+    expect(skillSwitch("agent-skills/a2a")).toBeChecked();
+  });
+
+  it("keeps a pending selection across an unrelated inventory, and clears it once applied", () => {
+    const { rerenderWith } = setup({ inventory: collectionInventory() });
+    fireEvent.click(skillSwitch("agent-skills/a2a"));
+    rerenderWith({ inventory: collectionInventory(collectionRepository({ assessment: { repositoryId: "repo-collection", status: "checking" } })) });
+    expect(screen.getByText(/1 pending change\b/)).toBeInTheDocument();
+    const applied = COLLECTION_SKILLS.map((skill) => (skill.relativePath === "agent-skills/a2a" ? { ...skill, state: "on-loaded" as const } : skill));
+    rerenderWith({ inventory: collectionInventory(collectionRepository({}, applied)) });
+    expect(screen.queryByText(/pending change/)).not.toBeInTheDocument();
+    expect(skillSwitch("agent-skills/a2a")).toBeChecked();
+  });
+
+  it("drops a pending selection whose repository vanished", () => {
+    const { rerenderWith } = setup({ inventory: collectionInventory() });
+    fireEvent.click(skillSwitch("agent-skills/a2a"));
+    rerenderWith({ inventory: { ...collectionInventory(), repositories: [] } });
+    rerenderWith({ inventory: collectionInventory() });
+    expect(screen.queryByText(/pending change/)).not.toBeInTheDocument();
+    expect(skillSwitch("agent-skills/a2a")).not.toBeChecked();
+  });
+
+  it("shows an apply in flight and a refused one", () => {
+    const { rerenderWith } = setup({ inventory: collectionInventory() });
+    fireEvent.click(skillSwitch("agent-skills/a2a"));
+    rerenderWith({ operations: operations({ skills: { "repo-collection": { requestId: "s", status: "loading" } } }) });
+    expect(screen.getByText("Applying…")).toBeInTheDocument();
+    expect(skillSwitch("dev-skills/rust")).toBeDisabled();
+    rerenderWith({ operations: operations({ skills: { "repo-collection": { requestId: "s", status: "error", message: "workspace-b is busy; wait for its current turn to finish" } } }) });
+    expect(screen.getByRole("alert")).toHaveTextContent("is busy");
+    expect(skillSwitch("agent-skills/a2a")).toBeChecked();
+  });
+
+  // openlore: scenario=AddRepositoryPreviewsRootsBeforeApplying spec=components
+  it("previews a collection with every skill off and adds it with nothing on", () => {
+    const preview: AgentResourceRepositoryPreview = {
+      token: "collection-token",
+      repositoryPath: "/srv/collection",
+      repositoryName: "collection",
+      headRevision: "abc",
+      mode: "collection",
+      roots: [],
+      skills: [
+        { relativePath: "dev-skills/react", name: "react", group: "dev-skills" },
+        { relativePath: "agent-skills/a2a", name: "a2a", group: "agent-skills" },
+      ],
+    };
+    const { onEnrollRepository } = setup({ operations: operations({ preview: { requestId: "p", status: "ready", preview } }) });
+    fireEvent.click(screen.getByRole("button", { name: "Add Git repository…" }));
+    expect(skillSwitch("dev-skills/react")).not.toBeChecked();
+    expect(skillSwitch("agent-skills/a2a")).not.toBeChecked();
+    expect(screen.getByRole("heading", { name: "collection" })).toBeInTheDocument();
+    fireEvent.click(skillSwitch("dev-skills/react"));
+    fireEvent.click(skillSwitch("dev-skills/react"));
+    expect(onEnrollRepository).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(onEnrollRepository).toHaveBeenCalledWith("collection-token", [], [], []);
+  });
+
+  it("adds a previewed collection with the skills turned on", () => {
+    const preview: AgentResourceRepositoryPreview = {
+      token: "collection-token",
+      repositoryPath: "/srv/collection",
+      repositoryName: "collection",
+      headRevision: "abc",
+      mode: "collection",
+      roots: [],
+      skills: [
+        { relativePath: "dev-skills/react", name: "react", group: "dev-skills" },
+        { relativePath: "dev-skills/rust", name: "rust", group: "dev-skills" },
+        { relativePath: "agent-skills/a2a", name: "a2a", group: "agent-skills" },
+      ],
+    };
+    const { onEnrollRepository } = setup({ operations: operations({ preview: { requestId: "p", status: "ready", preview } }) });
+    fireEvent.click(screen.getByRole("button", { name: "Add Git repository…" }));
+    fireEvent.click(skillSwitch("dev-skills/rust"));
+    fireEvent.click(skillSwitch("agent-skills/a2a"));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(onEnrollRepository).toHaveBeenCalledTimes(1);
+    const [token, roots, extensions, enabled] = onEnrollRepository.mock.calls[0];
+    expect([token, roots, extensions]).toEqual(["collection-token", [], []]);
+    expect([...enabled].sort()).toEqual(["agent-skills/a2a", "dev-skills/rust"]);
+  });
+
+  // openlore: scenario=RemoveRepositoryRequiresConfirmation spec=components
+  it("confirms before removing, names the path, and does nothing on cancel", () => {
+    const { onRemoveRepository } = setup({ inventory: collectionInventory() });
+    fireEvent.click(screen.getByRole("button", { name: "Remove repository" }));
+    const dialog = screen.getByRole("alertdialog", { name: /Remove claude-skills-collection/ });
+    expect(dialog).toHaveTextContent("/repos/collection");
+    expect(dialog).toHaveTextContent("cannot be undone");
+    fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
+    expect(onRemoveRepository).not.toHaveBeenCalled();
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove repository" }));
+    fireEvent.click(within(screen.getByRole("alertdialog")).getByRole("button", { name: "Delete and remove" }));
+    expect(onRemoveRepository).toHaveBeenCalledWith("repo-collection");
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  // openlore: scenario=RemovingAnUnmanagedRepositorySaysTheFilesStay spec=components
+  it("says the files stay when pi-outpost does not manage the repository", () => {
+    const { onRemoveRepository } = setup({ inventory: collectionInventory(collectionRepository({ removal: { allowed: true, deletesFiles: false, path: "/repos/collection" } })) });
+    fireEvent.click(screen.getByRole("button", { name: "Remove repository" }));
+    const dialog = screen.getByRole("alertdialog");
+    expect(dialog).toHaveTextContent(/files will be kept/);
+    expect(dialog).not.toHaveTextContent(/cannot be undone/);
+    fireEvent.click(within(dialog).getByRole("button", { name: "Remove repository" }));
+    expect(onRemoveRepository).toHaveBeenCalledWith("repo-collection");
+  });
+
+  // openlore: scenario=AConfigurationFileRepositoryCannotBeRemovedHere spec=components
+  it("offers no removal for a configuration-file repository, and says why", () => {
+    setup({ inventory: collectionInventory(collectionRepository({
+      removal: { allowed: false, deletesFiles: false, path: "/repos/collection", reason: "This repository supplies a path from the configuration file, so it can only be removed there" },
+    })) });
+    expect(screen.queryByRole("button", { name: "Remove repository" })).not.toBeInTheDocument();
+    expect(screen.getByText(/can only be removed there/)).toBeInTheDocument();
+  });
+
+  it("shows what removal did after the repository has left the list", () => {
+    const { rerenderWith } = setup({ inventory: collectionInventory(collectionRepository(), [teamRepository()]) });
+    fireEvent.click(screen.getByRole("button", { name: /claude-skills-collection/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Remove repository" }));
+    fireEvent.click(screen.getByRole("button", { name: "Delete and remove" }));
+    rerenderWith({ operations: operations({ removals: { "repo-collection": { requestId: "r", status: "loading" } } }) });
+    expect(screen.getByRole("status")).toHaveTextContent("Removing claude-skills-collection…");
+    rerenderWith({
+      inventory: inventory(),
+      operations: operations({ removals: { "repo-collection": { requestId: "r", status: "ready", result: { status: "removed-delete-failed", path: "/repos/collection", reason: "Could not delete every file: EBUSY" } } } }),
+    });
+    expect(screen.queryByRole("button", { name: /claude-skills-collection/ })).not.toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent(/not every file could be deleted — Could not delete every file: EBUSY\. What remains is at \/repos\/collection/);
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 });

--- a/ui/src/components/AgentResourceManager.tsx
+++ b/ui/src/components/AgentResourceManager.tsx
@@ -7,11 +7,25 @@ import type {
   AgentResourceRepositoryPreview,
 } from "@pi-outpost/shared";
 import type { AgentResourceOperationState, ServerBrowseState, SettingsApplyState } from "../useAgent";
+import { CollectionSkills, groupsOf, sameSelection, suppliedSelection } from "./CollectionSkills";
 import { ServerPathPicker } from "./ServerPathPicker";
 
 type Group =
-  | { id: string; name: string; path?: string; repository: AgentResourceRepository; resources: AgentResourceInfo[] }
-  | { id: string; name: string; reason: string; resources: AgentResourceInfo[] };
+  | { id: string; name: string; path?: string; repository: AgentResourceRepository; resources: AgentResourceInfo[]; count?: number; onCount?: number }
+  | { id: string; name: string; reason: string; resources: AgentResourceInfo[]; count?: number; onCount?: number };
+
+type RemovalState = AgentResourceOperationState["removals"][string];
+
+/** What removing a repository did, told in the words of the result rather than inferred. */
+function removalMessage(name: string, state: RemovalState): string {
+  if (state.status === "loading") return `Removing ${name}…`;
+  if (state.status === "error") return state.message ?? `Could not remove ${name}`;
+  const result = state.result;
+  if (!result) return `Removed ${name}.`;
+  if (result.status === "removed") return `Removed ${name} and deleted ${result.path}.`;
+  if (result.status === "removed-files-kept") return `Removed ${name}. ${result.reason ?? "Its files were kept"} (${result.path}).`;
+  return `Removed ${name}, but not every file could be deleted${result.reason ? ` — ${result.reason}` : ""}. What remains is at ${result.path}.`;
+}
 
 interface AgentResourceManagerProps {
   open: boolean;
@@ -28,7 +42,10 @@ interface AgentResourceManagerProps {
   onUpdateConfig: (update: { userSkillPaths?: string[]; userExtensionPaths?: string[] }) => void;
   onSuggestClonePath: (repositoryUrl: string) => void;
   onCloneRepository: (repositoryUrl: string, destinationPath: string) => void;
-  onEnrollRepository: (previewToken: string, skillRoots: string[], extensionRoots: string[]) => void;
+  onEnrollRepository: (previewToken: string, skillRoots: string[], extensionRoots: string[], enabledSkills?: string[]) => void;
+  /** The complete set of a collection's skills that should be on. */
+  onSetSkills: (repositoryId: string, enabledSkills: string[]) => void;
+  onRemoveRepository: (repositoryId: string) => void;
   onRefresh: (repositoryId?: string) => void;
   onUpdate: (
     repositoryId: string,
@@ -116,10 +133,23 @@ function ResourceList({ kind, resources, removalLocked = false, onRemove }: { ki
   );
 }
 
-function PreviewForm({ preview, busy, error, onApply }: { preview: AgentResourceRepositoryPreview; busy: boolean; error?: string; onApply: (skills: string[], extensions: string[]) => void }) {
+function PreviewForm({ preview, busy, error, onApply, onCancel }: { preview: AgentResourceRepositoryPreview; busy: boolean; error?: string; onApply: (skills: string[], extensions: string[], enabledSkills?: string[]) => void; onCancel: () => void }) {
   const [selected, setSelected] = useState<Set<string>>(() => new Set(preview.roots.filter((root) => !root.locked).map((root) => `${root.kind}:${root.path}`)));
   const [extensionsAcknowledged, setExtensionsAcknowledged] = useState(false);
+  // A collection's skills all start off; the preview only records which to turn on.
+  const [enabledSkills, setEnabledSkills] = useState<Set<string>>(() => new Set());
+  const collection = preview.mode === "collection";
+  const catalogue = useMemo(() => preview.skills.map((skill) => ({ ...skill, state: "off" as const })), [preview.skills]);
+  const catalogueGroups = useMemo(() => groupsOf(preview.skills, preview.repositoryName), [preview.skills, preview.repositoryName]);
   const selectedExtensions = preview.roots.filter((root) => root.kind === "extension" && selected.has(`extension:${root.path}`));
+  const extensionsUnacknowledged = selectedExtensions.length > 0 && !extensionsAcknowledged;
+  // A collection may be saved with nothing on: registering its catalogue is the point.
+  const saveBlocked = busy || (!collection && selected.size === 0) || extensionsUnacknowledged;
+  const save = () => {
+    const extensions = selectedExtensions.map((root) => root.path);
+    if (collection) onApply([], extensions, [...enabledSkills]);
+    else onApply(preview.roots.filter((root) => root.kind === "skill" && selected.has(`skill:${root.path}`)).map((root) => root.path), extensions);
+  };
   const toggle = (key: string) => {
     setExtensionsAcknowledged(false);
     setSelected((current) => {
@@ -130,7 +160,21 @@ function PreviewForm({ preview, busy, error, onApply }: { preview: AgentResource
   };
   return (
     <div className="space-y-3" data-testid="resource-preview">
-      <div><p className="text-sm font-semibold">Choose resources to activate</p><p className="mt-1 font-mono text-[11px] text-zinc-500">{preview.repositoryPath}</p></div>
+      {/* The repository is what this screen is about: its name leads, the path follows
+          small, and saving sits beside it rather than under a 700-row list. */}
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <h3 className="truncate text-xl font-semibold text-zinc-900 dark:text-zinc-100">{preview.repositoryName}</h3>
+          <p className="mt-0.5 truncate font-mono text-[11px] text-zinc-500" title={preview.repositoryPath}>{preview.repositoryPath}</p>
+        </div>
+        <div className="flex shrink-0 gap-2">
+          <button type="button" onClick={onCancel} className="rounded-md border px-3 py-1.5 text-xs">Cancel</button>
+          <button type="button" disabled={saveBlocked} onClick={save} className="rounded-md bg-zinc-900 px-3 py-1.5 text-xs font-medium text-white disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900">{busy ? "Saving…" : "Save"}</button>
+        </div>
+      </div>
+      {extensionsUnacknowledged ? <p className="text-xs text-amber-700">Confirm the extension warning below to save.</p> : null}
+      {error ? <p role="alert" className="text-xs text-red-600">{error}</p> : null}
+      {collection ? <CollectionSkills skills={catalogue} groups={catalogueGroups} enabled={enabledSkills} onChange={setEnabledSkills} disabled={busy} {...(preview.bound ? { bound: preview.bound } : {})} /> : null}
       {preview.roots.map((root) => {
         const key = `${root.kind}:${root.path}`;
         return <label key={key} className={`flex items-start gap-2 rounded border p-2 ${root.locked ? "opacity-50" : "cursor-pointer"}`}>
@@ -139,11 +183,7 @@ function PreviewForm({ preview, busy, error, onApply }: { preview: AgentResource
         </label>;
       })}
       {selectedExtensions.length > 0 ? <label className="flex gap-2 rounded-md border border-amber-300 bg-amber-50 p-3 text-xs text-amber-900"><input type="checkbox" checked={extensionsAcknowledged} onChange={(event) => setExtensionsAcknowledged(event.target.checked)} /><span>Extensions execute code with the agent's privileges. I trust the selected extension roots in this repository.</span></label> : null}
-      {error ? <p role="alert" className="text-xs text-red-600">{error}</p> : null}
-      <button type="button" disabled={busy || selected.size === 0 || (selectedExtensions.length > 0 && !extensionsAcknowledged)} onClick={() => onApply(
-        preview.roots.filter((root) => root.kind === "skill" && selected.has(`skill:${root.path}`)).map((root) => root.path),
-        preview.roots.filter((root) => root.kind === "extension" && selected.has(`extension:${root.path}`)).map((root) => root.path),
-      )} className="rounded-md bg-zinc-900 px-3 py-1.5 text-xs font-medium text-white disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900">{busy ? "Applying…" : "Activate selected resources"}</button>
+
     </div>
   );
 }
@@ -173,20 +213,53 @@ export function AgentResourceManager(props: AgentResourceManagerProps) {
    */
   const [suggestedFor, setSuggestedFor] = useState("");
   const [confirmRepository, setConfirmRepository] = useState<AgentResourceRepository | null>(null);
+  /**
+   * Selections not yet applied, keyed by repository id. Applying replaces the
+   * session, so switches only stage here and Apply sends the whole set once.
+   */
+  const [pendingSkills, setPendingSkills] = useState<Record<string, string[]>>({});
+  const [confirmRemoval, setConfirmRemoval] = useState<AgentResourceRepository | null>(null);
+  /** The removal whose outcome is on show — kept by id, since the repository leaves the list. */
+  const [removalShown, setRemovalShown] = useState<{ id: string; name: string } | null>(null);
   const allGroups = useMemo(() => groupInventory(props.inventory), [props.inventory]);
   const visibleGroups = useMemo(() => {
     const needle = query.trim().toLocaleLowerCase();
     return allGroups.flatMap((group): Group[] => {
-      const resources = kind === "all" ? group.resources : group.resources.filter((resource) => resource.kind === kind);
-      if (resources.length === 0) return [];
+      // A collection's skills are its catalogue, loaded or not; its loaded skill
+      // resources are the same skills again, so they are not counted twice.
+      const collection = "repository" in group ? group.repository.collection : undefined;
+      const flat = collection ? group.resources.filter((resource) => resource.kind !== "skill") : group.resources;
+      const resources = kind === "all" ? flat : flat.filter((resource) => resource.kind === kind);
+      const skills = collection && kind !== "extension" ? collection.skills : [];
+      const count = resources.length + skills.length;
+      // A collection stays reachable with nothing in it, or it could not be removed.
+      if (count === 0 && !(collection && kind === "all")) return [];
       if (attentionOnly && (!("repository" in group) || !["updateable", "dirty", "failed", "unavailable", "busy"].includes(group.repository.assessment.status))) return [];
-      const searchable = `${group.name} ${"path" in group ? group.path ?? "" : ""} ${resources.map((resource) => `${resource.name} ${resource.path ?? ""}`).join(" ")}`.toLocaleLowerCase();
-      return !needle || searchable.includes(needle) ? [{ ...group, resources }] : [];
+      const searchable = `${group.name} ${"path" in group ? group.path ?? "" : ""} ${resources.map((resource) => `${resource.name} ${resource.path ?? ""}`).join(" ")} ${skills.map((skill) => `${skill.name} ${skill.relativePath}`).join(" ")}`.toLocaleLowerCase();
+      const onCount = collection ? collection.skills.filter((skill) => skill.state !== "off").length : undefined;
+      return !needle || searchable.includes(needle) ? [{ ...group, resources, count, ...(onCount !== undefined ? { onCount } : {}) }] : [];
     });
   }, [allGroups, attentionOnly, kind, query]);
   const selected = visibleGroups.find((group) => group.id === selectedId) ?? visibleGroups[0] ?? null;
 
   useEffect(() => { closeHandler.current = props.onClose; }, [props.onClose]);
+  /**
+   * A new inventory rebases the pending selections rather than dropping them: one
+   * is let go only when the repository is gone, or when what the server now
+   * reports is exactly what was pending — the apply landed.
+   */
+  useEffect(() => {
+    setPendingSkills((current) => {
+      const next: Record<string, string[]> = {};
+      let changed = false;
+      for (const [id, wanted] of Object.entries(current)) {
+        const collection = props.inventory?.repositories.find((candidate) => candidate.id === id)?.collection;
+        if (!collection || sameSelection(wanted, suppliedSelection(collection))) changed = true;
+        else next[id] = wanted;
+      }
+      return changed ? next : current;
+    });
+  }, [props.inventory]);
   /**
    * Focus enters the dialog when it opens, and never again.
    *
@@ -249,6 +322,41 @@ export function AgentResourceManager(props: AgentResourceManagerProps) {
     if (!value.token || !value.localRevision || !value.upstreamRevision) return;
     props.onUpdate(target.id, value.token, value.localRevision, value.upstreamRevision, allowExecutableChanges);
   };
+  const collection = repository?.collection;
+  const suppliedSkills = collection ? suppliedSelection(collection) : [];
+  const effectiveSkills = new Set(repository && pendingSkills[repository.id] ? pendingSkills[repository.id] : suppliedSkills);
+  const pendingChanges = collection
+    ? [...new Set([...effectiveSkills, ...suppliedSkills])].filter((relative) => effectiveSkills.has(relative) !== suppliedSkills.includes(relative)).length
+    : 0;
+  // Read defensively: a caller holding an older operations shape must not unmount the dialog.
+  const skillsState = repository ? props.operations.skills?.[repository.id] : undefined;
+  const changeSkills = (next: Set<string>) => {
+    if (!repository) return;
+    const id = repository.id;
+    setPendingSkills((current) => {
+      const copy = { ...current };
+      if (sameSelection(next, suppliedSkills)) delete copy[id];
+      else copy[id] = [...next];
+      return copy;
+    });
+  };
+  const discardSkills = () => {
+    if (!repository) return;
+    const id = repository.id;
+    setPendingSkills((current) => {
+      const copy = { ...current };
+      delete copy[id];
+      return copy;
+    });
+  };
+  const applySkills = () => {
+    if (!repository || !collection) return;
+    // A skill the repository no longer has cannot be turned on; applying lets it go.
+    const present = new Set(collection.skills.filter((skill) => skill.state !== "on-missing").map((skill) => skill.relativePath));
+    props.onSetSkills(repository.id, [...effectiveSkills].filter((relative) => present.has(relative)));
+  };
+  const removalState = removalShown ? props.operations.removals?.[removalShown.id] : undefined;
+  const removalFailed = removalState?.status === "error" || removalState?.result?.status === "removed-delete-failed";
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 p-4" role="presentation" onMouseDown={(event) => { if (event.currentTarget === event.target) props.onClose(); }}>
@@ -266,7 +374,7 @@ export function AgentResourceManager(props: AgentResourceManagerProps) {
             </div>
             <div className="mt-3 min-h-0 flex-1 space-y-1 overflow-y-auto">
               {visibleGroups.map((group) => <button type="button" key={group.id} onClick={() => setSelectedId(group.id)} className={`w-full rounded-lg px-3 py-2.5 text-left ${selected?.id === group.id ? "bg-white shadow-sm ring-1 ring-zinc-200 dark:bg-zinc-800 dark:ring-zinc-700" : "hover:bg-white/70 dark:hover:bg-zinc-900"}`}>
-                <span className="flex items-center justify-between gap-2 text-sm font-medium"><span className="truncate">{group.name}</span><span className="text-xs text-zinc-400">{group.resources.length}</span></span>
+                <span className="flex items-center justify-between gap-2 text-sm font-medium"><span className="truncate">{group.name}</span><span className="shrink-0 text-xs text-zinc-400">{group.onCount !== undefined ? `${group.onCount} on · ${group.count}` : group.count ?? group.resources.length}</span></span>
                 <span className="mt-1 block text-xs text-zinc-500">{"repository" in group ? STATUS_LABEL[group.repository.assessment.status] : group.reason}</span>
               </button>)}
               {visibleGroups.length === 0 ? <p className="px-2 py-4 text-xs text-zinc-500">No matching resources</p> : null}
@@ -274,6 +382,12 @@ export function AgentResourceManager(props: AgentResourceManagerProps) {
             <div className="mt-3 grid gap-2 border-t pt-3"><button type="button" onClick={() => { setExtensionAcknowledged(false); setAddMode("local"); setPicker("local"); props.onBrowseServerPath(localPath || "/"); }} className="rounded-md border bg-white px-3 py-2 text-xs font-medium dark:bg-zinc-900">Add local folder…</button><button type="button" onClick={() => setAddMode("git")} className="rounded-md bg-zinc-900 px-3 py-2 text-xs font-medium text-white dark:bg-zinc-100 dark:text-zinc-900">Add Git repository…</button></div>
           </aside>
           <main className="min-w-0 overflow-y-auto p-6">
+            {removalShown && removalState ? (
+              <div role={removalFailed ? "alert" : "status"} className={`mb-4 flex items-start justify-between gap-3 rounded-lg border p-3 text-sm ${removalFailed ? "border-rose-200 bg-rose-50 text-rose-800" : "border-zinc-200 bg-zinc-50 text-zinc-700"}`}>
+                <p className="min-w-0 break-words">{removalMessage(removalShown.name, removalState)}</p>
+                {removalState.status !== "loading" ? <button type="button" onClick={() => setRemovalShown(null)} className="shrink-0 text-xs underline">Dismiss</button> : null}
+              </div>
+            ) : null}
             {addMode === "local" ? <div className="max-w-xl space-y-4" data-testid="add-local-folder">
               <div><h3 className="text-lg font-semibold">Add local folder</h3><p className="text-xs text-zinc-500">Choose an existing folder on the server and how the agent should load it.</p></div>
               <div className="flex gap-2">{(["skill", "extension"] as const).map((value) => <button type="button" key={value} aria-pressed={localKind === value} disabled={value === "extension" && props.extensionLock} onClick={() => { setLocalKind(value); setExtensionAcknowledged(false); }} className={`rounded-md px-3 py-1.5 text-xs ${localKind === value ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900" : "border"}`}>{value === "skill" ? "Skill folder" : "Extension folder"}</button>)}</div>
@@ -284,8 +398,10 @@ export function AgentResourceManager(props: AgentResourceManagerProps) {
               {props.applyState?.status === "error" ? <p role="alert" className="text-xs text-red-600">{props.applyState.message}</p> : null}
               <div className="flex gap-2"><button type="button" onClick={() => { setExtensionAcknowledged(false); setAddMode(null); setPicker(null); props.onCloseServerBrowser(); }} className="rounded-md border px-3 py-1.5 text-xs">Cancel</button><button type="button" disabled={!localPath.trim() || props.applyState?.status === "applying" || (localKind === "extension" && (!extensionAcknowledged || props.extensionLock))} onClick={applyLocal} className="rounded-md bg-zinc-900 px-3 py-1.5 text-xs text-white disabled:opacity-50">{props.applyState?.status === "applying" ? "Applying…" : "Add folder"}</button></div>
             </div> : addMode === "git" ? <div className="max-w-2xl space-y-4" data-testid="add-git-repository">
-              <div><h3 className="text-lg font-semibold">Add Git repository</h3><p className="text-xs text-zinc-500">Clone it to a visible local folder, then choose the resources to activate.</p></div>
-              {props.operations.preview?.status === "ready" && props.operations.preview.preview ? <PreviewForm preview={props.operations.preview.preview} busy={props.operations.enrollment?.status === "loading"} error={props.operations.enrollment?.status === "error" ? props.operations.enrollment.message : undefined} onApply={(skills, extensions) => props.onEnrollRepository(props.operations.preview!.preview!.token, skills, extensions)} /> : <>
+              {props.operations.preview?.status === "ready" && props.operations.preview.preview ? <PreviewForm onCancel={() => { setAddMode(null); setPicker(null); props.onCloseServerBrowser(); }} preview={props.operations.preview.preview} busy={props.operations.enrollment?.status === "loading"} error={props.operations.enrollment?.status === "error" ? props.operations.enrollment.message : undefined} onApply={(skills, extensions, enabledSkills) => enabledSkills
+                ? props.onEnrollRepository(props.operations.preview!.preview!.token, skills, extensions, enabledSkills)
+                : props.onEnrollRepository(props.operations.preview!.preview!.token, skills, extensions)} /> : <>
+                <div><h3 className="text-lg font-semibold">Add Git repository</h3><p className="text-xs text-zinc-500">Clone it to a local folder, then choose what to turn on.</p></div>
                 <label className="block"><span className="text-xs font-medium">Repository address</span><input aria-label="Repository address" value={repositoryUrl} onChange={(event) => setRepositoryUrl(event.target.value)} onBlur={() => { const address = repositoryUrl.trim(); if (address) { setDestinationEdited(false); setSuggestedFor(address); props.onSuggestClonePath(repositoryUrl); } }} placeholder="https://github.com/team/resources.git" className="mt-1 w-full rounded-md border bg-transparent px-3 py-2 text-sm" /></label>
                 <label className="block"><span className="text-xs font-medium">Local folder</span><div className="mt-1 flex gap-2"><input aria-label="Local clone folder" value={destinationPath} onChange={(event) => { setDestinationEdited(true); setDestinationPath(event.target.value); }} placeholder="/path/to/resource-repositories/team-resources-ab12cd" className="min-w-0 flex-1 rounded-md border bg-transparent px-3 py-2 text-sm" /><button type="button" onClick={() => { setPicker("clone-parent"); props.onBrowseServerPath(parentPath(destinationPath)); }} className="rounded-md border px-3 text-xs">Choose parent…</button></div></label>
                 {props.operations.clonePath?.status === "loading" ? <p className="text-xs text-zinc-500">Suggesting a managed folder…</p> : null}
@@ -295,17 +411,44 @@ export function AgentResourceManager(props: AgentResourceManagerProps) {
                 <div className="flex gap-2"><button type="button" onClick={() => { setAddMode(null); setPicker(null); props.onCloseServerBrowser(); }} className="rounded-md border px-3 py-1.5 text-xs">Cancel</button><button type="button" disabled={!repositoryUrl.trim() || !destinationPath.trim() || props.operations.preview?.status === "loading"} onClick={() => props.onCloneRepository(repositoryUrl, destinationPath)} className="rounded-md bg-zinc-900 px-3 py-1.5 text-xs text-white disabled:opacity-50">{props.operations.preview?.status === "loading" ? "Cloning…" : "Clone and inspect"}</button></div>
               </>}
             </div> : selected ? <>
-              <div className="flex items-start justify-between gap-4"><div className="min-w-0"><div className="flex items-center gap-2"><h3 className="text-xl font-semibold">{selected.name}</h3>{repository ? <span className="rounded-full border px-2 py-0.5 text-[11px]">{STATUS_LABEL[repository.assessment.status]}</span> : null}</div><p className="mt-1 truncate font-mono text-xs text-zinc-500">{"repository" in selected ? selected.path : selected.reason}</p>{assessment?.branch ? <p className="mt-1 text-xs text-zinc-400">{assessment.branch}{assessment.upstream ? ` → ${assessment.upstream}` : ""}</p> : null}</div>{repository ? <div className="flex gap-2"><button type="button" disabled={props.operations.refresh?.status === "loading"} onClick={() => props.onRefresh(repository.id)} className="rounded-md border px-3 py-1.5 text-xs">Check</button><button type="button" disabled={!updateable || updateState?.status === "loading"} onClick={() => repository.containsExtensions ? setConfirmRepository(repository) : requestUpdate(repository)} className="rounded-md bg-zinc-900 px-3 py-1.5 text-xs text-white disabled:opacity-50">{updateState?.status === "loading" ? "Updating…" : "Update repository"}</button></div> : null}</div>
+              <div className="flex items-start justify-between gap-4"><div className="min-w-0"><div className="flex items-center gap-2"><h3 className="text-xl font-semibold">{selected.name}</h3>{repository ? <span className="rounded-full border px-2 py-0.5 text-[11px]">{STATUS_LABEL[repository.assessment.status]}</span> : null}</div><p className="mt-1 truncate font-mono text-xs text-zinc-500">{"repository" in selected ? selected.path : selected.reason}</p>{assessment?.branch ? <p className="mt-1 text-xs text-zinc-400">{assessment.branch}{assessment.upstream ? ` → ${assessment.upstream}` : ""}</p> : null}{repository?.removal && !repository.removal.allowed ? <p className="mt-1 text-xs text-zinc-500">{repository.removal.reason}</p> : null}</div>{repository ? <div className="flex gap-2">{repository.removal?.allowed ? <button type="button" disabled={props.operations.removals?.[repository.id]?.status === "loading"} onClick={() => setConfirmRemoval(repository)} className="rounded-md border border-red-200 px-3 py-1.5 text-xs text-red-700 disabled:opacity-50 dark:border-red-900 dark:text-red-400">Remove repository</button> : null}<button type="button" disabled={props.operations.refresh?.status === "loading"} onClick={() => props.onRefresh(repository.id)} className="rounded-md border px-3 py-1.5 text-xs">Check</button>{/* Offered only when there is something to apply: a greyed button that does nothing on click explained nothing. */}{updateable || updateState?.status === "loading" ? <button type="button" disabled={updateState?.status === "loading"} onClick={() => repository.containsExtensions ? setConfirmRepository(repository) : requestUpdate(repository)} className="rounded-md bg-zinc-900 px-3 py-1.5 text-xs text-white disabled:opacity-50">{updateState?.status === "loading" ? "Updating…" : "Update repository"}</button> : null}</div> : null}</div>
               {assessment?.reason ? <div className={`mt-5 rounded-lg border p-3 text-sm ${assessment.status === "dirty" ? "border-rose-200 bg-rose-50 text-rose-800" : "border-zinc-200 bg-zinc-50 text-zinc-700"}`}>{assessment.reason}{assessment.status === "dirty" ? <p className="mt-1 text-xs">Review and resolve these local changes in an external terminal, then check again. This updater never commits, stashes, discards, rebases, or merges them.</p> : null}</div> : null}
               {assessment?.hasSubmodules ? <p className="mt-3 rounded border border-amber-200 bg-amber-50 p-2 text-xs text-amber-800">This repository declares submodules. Their working trees will not be initialized or updated.</p> : null}
               {updateState?.status === "ready" ? <p role="status" className="mt-3 text-xs text-zinc-600">{updateState.result?.status === "updated" ? "Repository updated and runtimes reloaded." : updateState.result?.status === "updated-reload-failed" ? "Repository updated on disk, but at least one runtime failed to reload." : updateState.result?.reason}</p> : null}
               {updateState?.status === "error" ? <p role="alert" className="mt-3 text-xs text-red-600">{updateState.message}</p> : null}
-              <div className="mt-6 grid grid-cols-2 gap-4"><ResourceList kind="skill" resources={selected.resources.filter((resource) => resource.kind === "skill")} onRemove={removeResource} /><ResourceList kind="extension" resources={selected.resources.filter((resource) => resource.kind === "extension")} removalLocked={props.extensionLock} onRemove={removeResource} /></div>
+              {collection && repository && kind !== "extension" ? <div className="mt-6 space-y-4">
+                {pendingChanges > 0 || skillsState?.status === "loading" ? (
+                  <div className="flex items-center justify-between gap-3 rounded-lg border border-sky-200 bg-sky-50 px-3 py-2 text-xs text-sky-900 dark:border-sky-900 dark:bg-sky-950/40 dark:text-sky-200">
+                    <span>{skillsState?.status === "loading" ? "Applying…" : `${pendingChanges} pending change${pendingChanges === 1 ? "" : "s"} — applying replaces the session`}</span>
+                    <div className="flex gap-2">
+                      <button type="button" disabled={skillsState?.status === "loading"} onClick={discardSkills} className="rounded border bg-white px-2.5 py-1 disabled:opacity-50 dark:bg-zinc-900">Discard</button>
+                      <button type="button" disabled={skillsState?.status === "loading" || pendingChanges === 0} onClick={applySkills} className="rounded bg-zinc-900 px-2.5 py-1 font-medium text-white disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900">Apply</button>
+                    </div>
+                  </div>
+                ) : null}
+                {skillsState?.status === "error" ? <p role="alert" className="text-xs text-red-600">{skillsState.message}</p> : null}
+                <CollectionSkills key={repository.id} skills={collection.skills} groups={collection.groups} enabled={effectiveSkills} onChange={changeSkills} disabled={skillsState?.status === "loading"} {...(collection.bound ? { bound: collection.bound } : {})} />
+                {selected.resources.some((resource) => resource.kind === "extension") ? <ResourceList kind="extension" resources={selected.resources.filter((resource) => resource.kind === "extension")} removalLocked={props.extensionLock} onRemove={removeResource} /> : null}
+              </div> : <div className="mt-6 grid grid-cols-2 gap-4"><ResourceList kind="skill" resources={selected.resources.filter((resource) => resource.kind === "skill")} onRemove={removeResource} /><ResourceList kind="extension" resources={selected.resources.filter((resource) => resource.kind === "extension")} removalLocked={props.extensionLock} onRemove={removeResource} /></div>}
             </> : <p className="text-sm text-zinc-500">No resources are reported by this runtime.</p>}
           </main>
         </div>
       </div>
       {confirmRepository ? <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/55 p-4"><div role="alertdialog" aria-modal="true" aria-labelledby="extension-update-title" className="w-full max-w-md rounded-xl bg-white p-5 shadow-2xl dark:bg-zinc-900"><h3 id="extension-update-title" className="font-semibold">Update executable extensions?</h3><p className="mt-2 text-sm text-zinc-600 dark:text-zinc-300">{confirmRepository.name} contains extensions that run with the agent's privileges. Confirm updating {confirmRepository.assessment.localRevision?.slice(0, 8)} to {confirmRepository.assessment.upstreamRevision?.slice(0, 8)}.</p><div className="mt-4 flex justify-end gap-2"><button type="button" onClick={() => setConfirmRepository(null)} className="rounded border px-3 py-1.5 text-xs">Cancel</button><button type="button" onClick={() => { requestUpdate(confirmRepository, true); setConfirmRepository(null); }} className="rounded bg-amber-600 px-3 py-1.5 text-xs font-medium text-white">Confirm executable update</button></div></div></div> : null}
+      {confirmRemoval ? <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/55 p-4">
+        <div role="alertdialog" aria-modal="true" aria-labelledby="remove-repository-title" aria-describedby="remove-repository-detail" className="w-full max-w-md rounded-xl bg-white p-5 shadow-2xl dark:bg-zinc-900">
+          <h3 id="remove-repository-title" className="font-semibold">Remove {confirmRemoval.name}?</h3>
+          <p id="remove-repository-detail" className="mt-2 break-words text-sm text-zinc-600 dark:text-zinc-300">
+            {confirmRemoval.removal?.deletesFiles
+              ? <>This stops loading everything from {confirmRemoval.name} and deletes <span className="font-mono">{confirmRemoval.removal.path}</span> from disk, with any local changes in it. This cannot be undone.</>
+              : <>This stops loading everything from {confirmRemoval.name}. pi-outpost does not manage <span className="font-mono">{confirmRemoval.removal?.path ?? confirmRemoval.path}</span>, so its files will be kept.</>}
+          </p>
+          <div className="mt-4 flex justify-end gap-2">
+            <button type="button" onClick={() => setConfirmRemoval(null)} className="rounded border px-3 py-1.5 text-xs">Cancel</button>
+            <button type="button" onClick={() => { props.onRemoveRepository(confirmRemoval.id); setRemovalShown({ id: confirmRemoval.id, name: confirmRemoval.name }); setConfirmRemoval(null); }} className="rounded bg-red-600 px-3 py-1.5 text-xs font-medium text-white">{confirmRemoval.removal?.deletesFiles ? "Delete and remove" : "Remove repository"}</button>
+          </div>
+        </div>
+      </div> : null}
     </div>
   );
 }

--- a/ui/src/components/CollectionSkills.tsx
+++ b/ui/src/components/CollectionSkills.tsx
@@ -1,0 +1,226 @@
+import { useState } from "react";
+import type { CSSProperties } from "react";
+import type { AgentCollectionSkill, AgentResourceCollection, AgentSkillCatalogueBound } from "@pi-outpost/shared";
+
+/** Above this many, the summary would be the whole list again; "Only on" takes over. */
+const SUMMARY_LIMIT = 30;
+const CLAMP_TWO_LINES: CSSProperties = { display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" };
+
+/**
+ * A skill collection's catalogue, grouped by the folders the repository keeps
+ * them in, one switch per skill.
+ *
+ * The switches show `enabled` — the selection the dialog is about to apply —
+ * and each skill's supplied state underneath, so a change that has not been
+ * applied yet reads as pending rather than as done. Nothing here talks to the
+ * server: every switch and bulk action reports the complete next selection
+ * through `onChange`.
+ */
+export function CollectionSkills({
+  skills,
+  groups,
+  enabled,
+  onChange,
+  disabled = false,
+  bound,
+}: {
+  skills: readonly AgentCollectionSkill[];
+  groups: AgentResourceCollection["groups"];
+  enabled: ReadonlySet<string>;
+  onChange: (next: Set<string>) => void;
+  disabled?: boolean;
+  bound?: AgentSkillCatalogueBound;
+}) {
+  // A large collection opens folded — 34 folders fit on a screen, 700 skills do not —
+  // except the folders holding a skill that is on: those are what the user looks for.
+  const [expanded, setExpanded] = useState<Set<string>>(() =>
+    skills.length > 40
+      ? new Set(skills.filter((skill) => enabled.has(skill.relativePath)).map((skill) => skill.group))
+      : new Set(groups.map((group) => group.path)),
+  );
+  const [query, setQuery] = useState("");
+  const [onlyOn, setOnlyOn] = useState(false);
+  const needle = query.trim().toLocaleLowerCase();
+  const filtering = needle !== "" || onlyOn;
+  const visible = (skill: AgentCollectionSkill) =>
+    (!onlyOn || enabled.has(skill.relativePath)) &&
+    (!needle || `${skill.name} ${skill.relativePath} ${skill.description ?? ""}`.toLocaleLowerCase().includes(needle));
+  const byGroup = new Map<string, AgentCollectionSkill[]>();
+  for (const skill of skills) byGroup.set(skill.group, [...(byGroup.get(skill.group) ?? []), skill]);
+  const onCount = skills.filter((skill) => enabled.has(skill.relativePath)).length;
+  const matchCount = filtering ? skills.filter(visible).length : skills.length;
+  const setAll = (members: readonly AgentCollectionSkill[], on: boolean) => {
+    const next = new Set(enabled);
+    for (const skill of members) {
+      if (on) next.add(skill.relativePath);
+      else next.delete(skill.relativePath);
+    }
+    onChange(next);
+  };
+  const toggle = (relativePath: string) => {
+    const next = new Set(enabled);
+    if (next.has(relativePath)) next.delete(relativePath);
+    else next.add(relativePath);
+    onChange(next);
+  };
+  const flip = (path: string) =>
+    setExpanded((current) => {
+      const next = new Set(current);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+
+  return (
+    <section className="rounded-xl border border-zinc-200 p-4 dark:border-zinc-800" aria-label="Collection skills">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold text-zinc-800 dark:text-zinc-200">
+          Skills <span className="font-normal text-zinc-500">· {onCount} of {skills.length} on</span>
+        </h3>
+        <div className="flex gap-2">
+          <button type="button" disabled={disabled || onCount === skills.length} onClick={() => setAll(skills, true)} className="rounded-md border px-2.5 py-1 text-xs disabled:opacity-50">All on</button>
+          <button type="button" disabled={disabled || onCount === 0} onClick={() => setAll(skills, false)} className="rounded-md border px-2.5 py-1 text-xs disabled:opacity-50">All off</button>
+        </div>
+      </div>
+      {bound ? (
+        <p className="mt-2 rounded border border-amber-200 bg-amber-50 p-2 text-xs text-amber-800">
+          {bound.kind === "count"
+            ? `This repository holds more skills than the ${bound.limit} listed here.`
+            : `Folders deeper than ${bound.limit} levels were not searched for skills.`}
+        </p>
+      ) : null}
+      {skills.length > 0 ? (
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          <input
+            type="search"
+            aria-label="Search skills"
+            placeholder="Search skills by name or folder"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            className="min-w-0 flex-1 rounded-md border bg-transparent px-2.5 py-1 text-xs"
+          />
+          <button
+            type="button"
+            aria-pressed={onlyOn}
+            onClick={() => setOnlyOn((value) => !value)}
+            className={`rounded-md px-2.5 py-1 text-xs ${onlyOn ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900" : "border"}`}
+          >
+            Only on ({onCount})
+          </button>
+        </div>
+      ) : null}
+      {/* The first question on coming back is "which ones are on?" — answered here,
+          above 35 folders, rather than at line 330 of the one folder holding it. */}
+      {!filtering && onCount > 0 && onCount <= SUMMARY_LIMIT ? (
+        <div role="region" aria-label="Skills that are on" className="mt-3 rounded-lg border border-emerald-200 bg-emerald-50/60 p-2 dark:border-emerald-900 dark:bg-emerald-950/30">
+          <p className="px-1 text-[11px] font-medium text-emerald-800 dark:text-emerald-300">Turned on</p>
+          <ul className="mt-1 space-y-1">
+            {skills.filter((skill) => enabled.has(skill.relativePath)).map((skill) => (
+              <li key={skill.relativePath} className="flex items-start justify-between gap-2 px-1">
+                <span className="min-w-0 text-xs">
+                  <span className="font-medium text-zinc-800 dark:text-zinc-100">{skill.name}</span>{" "}
+                  <span className="font-mono text-[11px] text-zinc-500">{skill.group || "(repository root)"}</span>
+                  <SkillState skill={skill} checked />
+                </span>
+                <button
+                  type="button"
+                  aria-label={`Turn off ${skill.name} (${skill.relativePath})`}
+                  disabled={disabled}
+                  onClick={() => toggle(skill.relativePath)}
+                  className="shrink-0 rounded border bg-white px-2 py-0.5 text-[11px] disabled:opacity-50 dark:bg-zinc-900"
+                >
+                  Turn off
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+      {skills.length === 0 ? <p className="mt-4 text-xs text-zinc-400">This repository holds no skills.</p> : null}
+      {filtering && matchCount === 0 ? <p className="mt-4 text-xs text-zinc-400">{onlyOn && !needle ? "No skill is on." : "No skill matches."}</p> : null}
+      <ul className="mt-3 space-y-2">
+        {groups.map((group) => {
+          // While filtering, a folder shows only its matches, open, and its bulk
+          // switches act on those alone — never on skills the filter is hiding.
+          const all = byGroup.get(group.path) ?? [];
+          const members = filtering ? all.filter(visible) : all;
+          if (filtering && members.length === 0) return null;
+          const on = members.filter((skill) => enabled.has(skill.relativePath)).length;
+          const open = filtering || expanded.has(group.path);
+          return (
+            <li key={group.path} className="rounded-lg border border-zinc-100 dark:border-zinc-800">
+              <div className="flex items-center justify-between gap-2 px-3 py-2">
+                <button type="button" aria-expanded={open} onClick={() => flip(group.path)} className="flex min-w-0 flex-1 items-center gap-2 text-left">
+                  <span aria-hidden="true" className="text-xs text-zinc-400">{open ? "▾" : "▸"}</span>
+                  <span className="truncate font-mono text-xs font-medium text-zinc-700 dark:text-zinc-200">{group.label}</span>
+                  <span className="shrink-0 text-[11px] text-zinc-500">{on}/{members.length} on</span>
+                </button>
+                <div className="flex shrink-0 gap-1">
+                  <button type="button" aria-label={`All on in ${group.label}`} disabled={disabled || on === members.length} onClick={() => setAll(members, true)} className="rounded border px-2 py-0.5 text-[11px] disabled:opacity-50">All on</button>
+                  <button type="button" aria-label={`All off in ${group.label}`} disabled={disabled || on === 0} onClick={() => setAll(members, false)} className="rounded border px-2 py-0.5 text-[11px] disabled:opacity-50">All off</button>
+                </div>
+              </div>
+              {open ? (
+                <ul className="space-y-1 border-t border-zinc-100 px-3 py-2 dark:border-zinc-800">
+                  {members.map((skill) => {
+                    const checked = enabled.has(skill.relativePath);
+                    return (
+                      <li key={skill.relativePath}>
+                        <label className={`flex items-start gap-2 rounded px-1 py-1 ${disabled ? "opacity-60" : "cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-800/60"}`}>
+                          <input
+                            type="checkbox"
+                            role="switch"
+                            aria-checked={checked}
+                            aria-label={`${skill.name} (${skill.relativePath})`}
+                            checked={checked}
+                            disabled={disabled}
+                            onChange={() => toggle(skill.relativePath)}
+                            className="mt-0.5"
+                          />
+                          <span className="min-w-0">
+                            <span className="block truncate text-sm text-zinc-800 dark:text-zinc-100">{skill.name}</span>
+                            {/* Inline rather than `line-clamp-2`: the embedded build ships no such
+                                utility, and unclamped descriptions made each row six lines tall. */}
+                            {skill.description ? <span title={skill.description} style={CLAMP_TWO_LINES} className="text-[11px] text-zinc-500">{skill.description}</span> : null}
+                            <SkillState skill={skill} checked={checked} />
+                          </span>
+                        </label>
+                      </li>
+                    );
+                  })}
+                </ul>
+              ) : null}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
+
+function SkillState({ skill, checked }: { skill: AgentCollectionSkill; checked: boolean }) {
+  const suppliedOn = skill.state !== "off";
+  if (checked !== suppliedOn) {
+    return <span className="block text-[11px] font-medium text-sky-700 dark:text-sky-300">{checked ? "Pending: on" : "Pending: off"}</span>;
+  }
+  if (skill.state === "on-loaded") return <span className="block text-[11px] text-emerald-700 dark:text-emerald-400">Loaded</span>;
+  if (skill.state === "on-not-loaded") return <span className="block text-[11px] text-amber-700 dark:text-amber-400">Not loaded — {skill.reason}</span>;
+  if (skill.state === "on-missing") return <span className="block text-[11px] text-rose-700 dark:text-rose-400">Missing — {skill.reason}</span>;
+  return null;
+}
+
+/** Folder groups for a catalogue that arrived without them, as a preview does. */
+export function groupsOf(skills: readonly { group: string }[], repositoryName: string): AgentResourceCollection["groups"] {
+  return [...new Set(skills.map((skill) => skill.group))].sort().map((group) => ({ path: group, label: group || repositoryName }));
+}
+
+/** The skills a collection's inventory reports as on, loaded or not. */
+export function suppliedSelection(collection: AgentResourceCollection): string[] {
+  return collection.skills.filter((skill) => skill.state !== "off").map((skill) => skill.relativePath);
+}
+
+export function sameSelection(a: Iterable<string>, b: Iterable<string>): boolean {
+  const left = new Set(a);
+  const right = new Set(b);
+  return left.size === right.size && [...left].every((value) => right.has(value));
+}

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -90,7 +90,9 @@ interface HeaderProps {
   }) => void;
   onSuggestAgentResourceClonePath: (repositoryUrl: string) => void;
   onCloneAgentResourceRepository: (repositoryUrl: string, destinationPath: string) => void;
-  onEnrollAgentResourceRepository: (previewToken: string, skillRoots: string[], extensionRoots: string[]) => void;
+  onEnrollAgentResourceRepository: (previewToken: string, skillRoots: string[], extensionRoots: string[], enabledSkills?: string[]) => void;
+  onSetAgentResourceSkills?: (repositoryId: string, enabledSkills: string[]) => void;
+  onRemoveAgentResourceRepository?: (repositoryId: string) => void;
   onRefreshAgentResourceRepositories: (repositoryId?: string) => void;
   onUpdateAgentResourceRepository: (
     repositoryId: string,
@@ -586,6 +588,8 @@ export function Header(props: HeaderProps) {
           onSuggestAgentResourceClonePath={props.onSuggestAgentResourceClonePath}
           onCloneAgentResourceRepository={props.onCloneAgentResourceRepository}
           onEnrollAgentResourceRepository={props.onEnrollAgentResourceRepository}
+          onSetAgentResourceSkills={props.onSetAgentResourceSkills}
+          onRemoveAgentResourceRepository={props.onRemoveAgentResourceRepository}
           onRefreshAgentResourceRepositories={props.onRefreshAgentResourceRepositories}
           onUpdateAgentResourceRepository={props.onUpdateAgentResourceRepository}
         />

--- a/ui/src/components/SettingsMenu.tsx
+++ b/ui/src/components/SettingsMenu.tsx
@@ -81,7 +81,9 @@ interface SettingsMenuProps {
   }) => void;
   onSuggestAgentResourceClonePath?: (repositoryUrl: string) => void;
   onCloneAgentResourceRepository?: (repositoryUrl: string, destinationPath: string) => void;
-  onEnrollAgentResourceRepository?: (previewToken: string, skillRoots: string[], extensionRoots: string[]) => void;
+  onEnrollAgentResourceRepository?: (previewToken: string, skillRoots: string[], extensionRoots: string[], enabledSkills?: string[]) => void;
+  onSetAgentResourceSkills?: (repositoryId: string, enabledSkills: string[]) => void;
+  onRemoveAgentResourceRepository?: (repositoryId: string) => void;
   onRefreshAgentResourceRepositories?: (repositoryId?: string) => void;
   onUpdateAgentResourceRepository?: (
     repositoryId: string,
@@ -107,7 +109,7 @@ export function SettingsMenu({
   onPickerOpened,
   applyState,
   agentResources = null,
-  agentResourceOperations = { clonePath: null, preview: null, enrollment: null, refresh: null, updates: {} },
+  agentResourceOperations = { clonePath: null, preview: null, enrollment: null, refresh: null, updates: {}, skills: {}, removals: {} },
   versions,
   onBrowseServerPath,
   onCloseServerBrowser,
@@ -115,6 +117,8 @@ export function SettingsMenu({
   onSuggestAgentResourceClonePath = () => {},
   onCloneAgentResourceRepository = () => {},
   onEnrollAgentResourceRepository = () => {},
+  onSetAgentResourceSkills = () => {},
+  onRemoveAgentResourceRepository = () => {},
   onRefreshAgentResourceRepositories = () => {},
   onUpdateAgentResourceRepository = () => {},
 }: SettingsMenuProps) {
@@ -520,6 +524,8 @@ export function SettingsMenu({
         onSuggestClonePath={onSuggestAgentResourceClonePath}
         onCloneRepository={onCloneAgentResourceRepository}
         onEnrollRepository={onEnrollAgentResourceRepository}
+        onSetSkills={onSetAgentResourceSkills}
+        onRemoveRepository={onRemoveAgentResourceRepository}
         onRefresh={onRefreshAgentResourceRepositories}
         onUpdate={onUpdateAgentResourceRepository}
       />

--- a/ui/src/useAgent.test.ts
+++ b/ui/src/useAgent.test.ts
@@ -2067,6 +2067,21 @@ describe("commands on the wire", () => {
         allowExecutableChanges: true,
       },
     ],
+    [
+      "enrollAgentResourceRepository with a collection selection",
+      (api) => api.enrollAgentResourceRepository("preview", [], [], ["dev-skills/react"]),
+      { type: "enroll_agent_resource_repository", previewToken: "preview", skillRoots: [], extensionRoots: [], enabledSkills: ["dev-skills/react"] },
+    ],
+    [
+      "setAgentResourceSkills",
+      (api) => api.setAgentResourceSkills("repo-1", ["dev-skills/react", "agent-skills/a2a"]),
+      { type: "set_agent_resource_skills", repositoryId: "repo-1", enabledSkills: ["dev-skills/react", "agent-skills/a2a"] },
+    ],
+    [
+      "removeAgentResourceRepository",
+      (api) => api.removeAgentResourceRepository("repo-1"),
+      { type: "remove_agent_resource_repository", repositoryId: "repo-1" },
+    ],
   ];
 
   for (const [name, call, expected] of cases) {
@@ -2701,5 +2716,78 @@ describe("agent resource operations", () => {
     act(() => mockWs!.receive({ type: "agent_resource_inventory", inventory: currentInventory }));
     expect(result.current.state.agentResources?.repositories[0].assessment.status).toBe("current");
     expect(result.current.state.agentResourceOperations.refresh?.status).toBe("loading");
+  });
+
+  it("correlates a skill selection by request and repository, and adopts its inventory", async () => {
+    const result = await connected([], { agentResources: inventory });
+    act(() => result.current.setAgentResourceSkills("repo-1", ["a"]));
+    const requestId = lastRequestId();
+    expect(result.current.state.agentResourceOperations.skills["repo-1"]).toMatchObject({ status: "loading", requestId });
+    const applied = { ...inventory, repositories: [{ ...inventory.repositories[0], name: "applied" }] };
+    act(() => mockWs!.receive({ type: "agent_resource_skills_applied", requestId: "stale", repositoryId: "repo-1", inventory: applied }));
+    expect(result.current.state.agentResourceOperations.skills["repo-1"].status).toBe("loading");
+    expect(result.current.state.agentResources?.repositories[0].name).toBe("repo");
+    act(() => mockWs!.receive({ type: "agent_resource_skills_applied", requestId, repositoryId: "repo-1", inventory: applied }));
+    expect(result.current.state.agentResourceOperations.skills["repo-1"].status).toBe("ready");
+    expect(result.current.state.agentResources?.repositories[0].name).toBe("applied");
+  });
+
+  it("routes a refused selection and a refused removal to their own entries, not the shared banner", async () => {
+    const result = await connected([], { agentResources: inventory });
+    act(() => result.current.setAgentResourceSkills("repo-1", ["a"]));
+    const selection = lastRequestId();
+    act(() => result.current.removeAgentResourceRepository("repo-1"));
+    const removal = lastRequestId();
+    act(() => mockWs!.receive({ type: "agent_resource_error", requestId: selection, message: "other is busy" }));
+    act(() => mockWs!.receive({ type: "agent_resource_error", requestId: removal, message: "configuration file" }));
+    expect(result.current.state.agentResourceOperations.skills["repo-1"]).toMatchObject({ status: "error", message: "other is busy" });
+    expect(result.current.state.agentResourceOperations.removals["repo-1"]).toMatchObject({ status: "error", message: "configuration file" });
+    expect(result.current.state.errors).toEqual([]);
+  });
+
+  it("keeps a removal's result after its repository leaves the inventory", async () => {
+    const result = await connected([], { agentResources: inventory });
+    act(() => result.current.removeAgentResourceRepository("repo-1"));
+    const requestId = lastRequestId();
+    act(() => mockWs!.receive({
+      type: "agent_resource_removed",
+      requestId,
+      repositoryId: "repo-1",
+      result: { status: "removed", path: "/repo" },
+      inventory: { ...inventory, repositories: [] },
+    }));
+    expect(result.current.state.agentResources?.repositories).toEqual([]);
+    expect(result.current.state.agentResourceOperations.removals["repo-1"]).toMatchObject({ status: "ready", result: { status: "removed", path: "/repo" } });
+  });
+
+  it("keeps a resource request through the session replacement it causes, and drops it on reconnect", async () => {
+    // Removing a repository or applying skills replaces the session, and the
+    // replacement's snapshot reaches the client before the operation's own answer.
+    // Clearing pending requests on that snapshot dropped the answer on the floor.
+    const workspace = { root: "/a", name: "a", activity: "idle" };
+    const frame = (type: string) => ({
+      type, sessionId: "sess_replaced", workspace, workspaces: [], branding: {}, model: "", thinkingLevel: "off",
+      models: [], commands: [], isStreaming: false, items: [], agentResources: inventory,
+    });
+    const result = await connected([], { agentResources: inventory, workspace });
+    act(() => result.current.removeAgentResourceRepository("repo-1"));
+    const requestId = lastRequestId();
+    act(() => mockWs!.receive(frame("session_replaced")));
+    expect(result.current.state.agentResourceOperations.removals["repo-1"]).toMatchObject({ status: "loading", requestId });
+    act(() => mockWs!.receive({
+      type: "agent_resource_removed",
+      requestId,
+      repositoryId: "repo-1",
+      result: { status: "removed", path: "/repo" },
+      inventory: { ...inventory, repositories: [] },
+    }));
+    expect(result.current.state.agentResourceOperations.removals["repo-1"]).toMatchObject({ status: "ready", result: { status: "removed" } });
+
+    act(() => result.current.setAgentResourceSkills("repo-1", ["a"]));
+    act(() => mockWs!.receive(frame("update_config_ack")));
+    expect(result.current.state.agentResourceOperations.skills["repo-1"]?.status).toBe("loading");
+    act(() => mockWs!.receive(frame("hello")));
+    expect(result.current.state.agentResourceOperations.skills).toEqual({});
+    expect(result.current.state.agentResourceOperations.removals).toEqual({});
   });
 });

--- a/ui/src/useAgent.ts
+++ b/ui/src/useAgent.ts
@@ -4,6 +4,7 @@ import { repoForPath } from "./util/gitRepos";
 import type {
   AgentResourceInventory,
   AgentResourceRepositoryPreview,
+  AgentResourceRemovalResult,
   AgentResourceUpdateResult,
   Branding,
   ChatItem,
@@ -212,10 +213,14 @@ export interface AgentResourceOperationState {
   enrollment: { requestId: string; status: "loading" | "ready" | "error"; message?: string } | null;
   refresh: { requestId: string; repositoryId?: string; status: "loading" | "ready" | "error"; message?: string } | null;
   updates: Record<string, { requestId: string; status: "loading" | "ready" | "error"; result?: AgentResourceUpdateResult; message?: string }>;
+  /** Collection selections being applied, keyed by repository. */
+  skills: Record<string, { requestId: string; status: "loading" | "ready" | "error"; message?: string }>;
+  /** Repository removals, keyed by repository: the result outlives the repository's entry. */
+  removals: Record<string, { requestId: string; status: "loading" | "ready" | "error"; result?: AgentResourceRemovalResult; message?: string }>;
 }
 
 function emptyAgentResourceOperations(): AgentResourceOperationState {
-  return { clonePath: null, preview: null, enrollment: null, refresh: null, updates: {} };
+  return { clonePath: null, preview: null, enrollment: null, refresh: null, updates: {}, skills: {}, removals: {} };
 }
 
 export interface AgentState {
@@ -450,6 +455,8 @@ type Action =
   | { type: "resource_enrollment_started"; requestId: string }
   | { type: "resource_refresh_started"; requestId: string; repositoryId?: string }
   | { type: "resource_update_started"; requestId: string; repositoryId: string }
+  | { type: "resource_skills_started"; requestId: string; repositoryId: string }
+  | { type: "resource_removal_started"; requestId: string; repositoryId: string }
   | { type: "outcome_started"; requestId: string; workspaceRoot: string | null; sessionId: string }
   | { type: "branding_settled" }
   | { type: "branding_loaded"; branding: Branding };
@@ -560,7 +567,14 @@ function applySnapshot(state: AgentState, message: ServerMessage & { sessionId: 
     settingsApply: null,
     versions: message.versions ?? null,
     agentResources: message.agentResources ?? null,
-    agentResourceOperations: emptyAgentResourceOperations(),
+    // A resource operation is what replaces the session: applying skills, enrolling,
+    // removing a repository. Its result arrives after the replacement's snapshot, so
+    // clearing here would drop the answer to the very request that caused it. Only a
+    // reconnect or another project makes the pending requests meaningless.
+    agentResourceOperations:
+      message.type === "hello" || message.type === "workspace_switched"
+        ? emptyAgentResourceOperations()
+        : state.agentResourceOperations,
   };
 }
 
@@ -714,6 +728,20 @@ function reduce(state: AgentState, action: Action): AgentState {
       },
     };
   }
+  if (action.type === "resource_skills_started") {
+    const operations = state.agentResourceOperations;
+    return {
+      ...state,
+      agentResourceOperations: { ...operations, skills: { ...operations.skills, [action.repositoryId]: { requestId: action.requestId, status: "loading" } } },
+    };
+  }
+  if (action.type === "resource_removal_started") {
+    const operations = state.agentResourceOperations;
+    return {
+      ...state,
+      agentResourceOperations: { ...operations, removals: { ...operations.removals, [action.repositoryId]: { requestId: action.requestId, status: "loading" } } },
+    };
+  }
   if (action.type === "outcome_started") {
     return { ...state, outcome: { status: "loading", requestId: action.requestId, workspaceRoot: action.workspaceRoot, sessionId: action.sessionId } };
   }
@@ -808,6 +836,29 @@ function reduce(state: AgentState, action: Action): AgentState {
         },
       };
     }
+    case "agent_resource_skills_applied": {
+      const operations = state.agentResourceOperations;
+      const pending = operations.skills[message.repositoryId];
+      if (pending?.requestId !== message.requestId) return state;
+      return {
+        ...state,
+        agentResources: message.inventory,
+        agentResourceOperations: { ...operations, skills: { ...operations.skills, [message.repositoryId]: { ...pending, status: "ready" } } },
+      };
+    }
+    case "agent_resource_removed": {
+      const operations = state.agentResourceOperations;
+      const pending = operations.removals[message.repositoryId];
+      if (pending?.requestId !== message.requestId) return state;
+      return {
+        ...state,
+        agentResources: message.inventory,
+        agentResourceOperations: {
+          ...operations,
+          removals: { ...operations.removals, [message.repositoryId]: { ...pending, status: "ready", result: message.result } },
+        },
+      };
+    }
     case "agent_resource_error": {
       const fail = <T extends { requestId: string }>(pending: T | null): (T & { status: "error"; message: string }) | null =>
         pending?.requestId === message.requestId ? { ...pending, status: "error", message: message.message } : null;
@@ -815,11 +866,14 @@ function reduce(state: AgentState, action: Action): AgentState {
       const preview = fail(state.agentResourceOperations.preview);
       const enrollment = fail(state.agentResourceOperations.enrollment);
       const refresh = fail(state.agentResourceOperations.refresh);
-      const updateEntry = Object.entries(state.agentResourceOperations.updates).find(([, value]) => value.requestId === message.requestId);
-      if (!clonePath && !preview && !enrollment && !refresh && !updateEntry) return state;
-      const updates = updateEntry
-        ? { ...state.agentResourceOperations.updates, [updateEntry[0]]: { ...updateEntry[1], status: "error" as const, message: message.message } }
-        : state.agentResourceOperations.updates;
+      const failKeyed = <T extends { requestId: string }>(entries: Record<string, T>): Record<string, T> | null => {
+        const hit = Object.entries(entries).find(([, value]) => value.requestId === message.requestId);
+        return hit ? { ...entries, [hit[0]]: { ...hit[1], status: "error" as const, message: message.message } } : null;
+      };
+      const updates = failKeyed(state.agentResourceOperations.updates);
+      const skills = failKeyed(state.agentResourceOperations.skills);
+      const removals = failKeyed(state.agentResourceOperations.removals);
+      if (!clonePath && !preview && !enrollment && !refresh && !updates && !skills && !removals) return state;
       return {
         ...state,
         agentResourceOperations: {
@@ -828,7 +882,9 @@ function reduce(state: AgentState, action: Action): AgentState {
           ...(preview ? { preview } : {}),
           ...(enrollment ? { enrollment } : {}),
           ...(refresh ? { refresh } : {}),
-          updates,
+          ...(updates ? { updates } : {}),
+          ...(skills ? { skills } : {}),
+          ...(removals ? { removals } : {}),
         },
       };
     }
@@ -1944,10 +2000,28 @@ export function useAgent(serverUrl = "", explicitToken?: string, embedded = fals
       dispatch({ type: "resource_preview_started", requestId });
       sendMessage({ type: "clone_agent_resource_repository", repositoryUrl, destinationPath, requestId });
     },
-    enrollAgentResourceRepository: (previewToken: string, skillRoots: string[], extensionRoots: string[]) => {
+    enrollAgentResourceRepository: (previewToken: string, skillRoots: string[], extensionRoots: string[], enabledSkills?: string[]) => {
       const requestId = `resource-enroll:${crypto.randomUUID()}`;
       dispatch({ type: "resource_enrollment_started", requestId });
-      sendMessage({ type: "enroll_agent_resource_repository", previewToken, skillRoots, extensionRoots, requestId });
+      sendMessage({
+        type: "enroll_agent_resource_repository",
+        previewToken,
+        skillRoots,
+        extensionRoots,
+        ...(enabledSkills ? { enabledSkills } : {}),
+        requestId,
+      });
+    },
+    /** Apply a collection's complete selection: every skill that should be on. */
+    setAgentResourceSkills: (repositoryId: string, enabledSkills: string[]) => {
+      const requestId = `resource-skills:${crypto.randomUUID()}`;
+      dispatch({ type: "resource_skills_started", requestId, repositoryId });
+      sendMessage({ type: "set_agent_resource_skills", repositoryId, enabledSkills, requestId });
+    },
+    removeAgentResourceRepository: (repositoryId: string) => {
+      const requestId = `resource-remove:${crypto.randomUUID()}`;
+      dispatch({ type: "resource_removal_started", requestId, repositoryId });
+      sendMessage({ type: "remove_agent_resource_repository", repositoryId, requestId });
     },
     refreshAgentResourceRepositories: (repositoryId?: string) => {
       const requestId = `resource-refresh:${crypto.randomUUID()}`;


### PR DESCRIPTION
## Summary

A Git repository carrying many skills (e.g. `khalilbenaz/claude-skills-collection`, 696 `SKILL.md`) could only be enrolled as whole roots — all or nothing — and could not be removed as a whole. It is now enrolled as a **skill collection**:

- The catalogue is listed by the repository's own folders (bounded walk, no manifest read, no dedupe), and **every skill starts off**.
- Skills are turned on one by one, or with **All on / All off** for the repository or a folder; changes are staged and applied once. The skills that are on are listed at the top, with **Search skills** and **Only on** for large collections; the repository list shows "N on · total".
- Only the skills that are on reach the session — one skill path each, on both runtimes, and in the sandbox's read-only exceptions. A skill added by an update stays off.
- **Remove repository** unregisters it as a whole and, for a clone pi-outpost manages, deletes it after a confirmation. Deletion is confined to the canonical worktree, never follows links, retries Windows read-only files, and reports a partial deletion as such.
- Repositories are named after their `origin`, not their clone folder. **Update repository** is shown only when an update is available. The add preview leads with the repository name and a top **Save**.
- Repositories enrolled before this change keep their root semantics; no migration. New config key: `userSkillCollections`.

OpenSpec change: `openspec/changes/manage-skill-collections/` (proposal, design, delta specs, tasks, scenario coverage).

### Defects found on the way, fixed here
- The snapshot of a session replacement cleared the pending resource request that caused it, so a removal's result, an enrollment's answer or an Apply error was dropped. `applySnapshot` now clears pending operations only on `hello` and `workspace_switched` (regression test in `useAgent.test.ts`).
- The Work Plan session sync was queued only after the inventory refresh, so a replacement awaiting it could run ahead of the inherited plan — a slower inventory exposed it in `work-plan-server.test.mjs`. `queueWorkPlanSessionSync` now takes the refresh as a dependency inside its chain.

## Testing
- Server: full suite 2032/2032; UI: full suite 1781/1781; `e2e/settings-extensions.spec.ts` 3/3; lint clean on touched files.
- `npm run check:scenarios -- --change manage-skill-collections`: 68 scenarios, all covered. `openspec validate --strict`: valid.
- Running app (embed bench): enrolled the real claude-skills-collection, turned skills on and found them again, applied, removed; monkey pass (double Apply, toggles in flight, repository switches with pending changes, bulk spam, clone deleted under the running app). Screenshots reviewed from a user's point of view.
- **Open:** task 5.5 needs this PR's Windows CI job to confirm clone deletion there.

## Documentation impact
- `README.md` — Settings table (Git repositories, removing a repository) and the `userSkillCollections` key.
- `docs/how-to.md` — collections start off, Turn on / Save / Apply, the "Turned on" list, search, removal deleting a managed clone, naming after `origin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mq1YBxTzEiwSpVsjLS74go
