### PR TITLE
Restore the ✎ on past prompts, and stop Outcome loading forever

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,7 +839,10 @@ Outcome data never crosses workspace boundaries. Refreshes are correlated with t
 workspace and session, so an older response is discarded after a project or session switch, and a
 result already on screen is dropped rather than carried into the next one. Switching project
 closes the drawer with the project it described; reopening it asks the workspace now bound. An
-Outcome left open across a dropped connection is asked for again once the connection is back. The
+Outcome left open across a dropped connection is asked for again once the connection is back.
+Every request is answered: a composition that fails says why in the drawer, and one the server
+never answers is given up on, so **Refresh** always works rather than being disarmed by a request
+that stayed outstanding. The
 section contract is extensible: future structured sources can add sections without changing the
 existing plan, verification, or changed-file sections.
 

--- a/server/src/convert.ts
+++ b/server/src/convert.ts
@@ -24,6 +24,29 @@ function relativizeUnderRoot(root: string, maybePath: string): string | undefine
   return rel.split(path.sep).join("/");
 }
 
+/**
+ * The text a user message is shown as — and therefore the only string anything
+ * may pair a bubble on. `user_entries` matches the client's bubbles by text, so
+ * the entry it sends has to be spelled the way the bubble is: images contribute
+ * nothing (they render as thumbnails), and an absolutized `@` mention goes back
+ * to the relative path the user typed. Computed in two places, the two spellings
+ * drifted the moment mentions were absolutized, and every bubble above the first
+ * `@` mention silently lost its ✎.
+ */
+export function userMessageText(content: string | AnyContent[] | undefined, browserRoot?: string): string {
+  const text =
+    typeof content === "string"
+      ? content
+      : Array.isArray(content)
+        ? content
+            .filter((c) => c.type === "text")
+            .map((c) => c.text ?? "")
+            .filter(Boolean)
+            .join("\n")
+        : "";
+  return browserRoot ? rewriteMentionedPathsSync(text, (p) => relativizeUnderRoot(browserRoot, p)) : text;
+}
+
 interface AnyContent {
   type: string;
   text?: string;
@@ -190,16 +213,7 @@ export function historyToItems(
     switch (message.role) {
       case "user": {
         // Text only — images render as thumbnails, no "[image]" marker needed
-        const text =
-          typeof message.content === "string"
-            ? message.content
-            : Array.isArray(message.content)
-              ? message.content
-                  .filter((c) => c.type === "text")
-                  .map((c) => c.text ?? "")
-                  .filter(Boolean)
-                  .join("\n")
-              : "";
+        const text = userMessageText(message.content, browserRoot);
         const images: WireImage[] = Array.isArray(message.content)
           ? message.content
               .filter((c) => c.type === "image" && c.data && c.mimeType)
@@ -208,7 +222,7 @@ export function historyToItems(
         if (text || images.length > 0) {
           const item: Extract<ChatItem, { kind: "user" }> = {
             kind: "user",
-            text: browserRoot ? rewriteMentionedPathsSync(text, (p) => relativizeUnderRoot(browserRoot, p)) : text,
+            text,
             ...(images.length > 0 ? { images } : {}),
           };
           items.push(item);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -111,7 +111,7 @@ import {
   validBaseUrl,
   validProviderId,
 } from "./credentials.ts";
-import { assistantToItem, contentText, customMessageToItem, historyToItems, structuredExchangeField, toProgressFraction, truncate } from "./convert.ts";
+import { assistantToItem, contentText, customMessageToItem, historyToItems, structuredExchangeField, toProgressFraction, truncate, userMessageText } from "./convert.ts";
 
 import { isStackExhaustion, noteCompaction, noteToolOutcome, noteTurnOutcome, recordTurnFailure } from "./turnFailureLog.ts";
 import {
@@ -1399,7 +1399,13 @@ function queueWorkPlanSessionSync(workspace: Workspace, after?: Promise<unknown>
     announceWorkspaceActivity();
     console.log(`[pi] session ${workspace.agent.snapshot().sessionId}`);
   });
-  workspace.workPlanSync.catch(reportError);
+  // Stored settled, never rejected. This promise is a sequencer — `get_outcome`
+  // and the prompt path await it to mean "the plan for this session has landed" —
+  // and a rejection left in it is not a one-off failure: every later awaiter
+  // inherits the same rejection, so one throw in this body (a snapshot that an
+  // extension renderer made throw, say) silently broke Outcome for the life of
+  // the workspace. Report it once here instead.
+  workspace.workPlanSync = workspace.workPlanSync.catch(reportError);
   return workspace.workPlanSync;
 }
 
@@ -1421,7 +1427,8 @@ function queueWorkPlanToolSync(workspace: Workspace, sessionFile: string, change
       announceWorkspaceActivity();
     }
   });
-  workspace.workPlanSync.catch(reportError);
+  // Settled, for the reason given in queueWorkPlanSessionSync.
+  workspace.workPlanSync = workspace.workPlanSync.catch(reportError);
 }
 
 function modelName(workspace: Workspace): string {
@@ -1501,12 +1508,19 @@ function credentialStatus(workspace: Workspace, ): CredentialStatus {
  * message_start, and historyToItems adds running tool cards for toolCalls
  * without a result yet.
  */
-/** User messages persisted on the current branch, oldest first — lets the UI edit a past prompt. */
+/**
+ * User messages persisted on the current branch, oldest first — lets the UI edit a past prompt.
+ *
+ * The text is the bubble's own spelling (`userMessageText`), not `contentText`:
+ * the client pairs these onto its bubbles by text, so a message whose `@` mention
+ * was absolutized — or that carried an image — would not match the bubble it
+ * belongs to, and the mismatch drops the id of every bubble above it too.
+ */
 function branchUserEntries(workspace: Workspace): { entryId: string; text: string }[] {
   return workspace.agent
     .contextEntries()
     .filter((e) => e.type === "message" && e.message?.role === "user")
-    .map((e) => ({ entryId: e.id, text: contentText(e.message!.content as never) }));
+    .map((e) => ({ entryId: e.id, text: userMessageText(e.message!.content as never, workspace.browserRoot) }));
 }
 
 /**
@@ -3398,16 +3412,34 @@ async function handleGitStatus(workspace: Workspace, socket: WebSocket, scope: s
   }
 }
 
-/** Compose only from the workspace bound to this socket; never broadcast Outcome content. */
+/**
+ * Compose only from the workspace bound to this socket; never broadcast Outcome content.
+ *
+ * Answers whatever happens. `composeWorkspaceOutcome` already turns a failing
+ * contributor into an unavailable section, but everything around it — the work
+ * plan sync this awaits, the runtime snapshot — can throw, and a throw here used
+ * to reach `reportError` and stop. The client has no timeout and starts no second
+ * request while one is outstanding, so that silence wedged the drawer on
+ * "Loading Outcome…" until the connection was replaced.
+ */
 async function handleGetOutcome(workspace: Workspace, socket: WebSocket, requestId: string): Promise<void> {
-  await workspace.workPlanSync;
-  const snapshot = workspace.agent.snapshot();
-  const plan = sameSessionFile(snapshot.sessionFile, workspace.workPlanSessionFile) ? workspace.workPlan : null;
-  const outcome = await composeWorkspaceOutcome(
-    { workspaceRoot: workspace.root, sessionId: snapshot.sessionId },
-    [workPlanContributor(plan), evidenceContributor(plan), repositoryContributor({ repos: workspace.repos, gitUnavailable: workspace.gitUnavailable })],
-  );
-  send(socket, { type: "workspace_outcome", requestId, outcome });
+  try {
+    await workspace.workPlanSync;
+    const snapshot = workspace.agent.snapshot();
+    const plan = sameSessionFile(snapshot.sessionFile, workspace.workPlanSessionFile) ? workspace.workPlan : null;
+    const outcome = await composeWorkspaceOutcome(
+      { workspaceRoot: workspace.root, sessionId: snapshot.sessionId },
+      [workPlanContributor(plan), evidenceContributor(plan), repositoryContributor({ repos: workspace.repos, gitUnavailable: workspace.gitUnavailable })],
+    );
+    send(socket, { type: "workspace_outcome", requestId, outcome });
+  } catch (error) {
+    reportError(error);
+    send(socket, {
+      type: "workspace_outcome_error",
+      requestId,
+      message: error instanceof Error && error.message ? error.message : "The Outcome could not be composed.",
+    });
+  }
 }
 
 /** Worktree-vs-HEAD contents of one file; missing sides (untracked/deleted) are "". */

--- a/server/test/mentionAbsolutization.test.mjs
+++ b/server/test/mentionAbsolutization.test.mjs
@@ -50,7 +50,13 @@ test("an @-mentioned path reaches the model absolute, and the user still sees it
           // persists the prompt it was given; the server replaces its in-memory
           // messages with this on every completed turn, so a fixture that answers
           // nothing makes a reconnect replay nothing.
-          replacement: { messages: [{ role: "user", content: absolutized, timestamp: 1 }] },
+          replacement: {
+            messages: [{ role: "user", content: absolutized, timestamp: 1 }],
+            // The branch the server reads `user_entries` from. Like the messages
+            // above, it holds what reached the runtime: the absolutized text.
+            tree: [{ entry: { id: "entry-1", type: "message", message: { role: "user", content: absolutized } }, children: [] }],
+            leafId: "entry-1",
+          },
           after: [
             { type: "message_end", message: { role: "user", content: absolutized } },
             // The turn has to *end*, not merely be accepted. The server persists
@@ -94,7 +100,17 @@ test("an @-mentioned path reaches the model absolute, and the user still sees it
     // true the moment the tab reloads.
     // `user_entries` is broadcast once the turn is persisted — the server saying
     // the history now holds what a reconnect would replay.
-    await client.waitFor("user_entries");
+    const entries = await client.waitFor("user_entries");
+
+    // And it must be broadcast the way the bubble is spelled. The client pairs
+    // these entries onto its bubbles by text and stops at the first mismatch, so
+    // an absolutized entry here does not merely fail to match its own bubble: it
+    // drops the entry id of every bubble above it, and the whole conversation
+    // loses its ✎ — no editing, no branching — until the tab is reloaded.
+    assert.deepEqual(
+      entries.entries.map((entry) => entry.text),
+      ["please check @notes/todo.md"],
+    );
 
     const reconnected = connect(server.wsUrl());
     try {

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -845,6 +845,14 @@ export type ServerMessage =
   | { type: "context_usage"; usage: ContextUsage }
   | { type: "work_plan_changed"; workPlan: WorkPlan | null }
   | { type: "workspace_outcome"; requestId: string; outcome: WorkspaceOutcome }
+  /**
+   * Composing the Outcome failed. Every `get_outcome` is answered by exactly one
+   * of these two messages: the client shows one request at a time and refuses to
+   * start another while one is outstanding, so a request that goes unanswered
+   * does not merely lose an answer — it leaves the drawer on "Loading Outcome…"
+   * with its own Refresh button disarmed, for the life of the connection.
+   */
+  | { type: "workspace_outcome_error"; requestId: string; message: string }
   | { type: "compaction_start" }
   | { type: "compaction_end"; errorMessage?: string }
   | { type: "error"; message: string }

--- a/ui/src/useAgent.test.ts
+++ b/ui/src/useAgent.test.ts
@@ -153,6 +153,96 @@ describe("workspace Outcome", () => {
     expect(result.current.state.outcome).toBeNull();
   });
 
+  it("forgets a request the snapshot orphaned, so the drawer can ask again", async () => {
+    // The answer to a request made before a switch is discarded on arrival — and
+    // while it counted as outstanding it blocked every later request, Refresh
+    // included. The drawer then sat on "Loading Outcome…" for the life of the
+    // connection, because the answer that would have released it never came.
+    const result = await connected([], { workspace: { root: "/a", name: "a", activity: "idle" } });
+    act(() => result.current.setOutcomeActive(true));
+    const orphaned = lastRequestId();
+    const before = mockWs!.sent.filter((frame) => JSON.parse(frame).type === "get_outcome").length;
+    act(() => mockWs!.receive({
+      type: "session_replaced",
+      sessionId: "sess_9",
+      workspace: { root: "/a", name: "a", activity: "idle" },
+      workspaces: [], branding: {}, model: "", thinkingLevel: "off", models: [], commands: [], isStreaming: false, items: [],
+    }));
+
+    act(() => result.current.refreshOutcome());
+    await waitFor(() => expect(mockWs!.sent.filter((frame) => JSON.parse(frame).type === "get_outcome")).toHaveLength(before + 1));
+    const asked = lastRequestId();
+    expect(asked).not.toBe(orphaned);
+    act(() => mockWs!.receive({ type: "workspace_outcome", requestId: asked, outcome: outcome("/a", "sess_9") }));
+    await waitFor(() => expect(result.current.state.outcome?.status).toBe("loaded"));
+  });
+
+  it("asks again after a snapshot that changes neither the session nor the project", async () => {
+    // Saving settings replaces the snapshot without changing what the drawer is
+    // looking at, so the effect that re-asks on a session or project change never
+    // fires. The Outcome on screen is dropped all the same — and nobody was left
+    // to ask for its replacement.
+    const result = await connected([], { workspace: { root: "/a", name: "a", activity: "idle" } });
+    act(() => result.current.setOutcomeActive(true));
+    act(() => mockWs!.receive({ type: "workspace_outcome", requestId: lastRequestId(), outcome: outcome() }));
+    await waitFor(() => expect(result.current.state.outcome?.status).toBe("loaded"));
+
+    const before = mockWs!.sent.filter((frame) => JSON.parse(frame).type === "get_outcome").length;
+    act(() => mockWs!.receive({
+      type: "update_config_ack",
+      sessionId: "sess_1",
+      workspace: { root: "/a", name: "a", activity: "idle" },
+      workspaces: [], branding: {}, model: "", thinkingLevel: "off", models: [], commands: [], isStreaming: false, items: [],
+    }));
+    await waitFor(() => expect(mockWs!.sent.filter((frame) => JSON.parse(frame).type === "get_outcome")).toHaveLength(before + 1));
+    act(() => mockWs!.receive({ type: "workspace_outcome", requestId: lastRequestId(), outcome: outcome() }));
+    await waitFor(() => expect(result.current.state.outcome?.status).toBe("loaded"));
+  });
+
+  it("answers a composition failure with the reason, and stays refreshable", async () => {
+    // The server answers every request, and a refusal is an answer: without one
+    // the drawer sits on "Loading Outcome…" and its own Refresh button is a
+    // no-op, because a request still counts as outstanding.
+    const result = await connected([], { workspace: { root: "/a", name: "a", activity: "idle" } });
+    act(() => result.current.setOutcomeActive(true));
+    const requestId = lastRequestId();
+    act(() => mockWs!.receive({ type: "workspace_outcome_error", requestId, message: "Cannot load the Work Plan" }));
+    const failed = result.current.state.outcome;
+    expect(failed?.status).toBe("error");
+    expect(failed?.status === "error" && failed.message).toBe("Cannot load the Work Plan");
+
+    const before = mockWs!.sent.filter((frame) => JSON.parse(frame).type === "get_outcome").length;
+    act(() => result.current.refreshOutcome());
+    await waitFor(() => expect(mockWs!.sent.filter((frame) => JSON.parse(frame).type === "get_outcome")).toHaveLength(before + 1));
+    await waitFor(() => expect(result.current.state.outcome?.status).toBe("loading"));
+  });
+
+  it("gives up on a request the server never answers instead of loading forever", async () => {
+    // A backend that has stopped answering leaves a socket that is still open and
+    // silent, so nothing here ever closes and nothing ever arrives. Say so, and
+    // re-arm Refresh: the alternative is a spinner for the life of the connection.
+    const result = await connected([], { workspace: { root: "/a", name: "a", activity: "idle" } });
+    // Fake timers only from here: connecting the hook runs on real ones.
+    vi.useFakeTimers();
+    try {
+      act(() => result.current.setOutcomeActive(true));
+      const before = mockWs!.sent.filter((frame) => JSON.parse(frame).type === "get_outcome").length;
+      expect(result.current.state.outcome?.status).toBe("loading");
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(45_000);
+      });
+      const failed = result.current.state.outcome;
+      expect(failed?.status).toBe("error");
+      expect(failed?.status === "error" && failed.message).toMatch(/too long/i);
+
+      act(() => result.current.refreshOutcome());
+      expect(mockWs!.sent.filter((frame) => JSON.parse(frame).type === "get_outcome")).toHaveLength(before + 1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("drops a loaded Outcome when the workspace or the session it describes is replaced", async () => {
     // Correlation only discards late answers. A result already on screen has to
     // go too: it is a claim about one workspace and one session, and the drawer

--- a/ui/src/useAgent.ts
+++ b/ui/src/useAgent.ts
@@ -458,6 +458,7 @@ type Action =
   | { type: "resource_skills_started"; requestId: string; repositoryId: string }
   | { type: "resource_removal_started"; requestId: string; repositoryId: string }
   | { type: "outcome_started"; requestId: string; workspaceRoot: string | null; sessionId: string }
+  | { type: "outcome_failed"; requestId: string; message: string }
   | { type: "branding_settled" }
   | { type: "branding_loaded"; branding: Branding };
 
@@ -745,6 +746,13 @@ function reduce(state: AgentState, action: Action): AgentState {
   if (action.type === "outcome_started") {
     return { ...state, outcome: { status: "loading", requestId: action.requestId, workspaceRoot: action.workspaceRoot, sessionId: action.sessionId } };
   }
+  if (action.type === "outcome_failed") {
+    const pending = state.outcome;
+    // Same correlation as a successful answer: a failure for a request this
+    // drawer is no longer waiting on says nothing about the one it is.
+    if (pending === null || pending.status !== "loading" || pending.requestId !== action.requestId) return state;
+    return { ...state, outcome: { ...pending, status: "error", message: action.message } };
+  }
 
   const message = action.message;
   switch (message.type) {
@@ -945,6 +953,11 @@ function reduce(state: AgentState, action: Action): AgentState {
       if (pending.sessionId !== state.sessionId || message.outcome.sessionId !== state.sessionId) return state;
       if (pending.workspaceRoot !== null && message.outcome.workspaceRoot !== pending.workspaceRoot) return state;
       return { ...state, outcome: { ...pending, status: "loaded", outcome: message.outcome } };
+    }
+    case "workspace_outcome_error": {
+      const pending = state.outcome;
+      if (pending === null || pending.status !== "loading" || pending.requestId !== message.requestId) return state;
+      return { ...state, outcome: { ...pending, status: "error", message: message.message } };
     }
     case "user":
       return {
@@ -1359,6 +1372,16 @@ function wsUrlFor(serverUrl: string, token: string | null, workspace?: string): 
  */
 const UPLOAD_TIMEOUT_MS = 120_000;
 
+/**
+ * How long the Outcome drawer waits for an answer before saying so.
+ *
+ * Comfortably above what composing costs — a git status per repository, each
+ * bounded at 10s server-side — because a false timeout on a large workspace
+ * would replace a slow panel with a wrong one. It is a backstop for a backend
+ * that has stopped answering, not a performance budget.
+ */
+const OUTCOME_TIMEOUT_MS = 45_000;
+
 /** WS close code the server sends for a bad/missing token (see WS_CLOSE_UNAUTHORIZED server-side). */
 const WS_CLOSE_UNAUTHORIZED = 4401;
 
@@ -1424,7 +1447,20 @@ export function useAgent(serverUrl = "", explicitToken?: string, embedded = fals
   const outcomeActiveRef = useRef(false);
   const outcomeInFlightRef = useRef<string | null>(null);
   const outcomeQueuedRef = useRef(false);
+  const outcomeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const requestOutcomeRef = useRef<() => void>(() => {});
+  /**
+   * Nothing outstanding any more — whatever the reason. One request is allowed at
+   * a time, so this is also what re-arms Refresh: while a request counts as
+   * outstanding the button is a no-op.
+   */
+  const settleOutcome = useCallback(() => {
+    outcomeInFlightRef.current = null;
+    if (outcomeTimerRef.current !== null) {
+      clearTimeout(outcomeTimerRef.current);
+      outcomeTimerRef.current = null;
+    }
+  }, []);
   const requestOutcome = useCallback(() => {
     const socket = socketRef.current;
     if (!socket || socket.readyState !== WebSocket.OPEN) return;
@@ -1437,7 +1473,18 @@ export function useAgent(serverUrl = "", explicitToken?: string, embedded = fals
     const identity = outcomeIdentityRef.current;
     dispatch({ type: "outcome_started", requestId, ...identity });
     sendMessage({ type: "get_outcome", requestId });
-  }, [sendMessage]);
+    // The server answers every request, success or failure — but it can only do
+    // that while it is answering at all. A wedged or paused backend leaves a
+    // socket that is still OPEN and silent, and without this the drawer would sit
+    // on "Loading Outcome…" with Refresh disarmed until the connection dropped.
+    // Say so instead, and let the button work.
+    outcomeTimerRef.current = setTimeout(() => {
+      if (outcomeInFlightRef.current !== requestId) return;
+      settleOutcome();
+      outcomeQueuedRef.current = false;
+      dispatch({ type: "outcome_failed", requestId, message: "The Outcome took too long to answer — try again." });
+    }, OUTCOME_TIMEOUT_MS);
+  }, [sendMessage, settleOutcome]);
   requestOutcomeRef.current = requestOutcome;
   const invalidateOutcome = useCallback(() => {
     if (outcomeActiveRef.current) requestOutcomeRef.current();
@@ -1722,10 +1769,38 @@ export function useAgent(serverUrl = "", explicitToken?: string, embedded = fals
           gitStatusSettled(message.requestId);
         }
         if (message.type === "work_plan_changed") invalidateOutcome();
-        if (message.type === "workspace_outcome" && outcomeInFlightRef.current === message.requestId) {
-          outcomeInFlightRef.current = null;
+        if (
+          (message.type === "workspace_outcome" || message.type === "workspace_outcome_error") &&
+          outcomeInFlightRef.current === message.requestId
+        ) {
+          settleOutcome();
           if (outcomeQueuedRef.current) {
             outcomeQueuedRef.current = false;
+            queueMicrotask(() => requestOutcomeRef.current());
+          }
+        }
+        // A snapshot discards the Outcome on screen (it belongs to the session or
+        // project being left), so a request outstanding for that one is owed to
+        // nobody. Forgetting it is the point: held, it blocks every later request
+        // — including the drawer's own Refresh — while the answer it waits for
+        // would be discarded on arrival anyway.
+        if (
+          message.type === "hello" ||
+          message.type === "session_replaced" ||
+          message.type === "workspace_switched" ||
+          message.type === "update_config_ack"
+        ) {
+          settleOutcome();
+          outcomeQueuedRef.current = false;
+          // Asking again is the drawer's own effect, which fires when the session
+          // or project it shows changes. A snapshot that changes neither — a
+          // settings save — leaves nobody to ask, and an open drawer would render
+          // its loading state until the user hit Refresh. Cover exactly that gap:
+          // the identity ref still holds what was on screen a moment ago.
+          const identity = outcomeIdentityRef.current;
+          const sameSession = message.sessionId === identity.sessionId;
+          const sameWorkspace = (message.workspace?.root ?? null) === identity.workspaceRoot;
+          if (outcomeActiveRef.current && sameSession && sameWorkspace) {
             queueMicrotask(() => requestOutcomeRef.current());
           }
         }
@@ -1755,7 +1830,7 @@ export function useAgent(serverUrl = "", explicitToken?: string, embedded = fals
         gitStatusInFlight.current.clear();
         gitStatusQueued.current.clear();
         gitStatusScopes.current.clear();
-        outcomeInFlightRef.current = null;
+        settleOutcome();
         outcomeQueuedRef.current = false;
         // Same reasoning, but a stuck upload is worse than a stale badge: the
         // composer blocks submission while one is in flight, so an unanswered
@@ -1782,7 +1857,7 @@ export function useAgent(serverUrl = "", explicitToken?: string, embedded = fals
       socketRef.current = null;
       socket?.close();
     };
-  }, [sendMessage, serverUrl, refreshGitStatus, gitStatusSettled, relistDirectory, requestDirectory, invalidateOutcome, authNonce, workspaceRoot]);
+  }, [sendMessage, serverUrl, refreshGitStatus, gitStatusSettled, relistDirectory, requestDirectory, invalidateOutcome, settleOutcome, authNonce, workspaceRoot]);
 
   return {
     state,


### PR DESCRIPTION
Two regressions reported together, unrelated in cause.

## Editing a past prompt no longer offered the ✎

`user_entries` is paired onto the conversation's bubbles **by text**, from the most recent backwards, stopping at the first mismatch — a bubble the server never persisted (an extension slash command, a steer aborted before delivery) must not shift the alignment onto the previous message's entry.

The two texts were built in two places, and they drifted when `@` mentions started being absolutized before the model reads them: the conversation shows the relative path the user typed, while the entry carried the absolute one — plus `[image]` markers the bubble never has. So the first prompt naming a file mismatched, and **every bubble above it lost its entry id with it**: no ✎, no branching. A reload hid it (the snapshot pairs positionally) and the next completed turn brought it back, which is why it was hard to date.

One `userMessageText(content, browserRoot)` now spells both sides.

## Outcome loaded forever

The drawer shows one request at a time and starts no second while one is outstanding. A request that goes unanswered therefore does not merely lose an answer — it leaves `Loading Outcome…` on screen **with the panel's own Refresh disarmed**, for the life of the connection. Three routes to that, all closed:

- `handleGetOutcome` could throw — into `reportError`, answering nothing. It answers `workspace_outcome_error` now, and the drawer shows the reason instead of a spinner.
- `workspace.workPlanSync` stored a **rejected** promise when its body threw (that body takes a snapshot, which runs extension renderers). The `await` at the top of every later request re-threw it, so one throw silenced Outcome for the life of the workspace. It is reported once and stored settled: the promise is a sequencer, not a result.
- A snapshot discards the Outcome on screen, but the request made for the session being replaced still counted as outstanding. It is forgotten now — and a snapshot that changes neither session nor project (saving settings) asks again itself, since the drawer's own effect only fires on a session or project change.

Client-side backstop: a request never answered at all — a backend that has stopped answering leaves a socket open and silent — gives up after 45s and says so.

## Evidence

Unit and wire tests, each red without the change:

- `server/test/mentionAbsolutization.test.mjs` — `user_entries` carries the mention as typed.
- `ui/src/useAgent.test.ts` — a composition failure renders and stays refreshable; an unanswered request gives up; an orphaned request is forgotten; an identity-preserving snapshot asks again.

Suites: server 2032 pass, ui 1785 pass.

Driven in the running app (`npm run dev`, real session):

- The ✎ survives a completed turn on a prompt carrying `@scratch/barré.docx`, and opens the editor with the mention still relative. Before: that bubble and the four above it lost it.
- With a failure injected in `handleGetOutcome`, the drawer shows `injected: Cannot load the Work Plan`; two Refresh clicks send two requests (before: zero — wedged). Restarting the server healthy replaced the error with real content without any click.
- Monkey pass: six rapid Outcome toggles, five Refresh clicks, a session switch with the drawer open — reopening loads.

## Documentation impact

`README.md` — the Outcome section now states that every request is answered and that Refresh cannot be disarmed by an outstanding request. No other user or developer document describes these behaviours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmrcyqbHMCexFamj8wJP7o
